### PR TITLE
fix: improve error handling and resource cleanup

### DIFF
--- a/src/gateway/util/AsyncQueue.ts
+++ b/src/gateway/util/AsyncQueue.ts
@@ -10,7 +10,10 @@
  */
 export class AsyncQueue<T> {
   private readonly buffer: T[] = [];
-  private readonly waiters: Array<{ resolve(value: IteratorResult<T>): void }> = [];
+  private readonly waiters: Array<{
+    resolve(value: IteratorResult<T>): void;
+    reject(error: Error): void;
+  }> = [];
   private closed = false;
   private error: Error | undefined;
 
@@ -33,7 +36,11 @@ export class AsyncQueue<T> {
 
   fail(error: Error): void {
     this.error = error;
-    this.close();
+    this.closed = true;
+    // Reject all pending waiters with the error
+    while (this.waiters.length > 0) {
+      this.waiters.shift()!.reject(error);
+    }
   }
 
   [Symbol.asyncIterator](): AsyncIterator<T> {
@@ -50,8 +57,8 @@ export class AsyncQueue<T> {
         if (this.closed) {
           return Promise.resolve({ value: undefined as unknown as T, done: true });
         }
-        return new Promise<IteratorResult<T>>((resolve) => {
-          this.waiters.push({ resolve });
+        return new Promise<IteratorResult<T>>((resolve, reject) => {
+          this.waiters.push({ resolve, reject });
         });
       },
     };

--- a/ui/src/components/chat/hooks/useChatSessionState.ts
+++ b/ui/src/components/chat/hooks/useChatSessionState.ts
@@ -754,6 +754,7 @@ export function useChatSessionState({
 
     const target = searchTarget;
     setSearchTarget(null);
+    let cancelled = false;
 
     const scrollToTarget = async () => {
       if (!allMessagesLoadedRef.current && selectedSession && selectedProject) {
@@ -767,6 +768,7 @@ export function useChatSessionState({
               limit: null,
               offset: 0,
             });
+            if (cancelled) return;
             if (slot) {
               setHasMoreMessages(false);
               setTotalMessages(slot.total);
@@ -775,6 +777,7 @@ export function useChatSessionState({
               setAllMessagesLoaded(true);
               allMessagesLoadedRef.current = true;
               await new Promise(resolve => setTimeout(resolve, 300));
+              if (cancelled) return;
             }
           } catch {
             // Fall through and scroll in current messages
@@ -784,6 +787,7 @@ export function useChatSessionState({
       setVisibleMessageCount(Infinity);
 
       const findAndScroll = (retriesLeft: number) => {
+        if (cancelled) return;
         const container = scrollContainerRef.current;
         if (!container) return;
 
@@ -816,7 +820,9 @@ export function useChatSessionState({
         if (targetElement) {
           targetElement.scrollIntoView({ block: 'center', behavior: 'smooth' });
           targetElement.classList.add('search-highlight-flash');
-          setTimeout(() => targetElement?.classList.remove('search-highlight-flash'), 4000);
+          setTimeout(() => {
+            if (!cancelled) targetElement?.classList.remove('search-highlight-flash');
+          }, 4000);
           searchScrollActiveRef.current = false;
         } else if (retriesLeft > 0) {
           setTimeout(() => findAndScroll(retriesLeft - 1), 200);
@@ -829,6 +835,7 @@ export function useChatSessionState({
     };
 
     scrollToTarget();
+    return () => { cancelled = true; };
   }, [chatMessages.length, isLoadingSessionMessages, searchTarget, selectedProject, selectedSession, sessionRequestParams, sessionStore]);
 
   useEffect(() => {

--- a/ui/src/contexts/TasksSettingsContext.jsx
+++ b/ui/src/contexts/TasksSettingsContext.jsx
@@ -23,7 +23,12 @@ export const TasksSettingsProvider = ({ children }) => {
   const [tasksEnabled, setTasksEnabled] = useState(() => {
     // Load from localStorage on initialization
     const saved = localStorage.getItem('tasks-enabled');
-    return saved !== null ? JSON.parse(saved) : true; // Default to true
+    if (saved === null) return true; // Default to true
+    try {
+      return JSON.parse(saved);
+    } catch {
+      return true;
+    }
   });
   
   const [isTaskMasterInstalled, setIsTaskMasterInstalled] = useState(null);


### PR DESCRIPTION
## Summary

- Add try-catch for `JSON.parse` in `TasksSettingsContext` to prevent app crash on corrupted localStorage
- Fix `AsyncQueue.fail()` to properly reject all pending waiters instead of silently swallowing errors
- Add cleanup mechanism for `setTimeout` in `useChatSessionState` to prevent memory leaks

## Changes

### 1. TasksSettingsContext.jsx - Prevent crash on corrupted localStorage
Previously, `JSON.parse` was called without try-catch. If localStorage data was corrupted (e.g., by browser extensions or manual editing), the entire app would crash with a white screen.

### 2. AsyncQueue.ts - Fix error propagation to multiple consumers
When `fail()` was called, only the first consumer would receive the error. Other pending consumers would silently receive `{ done: true }`, losing the error information. Now all pending waiters are properly rejected.

### 3. useChatSessionState.ts - Prevent memory leaks from setTimeout
The search scroll navigation used recursive `setTimeout` calls without cleanup. If the component unmounted during these retries, the callbacks would still execute, potentially causing memory leaks or setState on unmounted components.

## Test plan

- [ ] Verify app doesn't crash when localStorage `tasks-enabled` contains invalid JSON
- [ ] Verify AsyncQueue propagates errors to all waiting consumers
- [ ] Verify search navigation doesn't cause memory leaks on rapid session switches