### PR TITLE
fix: accept case-insensitive SKILL.md filenames

### DIFF
--- a/src/extension/skills/SkillManager.ts
+++ b/src/extension/skills/SkillManager.ts
@@ -38,6 +38,8 @@ const SLUG_RE = /^[a-zA-Z0-9][a-zA-Z0-9._-]{0,99}$/;
 const MAX_TOTAL_BYTES = 50 * 1024 * 1024;
 const MAX_FILE_BYTES = 10 * 1024 * 1024;
 const MAX_FILE_COUNT = 500;
+const CANONICAL_SKILL_MD = "SKILL.md";
+const SKILL_MD_RE = /^skill\.md$/iu;
 const RISKY_EXTS = new Set([
   ".sh",
   ".bash",
@@ -145,7 +147,10 @@ export class SkillManager {
 
   async read(input: SkillAddressInput): Promise<SkillReadResult> {
     const skillDir = this.resolveSkillDir(input);
-    const skillFile = join(skillDir, "SKILL.md");
+    const skillFile = await findSkillMdFile(skillDir);
+    if (!skillFile) {
+      throw new SkillManagerError("not_found", `SKILL.md not found at ${join(skillDir, CANONICAL_SKILL_MD)}.`);
+    }
     let content: string;
     try {
       content = await fs.readFile(skillFile, "utf8");
@@ -165,7 +170,7 @@ export class SkillManager {
     }
     const skillDir = this.resolveSkillDir(input);
     await fs.mkdir(skillDir, { recursive: true });
-    const skillFile = join(skillDir, "SKILL.md");
+    const skillFile = await findSkillMdFile(skillDir) ?? join(skillDir, CANONICAL_SKILL_MD);
     await fs.writeFile(skillFile, input.content, "utf8");
     const skill = await readSkillMeta(skillDir, input.scope);
     return { ok: true, scope: input.scope, slug: input.slug, skill };
@@ -195,7 +200,7 @@ export class SkillManager {
             description: input.description,
             body: input.body,
           });
-    const skillFile = join(skillDir, "SKILL.md");
+    const skillFile = join(skillDir, CANONICAL_SKILL_MD);
     await fs.writeFile(skillFile, finalContent, "utf8");
     const skill = await readSkillMeta(skillDir, input.scope);
     return {
@@ -257,9 +262,7 @@ export class SkillManager {
         `Source path is not a directory: ${resolvedSource}`,
       );
     }
-    try {
-      await fs.access(join(resolvedSource, "SKILL.md"));
-    } catch {
+    if (!(await findSkillMdFile(resolvedSource))) {
       throw new SkillManagerError(
         "no_skill_md",
         `Source folder does not contain a SKILL.md at the root: ${resolvedSource}`,
@@ -364,12 +367,10 @@ export class SkillManager {
       const subDir = join(resolvedRoot, entry.name);
       let hasSkillMd = false;
       let meta: SkillSummary | null = null;
-      try {
-        await fs.access(join(subDir, "SKILL.md"));
+      const skillFile = await findSkillMdFile(subDir);
+      if (skillFile) {
         hasSkillMd = true;
         meta = await readSkillMeta(subDir, "user");
-      } catch {
-        /* no SKILL.md */
       }
 
       let fileCount = 0;
@@ -454,6 +455,26 @@ function expandHome(p: string): string {
   return p;
 }
 
+function isSkillMdFileName(name: string): boolean {
+  return SKILL_MD_RE.test(name);
+}
+
+function isRootSkillMdPath(relativePath: string): boolean {
+  const normalized = relativePath.replace(/\\/g, "/");
+  return !normalized.includes("/") && isSkillMdFileName(normalized);
+}
+
+async function findSkillMdFile(skillDir: string): Promise<string | null> {
+  let entries: string[];
+  try {
+    entries = await fs.readdir(skillDir);
+  } catch {
+    return null;
+  }
+  const name = entries.find(isSkillMdFileName);
+  return name ? join(skillDir, name) : null;
+}
+
 /**
  * Build a fresh SKILL.md from user-supplied fields. We emit a minimal
  * YAML frontmatter block (just `name` and `description`) plus a markdown
@@ -507,7 +528,8 @@ function parseSkillFrontmatter(content: string): Record<string, unknown> {
 }
 
 async function readSkillMeta(skillDir: string, scope: SkillScope): Promise<SkillSummary | null> {
-  const skillFile = join(skillDir, "SKILL.md");
+  const skillFile = await findSkillMdFile(skillDir);
+  if (!skillFile) return null;
   let content: string;
   try {
     content = await fs.readFile(skillFile, "utf8");
@@ -640,10 +662,15 @@ async function validateFromDisk(sourcePath: string): Promise<SkillValidationResu
   }
 
   let skillMdContent = "";
-  try {
-    skillMdContent = await fs.readFile(join(sourcePath, "SKILL.md"), "utf8");
-  } catch {
+  const skillFile = await findSkillMdFile(sourcePath);
+  if (!skillFile) {
     pushIssue(hardFails, "no_skill_md", "Source folder does not contain a SKILL.md at the root.");
+    return { ok: false, hardFails, warnings, stats, frontmatter };
+  }
+  try {
+    skillMdContent = await fs.readFile(skillFile, "utf8");
+  } catch {
+    pushIssue(hardFails, "no_skill_md", "Source folder does not contain a readable SKILL.md at the root.");
     return { ok: false, hardFails, warnings, stats, frontmatter };
   }
   frontmatter = validateRequiredFrontmatter(skillMdContent, hardFails, warnings);
@@ -734,7 +761,7 @@ function validateFromManifest(
   for (const f of files) {
     const rel = typeof f.relativePath === "string" ? f.relativePath : null;
     if (!rel) continue;
-    if (rel === "SKILL.md") hasSkillMd = true;
+    if (isRootSkillMdPath(rel)) hasSkillMd = true;
     if (rel.includes("..") || isAbsolute(rel)) {
       pushIssue(hardFails, "unsafe_path", `File path is unsafe: ${rel}`);
       continue;

--- a/src/extension/skills/migrateSkills.ts
+++ b/src/extension/skills/migrateSkills.ts
@@ -57,6 +57,7 @@ const DEFAULT_INCLUDE: Array<Exclude<SkillMigrationSourceKind, "custom">> = [
   "openclaw",
   "hermes",
 ];
+const SKILL_MD_RE = /^skill\.md$/iu;
 
 export async function migrateSkillsToPilotDeck(
   options: MigrateSkillsToPilotDeckOptions,
@@ -241,32 +242,45 @@ function dedupeSources(sources: SkillMigrationSource[]): SkillMigrationSource[] 
 
 async function discoverSkillDirs(sourceRoot: string): Promise<string[] | null> {
   try {
-    await access(join(sourceRoot, "SKILL.md"));
-    return [sourceRoot];
-  } catch {
-    /* Source root is a parent directory, not a single skill. */
-  }
-
-  let entries: import("node:fs").Dirent[];
-  try {
-    entries = await readdir(sourceRoot, { withFileTypes: true });
+    if (await hasSkillMdAtRoot(sourceRoot)) {
+      return [sourceRoot];
+    }
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
     throw error;
   }
 
-  const dirs: string[] = [];
-  for (const entry of entries) {
-    if (!entry.isDirectory() && !entry.isSymbolicLink()) continue;
-    const skillDir = join(sourceRoot, entry.name);
-    try {
-      await access(join(skillDir, "SKILL.md"));
-      dirs.push(skillDir);
-    } catch {
-      continue;
-    }
+  try {
+    await access(sourceRoot);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw error;
   }
-  return dirs.sort((a, b) => basename(a).localeCompare(basename(b)));
+
+  try {
+    const statEntries = await readdir(sourceRoot, { withFileTypes: true });
+    const dirs: string[] = [];
+    for (const entry of statEntries) {
+      if (!entry.isDirectory() && !entry.isSymbolicLink()) continue;
+      const skillDir = join(sourceRoot, entry.name);
+      try {
+        if (await hasSkillMdAtRoot(skillDir)) {
+          dirs.push(skillDir);
+        }
+      } catch {
+        continue;
+      }
+    }
+    return dirs.sort((a, b) => basename(a).localeCompare(basename(b)));
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw error;
+  }
+}
+
+async function hasSkillMdAtRoot(directory: string): Promise<boolean> {
+  const entries = await readdir(directory);
+  return entries.some((entry) => SKILL_MD_RE.test(entry));
 }
 
 async function resolveDestinationSlug(

--- a/tests/extension/skills/skill-manager.test.ts
+++ b/tests/extension/skills/skill-manager.test.ts
@@ -1,0 +1,82 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { SkillManager } from "../../../src/extension/skills/index.js";
+
+const VALID_SKILL_MD = [
+  "---",
+  "name: Caps Skill",
+  "description: A useful skill with an uppercase markdown filename.",
+  "---",
+  "",
+  "# Caps Skill",
+  "",
+].join("\n");
+
+async function withTempDir<T>(fn: (dir: string) => Promise<T>): Promise<T> {
+  const dir = await mkdtemp(join(tmpdir(), "pilotdeck-skill-test-"));
+  try {
+    return await fn(dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+test("SkillManager accepts SKILL.MD for path-based skill import and reads the imported skill", async () => {
+  await withTempDir(async (dir) => {
+    const sourceParent = join(dir, "sources");
+    const sourceSkill = join(sourceParent, "caps-skill");
+    await mkdir(sourceSkill, { recursive: true });
+    await writeFile(join(sourceSkill, "SKILL.MD"), VALID_SKILL_MD, { encoding: "utf8" });
+
+    const manager = new SkillManager({ pilotHome: join(dir, "pilot-home") });
+
+    const scan = await manager.scan({ parentPath: sourceParent });
+    assert.equal(scan.folders.length, 1);
+    assert.equal(scan.folders[0]?.hasSkillMd, true);
+    assert.equal(scan.folders[0]?.name, "Caps Skill");
+
+    const validation = await manager.validate({ sourcePath: sourceSkill });
+    assert.equal(validation.ok, true);
+
+    const imported = await manager.import({
+      sourcePath: sourceSkill,
+      scope: "user",
+      mode: "copy",
+    });
+    assert.equal(imported.ok, true);
+    assert.equal(imported.skill?.name, "Caps Skill");
+
+    const listed = await manager.list({});
+    assert.deepEqual(listed.user.map((skill) => skill.slug), ["caps-skill"]);
+
+    const read = await manager.read({ scope: "user", slug: "caps-skill" });
+    assert.match(read.content, /# Caps Skill/);
+
+    await manager.write({
+      scope: "user",
+      slug: "caps-skill",
+      content: VALID_SKILL_MD.replace("# Caps Skill", "# Updated Skill"),
+    });
+
+    const targetUppercase = join(imported.skillPath, "SKILL.MD");
+    assert.equal((await stat(targetUppercase)).isFile(), true);
+    assert.match(await readFile(targetUppercase, "utf8"), /# Updated Skill/);
+  });
+});
+
+test("SkillManager validates uploaded manifest SKILL.MD files case-insensitively", async () => {
+  await withTempDir(async (dir) => {
+    const manager = new SkillManager({ pilotHome: join(dir, "pilot-home") });
+    const validation = await manager.validate({
+      skillMdContent: VALID_SKILL_MD,
+      files: [{ relativePath: "SKILL.MD", size: Buffer.byteLength(VALID_SKILL_MD) }],
+    });
+
+    assert.equal(validation.ok, true);
+    assert.equal(validation.frontmatter?.name, "Caps Skill");
+  });
+});

--- a/ui/server/routes/commands.js
+++ b/ui/server/routes/commands.js
@@ -18,6 +18,21 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 const router = express.Router();
+const SKILL_MD_RE = /^skill\.md$/i;
+
+function isSkillMdFileName(name) {
+  return typeof name === 'string' && SKILL_MD_RE.test(name);
+}
+
+async function findSkillMdFile(skillDir) {
+  try {
+    const entries = await fs.readdir(skillDir);
+    const name = entries.find(isSkillMdFileName);
+    return name ? path.join(skillDir, name) : null;
+  } catch {
+    return null;
+  }
+}
 
 /**
  * Slash commands curated to always appear at the top of the menu in this exact
@@ -138,7 +153,8 @@ async function scanSkillsDirectory(dir, namespace) {
       }
 
       const skillDir = path.join(dir, entry.name);
-      const skillFile = path.join(skillDir, 'SKILL.md');
+      const skillFile = await findSkillMdFile(skillDir);
+      if (!skillFile) continue;
 
       let content;
       try {
@@ -163,7 +179,7 @@ async function scanSkillsDirectory(dir, namespace) {
         skills.push({
           name: skillName,
           path: skillFile,
-          relativePath: path.join(entry.name, 'SKILL.md'),
+          relativePath: path.join(entry.name, path.basename(skillFile)),
           description,
           namespace,
           metadata: { ...frontmatter, type: 'skill' },
@@ -695,11 +711,11 @@ Custom commands can be created in:
 
     let installed = false;
     let skillMeta = null;
-    try {
-      await fs.access(path.join(installPath, 'SKILL.md'));
+    const installedSkillFile = await findSkillMdFile(installPath);
+    if (installedSkillFile) {
       installed = true;
       try {
-        const content = await fs.readFile(path.join(installPath, 'SKILL.md'), 'utf8');
+        const content = await fs.readFile(installedSkillFile, 'utf8');
         const { data: fm } = parseFrontmatter(content);
         skillMeta = {
           name: fm.name || slug,
@@ -709,8 +725,6 @@ Custom commands can be created in:
       } catch {
         /* SKILL.md exists but unreadable/unparseable — keep installed=true */
       }
-    } catch {
-      /* SKILL.md missing — installed stays false */
     }
 
     if (runError && runError.code === 'ENOENT') {

--- a/ui/server/routes/skills.js
+++ b/ui/server/routes/skills.js
@@ -55,12 +55,33 @@ const upload = multer({
 // ---------------------------------------------------------------------------
 
 const SLUG_RE = /^[a-zA-Z0-9][a-zA-Z0-9._-]{0,99}$/;
+const SKILL_MD_RE = /^skill\.md$/i;
 const PILOT_HOME = resolvePilotHome(process.env);
 const PROJECT_DIR = '.pilotdeck';
 const SKILLS_SUBDIR = 'skills';
 
 function safeSlug(slug) {
   return typeof slug === 'string' && SLUG_RE.test(slug) && !slug.includes('..');
+}
+
+function isSkillMdFileName(name) {
+  return typeof name === 'string' && SKILL_MD_RE.test(name);
+}
+
+function isRootSkillMdPath(relativePath) {
+  if (typeof relativePath !== 'string') return false;
+  const normalized = relativePath.replace(/\\/g, '/');
+  return !normalized.includes('/') && isSkillMdFileName(normalized);
+}
+
+async function findSkillMdFile(skillDir) {
+  try {
+    const entries = await fs.readdir(skillDir);
+    const name = entries.find(isSkillMdFileName);
+    return name ? path.join(skillDir, name) : null;
+  } catch {
+    return null;
+  }
 }
 
 const GENERAL_CWD_PATHS = [path.resolve(PILOT_HOME)];
@@ -348,7 +369,7 @@ router.post('/import-upload', upload.array('files', 500), async (req, res) => {
 
     let skillMdContent = '';
     for (const m of manifest) {
-      if (m.relativePath === 'SKILL.md') {
+      if (isRootSkillMdPath(m.relativePath)) {
         skillMdContent = m.buffer.toString('utf8');
         break;
       }
@@ -559,16 +580,18 @@ router.post('/clawhub/install', async (req, res) => {
 
     let installed = false;
     let skill = null;
-    try {
-      await fs.access(path.join(installPath, 'SKILL.md'));
+    const installedSkillFile = await findSkillMdFile(installPath);
+    if (installedSkillFile) {
       installed = true;
-      // Pull the summary back through the gateway so descriptions reflect
-      // the same frontmatter parser the agent will use.
-      const list = await callGateway('skillsList', { projectKey: effectiveProjectPath });
-      const bucket = resolvedScope === 'project' ? list.project : list.user;
-      skill = bucket.find((s) => s.slug === slug) ?? null;
-    } catch {
-      /* not installed */
+      try {
+        // Pull the summary back through the gateway so descriptions reflect
+        // the same frontmatter parser the agent will use.
+        const list = await callGateway('skillsList', { projectKey: effectiveProjectPath });
+        const bucket = resolvedScope === 'project' ? list.project : list.user;
+        skill = bucket.find((s) => s.slug === slug) ?? null;
+      } catch {
+        /* installed, but summary lookup failed */
+      }
     }
 
     const needsForce =

--- a/ui/src/components/main-content-v2/SkillsV2.tsx
+++ b/ui/src/components/main-content-v2/SkillsV2.tsx
@@ -82,6 +82,10 @@ function isGeneralProject(p: Project | null): boolean {
   return p.name === 'general' || p.displayName === 'general';
 }
 
+function isSkillMdFileName(name: string): boolean {
+  return /^skill\.md$/i.test(name);
+}
+
 async function api<T>(url: string, body: unknown): Promise<T> {
   const r = await authenticatedFetch(url, {
     method: 'POST',
@@ -1290,7 +1294,7 @@ function ImportFromFolder({
     const rootSkillFile = files.find((f) => {
       const rel = f.webkitRelativePath || f.name;
       const stripped = rootName && rel.startsWith(rootName + '/') ? rel.slice(rootName.length + 1) : rel;
-      return stripped === 'SKILL.md';
+      return isSkillMdFileName(stripped);
     });
 
     if (rootSkillFile) {
@@ -1325,7 +1329,7 @@ function ImportFromFolder({
         const rel = f.webkitRelativePath || f.name;
         const prefix = rootName ? rootName + '/' + folderName + '/' : folderName + '/';
         const stripped = rel.startsWith(prefix) ? rel.slice(prefix.length) : rel;
-        return stripped === 'SKILL.md';
+        return isSkillMdFileName(stripped);
       });
 
       let name: string | null = null;


### PR DESCRIPTION
Fixes #37

## Summary
- resolve root `SKILL.md` files case-insensitively in SkillManager import/read/write/scan/validate flows
- apply the same case-insensitive detection in migration, slash-command skill scan, ClawHub installed checks, and UI folder upload detection
- add node:test coverage for importing and validating a skill folder that contains `SKILL.MD`

## Testing
- `PILOTDECK_SKIP_BOOTSTRAP=1 npm_config_cache=.npm-cache npm run build`
- `node --test --test-force-exit --test-timeout 60000 "dist/tests/**/*.test.js"`
- `corepack pnpm --dir ui run build`

## Note
- `corepack pnpm --dir ui run typecheck` currently fails before this change due to an existing React type version mismatch between root `@types/react@19` and UI React 18 types.