### PR TITLE
fix(windows): resolve spawn npm ENOENT error in dev-launcher

### DIFF
--- a/scripts/dev-launcher.mjs
+++ b/scripts/dev-launcher.mjs
@@ -122,7 +122,7 @@ async function main() {
   const child = spawn(
     'npm',
     ['--workspace', 'ui', 'run', 'dev:concurrent'],
-    { cwd: repoRoot, env, stdio: 'inherit' },
+    { cwd: repoRoot, env, stdio: 'inherit', shell: true },
   );
 
   const forward = (signal) => {


### PR DESCRIPTION
This PR adds shell: true to the spawn command in dev-launcher.mjs. This fixes an issue where the launcher would fail to execute correctly on Windows environments.