### PR TITLE
Fix OpenAI tool call normalization

### DIFF
--- a/src/model/providers/openai/request.ts
+++ b/src/model/providers/openai/request.ts
@@ -55,7 +55,9 @@ export function buildOpenAIRequest(
   request: CanonicalModelRequest,
   model: ModelDefinition,
 ): OpenAIRequestBody {
-  const messages = repairOpenAIToolPairing(request.messages.flatMap(toOpenAIMessages));
+  const messages = repairOpenAIToolPairing(
+    request.messages.flatMap((message, messageIndex) => toOpenAIMessages(message, messageIndex)),
+  );
   if (request.systemPrompt) {
     messages.unshift({ role: "system", content: request.systemPrompt });
   }
@@ -90,7 +92,7 @@ export function buildOpenAIRequest(
   return body;
 }
 
-function toOpenAIMessages(message: CanonicalMessage): OpenAIMessage[] {
+function toOpenAIMessages(message: CanonicalMessage, messageIndex: number): OpenAIMessage[] {
   if (message.role === "user") {
     return toOpenAIUserMessages(message);
   }
@@ -106,8 +108,8 @@ function toOpenAIMessages(message: CanonicalMessage): OpenAIMessage[] {
 
   const assistantToolCalls = message.content
     .filter((block) => block.type === "tool_call")
-    .map((block) => ({
-      id: block.id,
+    .map((block, toolCallIndex) => ({
+      id: normalizeToolCallId(block.id, messageIndex, toolCallIndex),
       type: "function",
       function: {
         name: block.name,
@@ -334,6 +336,12 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
 
+function normalizeToolCallId(id: unknown, messageIndex: number, toolCallIndex: number): string {
+  return typeof id === "string" && id.trim().length > 0
+    ? id
+    : `call_${messageIndex}_${toolCallIndex}`;
+}
+
 /**
  * Last-resort safety net: walk the flattened OpenAI message list and ensure
  * every assistant message with `tool_calls` is immediately followed by `tool`
@@ -343,12 +351,22 @@ function repairOpenAIToolPairing(messages: OpenAIMessage[]): OpenAIMessage[] {
   const out: OpenAIMessage[] = [];
   for (let i = 0; i < messages.length; i++) {
     const msg = messages[i];
-    out.push(msg);
+    if (msg.role === "tool" && (typeof msg.tool_call_id !== "string" || msg.tool_call_id.trim().length === 0)) {
+      continue;
+    }
 
-    if (msg.role !== "assistant" || !msg.tool_calls?.length) continue;
+    if (msg.role !== "assistant" || !msg.tool_calls?.length) {
+      out.push(msg);
+      continue;
+    }
+
+    const toolCalls = msg.tool_calls.map((toolCall, toolCallIndex) =>
+      normalizeOpenAIToolCall(toolCall, i, toolCallIndex)
+    );
+    out.push({ ...msg, tool_calls: toolCalls });
 
     const expectedIds = new Set(
-      (msg.tool_calls as Array<{ id: string }>).map((tc) => tc.id),
+      toolCalls.map((tc) => tc.id),
     );
 
     // Scan ahead for matching tool messages.
@@ -369,6 +387,24 @@ function repairOpenAIToolPairing(messages: OpenAIMessage[]): OpenAIMessage[] {
     }
   }
   return out;
+}
+
+function normalizeOpenAIToolCall(
+  toolCall: unknown,
+  messageIndex: number,
+  toolCallIndex: number,
+): { id: string; type: "function"; function: { name: string; arguments: string } } {
+  const record = isRecord(toolCall) ? toolCall : {};
+  const fn = isRecord(record.function) ? record.function : {};
+  const args = fn.arguments;
+  return {
+    id: normalizeToolCallId(record.id, messageIndex, toolCallIndex),
+    type: "function",
+    function: {
+      name: typeof fn.name === "string" ? fn.name : "",
+      arguments: typeof args === "string" ? args : JSON.stringify(args ?? {}),
+    },
+  };
 }
 
 function toOpenAIToolChoice(toolChoice: CanonicalToolChoice | undefined): unknown {

--- a/src/model/providers/openai/request.ts
+++ b/src/model/providers/openai/request.ts
@@ -343,20 +343,22 @@ function normalizeToolCallId(id: unknown, messageIndex: number, toolCallIndex: n
 }
 
 /**
- * Last-resort safety net: walk the flattened OpenAI message list and ensure
- * every assistant message with `tool_calls` is immediately followed by `tool`
- * messages covering every `tool_call_id`. Missing ones get a placeholder.
+ * Last-resort safety net for OpenAI's strict tool-pairing rules:
+ *  - normalize every assistant `tool_calls[]` item to the required shape;
+ *  - keep only immediately-following tool messages whose `tool_call_id`
+ *    matches that assistant message;
+ *  - inject placeholders for missing tool results;
+ *  - drop orphaned / duplicate / mismatched `role: "tool"` messages.
  */
 function repairOpenAIToolPairing(messages: OpenAIMessage[]): OpenAIMessage[] {
   const out: OpenAIMessage[] = [];
   for (let i = 0; i < messages.length; i++) {
     const msg = messages[i];
-    if (msg.role === "tool" && (typeof msg.tool_call_id !== "string" || msg.tool_call_id.trim().length === 0)) {
-      continue;
-    }
 
     if (msg.role !== "assistant" || !msg.tool_calls?.length) {
-      out.push(msg);
+      if (msg.role !== "tool") {
+        out.push(msg);
+      }
       continue;
     }
 
@@ -365,26 +367,35 @@ function repairOpenAIToolPairing(messages: OpenAIMessage[]): OpenAIMessage[] {
     );
     out.push({ ...msg, tool_calls: toolCalls });
 
-    const expectedIds = new Set(
-      toolCalls.map((tc) => tc.id),
-    );
-
-    // Scan ahead for matching tool messages.
+    const expectedIds = new Set(toolCalls.map((tc) => tc.id));
+    const matchedIds = new Set<string>();
     let j = i + 1;
     while (j < messages.length && messages[j].role === "tool") {
       const tid = messages[j].tool_call_id;
-      if (tid) expectedIds.delete(tid);
+      if (
+        typeof tid === "string" &&
+        tid.trim().length > 0 &&
+        expectedIds.has(tid) &&
+        !matchedIds.has(tid)
+      ) {
+        out.push(messages[j]);
+        matchedIds.add(tid);
+      }
       j++;
     }
 
     // Inject placeholders for any still-missing results.
     for (const missingId of expectedIds) {
+      if (matchedIds.has(missingId)) {
+        continue;
+      }
       out.push({
         role: "tool",
         tool_call_id: missingId,
         content: "[result truncated]",
       });
     }
+    i = j - 1;
   }
   return out;
 }

--- a/src/model/providers/openai/response.ts
+++ b/src/model/providers/openai/response.ts
@@ -1,4 +1,5 @@
 import { jsonrepair } from "jsonrepair";
+import { randomUUID } from "node:crypto";
 import type {
   CanonicalContentBlock,
   CanonicalModelResponse,
@@ -66,7 +67,7 @@ function toCanonicalToolCall(toolCall: unknown, provider: string): CanonicalTool
 
   return {
     type: "tool_call",
-    id: typeof record.id === "string" ? record.id : "",
+    id: readNonEmptyString(record.id) ?? generateToolCallId(),
     name: typeof fn.name === "string" ? fn.name : "",
     input,
     raw: toolCall,
@@ -77,4 +78,12 @@ function asRecord(value: unknown): Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value)
     ? (value as Record<string, unknown>)
     : {};
+}
+
+function readNonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value : undefined;
+}
+
+function generateToolCallId(): string {
+  return `call_${randomUUID().slice(0, 8)}`;
 }

--- a/src/model/providers/openai/stream.ts
+++ b/src/model/providers/openai/stream.ts
@@ -191,10 +191,11 @@ function toolCallEvents(
     }
 
     if (!state.toolCalls.has(index)) {
+      current.id = readNonEmptyString(current.id) ?? generateStreamToolCallId(index);
       state.toolCalls.set(index, current);
       events.push({
         type: "tool_call_start",
-        id: current.id ?? String(index),
+        id: current.id,
         name: current.name ?? "",
         raw,
       });
@@ -204,7 +205,7 @@ function toolCallEvents(
       current.argumentsBuffer = `${current.argumentsBuffer ?? ""}${fn.arguments}`;
       events.push({
         type: "tool_call_delta",
-        id: current.id ?? String(index),
+        id: current.id ?? generateStreamToolCallId(index),
         delta: fn.arguments,
         raw,
       });
@@ -253,7 +254,7 @@ function finishToolCalls(state: OpenAIStreamState, raw: unknown): CanonicalModel
     events.push({
       type: "tool_call_end",
       toolCall: {
-        id: toolCall.id ?? String(index),
+        id: readNonEmptyString(toolCall.id) ?? generateStreamToolCallId(index),
         name: toolCall.name ?? "",
         input,
         raw,
@@ -270,4 +271,12 @@ function asRecord(value: unknown): Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value)
     ? (value as Record<string, unknown>)
     : {};
+}
+
+function readNonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value : undefined;
+}
+
+function generateStreamToolCallId(index: number): string {
+  return `call_${index}`;
 }

--- a/tests/model/providers/openai/request.test.ts
+++ b/tests/model/providers/openai/request.test.ts
@@ -95,3 +95,52 @@ test("buildOpenAIRequest preserves existing items and does not mutate original s
   assert.equal((originalProps.ids as Record<string, unknown>).items, undefined);
   assert.deepEqual((originalProps.labels as Record<string, unknown>).items, { type: "string" });
 });
+
+test("buildOpenAIRequest repairs assistant tool calls missing OpenAI-required fields", () => {
+  const request: CanonicalModelRequest = {
+    model: "openai/test",
+    provider: "openai",
+    messages: [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool_call",
+            id: "",
+            name: "find_skills",
+            input: { query: "popular skills" },
+          },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            toolCallId: "",
+            content: [{ type: "text", text: "[]" }],
+          },
+        ],
+      },
+    ],
+    tools: [{ name: "find_skills", inputSchema: { type: "object", properties: {} } }],
+  };
+
+  const body = buildOpenAIRequest(request, TEST_MODEL);
+  const assistant = body.messages[0]!;
+  const toolCall = assistant.tool_calls?.[0] as {
+    id: string;
+    type: string;
+    function: { name: string; arguments: string };
+  };
+
+  assert.equal(assistant.role, "assistant");
+  assert.equal(toolCall.id, "call_0_0");
+  assert.equal(toolCall.type, "function");
+  assert.equal(toolCall.function.name, "find_skills");
+  assert.equal(toolCall.function.arguments, JSON.stringify({ query: "popular skills" }));
+  assert.deepEqual(
+    body.messages.filter((message) => message.role === "tool").map((message) => message.tool_call_id),
+    ["call_0_0"],
+  );
+});

--- a/tests/model/providers/openai/request.test.ts
+++ b/tests/model/providers/openai/request.test.ts
@@ -144,3 +144,56 @@ test("buildOpenAIRequest repairs assistant tool calls missing OpenAI-required fi
     ["call_0_0"],
   );
 });
+
+test("buildOpenAIRequest drops orphaned tool messages that are not responses to tool calls", () => {
+  const request: CanonicalModelRequest = {
+    model: "openai/test",
+    provider: "openai",
+    messages: [
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            toolCallId: "orphaned_call",
+            content: [{ type: "text", text: "stale result" }],
+          },
+          { type: "text", text: "continue" },
+        ],
+      },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool_call",
+            id: "call_valid",
+            name: "find_skills",
+            input: { query: "popular skills" },
+          },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            toolCallId: "wrong_call",
+            content: [{ type: "text", text: "wrong result" }],
+          },
+          {
+            type: "tool_result",
+            toolCallId: "call_valid",
+            content: [{ type: "text", text: "valid result" }],
+          },
+        ],
+      },
+    ],
+    tools: [{ name: "find_skills", inputSchema: { type: "object", properties: {} } }],
+  };
+
+  const body = buildOpenAIRequest(request, TEST_MODEL);
+  const toolMessages = body.messages.filter((message) => message.role === "tool");
+
+  assert.deepEqual(toolMessages.map((message) => message.tool_call_id), ["call_valid"]);
+  assert.equal(toolMessages[0]?.content, "valid result");
+});

