### PR TITLE
fix(ui): reduce Electron renderer CPU during streaming and projects_updated

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -20,6 +20,8 @@
     "typecheck": "tsc --noEmit -p tsconfig.json",
     "lint": "eslint src/",
     "lint:fix": "eslint src/ --fix",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "start": "npm run build && npm run start:built",
     "start:built": "concurrently --kill-others-on-fail --names gateway,server \"npm:gateway\" \"npm:server\"",
     "postinstall": "node scripts/fix-node-pty.js"

--- a/ui/src/components/chat/hooks/useChatRealtimeHandlers.ts
+++ b/ui/src/components/chat/hooks/useChatRealtimeHandlers.ts
@@ -310,6 +310,7 @@ export function useChatRealtimeHandlers({
         () => new SmoothTextStream({
           emit: (content) => sessionStore.updateStreaming(sid, content, provider),
           finalize: () => sessionStore.finalizeStreaming(sid),
+          frameMs: 50,
         }),
       );
       state.append(text);
@@ -326,6 +327,7 @@ export function useChatRealtimeHandlers({
         () => new SmoothTextStream({
           emit: (content) => sessionStore.updateStreamingThinking(sid, content, provider),
           finalize: () => sessionStore.finalizeStreamingThinking(sid),
+          frameMs: 50,
         }),
       );
       state.append(text);

--- a/ui/src/hooks/useProjectsState.test.ts
+++ b/ui/src/hooks/useProjectsState.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+import type { Project } from '../types/app';
+import {
+  applyProjectsSocketUpdate,
+  preserveLoadedSessions,
+  projectsHaveChanges,
+} from './useProjectsState';
+
+function makeProject(name: string, overrides: Partial<Project> = {}): Project {
+  return {
+    name,
+    displayName: name,
+    fullPath: `/tmp/${name}`,
+    sessions: [
+      {
+        id: 'web:s_1',
+        title: 'Session 1',
+        created_at: '2026-05-28T00:00:00.000Z',
+        updated_at: '2026-05-28T00:00:00.000Z',
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe('applyProjectsSocketUpdate', () => {
+  it('returns the same array reference when the socket payload is unchanged', () => {
+    const prev = [makeProject('alpha')];
+    const next = [makeProject('alpha')];
+
+    const mergedOnce = applyProjectsSocketUpdate(prev, next);
+    const mergedTwice = applyProjectsSocketUpdate(mergedOnce, next);
+
+    expect(mergedTwice).toBe(prev);
+  });
+
+  it('returns a new reference when a project field changes', () => {
+    const prev = [makeProject('alpha')];
+    const next = [
+      makeProject('alpha', {
+        sessions: [
+          {
+            id: 'web:s_1',
+            title: 'Session 1',
+            created_at: '2026-05-28T00:00:00.000Z',
+            updated_at: '2026-05-29T12:00:00.000Z',
+          },
+        ],
+      }),
+    ];
+
+    const merged = applyProjectsSocketUpdate(prev, next);
+
+    expect(merged).not.toBe(prev);
+    expect(merged[0]?.sessions?.[0]?.updated_at).toBe('2026-05-29T12:00:00.000Z');
+  });
+
+  it('preserves optimistic new-session placeholders across updates', () => {
+    const prev = [
+      makeProject('alpha', {
+        sessions: [
+          {
+            id: 'new-session-123',
+            title: 'New session',
+            created_at: '2026-05-28T00:00:00.000Z',
+            updated_at: '2026-05-28T00:00:00.000Z',
+          },
+        ],
+      }),
+    ];
+    const next = [makeProject('alpha')];
+
+    const merged = applyProjectsSocketUpdate(prev, next);
+    const placeholder = merged[0]?.sessions?.find((s) => s.id === 'new-session-123');
+
+    expect(placeholder?.title).toBe('New session');
+  });
+});
+
+describe('projectsHaveChanges', () => {
+  it('detects no changes for structurally equal projects', () => {
+    const a = [makeProject('alpha')];
+    const b = [makeProject('alpha')];
+    expect(projectsHaveChanges(a, b, true)).toBe(false);
+  });
+});
+
+describe('preserveLoadedSessions', () => {
+  it('keeps loaded sessions when the server preview is shorter', () => {
+    const prev = [
+      makeProject('alpha', {
+        sessions: Array.from({ length: 8 }, (_, index) => ({
+          id: `web:s_${index}`,
+          title: `Session ${index}`,
+          created_at: '2026-05-28T00:00:00.000Z',
+          updated_at: '2026-05-28T00:00:00.000Z',
+        })),
+        sessionMeta: { total: 8, hasMore: false },
+      }),
+    ];
+    const next = [
+      makeProject('alpha', {
+        sessions: prev[0].sessions?.slice(0, 5),
+        sessionMeta: { total: 8, hasMore: true },
+      }),
+    ];
+
+    const merged = preserveLoadedSessions(prev, next);
+
+    expect(merged[0]?.sessions?.length).toBe(8);
+  });
+});

--- a/ui/src/hooks/useProjectsState.ts
+++ b/ui/src/hooks/useProjectsState.ts
@@ -28,7 +28,7 @@ const SESSION_PAGE_SIZE = 30;
 
 const serialize = (value: unknown) => JSON.stringify(value ?? null);
 
-const projectsHaveChanges = (
+export const projectsHaveChanges = (
   prevProjects: Project[],
   nextProjects: Project[],
   includeExternalSessions: boolean,
@@ -84,7 +84,7 @@ const isTemporarySessionId = (id: unknown): boolean =>
 const normalizeSessionId = (id: string): string => id.replace(/^web:s_/, 'web-s_');
 const sessionTranscriptFilename = (id: string): string => `${normalizeSessionId(id)}.jsonl`;
 
-const preserveLoadedSessions = (prevProjects: Project[], nextProjects: Project[]): Project[] =>
+export const preserveLoadedSessions = (prevProjects: Project[], nextProjects: Project[]): Project[] =>
   nextProjects.map((updated) => {
     const prev = prevProjects.find((p) => p.name === updated.name);
     if (!prev) return updated;
@@ -124,6 +124,25 @@ const preserveLoadedSessions = (prevProjects: Project[], nextProjects: Project[]
       },
     };
   });
+
+/**
+ * Merge a `projects_updated` payload into local state without spurious
+ * reference churn. Returns `prevProjects` when nothing meaningful changed
+ * so React can skip re-renders and effects won't re-fire on `projects`.
+ */
+export function applyProjectsSocketUpdate(
+  prevProjects: Project[],
+  updatedProjects: Project[],
+): Project[] {
+  if (prevProjects.length === 0) {
+    return updatedProjects;
+  }
+  const merged = preserveLoadedSessions(prevProjects, updatedProjects);
+  if (!projectsHaveChanges(prevProjects, merged, true)) {
+    return prevProjects;
+  }
+  return merged;
+}
 
 const resetProjectSessionPreview = (project: Project): Project => {
   const sessions = project.sessions ?? [];
@@ -380,12 +399,14 @@ export function useProjectsState({
     // the user manually refreshed.
     const skipSelectedReplacement =
       hasActiveSession &&
-      !isUpdateAdditive(projects, updatedProjects, selectedProject, selectedSession);
+      !isUpdateAdditive(
+        projectsRef.current,
+        updatedProjects,
+        selectedProject,
+        selectedSession,
+      );
 
-    setProjects((prevProjects) => {
-      if (prevProjects.length === 0) return updatedProjects;
-      return preserveLoadedSessions(prevProjects, updatedProjects);
-    });
+    setProjects((prevProjects) => applyProjectsSocketUpdate(prevProjects, updatedProjects));
 
     if (skipSelectedReplacement) {
       return;
@@ -433,7 +454,7 @@ export function useProjectsState({
     if (serialize(normalizedUpdatedSelectedSession) !== serialize(selectedSession)) {
       setSelectedSession(normalizedUpdatedSelectedSession);
     }
-  }, [latestMessage, selectedProject, selectedSession, activeSessions, projects]);
+  }, [latestMessage, selectedProject, selectedSession, activeSessions]);
 
   useEffect(() => {
     return () => {

--- a/ui/src/stores/useSessionStore.streaming.test.ts
+++ b/ui/src/stores/useSessionStore.streaming.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { SessionProvider } from '../types/app';
+import {
+  createRafNotifyScheduler,
+  patchMergedStreamingMessage,
+  type NormalizedMessage,
+  type SessionSlot,
+} from './useSessionStore';
+
+const PROVIDER = 'pilotdeck' as SessionProvider;
+
+function makeSlot(overrides: Partial<SessionSlot> = {}): SessionSlot {
+  return {
+    serverMessages: [],
+    realtimeMessages: [],
+    activityMessages: [],
+    merged: [],
+    _lastServerRef: [],
+    _lastRealtimeRef: [],
+    status: 'streaming',
+    fetchedAt: 0,
+    lastError: null,
+    total: 0,
+    hasMore: false,
+    offset: 0,
+    tokenUsage: null,
+    ...overrides,
+  };
+}
+
+function streamingMessage(sessionId: string, content: string): NormalizedMessage {
+  return {
+    id: `__streaming_${sessionId}`,
+    sessionId,
+    timestamp: '2026-05-28T00:00:00.000Z',
+    provider: PROVIDER,
+    kind: 'stream_delta',
+    content,
+  };
+}
+
+describe('patchMergedStreamingMessage', () => {
+  it('updates merged content in place without replacing the merged array', () => {
+    const sessionId = 'web:s_test';
+    const streamId = `__streaming_${sessionId}`;
+    const merged = [streamingMessage(sessionId, 'hello')];
+    const slot = makeSlot({
+      realtimeMessages: [streamingMessage(sessionId, 'hello')],
+      merged,
+      _lastRealtimeRef: [streamingMessage(sessionId, 'hello')],
+    });
+
+    const mergedBefore = slot.merged;
+    const patched = patchMergedStreamingMessage(slot, streamId, 'hello world', PROVIDER);
+
+    expect(patched).toBe(true);
+    expect(slot.merged).toBe(mergedBefore);
+    expect(slot.merged[0]?.content).toBe('hello world');
+  });
+
+  it('returns false when the streaming row is not yet in merged', () => {
+    const slot = makeSlot();
+    expect(patchMergedStreamingMessage(slot, '__streaming_missing', 'text', PROVIDER)).toBe(false);
+  });
+
+  it('skips object replacement when content is unchanged', () => {
+    const sessionId = 'web:s_test';
+    const streamId = `__streaming_${sessionId}`;
+    const row = streamingMessage(sessionId, 'same');
+    const slot = makeSlot({ merged: [row] });
+    const rowBefore = slot.merged[0];
+
+    patchMergedStreamingMessage(slot, streamId, 'same', PROVIDER);
+
+    expect(slot.merged[0]).toBe(rowBefore);
+  });
+});
+
+describe('createRafNotifyScheduler', () => {
+  it('coalesces multiple schedules for the same session into one frame callback', () => {
+    const frames: Array<() => void> = [];
+    let activeSessionId: string | null = 'web:s_1';
+    let notifyCount = 0;
+
+    const scheduler = createRafNotifyScheduler(
+      (sessionId) => sessionId === activeSessionId,
+      () => {
+        notifyCount += 1;
+      },
+      (callback) => {
+        frames.push(callback);
+        return frames.length;
+      },
+      () => {},
+    );
+
+    scheduler.schedule('web:s_1');
+    scheduler.schedule('web:s_1');
+    scheduler.schedule('web:s_1');
+
+    expect(frames).toHaveLength(1);
+
+    frames[0]?.();
+    expect(notifyCount).toBe(1);
+
+    scheduler.schedule('web:s_1');
+    expect(frames).toHaveLength(2);
+  });
+
+  it('does not schedule when the session is not active', () => {
+    const frames: Array<() => void> = [];
+    const onNotify = vi.fn();
+
+    const scheduler = createRafNotifyScheduler(
+      () => false,
+      onNotify,
+      (callback) => {
+        frames.push(callback);
+        return frames.length;
+      },
+      () => {},
+    );
+
+    scheduler.schedule('web:s_1');
+    expect(frames).toHaveLength(0);
+    expect(onNotify).not.toHaveBeenCalled();
+  });
+
+  it('cancelAll clears pending frame callbacks', () => {
+    const frames: Array<() => void> = [];
+    const cancelled: number[] = [];
+    const onNotify = vi.fn();
+
+    const scheduler = createRafNotifyScheduler(
+      () => true,
+      onNotify,
+      (callback) => {
+        frames.push(callback);
+        return frames.length;
+      },
+      (handle) => {
+        cancelled.push(handle);
+      },
+    );
+
+    scheduler.schedule('web:s_1');
+    scheduler.cancelAll();
+
+    expect(cancelled).toEqual([1]);
+    frames[0]?.();
+    expect(onNotify).not.toHaveBeenCalled();
+  });
+});

--- a/ui/src/stores/useSessionStore.ts
+++ b/ui/src/stores/useSessionStore.ts
@@ -334,6 +334,80 @@ function recomputeMergedIfNeeded(slot: SessionSlot): boolean {
   return true;
 }
 
+function forceRecomputeMerged(slot: SessionSlot): void {
+  slot._lastServerRef = slot.serverMessages;
+  slot._lastRealtimeRef = slot.realtimeMessages;
+  slot.merged = computeMerged(slot.serverMessages, slot.realtimeMessages);
+}
+
+/**
+ * Patch a single streaming row in `slot.merged` without recomputing the full list.
+ * Returns true when the merged row was updated in place.
+ */
+export function patchMergedStreamingMessage(
+  slot: SessionSlot,
+  streamId: string,
+  content: string,
+  msgProvider?: SessionProvider,
+): boolean {
+  const mergedIdx = slot.merged.findIndex((message) => message.id === streamId);
+  if (mergedIdx < 0) {
+    return false;
+  }
+
+  const existing = slot.merged[mergedIdx];
+  if (existing.content === content && (msgProvider == null || existing.provider === msgProvider)) {
+    return true;
+  }
+
+  slot.merged[mergedIdx] = {
+    ...existing,
+    content,
+    ...(msgProvider != null ? { provider: msgProvider } : {}),
+  };
+  return true;
+}
+
+type RafScheduler = {
+  schedule: (sessionId: string) => void;
+  cancelAll: () => void;
+};
+
+/**
+ * Coalesce per-session store notifications to one React update per animation frame.
+ */
+export function createRafNotifyScheduler(
+  isActiveSession: (sessionId: string) => boolean,
+  onNotify: () => void,
+  scheduleFrame: (callback: () => void) => number = (callback) => requestAnimationFrame(callback),
+  cancelFrame: (handle: number) => void = (handle) => cancelAnimationFrame(handle),
+): RafScheduler {
+  const pendingBySession = new Map<string, number>();
+
+  return {
+    schedule(sessionId: string) {
+      if (!isActiveSession(sessionId)) {
+        return;
+      }
+      if (pendingBySession.has(sessionId)) {
+        return;
+      }
+      const handle = scheduleFrame(() => {
+        if (!pendingBySession.has(sessionId)) {
+          return;
+        }
+        pendingBySession.delete(sessionId);
+        onNotify();
+      });
+      pendingBySession.set(sessionId, handle);
+    },
+    cancelAll() {
+      pendingBySession.forEach((handle) => cancelFrame(handle));
+      pendingBySession.clear();
+    },
+  };
+}
+
 // ─── Stale threshold ─────────────────────────────────────────────────────────
 
 const STALE_THRESHOLD_MS = 30_000;
@@ -347,10 +421,18 @@ export function useSessionStore() {
   const activeSessionIdRef = useRef<string | null>(null);
   // Bump to force re-render — only when the active session's data changes
   const [, setTick] = useState(0);
-  const notify = useCallback((sessionId: string) => {
-    if (sessionId === activeSessionIdRef.current) {
-      setTick(n => n + 1);
+  const notifySchedulerRef = useRef<RafScheduler | null>(null);
+  const getNotifyScheduler = (): RafScheduler => {
+    if (notifySchedulerRef.current == null) {
+      notifySchedulerRef.current = createRafNotifyScheduler(
+        (sessionId) => sessionId === activeSessionIdRef.current,
+        () => setTick((n) => n + 1),
+      );
     }
+    return notifySchedulerRef.current;
+  };
+  const notify = useCallback((sessionId: string) => {
+    getNotifyScheduler().schedule(sessionId);
   }, []);
 
   const setActiveSession = useCallback((sessionId: string | null) => {
@@ -648,12 +730,16 @@ export function useSessionStore() {
       // Subsequent delta — preserve the original turn-start timestamp so
       // computeMerged can tell which server snapshots belong to this turn.
       const existing = slot.realtimeMessages[idx];
-      slot.realtimeMessages = [...slot.realtimeMessages];
-      slot.realtimeMessages[idx] = {
-        ...existing,
-        provider: msgProvider,
-        content: accumulatedText,
-      };
+      if (existing.content === accumulatedText && existing.provider === msgProvider) {
+        return;
+      }
+      existing.content = accumulatedText;
+      existing.provider = msgProvider;
+      if (!patchMergedStreamingMessage(slot, streamId, accumulatedText, msgProvider)) {
+        forceRecomputeMerged(slot);
+      }
+      notify(sessionId);
+      return;
     } else {
       // Record the id of server's tail message at the moment this turn
       // started streaming. computeMerged uses this for an id-based
@@ -713,12 +799,16 @@ export function useSessionStore() {
     const idx = slot.realtimeMessages.findIndex(m => m.id === streamId);
     if (idx >= 0) {
       const existing = slot.realtimeMessages[idx];
-      slot.realtimeMessages = [...slot.realtimeMessages];
-      slot.realtimeMessages[idx] = {
-        ...existing,
-        provider: msgProvider,
-        content: accumulatedText,
-      };
+      if (existing.content === accumulatedText && existing.provider === msgProvider) {
+        return;
+      }
+      existing.content = accumulatedText;
+      existing.provider = msgProvider;
+      if (!patchMergedStreamingMessage(slot, streamId, accumulatedText, msgProvider)) {
+        forceRecomputeMerged(slot);
+      }
+      notify(sessionId);
+      return;
     } else {
       const msg: NormalizedMessage = {
         id: streamId,


### PR DESCRIPTION
## Summary

- Fix an infinite re-render loop when handling `projects_updated` WebSocket messages: `projects` was in the effect dependency array while `setProjects` always produced a new array reference via `preserveLoadedSessions`.
- Reduce streaming-path CPU: patch streaming message content in place instead of copying `realtimeMessages` on every frame, skip full `computeMerged` for content-only deltas, and coalesce session store notifications to one React update per animation frame.
- Lower `SmoothTextStream` emit rate to ~20fps (`frameMs: 50`) for assistant and thinking streams.

## Root cause

During agent streaming, `SmoothTextStream` called `updateStreaming` ~30 times/sec, each triggering array copies, full `computeMerged`, and `setTick` — causing Electron Renderer CPU to exceed 100%. A separate `projects_updated` handler could loop when transcript files changed after tasks completed.

## Test plan

- [x] `npx vitest run src/hooks/useProjectsState.test.ts src/stores/useSessionStore.streaming.test.ts` (11 tests)
- [x] Root `npm test` (release gate, 7/7 pass)
- [ ] Manual: Mac APP idle Renderer ~0% CPU
- [ ] Manual: Mac APP streaming Renderer target &lt;40% (was 100%+)


Made with [Cursor](https://cursor.com)