### PR TITLE
fix: installer browser timeout + allow workspace from any path

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -448,7 +448,7 @@ echo "Checking native build tools..."
 ensure_native_build_tools
 echo ""
 
-echo "Installing PilotDeck to ${DIM}${INSTALL_DIR}${RESET} ..."
+echo -e "Installing PilotDeck to ${DIM}${INSTALL_DIR}${RESET} ..."
 install_or_update_repo
 ensure_lfs_assets
 echo ""

--- a/install.sh
+++ b/install.sh
@@ -24,6 +24,30 @@ ok() { printf "  ${GREEN}✓${RESET} %s\n" "$1"; }
 warn() { printf "  ${YELLOW}→${RESET} %s\n" "$1"; }
 fail() { printf "  ${RED}✗${RESET} %s\n" "$1"; exit 1; }
 
+# Portable timeout: use GNU timeout if available, else fall back to a bg+kill approach.
+# Returns 124 on timeout (same convention as GNU timeout).
+run_with_timeout() {
+  local secs="$1"; shift
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$secs" "$@"
+  else
+    "$@" &
+    local pid=$!
+    ( sleep "$secs" && kill "$pid" 2>/dev/null ) &
+    local watchdog=$!
+    if wait "$pid" 2>/dev/null; then
+      kill "$watchdog" 2>/dev/null; wait "$watchdog" 2>/dev/null
+      return 0
+    else
+      local rc=$?
+      kill "$watchdog" 2>/dev/null; wait "$watchdog" 2>/dev/null
+      # 143 = SIGTERM (128+15), treat as timeout
+      if [[ $rc -eq 143 ]]; then return 124; fi
+      return $rc
+    fi
+  fi
+}
+
 run_as_root() {
   if [[ "${EUID:-$(id -u)}" -eq 0 ]]; then
     "$@"
@@ -471,12 +495,27 @@ echo ""
 
 echo "Checking Playwright browser for browser-use plugin..."
 cd "$INSTALL_DIR"
+BROWSER_INSTALL_TIMEOUT="${PILOTDECK_BROWSER_INSTALL_TIMEOUT:-300}"
 if has_playwright_chrome_for_testing; then
   ok "Chrome for Testing already installed"
+elif [[ "${PILOTDECK_SKIP_BROWSER_INSTALL:-0}" == "1" ]]; then
+  warn "Skipping Chrome for Testing install because PILOTDECK_SKIP_BROWSER_INSTALL=1"
 else
-  npx @playwright/mcp install-browser chrome-for-testing </dev/null 2>/dev/null && \
-    ok "Chrome for Testing installed" || \
-    warn "Chrome for Testing install failed (browser-use plugin may not work)"
+  echo "  Downloading and extracting Chrome for Testing (timeout: ${BROWSER_INSTALL_TIMEOUT}s)..."
+  echo "  This may take a few minutes — the extraction step can appear to stall."
+  if run_with_timeout "${BROWSER_INSTALL_TIMEOUT}" npx @playwright/mcp install-browser chrome-for-testing </dev/null; then
+    ok "Chrome for Testing installed"
+  else
+    exit_code=$?
+    if [[ $exit_code -eq 124 ]]; then
+      warn "Chrome for Testing install timed out after ${BROWSER_INSTALL_TIMEOUT}s."
+    else
+      warn "Chrome for Testing install failed (exit code $exit_code)."
+    fi
+    warn "PilotDeck core features are still available."
+    warn "To enable browser-use later, run: cd \"$INSTALL_DIR\" && npm run install:browser"
+    warn "To increase timeout, set PILOTDECK_BROWSER_INSTALL_TIMEOUT=600 and re-run."
+  fi
 fi
 echo ""
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "predev": "node ../scripts/bootstrap-pilotdeck-config.mjs",
     "dev": "node ../scripts/dev-launcher.mjs",
-    "dev:concurrent": "concurrently --kill-others --names gateway,server,client \"npm:dev:gateway\" \"npm:dev:server\" \"npm:dev:client\"",
+    "dev:concurrent": "concurrently --kill-others-on-fail --names gateway,server,client \"npm:dev:gateway\" \"npm:dev:server\" \"npm:dev:client\"",
     "dev:gateway": "npm --prefix .. run server",
     "dev:server": "node --import tsx server/index.js",
     "dev:client": "vite",
@@ -21,7 +21,7 @@
     "lint": "eslint src/",
     "lint:fix": "eslint src/ --fix",
     "start": "npm run build && npm run start:built",
-    "start:built": "concurrently --kill-others --names gateway,server \"npm:gateway\" \"npm:server\"",
+    "start:built": "concurrently --kill-others-on-fail --names gateway,server \"npm:gateway\" \"npm:server\"",
     "postinstall": "node scripts/fix-node-pty.js"
   },
   "dependencies": {

--- a/ui/server/index.js
+++ b/ui/server/index.js
@@ -997,12 +997,12 @@ app.get('/api/browse-filesystem', authenticateToken, async (req, res) => {
         // Resolve and normalize the path
         targetPath = path.resolve(targetPath);
 
-        // Security check - ensure path is within allowed workspace root
-        const validation = await validateWorkspacePath(targetPath);
-        if (!validation.valid) {
-            return res.status(403).json({ error: validation.error });
-        }
-        const resolvedPath = validation.resolvedPath || targetPath;
+        // Browsing a directory is read-only — we only list its children.
+        // The actual workspace-selection validation happens in the
+        // create-workspace / clone-progress endpoints, so we don't gate
+        // browsing with validateWorkspacePath (which would block navigating
+        // through forbidden directories like "/" to reach valid children).
+        const resolvedPath = targetPath;
 
         // Security check - ensure path is accessible
         try {

--- a/ui/server/routes/projects.js
+++ b/ui/server/routes/projects.js
@@ -24,7 +24,7 @@ function sanitizeGitError(message, token) {
   return message.replace(new RegExp(token.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g'), '***');
 }
 
-// Configure allowed workspace root (defaults to user's home directory)
+// Default root used by the folder browser when no path is provided.
 export const WORKSPACES_ROOT = process.env.WORKSPACES_ROOT || os.homedir();
 
 // System-critical paths that should never be used as workspace directories
@@ -44,7 +44,6 @@ export const FORBIDDEN_PATHS = [
   '/lib',
   '/lib64',
   '/opt',
-  '/tmp',
   '/run',
   // Windows
   'C:\\Windows',
@@ -54,6 +53,28 @@ export const FORBIDDEN_PATHS = [
   'C:\\System Volume Information',
   'C:\\$Recycle.Bin'
 ];
+
+function isForbiddenWorkspacePath(inputPath) {
+  const normalizedPath = path.normalize(path.resolve(inputPath));
+  if (normalizedPath === '/' || FORBIDDEN_PATHS.includes(normalizedPath)) {
+    return true;
+  }
+
+  for (const forbidden of FORBIDDEN_PATHS) {
+    if (normalizedPath === forbidden || normalizedPath.startsWith(forbidden + path.sep)) {
+      // Exception: allow user-accessible temporary folders under /var.
+      if (
+        forbidden === '/var' &&
+        (normalizedPath.startsWith('/var/tmp') || normalizedPath.startsWith('/var/folders'))
+      ) {
+        continue;
+      }
+      return true;
+    }
+  }
+
+  return false;
+}
 
 /**
  * Validates that a path is safe for workspace operations
@@ -65,32 +86,12 @@ export async function validateWorkspacePath(requestedPath) {
     // Resolve to absolute path
     let absolutePath = path.resolve(requestedPath);
 
-    // Check if path is a forbidden system directory
-    const normalizedPath = path.normalize(absolutePath);
-    if (FORBIDDEN_PATHS.includes(normalizedPath) || normalizedPath === '/') {
+    // Reject system-critical directories and descendants.
+    if (isForbiddenWorkspacePath(absolutePath)) {
       return {
         valid: false,
-        error: 'Cannot use system-critical directories as workspace locations'
+        error: 'Cannot create workspace in system-critical directories'
       };
-    }
-
-    // Additional check for paths starting with forbidden directories
-    for (const forbidden of FORBIDDEN_PATHS) {
-      if (normalizedPath === forbidden ||
-          normalizedPath.startsWith(forbidden + path.sep)) {
-        // Exception: /var/tmp and similar user-accessible paths might be allowed
-        // but /var itself and most /var subdirectories should be blocked
-        if (forbidden === '/var' &&
-            (normalizedPath.startsWith('/var/tmp') ||
-             normalizedPath.startsWith('/var/folders'))) {
-          continue; // Allow these specific cases
-        }
-
-        return {
-          valid: false,
-          error: `Cannot create workspace in system directory: ${forbidden}`
-        };
-      }
     }
 
     // Try to resolve the real path (following symlinks)
@@ -122,15 +123,11 @@ export async function validateWorkspacePath(requestedPath) {
       }
     }
 
-    // Resolve the workspace root to its real path
-    const resolvedWorkspaceRoot = await fs.realpath(WORKSPACES_ROOT);
-
-    // Ensure the resolved path is contained within the allowed workspace root
-    if (!realPath.startsWith(resolvedWorkspaceRoot + path.sep) &&
-        realPath !== resolvedWorkspaceRoot) {
+    // Apply the same checks after symlink/canonical path resolution.
+    if (isForbiddenWorkspacePath(realPath)) {
       return {
         valid: false,
-        error: `Workspace path must be within the allowed workspace root: ${WORKSPACES_ROOT}`
+        error: 'Resolved path points to a system-critical directory'
       };
     }
 
@@ -140,16 +137,15 @@ export async function validateWorkspacePath(requestedPath) {
       const stats = await fs.lstat(absolutePath);
 
       if (stats.isSymbolicLink()) {
-        // Verify symlink target is also within allowed root
+        // Verify symlink target is not a forbidden system path.
         const linkTarget = await fs.readlink(absolutePath);
         const resolvedTarget = path.resolve(path.dirname(absolutePath), linkTarget);
         const realTarget = await fs.realpath(resolvedTarget);
 
-        if (!realTarget.startsWith(resolvedWorkspaceRoot + path.sep) &&
-            realTarget !== resolvedWorkspaceRoot) {
+        if (isForbiddenWorkspacePath(realTarget)) {
           return {
             valid: false,
-            error: 'Symlink target is outside the allowed workspace root'
+            error: 'Symlink target points to a system-critical directory'
           };
         }
       }

--- a/ui/src/components/project-creation-wizard/utils/pathUtils.ts
+++ b/ui/src/components/project-creation-wizard/utils/pathUtils.ts
@@ -28,8 +28,11 @@ export const getSuggestionRootPath = (inputPath: string): string => {
 
 // Handles root edge cases for Unix-like and Windows paths.
 export const getParentPath = (currentPath: string): string | null => {
-  if (currentPath === '~' || currentPath === '/' || WINDOWS_DRIVE_PATTERN.test(currentPath)) {
+  if (currentPath === '/' || WINDOWS_DRIVE_PATTERN.test(currentPath)) {
     return null;
+  }
+  if (currentPath === '~') {
+    return '/';
   }
 
   const lastSeparatorIndex = Math.max(currentPath.lastIndexOf('/'), currentPath.lastIndexOf('\\'));


### PR DESCRIPTION
## Changes

### 1. Chrome browser install timeout (install.sh)

The Playwright browser download+extraction can stall indefinitely, especially on Linux.

- 300s timeout (configurable via `PILOTDECK_BROWSER_INSTALL_TIMEOUT`)
- Portable `run_with_timeout` helper (GNU timeout || bg+kill fallback for macOS)
- Progress message before install so users know extraction may appear slow
- Distinct messages for timeout vs other failures with recovery instructions

### 2. Allow workspace selection from any filesystem path (fixes #20)

Workspace folder browser was locked to the user's home directory.

- Remove `/tmp` from `FORBIDDEN_PATHS` — subdirectories are valid workspace locations
- `getParentPath('~')` returns `'/'` instead of `null` — users can navigate above home to reach `/Volumes`, `/mnt`, etc.
- Skip `validateWorkspacePath` in browse endpoint — browsing is read-only; creation endpoints still enforce the blacklist

System-critical directories (`/`, `/etc`, `/bin`, `/usr`, etc.) are still blocked as workspace targets.