--- a/tests/model/providers/openai/response.test.ts
+++ b/tests/model/providers/openai/response.test.ts
@@ -1,0 +1,34 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { parseOpenAIResponse } from "../../../../src/model/providers/openai/response.js";
+
+test("parseOpenAIResponse synthesizes a tool call id when provider omits it", () => {
+  const response = parseOpenAIResponse({
+    choices: [
+      {
+        finish_reason: "tool_calls",
+        message: {
+          role: "assistant",
+          content: null,
+          tool_calls: [
+            {
+              type: "function",
+              function: {
+                name: "find_skills",
+                arguments: JSON.stringify({ query: "popular skills" }),
+              },
+            },
+          ],
+        },
+      },
+    ],
+  });
+
+  const toolCall = response.content.find((block) => block.type === "tool_call");
+  assert.ok(toolCall);
+  if (toolCall.type !== "tool_call") {
+    throw new Error(`Expected tool_call block, got ${toolCall.type}`);
+  }
+  assert.match(toolCall.id, /^call_[0-9a-f]{8}$/);
+});


### PR DESCRIPTION
## Summary
- Normalize OpenAI assistant tool calls before sending history back to chat completions.
- Synthesize missing tool call IDs from non-streaming and streaming OpenAI-compatible responses.
- Add coverage for malformed/missing tool call IDs in OpenAI provider tests.

## Test plan
- npx tsc -p tsconfig.json --noEmit
- npm run build && node --test --test-timeout 60000 \"dist/tests/model/providers/openai/*.test.js\"


Made with [Cursor](https://cursor.com)