### PR TITLE
fix(i18n): complete zh-CN translations and fix hardcoded English strings

### DIFF
--- a/ui/src/components/app-shell/AppShellV2.tsx
+++ b/ui/src/components/app-shell/AppShellV2.tsx
@@ -97,7 +97,7 @@ export default function AppShellV2() {
     matchProjectChat?.params.projectName ?? matchProject?.params.projectName ?? undefined;
   const sessionId =
     matchProjectChat?.params.sessionId ?? matchLegacySession?.params.sessionId ?? undefined;
-  useTranslation('common');
+  const { t } = useTranslation('common');
 
   const { isMobile } = useDeviceSettings({ trackPWA: false });
   const [desktopSidebarOpen, setDesktopSidebarOpen] = useState(true);
@@ -594,7 +594,7 @@ export default function AppShellV2() {
             type="button"
             className="fixed inset-0 bg-black/40 backdrop-blur-sm"
             onClick={() => setSidebarOpen(false)}
-            aria-label="Close sidebar"
+            aria-label={t('versionUpdate.ariaLabels.closeSidebar')}
           />
           <div
             className={`relative h-full w-[85vw] max-w-sm transform transition-transform duration-150 ${
@@ -716,6 +716,7 @@ function DeleteProjectDialog({
   onCancel,
   onConfirm,
 }: DeleteProjectDialogProps) {
+  const { t } = useTranslation();
   const sessionCount = project.sessions?.length ?? 0;
   const displayName = project.displayName || project.name;
 
@@ -727,7 +728,7 @@ function DeleteProjectDialog({
             <Trash2 className="h-5 w-5" strokeWidth={1.75} />
           </div>
           <div className="min-w-0 flex-1">
-            <h3 className="text-base font-semibold text-foreground">Delete project?</h3>
+            <h3 className="text-base font-semibold text-foreground">{t('alwaysOn:deleteProject.title')}</h3>
             <p className="mt-1 break-all text-sm text-muted-foreground">
               <span className="font-mono text-xs">{displayName}</span>
             </p>
@@ -736,20 +737,18 @@ function DeleteProjectDialog({
 
         <div className="space-y-3 p-5">
           <p className="text-sm text-foreground">
-            This removes the project from PilotDeck and deletes its session metadata.
+            {t('alwaysOn:deleteProject.description')}
             {sessionCount > 0 ? (
               <>
                 {' '}
                 <span className="font-medium">
-                  {sessionCount} session{sessionCount === 1 ? '' : 's'}
-                </span>{' '}
-                will also be removed.
+                  {t('alwaysOn:deleteProject.sessionWarning', { count: sessionCount })}
+                </span>
               </>
             ) : null}
           </p>
           <p className="text-xs text-muted-foreground">
-            Files on disk are <span className="font-medium text-foreground">not</span> deleted —
-            only PilotDeck&apos;s reference to them.
+            {t('alwaysOn:deleteProject.diskNote')}
           </p>
           {error ? (
             <div className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive">
@@ -765,7 +764,7 @@ function DeleteProjectDialog({
             disabled={isDeleting}
             className="inline-flex h-9 items-center justify-center rounded-md border border-border bg-background px-3 text-sm font-medium text-foreground hover:bg-accent disabled:opacity-50"
           >
-            Cancel
+            {t('alwaysOn:deleteProject.cancel')}
           </button>
           <button
             type="button"
@@ -774,7 +773,7 @@ function DeleteProjectDialog({
             className="inline-flex h-9 items-center justify-center gap-2 rounded-md bg-destructive px-3 text-sm font-medium text-destructive-foreground hover:bg-destructive/90 disabled:opacity-60"
           >
             {isDeleting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Trash2 className="h-4 w-4" strokeWidth={1.75} />}
-            {isDeleting ? 'Deleting…' : 'Delete project'}
+            {isDeleting ? t('alwaysOn:deleteProject.deleting') : t('alwaysOn:deleteProject.confirm')}
           </button>
         </div>
       </div>
@@ -797,6 +796,7 @@ function DeleteSessionDialog({
   onCancel,
   onConfirm,
 }: DeleteSessionDialogProps) {
+  const { t } = useTranslation();
   const projectName = target.project.displayName || target.project.name;
   const sessionTitle = sessionDisplayTitle(target.session);
 
@@ -808,7 +808,7 @@ function DeleteSessionDialog({
             <Trash2 className="h-5 w-5" strokeWidth={1.75} />
           </div>
           <div className="min-w-0 flex-1">
-            <h3 className="text-base font-semibold text-foreground">Delete conversation?</h3>
+            <h3 className="text-base font-semibold text-foreground">{t('alwaysOn:deleteConversation.title')}</h3>
             <p className="mt-1 truncate text-sm text-muted-foreground">
               {sessionTitle}
             </p>
@@ -817,9 +817,9 @@ function DeleteSessionDialog({
 
         <div className="space-y-3 p-5">
           <p className="text-sm text-foreground">
-            This removes the conversation from <span className="font-medium">{projectName}</span>.
+            {t('alwaysOn:deleteConversation.description', { projectName })}
           </p>
-          
+
           {error ? (
             <div className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive">
               {error}
@@ -834,7 +834,7 @@ function DeleteSessionDialog({
             disabled={isDeleting}
             className="inline-flex h-9 items-center justify-center rounded-md border border-border bg-background px-3 text-sm font-medium text-foreground hover:bg-accent disabled:opacity-50"
           >
-            Cancel
+            {t('alwaysOn:deleteConversation.cancel')}
           </button>
           <button
             type="button"
@@ -843,7 +843,7 @@ function DeleteSessionDialog({
             className="inline-flex h-9 items-center justify-center gap-2 rounded-md bg-destructive px-3 text-sm font-medium text-destructive-foreground hover:bg-destructive/90 disabled:opacity-60"
           >
             {isDeleting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Trash2 className="h-4 w-4" strokeWidth={1.75} />}
-            {isDeleting ? 'Deleting…' : 'Delete conversation'}
+            {isDeleting ? t('alwaysOn:deleteConversation.deleting') : t('alwaysOn:deleteConversation.confirm')}
           </button>
         </div>
       </div>

--- a/ui/src/components/auth/view/SetupForm.tsx
+++ b/ui/src/components/auth/view/SetupForm.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useState } from 'react';
 import type { FormEvent } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useAuth } from '../context/AuthContext';
 import pilotdeckLogoDark from '../../../assets/pilotdeck-wordmark-dark.png';
 import pilotdeckLogoLight from '../../../assets/pilotdeck-wordmark-light.png';
@@ -51,6 +52,7 @@ function validateSetupForm(formState: SetupFormState): string | null {
  * credentials after submission.
  */
 export default function SetupForm() {
+  const { t } = useTranslation('auth');
   const { register } = useAuth();
 
   const [formState, setFormState] = useState<SetupFormState>(initialState);
@@ -84,9 +86,9 @@ export default function SetupForm() {
 
   return (
     <AuthScreenLayout
-      title="Welcome to PilotDeck"
-      description="Set up your account to get started"
-      footerText="This is a single-user system. Only one account can be created."
+      title={t('setup.title')}
+      description={t('setup.description')}
+      footerText={t('setup.footerText')}
       logo={
         <div className="flex items-center justify-center gap-2">
           <img
@@ -108,10 +110,10 @@ export default function SetupForm() {
         <AuthInputField
           id="username"
           name="username"
-          label="Username"
+          label={t('setup.username')}
           value={formState.username}
           onChange={(value) => updateField('username', value)}
-          placeholder="Enter your username"
+          placeholder={t('setup.placeholders.username')}
           isDisabled={isSubmitting}
           autoComplete="username"
         />
@@ -119,10 +121,10 @@ export default function SetupForm() {
         <AuthInputField
           id="password"
           name="password"
-          label="Password"
+          label={t('setup.password')}
           value={formState.password}
           onChange={(value) => updateField('password', value)}
-          placeholder="Enter your password"
+          placeholder={t('setup.placeholders.password')}
           isDisabled={isSubmitting}
           type="password"
           autoComplete="new-password"
@@ -131,10 +133,10 @@ export default function SetupForm() {
         <AuthInputField
           id="confirmPassword"
           name="confirmPassword"
-          label="Confirm Password"
+          label={t('setup.confirmPassword')}
           value={formState.confirmPassword}
           onChange={(value) => updateField('confirmPassword', value)}
-          placeholder="Confirm your password"
+          placeholder={t('setup.placeholders.confirmPassword')}
           isDisabled={isSubmitting}
           type="password"
           autoComplete="new-password"
@@ -147,7 +149,7 @@ export default function SetupForm() {
           disabled={isSubmitting}
           className="w-full rounded-md bg-blue-600 px-4 py-2 font-medium text-white transition-colors duration-200 hover:bg-blue-700 disabled:bg-blue-400"
         >
-          {isSubmitting ? 'Setting up...' : 'Create Account'}
+          {isSubmitting ? t('setup.loading') : t('setup.submit')}
         </button>
       </form>
     </AuthScreenLayout>

--- a/ui/src/components/chat-v2/MessageRowV2.tsx
+++ b/ui/src/components/chat-v2/MessageRowV2.tsx
@@ -263,7 +263,7 @@ function MessageRowV2({
                     >
                       <img
                         src={image.data}
-                        alt={image.name || 'Uploaded image'}
+                        alt={image.name || t('chat:imageAlt.uploaded')}
                         className="block h-auto max-h-64 w-full cursor-zoom-in object-contain transition-opacity hover:opacity-90"
                         loading="lazy"
                       />
@@ -340,6 +340,7 @@ function MessageRowV2({
 }
 
 function CopyMarkdownButton({ content }: { content: string }) {
+  const { t } = useTranslation('chat');
   const [copied, setCopied] = useState(false);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -356,8 +357,8 @@ function CopyMarkdownButton({ content }: { content: string }) {
       type="button"
       onClick={handleClick}
       className="rounded p-1 text-neutral-400 transition-colors hover:text-neutral-600 dark:text-neutral-500 dark:hover:text-neutral-300"
-      aria-label={copied ? 'Copied' : 'Copy'}
-      title={copied ? 'Copied' : 'Copy'}
+      aria-label={copied ? t('chat:messageRow.copied') : t('chat:messageRow.copy')}
+      title={copied ? t('chat:messageRow.copied') : t('chat:messageRow.copy')}
     >
       {copied ? <Check className="h-3.5 w-3.5" strokeWidth={2} /> : <Copy className="h-3.5 w-3.5" strokeWidth={2} />}
     </button>
@@ -459,7 +460,7 @@ function ProcessAttachmentRow({
             >
               <img
                 src={image.data}
-                alt={image.name || 'Tool result image'}
+                alt={image.name || t('chat:imageAlt.toolResult')}
                 className="block h-auto max-h-72 max-w-xs cursor-zoom-in object-contain"
                 loading="lazy"
               />

--- a/ui/src/components/chat-v2/ProcessTrace.tsx
+++ b/ui/src/components/chat-v2/ProcessTrace.tsx
@@ -1,4 +1,5 @@
 import { useState, type ReactNode } from 'react';
+import { useTranslation } from 'react-i18next';
 import {
   Activity,
   AlertCircle,
@@ -89,8 +90,9 @@ export function ProcessLiveStatus({
     }
     onExpandedChange?.(resolvedExpanded);
   };
+  const { t } = useTranslation('chat');
   const Icon = getStepIcon(step);
-  const title = step.title || step.toolName || 'Working';
+  const title = step.title || step.toolName || t('chat:processTrace.working');
   const isRunning = step.state !== 'failed' && step.state !== 'completed' && step.state !== 'cancelled';
   const hasDetails = Boolean(children);
   const statusContent = (
@@ -191,9 +193,10 @@ function getStepIconClass(step: ProcessTraceStep): string {
 }
 
 function ProcessTraceLine({ step }: { step: ProcessTraceStep }) {
+  const { t } = useTranslation('chat');
   const Icon = getStepIcon(step);
   const isRunning = step.state === 'running';
-  const title = step.title || step.toolName || 'Step';
+  const title = step.title || step.toolName || t('chat:processTrace.step');
 
   return (
     <div

--- a/ui/src/components/chat/constants/thinkingModes.ts
+++ b/ui/src/components/chat/constants/thinkingModes.ts
@@ -5,6 +5,8 @@ export const thinkingModes = [
     id: 'none',
     name: 'Standard',
     description: 'Regular response',
+    labelKey: 'chat:thinkingModes.standard.name',
+    descKey: 'chat:thinkingModes.standard.description',
     icon: null,
     prefix: '',
     color: 'text-gray-600'
@@ -13,6 +15,8 @@ export const thinkingModes = [
     id: 'think',
     name: 'Think',
     description: 'Basic extended thinking',
+    labelKey: 'chat:thinkingModes.think.name',
+    descKey: 'chat:thinkingModes.think.description',
     icon: Brain,
     prefix: 'think',
     color: 'text-blue-600'
@@ -21,6 +25,8 @@ export const thinkingModes = [
     id: 'think-hard',
     name: 'Think Hard',
     description: 'More thorough evaluation',
+    labelKey: 'chat:thinkingModes.thinkHard.name',
+    descKey: 'chat:thinkingModes.thinkHard.description',
     icon: Zap,
     prefix: 'think hard',
     color: 'text-purple-600'
@@ -29,6 +35,8 @@ export const thinkingModes = [
     id: 'think-harder',
     name: 'Think Harder',
     description: 'Deep analysis with alternatives',
+    labelKey: 'chat:thinkingModes.thinkHarder.name',
+    descKey: 'chat:thinkingModes.thinkHarder.description',
     icon: Sparkles,
     prefix: 'think harder',
     color: 'text-indigo-600'
@@ -37,6 +45,8 @@ export const thinkingModes = [
     id: 'ultrathink',
     name: 'Ultrathink',
     description: 'Maximum thinking budget',
+    labelKey: 'chat:thinkingModes.ultrathink.name',
+    descKey: 'chat:thinkingModes.ultrathink.description',
     icon: Atom,
     prefix: 'ultrathink',
     color: 'text-red-600'

--- a/ui/src/components/chat/tools/ToolRenderer.tsx
+++ b/ui/src/components/chat/tools/ToolRenderer.tsx
@@ -1,4 +1,6 @@
 import React, { memo, useMemo, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import i18n from '../../../i18n/config.js';
 import type { Project } from '../../../types/app';
 import type { SubagentChildTool } from '../types/types';
 import { getCanonicalToolName, getToolConfig } from './configs/toolConfigs';
@@ -66,7 +68,7 @@ class ToolRendererErrorBoundary extends React.Component<
     if (this.state.error) {
       return (
         <div className="my-1 rounded-lg border border-amber-200 bg-amber-50/70 px-3 py-2 text-xs text-amber-800 dark:border-amber-800/50 dark:bg-amber-950/20 dark:text-amber-200">
-          <div className="font-medium">Tool output could not be rendered.</div>
+          <div className="font-medium">{i18n.t('chat:tools.toolOutputError')}</div>
           <div className="mt-0.5 opacity-80">{this.props.toolName}</div>
         </div>
       );
@@ -132,6 +134,7 @@ const ToolRendererInner: React.FC<ToolRendererProps> = ({
   isSubagentContainer,
   subagentState
 }) => {
+  const { t } = useTranslation('chat');
   const canonicalToolName = getCanonicalToolName(toolName);
   const config = getToolConfig(toolName);
   const displayConfig: any = mode === 'input' ? config.input : config.result;
@@ -204,9 +207,9 @@ const ToolRendererInner: React.FC<ToolRendererProps> = ({
         () => typeof displayConfig.title === 'function'
           ? displayConfig.title(parsedData)
           : displayConfig.title,
-        'Details',
+        t('chat:tools.details'),
       ),
-      'Details',
+      t('chat:tools.details'),
     );
 
     const defaultOpen = displayConfig.defaultOpen !== undefined

--- a/ui/src/components/chat/tools/components/CollapsibleDisplay.tsx
+++ b/ui/src/components/chat/tools/components/CollapsibleDisplay.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import { CollapsibleSection } from './CollapsibleSection';
 
 interface CollapsibleDisplayProps {
@@ -41,6 +42,7 @@ export const CollapsibleDisplay: React.FC<CollapsibleDisplayProps> = ({
   toolCategory,
   autoExpandable = true
 }) => {
+  const { t } = useTranslation('chat');
   // Fall back to default styling for unknown/new categories so className never includes "undefined".
   const borderColor = borderColorMap[toolCategory || 'default'] || borderColorMap.default;
 
@@ -67,7 +69,7 @@ export const CollapsibleDisplay: React.FC<CollapsibleDisplayProps> = ({
               >
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
               </svg>
-              raw params
+              {t('chat:tools.rawParams')}
             </summary>
             <pre className="mt-1 overflow-hidden whitespace-pre-wrap break-words rounded border border-gray-200/40 bg-gray-50 p-2 font-mono text-[11px] text-gray-600 dark:border-gray-700/40 dark:bg-gray-900/50 dark:text-gray-400">
               {rawContent}

--- a/ui/src/components/chat/tools/components/ContentRenderers/QuestionAnswerContent.tsx
+++ b/ui/src/components/chat/tools/components/ContentRenderers/QuestionAnswerContent.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import type { Question } from '../../../types/types';
 
 interface QuestionAnswerContentProps {
@@ -77,6 +78,7 @@ export const QuestionAnswerContent: React.FC<QuestionAnswerContentProps> = ({
   answers,
   className = '',
 }) => {
+  const { t } = useTranslation('chat');
   const [expandedIdx, setExpandedIdx] = useState<number | null>(null);
   const normalizedQuestions = normalizeQuestions(questions);
   const normalizedAnswers = normalizeAnswers(answers);
@@ -88,7 +90,7 @@ export const QuestionAnswerContent: React.FC<QuestionAnswerContentProps> = ({
 
     return (
       <div className={`rounded-lg border border-amber-200 bg-amber-50/70 p-3 text-xs text-amber-800 dark:border-amber-800/50 dark:bg-amber-950/20 dark:text-amber-200 ${className}`}>
-        <div className="font-medium">Question payload could not be rendered.</div>
+        <div className="font-medium">{t('chat:questionContent.renderError')}</div>
         <pre className="mt-2 max-h-40 overflow-auto whitespace-pre-wrap break-words text-[11px] opacity-80">
           {formatInvalidPayload(questions)}
         </pre>
@@ -159,7 +161,7 @@ export const QuestionAnswerContent: React.FC<QuestionAnswerContentProps> = ({
                         >
                           {lbl}
                           {isCustom && (
-                            <span className="text-[9px] font-normal text-blue-400 dark:text-blue-500">(custom)</span>
+                            <span className="text-[9px] font-normal text-blue-400 dark:text-blue-500">{t('chat:questionContent.custom')}</span>
                           )}
                         </span>
                       );
@@ -169,7 +171,7 @@ export const QuestionAnswerContent: React.FC<QuestionAnswerContentProps> = ({
 
                 {!isExpanded && skipped && hasAnyAnswer && (
                   <span className="mt-1 inline-block text-[10px] italic text-gray-400 dark:text-gray-500">
-                    Skipped
+                    {t('chat:questionContent.skipped')}
                   </span>
                 )}
               </div>
@@ -244,7 +246,7 @@ export const QuestionAnswerContent: React.FC<QuestionAnswerContentProps> = ({
 
                   {skipped && hasAnyAnswer && (
                     <div className="px-2.5 py-1 text-[11px] italic text-gray-400 dark:text-gray-500">
-                      No answer provided
+                      {t('chat:questionContent.noAnswer')}
                     </div>
                   )}
                 </div>
@@ -256,7 +258,7 @@ export const QuestionAnswerContent: React.FC<QuestionAnswerContentProps> = ({
 
       {!hasAnyAnswer && total === 1 && (
         <div className="text-[11px] italic text-gray-400 dark:text-gray-500">
-          Skipped
+          {t('chat:questionContent.skipped')}
         </div>
       )}
     </div>

--- a/ui/src/components/chat/tools/components/ContentRenderers/TaskListContent.tsx
+++ b/ui/src/components/chat/tools/components/ContentRenderers/TaskListContent.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 
 interface TaskItem {
   id: string;
@@ -81,6 +82,7 @@ const statusConfig = {
  * Parses text content from TaskList/TaskGet results
  */
 export const TaskListContent: React.FC<TaskListContentProps> = ({ content }) => {
+  const { t } = useTranslation('chat');
   const safeContent = stringifyTaskContent(content);
   const tasks = parseTaskContent(content);
 
@@ -100,7 +102,7 @@ export const TaskListContent: React.FC<TaskListContentProps> = ({ content }) => 
     <div>
       <div className="mb-1.5 flex items-center gap-2">
         <span className="text-[11px] text-gray-500 dark:text-gray-400">
-          {completed}/{total} completed
+          {t('chat:taskContent.completed', { completed, total })}
         </span>
         <div className="h-1 flex-1 overflow-hidden rounded-full bg-gray-200 dark:bg-gray-700">
           <div

--- a/ui/src/components/chat/tools/components/ContentRenderers/TodoList.tsx
+++ b/ui/src/components/chat/tools/components/ContentRenderers/TodoList.tsx
@@ -1,4 +1,5 @@
 import { memo, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import { CheckCircle2, Circle, Clock, type LucideIcon } from 'lucide-react';
 import { Badge } from '../../../../../shared/view/ui';
 
@@ -95,6 +96,7 @@ const TodoList = memo(
     todos: TodoItem[];
     isResult?: boolean;
   }) => {
+    const { t } = useTranslation('chat');
     // Memoize normalization to avoid recomputing list metadata on every render.
     const normalizedTodos = useMemo<NormalizedTodoItem[]>(
       () =>
@@ -114,8 +116,8 @@ const TodoList = memo(
       <div className="space-y-1.5">
         {isResult && (
           <div className="mb-1.5 text-xs font-medium text-gray-600 dark:text-gray-400">
-            Todo List ({normalizedTodos.length}{' '}
-            {normalizedTodos.length === 1 ? 'item' : 'items'})
+            {t('chat:todoContent.todoList')} ({normalizedTodos.length}{' '}
+            {normalizedTodos.length === 1 ? t('chat:todoContent.itemSingular') : t('chat:todoContent.itemPlural')})
           </div>
         )}
         {normalizedTodos.map((todo, index) => (

--- a/ui/src/components/chat/tools/components/InteractiveRenderers/AskUserQuestionPanel.tsx
+++ b/ui/src/components/chat/tools/components/InteractiveRenderers/AskUserQuestionPanel.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useCallback, useRef, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Check, ChevronLeft, HelpCircle } from 'lucide-react';
 import type { PermissionPanelProps } from '../../configs/permissionPanelRegistry';
 import type { Question } from '../../../types/types';
@@ -43,6 +44,7 @@ export const AskUserQuestionPanel: React.FC<PermissionPanelProps> = ({
   request,
   onDecision,
 }) => {
+  const { t } = useTranslation('chat');
   const input = request.input as { questions?: unknown } | undefined;
   const questions = normalizeQuestions(input?.questions);
 
@@ -200,7 +202,7 @@ export const AskUserQuestionPanel: React.FC<PermissionPanelProps> = ({
 
             <div className="flex min-w-0 flex-1 items-center gap-2">
               <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
-                Agent needs your input
+                {t('chat:askUser.agentNeedsInput')}
               </span>
               {q.header && (
                 <span className="inline-flex items-center rounded border border-border bg-muted px-1.5 py-px text-[9px] font-semibold uppercase tracking-wider text-muted-foreground">
@@ -243,7 +245,7 @@ export const AskUserQuestionPanel: React.FC<PermissionPanelProps> = ({
             {q.question}
           </p>
           {multi && (
-            <span className="text-[10px] text-muted-foreground">Select all that apply</span>
+            <span className="text-[10px] text-muted-foreground">{t('chat:askUser.selectApply')}</span>
           )}
         </div>
 
@@ -331,7 +333,7 @@ export const AskUserQuestionPanel: React.FC<PermissionPanelProps> = ({
                   isOtherOn ? 'font-medium text-foreground' : 'text-muted-foreground',
                 )}
               >
-                Other...
+                {t('chat:askUser.other')}
               </span>
               {isOtherOn && (
                 <Check className="ml-auto h-4 w-4 flex-shrink-0 text-foreground" strokeWidth={2.5} />
@@ -360,7 +362,7 @@ export const AskUserQuestionPanel: React.FC<PermissionPanelProps> = ({
                       // Prevent container keydown from firing
                       e.stopPropagation();
                     }}
-                    placeholder="Type your answer..."
+                    placeholder={t('chat:askUser.typeAnswer')}
                     className="h-8 pr-14 text-[13px]"
                   />
                   <kbd className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 rounded border border-border bg-muted px-1 py-0.5 font-mono text-[9px] text-muted-foreground">
@@ -381,7 +383,7 @@ export const AskUserQuestionPanel: React.FC<PermissionPanelProps> = ({
             onClick={handleSkip}
             className="h-7 px-2 text-[11px] text-muted-foreground hover:text-foreground"
           >
-            {isSingle ? 'Skip' : 'Skip all'}
+            {isSingle ? t('chat:askUser.skip') : t('chat:askUser.skipAll')}
             <span className="ml-1 font-mono text-[9px] opacity-60">Esc</span>
           </Button>
 
@@ -395,7 +397,7 @@ export const AskUserQuestionPanel: React.FC<PermissionPanelProps> = ({
                 className="h-7 gap-0.5 px-2 text-[11px]"
               >
                 <ChevronLeft className="!h-3 !w-3" />
-                Back
+                {t('chat:askUser.back')}
               </Button>
             )}
 
@@ -406,7 +408,7 @@ export const AskUserQuestionPanel: React.FC<PermissionPanelProps> = ({
               disabled={isLast && !hasCurrentSelection && !Object.keys(buildAnswers()).length}
               className="h-7 gap-1 px-3 text-[11px] font-medium"
             >
-              {isLast ? 'Submit' : 'Next'}
+              {isLast ? t('chat:askUser.submit') : t('chat:askUser.next')}
               <span className="font-mono text-[9px] opacity-60">Enter</span>
             </Button>
           </div>

--- a/ui/src/components/chat/tools/components/OneLineDisplay.tsx
+++ b/ui/src/components/chat/tools/components/OneLineDisplay.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { copyTextToClipboard } from '../../../../utils/clipboard';
 
 type ActionType = 'copy' | 'open-file' | 'jump-to-results' | 'none';
@@ -49,6 +50,7 @@ export const OneLineDisplay: React.FC<OneLineDisplayProps> = ({
   toolResult,
   toolId
 }) => {
+  const { t } = useTranslation('chat');
   const [copied, setCopied] = useState(false);
   const isTerminal = style === 'terminal';
 
@@ -69,8 +71,8 @@ export const OneLineDisplay: React.FC<OneLineDisplayProps> = ({
     <button
       onClick={handleAction}
       className="ml-1 flex-shrink-0 text-gray-400 opacity-0 transition-all hover:text-gray-600 group-hover:opacity-100 dark:hover:text-gray-200"
-      title="Copy to clipboard"
-      aria-label="Copy to clipboard"
+      title={t('chat:tools.copyToClipboard')}
+      aria-label={t('chat:tools.copyToClipboard')}
     >
       {copied ? (
         <svg className="h-3 w-3 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/ui/src/components/chat/tools/components/SubagentContainer.tsx
+++ b/ui/src/components/chat/tools/components/SubagentContainer.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import type { SubagentChildTool } from '../../types/types';
 import { CollapsibleSection } from './CollapsibleSection';
 
@@ -44,19 +45,20 @@ export const SubagentContainer: React.FC<SubagentContainerProps> = ({
   toolResult,
   subagentState,
 }) => {
+  const { t } = useTranslation('chat');
   const parsedInput = typeof toolInput === 'string' ? (() => {
     try { return JSON.parse(toolInput); } catch { return {}; }
   })() : (toolInput || {});
 
   const subagentType = parsedInput?.subagent_type || parsedInput?.subagentType || 'Agent';
-  const description = parsedInput?.description || 'Running task';
+  const description = parsedInput?.description || t('chat:tools.runningTask');
   const prompt = parsedInput?.prompt || '';
   const childTools = Array.isArray(subagentState.childTools) ? subagentState.childTools : [];
   const { currentToolIndex, isComplete } = subagentState;
   const isFailed = Boolean(subagentState.isFailed || toolResult?.isError);
   const currentTool = currentToolIndex >= 0 ? childTools[currentToolIndex] : null;
 
-  const title = `Subagent / ${subagentType}: ${description}`;
+  const title = `${t('chat:tools.subagentPrefix')}${subagentType}: ${description}`;
 
   return (
     <div className="my-1 border-l-2 border-l-purple-500 py-0.5 pl-3 dark:border-l-purple-400">
@@ -76,7 +78,7 @@ export const SubagentContainer: React.FC<SubagentContainerProps> = ({
         {currentTool && !isComplete && (
           <div className="mt-1 flex items-center gap-1.5 text-xs text-gray-500 dark:text-gray-400">
             <span className="h-1.5 w-1.5 flex-shrink-0 animate-pulse rounded-full bg-purple-500 dark:bg-purple-400" />
-            <span className="text-gray-400 dark:text-gray-500">Currently:</span>
+            <span className="text-gray-400 dark:text-gray-500">{t('chat:subagent.currently')}</span>
             <span className="font-medium text-gray-600 dark:text-gray-300">{currentTool.toolName}</span>
             {getCompactToolDisplay(currentTool.toolName, currentTool.toolInput) && (
               <>
@@ -92,7 +94,7 @@ export const SubagentContainer: React.FC<SubagentContainerProps> = ({
         {!currentTool && !isComplete && (
           <div className="mt-1 flex items-center gap-1.5 text-xs text-gray-500 dark:text-gray-400">
             <span className="h-1.5 w-1.5 flex-shrink-0 animate-pulse rounded-full bg-purple-500 dark:bg-purple-400" />
-            <span>Running subagent...</span>
+            <span>{t('chat:subagent.running')}</span>
           </div>
         )}
 
@@ -102,7 +104,7 @@ export const SubagentContainer: React.FC<SubagentContainerProps> = ({
             <svg className="h-3 w-3 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
             </svg>
-            <span>Failed ({childTools.length} {childTools.length === 1 ? 'tool' : 'tools'})</span>
+            <span>{t('chat:subagent.failed', { count: childTools.length, toolType: childTools.length === 1 ? 'tool' : 'tools' })}</span>
           </div>
         )}
 
@@ -111,7 +113,7 @@ export const SubagentContainer: React.FC<SubagentContainerProps> = ({
             <svg className="h-3 w-3 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
             </svg>
-            <span>Completed ({childTools.length} {childTools.length === 1 ? 'tool' : 'tools'})</span>
+            <span>{t('chat:subagent.completed', { count: childTools.length, toolType: childTools.length === 1 ? 'tool' : 'tools' })}</span>
           </div>
         )}
 
@@ -127,7 +129,7 @@ export const SubagentContainer: React.FC<SubagentContainerProps> = ({
               >
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
               </svg>
-              <span>View tool history ({childTools.length})</span>
+              <span>{t('chat:subagent.viewHistory', { count: childTools.length })}</span>
             </summary>
             <div className="mt-1 space-y-0.5 border-l border-gray-200 pl-3 dark:border-gray-700">
               {childTools.map((child, index) => (

--- a/ui/src/components/chat/view/subcomponents/ImageAttachment.tsx
+++ b/ui/src/components/chat/view/subcomponents/ImageAttachment.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 
 const MIME_FRIENDLY_LABELS: Record<string, string> = {
   'application/vnd.openxmlformats-officedocument.wordprocessingml.document': 'DOCX',
@@ -38,6 +39,7 @@ interface ImageAttachmentProps {
 }
 
 const ImageAttachment = ({ file, onRemove, uploadProgress, error }: ImageAttachmentProps) => {
+  const { t } = useTranslation('chat');
   const [preview, setPreview] = useState<string | undefined>(undefined);
   const isImage = file.type.startsWith('image/');
   
@@ -87,7 +89,7 @@ const ImageAttachment = ({ file, onRemove, uploadProgress, error }: ImageAttachm
         type="button"
         onClick={onRemove}
         className="absolute -right-2 -top-2 rounded-full bg-red-500 p-1 text-white opacity-100 transition-opacity focus:opacity-100 sm:opacity-0 sm:group-hover:opacity-100"
-        aria-label="Remove attachment"
+        aria-label={t('chat:imagePreview.remove')}
       >
         <svg className="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />

--- a/ui/src/components/chat/view/subcomponents/ImageLightbox.tsx
+++ b/ui/src/components/chat/view/subcomponents/ImageLightbox.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { createPortal } from 'react-dom';
 
 export interface LightboxImage {
@@ -14,6 +15,7 @@ interface ImageLightboxProps {
 }
 
 const ImageLightbox = ({ images, startIndex = 0, onClose }: ImageLightboxProps) => {
+  const { t } = useTranslation('chat');
   const safeStart = useMemo(() => {
     if (images.length === 0) return 0;
     if (startIndex < 0) return 0;
@@ -71,7 +73,7 @@ const ImageLightbox = ({ images, startIndex = 0, onClose }: ImageLightboxProps) 
     <div
       role="dialog"
       aria-modal="true"
-      aria-label={active?.name || 'Image preview'}
+      aria-label={active?.name || t('chat:imagePreview.preview')}
       className="fixed inset-0 z-[2147483647] flex items-center justify-center bg-black/85 backdrop-blur-sm"
       onClick={onClose}
     >
@@ -82,7 +84,7 @@ const ImageLightbox = ({ images, startIndex = 0, onClose }: ImageLightboxProps) 
           onClose();
         }}
         className="absolute right-4 top-4 flex h-9 w-9 items-center justify-center rounded-full bg-white/15 text-white shadow-sm transition hover:bg-white/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
-        aria-label="Close preview"
+        aria-label={t('chat:imagePreview.close')}
       >
         <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
           <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
@@ -97,7 +99,7 @@ const ImageLightbox = ({ images, startIndex = 0, onClose }: ImageLightboxProps) 
             showPrev();
           }}
           className="absolute left-4 top-1/2 flex h-10 w-10 -translate-y-1/2 items-center justify-center rounded-full bg-white/15 text-white shadow-sm transition hover:bg-white/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
-          aria-label="Previous image"
+          aria-label={t('chat:imagePreview.previous')}
         >
           <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
             <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
@@ -113,7 +115,7 @@ const ImageLightbox = ({ images, startIndex = 0, onClose }: ImageLightboxProps) 
             showNext();
           }}
           className="absolute right-4 top-1/2 flex h-10 w-10 -translate-y-1/2 items-center justify-center rounded-full bg-white/15 text-white shadow-sm transition hover:bg-white/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
-          aria-label="Next image"
+          aria-label={t('chat:imagePreview.next')}
         >
           <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
             <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
@@ -128,7 +130,7 @@ const ImageLightbox = ({ images, startIndex = 0, onClose }: ImageLightboxProps) 
         <img
           key={active.data}
           src={active.data}
-          alt={active.name || 'Image preview'}
+          alt={active.name || t('chat:imagePreview.preview')}
           className="max-h-[88vh] max-w-[92vw] rounded-md object-contain shadow-2xl"
         />
         {active.name || images.length > 1 ? (

--- a/ui/src/components/chat/view/subcomponents/PermissionRequestsBanner.tsx
+++ b/ui/src/components/chat/view/subcomponents/PermissionRequestsBanner.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import type { PendingPermissionRequest } from '../../types/types';
 import { buildPilotDeckToolPermissionEntry, formatToolInputForDisplay } from '../../utils/chatPermissions';
 import { getPilotDeckSettings } from '../../utils/chatStorage';
@@ -27,6 +28,7 @@ export default function PermissionRequestsBanner({
   handleGrantToolPermission,
   onPlanExecutionApproved,
 }: PermissionRequestsBannerProps) {
+  const { t } = useTranslation('chat');
   if (!pendingPermissionRequests.length) {
     return null;
   }
@@ -70,7 +72,7 @@ export default function PermissionRequestsBanner({
         const permissionEntry = buildPilotDeckToolPermissionEntry(first.toolName, rawInput);
         const settings = getPilotDeckSettings();
         const alreadyAllowed = permissionEntry ? settings.allowedTools.includes(permissionEntry) : false;
-        const rememberLabel = alreadyAllowed ? 'Allow (saved)' : 'Allow & remember';
+        const rememberLabel = alreadyAllowed ? t('chat:permission.allowSaved') : t('chat:permission.allowRemember');
 
         return (
           <div
@@ -80,15 +82,15 @@ export default function PermissionRequestsBanner({
             <div className="flex flex-wrap items-start justify-between gap-3">
               <div>
                 <div className="text-sm font-semibold text-amber-900 dark:text-amber-100">
-                  Permission required{requests.length > 1 ? ` (${requests.length})` : ''}
+                  {t('chat:permission.required')}{requests.length > 1 ? ` (${requests.length})` : ''}
                 </div>
                 <div className="text-xs text-amber-800 dark:text-amber-200">
-                  Tool: <span className="font-mono">{first.toolName}</span>
+                  {t('chat:permission.toolLabel')}<span className="font-mono">{first.toolName}</span>
                 </div>
               </div>
               {permissionEntry && (
                 <div className="text-xs text-amber-700 dark:text-amber-300">
-                  Allow rule: <span className="font-mono">{permissionEntry}</span>
+                  {t('chat:permission.allowRule')}<span className="font-mono">{permissionEntry}</span>
                 </div>
               )}
             </div>
@@ -96,7 +98,7 @@ export default function PermissionRequestsBanner({
             {requests.length <= 1 && rawInput && (
               <details className="mt-2">
                 <summary className="cursor-pointer text-xs text-amber-800 hover:text-amber-900 dark:text-amber-200 dark:hover:text-amber-100">
-                  View tool input
+                  {t('chat:permission.viewInput')}
                 </summary>
                 <pre className="mt-2 max-h-40 overflow-auto whitespace-pre-wrap rounded-md border border-amber-200/60 bg-white/80 p-2 text-xs text-amber-900 dark:border-amber-800/60 dark:bg-gray-900/60 dark:text-amber-100">
                   {rawInput}
@@ -107,7 +109,7 @@ export default function PermissionRequestsBanner({
             {requests.length > 1 && (
               <details className="mt-2">
                 <summary className="cursor-pointer text-xs text-amber-800 hover:text-amber-900 dark:text-amber-200 dark:hover:text-amber-100">
-                  View {requests.length} tool inputs
+                  {t('chat:permission.viewInputs', { count: requests.length })}
                 </summary>
                 <div className="mt-2 space-y-1">
                   {requests.map((r) => {
@@ -128,7 +130,7 @@ export default function PermissionRequestsBanner({
                 onClick={() => handlePermissionDecision(allIds, { allow: true })}
                 className="inline-flex items-center gap-2 rounded-md bg-amber-600 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-amber-700"
               >
-                Allow once
+                {t('chat:permission.allowOnce')}
               </button>
               <button
                 type="button"
@@ -149,10 +151,10 @@ export default function PermissionRequestsBanner({
               </button>
               <button
                 type="button"
-                onClick={() => handlePermissionDecision(allIds, { allow: false, message: 'User denied tool use' })}
+                onClick={() => handlePermissionDecision(allIds, { allow: false, message: t('chat:permission.denied') })}
                 className="inline-flex items-center gap-2 rounded-md border border-red-300 px-3 py-1.5 text-xs font-medium text-red-700 transition-colors hover:bg-red-50 dark:border-red-800 dark:text-red-200 dark:hover:bg-red-900/30"
               >
-                Deny
+                {t('chat:permission.deny')}
               </button>
             </div>
           </div>

--- a/ui/src/components/code-editor/view/EditorSidebar.tsx
+++ b/ui/src/components/code-editor/view/EditorSidebar.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
 import type { MouseEvent, MutableRefObject } from 'react';
 import type { CodeEditorFile } from '../types/types';
 import CodeEditor from './CodeEditor';
@@ -37,6 +38,7 @@ export default function EditorSidebar({
   projectPath,
   fillSpace,
 }: EditorSidebarProps) {
+  const { t } = useTranslation();
   const [poppedOut, setPoppedOut] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
   const [effectiveWidth, setEffectiveWidth] = useState(editorWidth);
@@ -123,7 +125,7 @@ export default function EditorSidebar({
           ref={resizeHandleRef}
           onMouseDown={onResizeStart}
           className="group relative z-10 w-px flex-shrink-0 cursor-col-resize bg-neutral-200 transition-colors hover:bg-neutral-400 dark:bg-neutral-800 dark:hover:bg-neutral-600"
-          title="Drag to resize"
+          title={t('alwaysOn:codeEditorSidebar.dragToResize')}
         >
           <div className="absolute inset-y-0 left-1/2 w-3 -translate-x-1/2" />
           <div className="absolute inset-y-0 left-1/2 w-0.5 -translate-x-1/2 bg-neutral-400 opacity-0 transition-opacity group-hover:opacity-100 dark:bg-neutral-600" />

--- a/ui/src/components/code-editor/view/subcomponents/CodeEditorBinaryFile.tsx
+++ b/ui/src/components/code-editor/view/subcomponents/CodeEditorBinaryFile.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { api } from '../../../../utils/api';
 import type { CodeEditorFile } from '../../types/types';
 import { isImageFile, isPdfFile } from '../../utils/binaryFile';
@@ -66,6 +67,7 @@ function PreviewSpinner() {
 }
 
 function FallbackContent({ title, message, onClose }: { title: string; message: string; onClose: () => void }) {
+  const { t } = useTranslation();
   return (
     <div className="flex h-full w-full flex-col items-center justify-center bg-white p-8 dark:bg-neutral-950">
       <div className="flex max-w-md flex-col items-center gap-4 text-center">
@@ -94,7 +96,7 @@ function FallbackContent({ title, message, onClose }: { title: string; message: 
           onClick={onClose}
           className="mt-2 rounded-md bg-neutral-900 px-4 py-1.5 text-[13px] text-white transition-colors hover:opacity-90 dark:bg-neutral-100 dark:text-neutral-900"
         >
-          Close
+          {t('alwaysOn:codeEditorBinary.close')}
         </button>
       </div>
     </div>
@@ -163,6 +165,7 @@ export default function CodeEditorBinaryFile({
   title,
   message,
 }: CodeEditorBinaryFileProps) {
+  const { t } = useTranslation();
   const iconBtn =
     'flex h-7 w-7 items-center justify-center rounded-md text-neutral-500 transition-colors hover:bg-neutral-100 hover:text-neutral-900 dark:text-neutral-400 dark:hover:bg-neutral-800 dark:hover:text-neutral-100';
 
@@ -189,7 +192,7 @@ export default function CodeEditorBinaryFile({
             type="button"
             onClick={onToggleFullscreen}
             className={iconBtn}
-            title={isFullscreen ? 'Exit fullscreen' : 'Fullscreen'}
+            title={isFullscreen ? t('alwaysOn:codeEditorBinary.exitFullscreen') : t('alwaysOn:codeEditorBinary.fullscreen')}
           >
             {isFullscreen ? (
               <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -212,7 +215,7 @@ export default function CodeEditorBinaryFile({
             )}
           </button>
         )}
-        <button type="button" onClick={onClose} className={iconBtn} title="Close">
+        <button type="button" onClick={onClose} className={iconBtn} title={t('alwaysOn:codeEditorBinary.close')}>
           <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path
               strokeLinecap="round"

--- a/ui/src/components/code-editor/view/subcomponents/markdown/MarkdownCodeBlock.tsx
+++ b/ui/src/components/code-editor/view/subcomponents/markdown/MarkdownCodeBlock.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import type { ComponentProps } from 'react';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { oneDark as prismOneDark } from 'react-syntax-highlighter/dist/esm/styles/prism';
@@ -16,6 +17,7 @@ export default function MarkdownCodeBlock({
   node: _node,
   ...props
 }: MarkdownCodeBlockProps) {
+  const { t } = useTranslation();
   const [copied, setCopied] = useState(false);
   const rawContent = Array.isArray(children) ? children.join('') : String(children ?? '');
   const looksMultiline = /[\r\n]/.test(rawContent);
@@ -52,7 +54,7 @@ export default function MarkdownCodeBlock({
           })}
         className="absolute right-2 top-2 z-10 rounded-md border border-gray-600 bg-gray-700/80 px-2 py-1 text-xs text-white opacity-0 transition-opacity hover:bg-gray-700 group-hover:opacity-100"
       >
-        {copied ? 'Copied!' : 'Copy'}
+        {copied ? t('alwaysOn:markdownCode.copied') : t('alwaysOn:markdownCode.copy')}
       </button>
 
       <SyntaxHighlighter

--- a/ui/src/components/main-content-v2/DashboardV2.tsx
+++ b/ui/src/components/main-content-v2/DashboardV2.tsx
@@ -613,6 +613,8 @@ function ProjectGroupCard({
   group: ProjectGroup;
   defaultOpen?: boolean;
 }) {
+  const { t } = useTranslation('routing');
+  const { t: tCommon } = useTranslation();
   const [open, setOpen] = useState(defaultOpen);
   const agg = group.aggregated;
   const hasData = agg.total.requestCount > 0;
@@ -643,7 +645,7 @@ function ProjectGroupCard({
           {/* Tier breakdown */}
           {Object.keys(agg.byTier || {}).length > 0 && (
             <div className="mb-3">
-              <div className="text-xxs mb-2 text-neutral-400 dark:text-neutral-500">Tier breakdown</div>
+              <div className="text-xxs mb-2 text-neutral-400 dark:text-neutral-500">{tCommon('dashboard.tierBreakdown')}</div>
               <div className="flex flex-wrap gap-2">
                 {getSortedTierEntries(agg.byTier).map(([tier, bucket]) => (
                   <span
@@ -664,7 +666,7 @@ function ProjectGroupCard({
           {/* Session list — show all sessions */}
           {group.allSessions.length > 0 ? (
             <div>
-              <div className="text-xxs mb-2 text-neutral-400 dark:text-neutral-500">Sessions</div>
+              <div className="text-xxs mb-2 text-neutral-400 dark:text-neutral-500">{t('dashboard.sessions.title', { defaultValue: 'Sessions' })}</div>
               <div className="space-y-1">
                 {group.allSessions.map((session) => (
                   <SessionRow key={session.sessionId} session={session} />
@@ -672,7 +674,7 @@ function ProjectGroupCard({
               </div>
             </div>
           ) : (
-            <p className="text-xxs text-neutral-400 dark:text-neutral-500">No sessions yet.</p>
+            <p className="text-xxs text-neutral-400 dark:text-neutral-500">{t('dashboard.sessions.empty', { defaultValue: 'No sessions yet.' })}</p>
           )}
         </div>
       )}
@@ -724,6 +726,7 @@ function TierBar({ byTier }: { byTier: Record<string, { estimatedCost?: number; 
 
 function ProjectCostCard({ group, onClick }: { group: ProjectGroup; onClick?: () => void }) {
   const { t } = useTranslation('routing');
+  const { t: tCommon } = useTranslation();
   const agg = group.aggregated;
   const cost = agg.total.estimatedCost || 0;
   const requests = agg.total.requestCount || 0;

--- a/ui/src/components/main-content-v2/GitV2.tsx
+++ b/ui/src/components/main-content-v2/GitV2.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import {
   AlertCircle,
   Check,
@@ -32,6 +33,7 @@ const STATUS_COLOR: Record<ChangeRow['status'], string> = {
 };
 
 export default function GitV2({ selectedProject, onFileOpen }: GitV2Props) {
+  const { t } = useTranslation();
   const controller = useGitPanelController({
     selectedProject,
     activeView: 'changes',
@@ -84,7 +86,7 @@ export default function GitV2({ selectedProject, onFileOpen }: GitV2Props) {
   if (!selectedProject) {
     return (
       <div className="flex h-full items-center justify-center bg-white text-[13px] text-neutral-500 dark:bg-neutral-950 dark:text-neutral-400">
-        Pick a project to view source control.
+        {t('alwaysOn:gitV2.noProject')}
       </div>
     );
   }
@@ -137,7 +139,7 @@ export default function GitV2({ selectedProject, onFileOpen }: GitV2Props) {
             className={cn('h-3.5 w-3.5', controller.isFetching && 'animate-spin')}
             strokeWidth={1.75}
           />
-          <span>Fetch</span>
+          <span>{t('alwaysOn:gitV2.fetch')}</span>
         </button>
       </div>
 
@@ -145,7 +147,7 @@ export default function GitV2({ selectedProject, onFileOpen }: GitV2Props) {
         {isLoading && !controller.gitStatus ? (
           <div className="flex items-center justify-center gap-2 py-10 text-[13px] text-neutral-500 dark:text-neutral-400">
             <Loader2 className="h-3.5 w-3.5 animate-spin" strokeWidth={1.75} />
-            <span>Loading git status…</span>
+            <span>{t('alwaysOn:gitV2.loading')}</span>
           </div>
         ) : hasError ? (
           <div className="flex items-start gap-2 rounded-xl border border-red-200 bg-red-50 p-4 text-[13px] text-red-700 dark:border-red-900/60 dark:bg-red-950/30 dark:text-red-400">
@@ -159,15 +161,15 @@ export default function GitV2({ selectedProject, onFileOpen }: GitV2Props) {
           </div>
         ) : stagedRows.length === 0 && changeRows.length === 0 ? (
           <div className="py-10 text-center text-[13px] text-neutral-500 dark:text-neutral-400">
-            Working tree clean.
+            {t('alwaysOn:gitV2.clean')}
           </div>
         ) : (
           <div className="space-y-5">
             {stagedRows.length > 0 ? (
-              <ChangeList title="Staged" rows={stagedRows} onFileOpen={onFileOpen} />
+              <ChangeList title={t('alwaysOn:gitV2.staged')} rows={stagedRows} onFileOpen={onFileOpen} />
             ) : null}
             {changeRows.length > 0 ? (
-              <ChangeList title="Changes" rows={changeRows} onFileOpen={onFileOpen} />
+              <ChangeList title={t('alwaysOn:gitV2.changes')} rows={changeRows} onFileOpen={onFileOpen} />
             ) : null}
           </div>
         )}
@@ -177,7 +179,7 @@ export default function GitV2({ selectedProject, onFileOpen }: GitV2Props) {
         <textarea
           value={commitMessage}
           onChange={(event) => setCommitMessage(event.target.value)}
-          placeholder="Commit message"
+          placeholder={t('git.commitMessage')}
           rows={2}
           disabled={isCommitting || allChangeFiles.length === 0}
           className="w-full resize-none rounded-lg border border-neutral-200 bg-transparent p-2.5 text-[13px] outline-none placeholder:text-neutral-400 focus:border-neutral-300 disabled:opacity-50 dark:border-neutral-800 dark:placeholder:text-neutral-500 dark:focus:border-neutral-700"
@@ -194,14 +196,14 @@ export default function GitV2({ selectedProject, onFileOpen }: GitV2Props) {
             ) : (
               <Check className="h-3.5 w-3.5" strokeWidth={2} />
             )}
-            <span>Commit</span>
+            <span>{t('alwaysOn:gitV2.commit')}</span>
           </button>
           <button
             type="button"
             onClick={() => void handleGenerate()}
             disabled={isGenerating || allChangeFiles.length === 0}
             className="inline-flex items-center justify-center gap-1.5 rounded-md border border-neutral-200 px-3 py-2 text-[13px] text-neutral-700 transition hover:bg-neutral-50 disabled:opacity-40 dark:border-neutral-800 dark:text-neutral-300 dark:hover:bg-neutral-900"
-            title="AI suggest commit message"
+            title={t('alwaysOn:gitV2.aiSuggest')}
           >
             {isGenerating ? (
               <Loader2 className="h-3.5 w-3.5 animate-spin" strokeWidth={2} />
@@ -220,7 +222,7 @@ export default function GitV2({ selectedProject, onFileOpen }: GitV2Props) {
             ) : (
               <Upload className="h-3.5 w-3.5" strokeWidth={1.75} />
             )}
-            <span>Push</span>
+            <span>{t('alwaysOn:gitV2.push')}</span>
           </button>
         </div>
         {controller.operationError ? (
@@ -232,7 +234,7 @@ export default function GitV2({ selectedProject, onFileOpen }: GitV2Props) {
               onClick={controller.clearOperationError}
               className="ml-auto opacity-70 hover:opacity-100"
             >
-              Dismiss
+              {t('alwaysOn:gitV2.dismiss')}
             </button>
           </div>
         ) : null}

--- a/ui/src/components/main-content-v2/ShellV2.tsx
+++ b/ui/src/components/main-content-v2/ShellV2.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import { Terminal } from 'lucide-react';
 import type { Project, ProjectSession } from '../../types/app';
 import Shell from '../shell/view/Shell';
@@ -9,10 +10,11 @@ type ShellV2Props = {
 };
 
 export default function ShellV2({ selectedProject, selectedSession, isActive }: ShellV2Props) {
+  const { t } = useTranslation();
   if (!selectedProject) {
     return (
       <div className="flex h-full items-center justify-center bg-neutral-950 text-[13px] text-neutral-500">
-        Pick a project to open a shell.
+        {t('alwaysOn:shell.noProject')}
       </div>
     );
   }

--- a/ui/src/components/main-content-v2/TasksV2.tsx
+++ b/ui/src/components/main-content-v2/TasksV2.tsx
@@ -27,15 +27,18 @@ function flattenTasks(tasks: TaskMasterTask[]): TaskMasterTask[] {
   return out;
 }
 
-const STATUS_LABEL: Record<string, string> = {
-  pending: 'Not started',
-  'in-progress': 'In progress',
-  done: 'Done',
-  review: 'In review',
-  blocked: 'Blocked',
-  deferred: 'Deferred',
-  cancelled: 'Cancelled',
-};
+function getStatusLabel(status: string, t: (key: string) => string): string {
+  const labels: Record<string, string> = {
+    pending: t('alwaysOn:tasksV2.notStarted'),
+    'in-progress': t('alwaysOn:tasksV2.inProgress'),
+    done: t('alwaysOn:tasksV2.done'),
+    review: t('alwaysOn:tasksV2.inReview'),
+    blocked: t('alwaysOn:tasksV2.blocked'),
+    deferred: t('alwaysOn:tasksV2.deferred'),
+    cancelled: t('alwaysOn:tasksV2.cancelled'),
+  };
+  return labels[status] ?? status;
+}
 
 const STATUS_BADGE_CLASS: Record<string, string> = {
   pending: 'bg-neutral-100 text-neutral-600 dark:bg-neutral-900 dark:text-neutral-400',
@@ -95,10 +98,10 @@ export default function TasksV2({ isVisible }: TasksV2Props) {
         <div className="flex items-center justify-between">
           <div>
             <h2 className="text-[20px] font-semibold tracking-tight text-neutral-900 dark:text-neutral-100">
-              Tasks
+              {t('alwaysOn:tasksV2.title')}
             </h2>
             <p className="mt-0.5 text-[13px] text-neutral-500 dark:text-neutral-400">
-              {flat.length} tasks · {inProgressCount} in progress
+              {t('alwaysOn:tasksV2.taskCount', { count: flat.length })} · {t('alwaysOn:tasksV2.inProgress')}
             </p>
           </div>
           <button
@@ -107,7 +110,7 @@ export default function TasksV2({ isVisible }: TasksV2Props) {
             className="text-xxs inline-flex h-8 items-center gap-1.5 rounded-md bg-neutral-900 px-2.5 text-white transition hover:opacity-90 dark:bg-neutral-50 dark:text-neutral-900"
           >
             <Plus className="h-3.5 w-3.5" strokeWidth={2} />
-            <span>Refresh</span>
+            <span>{t('alwaysOn:tasksV2.refresh')}</span>
           </button>
         </div>
 
@@ -118,7 +121,7 @@ export default function TasksV2({ isVisible }: TasksV2Props) {
           </div>
         ) : flat.length === 0 ? (
           <div className="rounded-xl border border-neutral-200 p-10 text-center text-[13px] text-neutral-500 dark:border-neutral-800 dark:text-neutral-400">
-            No tasks yet. Initialize Task Master from the legacy tasks panel to get started.
+            {t('alwaysOn:tasksV2.noTasks')}
           </div>
         ) : (
           <div className="divide-y divide-neutral-200 rounded-xl border border-neutral-200 dark:divide-neutral-800 dark:border-neutral-800">
@@ -151,7 +154,7 @@ export default function TasksV2({ isVisible }: TasksV2Props) {
                       {task.title}
                     </div>
                     <div className="text-xxs mt-0.5 text-neutral-500 dark:text-neutral-400">
-                      {STATUS_LABEL[status] ?? status}
+                      {getStatusLabel(status, t)}
                       {task.priority ? ` · ${task.priority}` : ''}
                     </div>
                   </div>
@@ -163,7 +166,7 @@ export default function TasksV2({ isVisible }: TasksV2Props) {
                           'bg-neutral-100 text-neutral-600 dark:bg-neutral-900 dark:text-neutral-400',
                       )}
                     >
-                      {STATUS_LABEL[status] ?? status}
+                      {getStatusLabel(status, t)}
                     </span>
                   ) : null}
                 </label>

--- a/ui/src/components/main-content/view/ErrorBoundary.tsx
+++ b/ui/src/components/main-content/view/ErrorBoundary.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useState, type ErrorInfo, type ReactNode } from 'react';
+import { useTranslation } from 'react-i18next';
 import {
   ErrorBoundary as ReactErrorBoundary,
   type FallbackProps,
@@ -30,6 +31,7 @@ function ErrorFallback({
   showDetails,
   componentStack,
 }: ErrorFallbackProps) {
+  const { t } = useTranslation();
   return (
     <div className="flex flex-col items-center justify-center p-8 text-center">
       <div className="max-w-md rounded-lg border border-red-200 bg-red-50 p-6">
@@ -43,13 +45,13 @@ function ErrorFallback({
               />
             </svg>
           </div>
-          <h3 className="ml-3 text-sm font-medium text-red-800">Something went wrong</h3>
+          <h3 className="ml-3 text-sm font-medium text-red-800">{t('errorBoundary.somethingWentWrong')}</h3>
         </div>
         <div className="text-sm text-red-700">
           <p className="mb-2">An error occurred while loading the chat interface.</p>
           {showDetails && (
             <details className="mt-4">
-              <summary className="cursor-pointer font-mono text-xs">Error Details</summary>
+              <summary className="cursor-pointer font-mono text-xs">{t('alwaysOn:errorBoundary.errorDetails')}</summary>
               <pre className="mt-2 max-h-40 overflow-auto rounded bg-red-100 p-2 text-xs">
                 {formatError(error)}
                 {componentStack}

--- a/ui/src/components/main-content/view/memory/MemoryPanel.tsx
+++ b/ui/src/components/main-content/view/memory/MemoryPanel.tsx
@@ -15,23 +15,6 @@ function normalizeMemoryTheme(isDarkMode: boolean): 'light' | 'dark' {
   return isDarkMode ? 'dark' : 'light';
 }
 
-const MEMORY_PANEL_TEXT: Record<'zh' | 'en', {
-  emptyProject: string;
-  unavailable: string;
-  title: string;
-}> = {
-  zh: {
-    emptyProject: '请选择一个项目查看 Memory。',
-    unavailable: '身份验证和项目上下文准备完成后，Memory 面板才可用。',
-    title: 'Memory 面板',
-  },
-  en: {
-    emptyProject: 'Select a project to inspect memory.',
-    unavailable: 'Memory dashboard is unavailable until auth and project context are ready.',
-    title: 'Memory Dashboard',
-  },
-};
-
 function buildMemoryDashboardUrl(project: Project, locale: 'zh' | 'en', theme: 'light' | 'dark'): string | null {
   const token = localStorage.getItem(AUTH_TOKEN_STORAGE_KEY);
   const projectPath = project.fullPath || project.path;
@@ -49,16 +32,15 @@ function buildMemoryDashboardUrl(project: Project, locale: 'zh' | 'en', theme: '
 }
 
 export default function MemoryPanel({ selectedProject }: MemoryPanelProps) {
-  const { i18n } = useTranslation();
+  const { t, i18n } = useTranslation();
   const { isDarkMode } = useTheme();
   const memoryLocale = normalizeMemoryLocale(i18n.language);
   const memoryTheme = normalizeMemoryTheme(isDarkMode);
-  const text = MEMORY_PANEL_TEXT[memoryLocale];
 
   if (!selectedProject) {
     return (
       <div className="flex h-full items-center justify-center bg-white text-[13px] text-neutral-500 dark:bg-neutral-950 dark:text-neutral-400">
-        {text.emptyProject}
+        {t('alwaysOn:memoryPanel.emptyProject')}
       </div>
     );
   }
@@ -67,7 +49,7 @@ export default function MemoryPanel({ selectedProject }: MemoryPanelProps) {
   if (!dashboardUrl) {
     return (
       <div className="flex h-full items-center justify-center bg-white text-[13px] text-neutral-500 dark:bg-neutral-950 dark:text-neutral-400">
-        {text.unavailable}
+        {t('alwaysOn:memoryPanel.unavailable')}
       </div>
     );
   }
@@ -80,7 +62,7 @@ export default function MemoryPanel({ selectedProject }: MemoryPanelProps) {
     <div className="h-full w-full bg-white dark:bg-neutral-950">
       <iframe
         key={`${selectedProject.fullPath || selectedProject.path || 'memory'}:${memoryLocale}:${memoryTheme}`}
-        title={text.title}
+        title={t('memory', { defaultValue: 'Memory Dashboard' })}
         src={dashboardUrl}
         className="block h-full w-full border-0 bg-white dark:bg-neutral-950"
       />

--- a/ui/src/components/onboarding/view/subcomponents/LlmConfigurationStep.tsx
+++ b/ui/src/components/onboarding/view/subcomponents/LlmConfigurationStep.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Check, ChevronDown, Loader2, Plus } from 'lucide-react';
 import { authenticatedFetch } from '../../../../utils/api';
 import { CATALOG_PROVIDERS, findCatalogProviderByUrl, type CatalogProvider } from '../../../../shared/catalogProviders';
@@ -41,6 +42,7 @@ function hasUsableApiKey(value: unknown) {
 }
 
 export default function LlmConfigurationStep({ onSaved }: LlmConfigurationStepProps) {
+  const { t } = useTranslation('settings');
   const [selectedProvider, setSelectedProvider] = useState<CatalogProvider | null>(DEFAULT_PROVIDER);
   const [selectedModelId, setSelectedModelId] = useState(() => defaultModelForProvider(DEFAULT_PROVIDER));
   const [customModelId, setCustomModelId] = useState('');
@@ -408,7 +410,7 @@ export default function LlmConfigurationStep({ onSaved }: LlmConfigurationStepPr
               onClick={() => setShowAdvanced(!showAdvanced)}
               className="text-xs text-muted-foreground hover:text-foreground"
             >
-              {showAdvanced ? 'Hide' : 'Show'} advanced settings
+              {showAdvanced ? t('pilotDeckConfig.hideAdvanced') : t('pilotDeckConfig.showAdvanced')}
             </button>
             {showAdvanced && (
               <div className="mt-3 space-y-3 rounded-lg border border-border/60 bg-muted/30 p-3">

--- a/ui/src/components/project-creation-wizard/components/FolderBrowserModal.tsx
+++ b/ui/src/components/project-creation-wizard/components/FolderBrowserModal.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Eye, EyeOff, FolderOpen, FolderPlus, Loader2, Plus, X } from 'lucide-react';
 import { Button, Input } from '../../../shared/view/ui';
 import { browseFilesystemFolders, createFolderInFilesystem } from '../data/workspaceApi';
@@ -19,6 +20,7 @@ export default function FolderBrowserModal({
   onClose,
   onFolderSelected,
 }: FolderBrowserModalProps) {
+  const { t } = useTranslation();
   const [currentPath, setCurrentPath] = useState('~');
   const [folders, setFolders] = useState<FolderSuggestion[]>([]);
   const [loadingFolders, setLoadingFolders] = useState(false);
@@ -105,7 +107,7 @@ export default function FolderBrowserModal({
             <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-muted text-foreground">
               <FolderOpen className="h-4 w-4" strokeWidth={1.75} />
             </div>
-            <h3 className="text-lg font-semibold text-foreground">Select Folder</h3>
+            <h3 className="text-lg font-semibold text-foreground">{t('folderBrowser.selectFolder')}</h3>
           </div>
 
           <div className="flex items-center gap-2">
@@ -116,7 +118,7 @@ export default function FolderBrowserModal({
                   ? 'bg-accent text-foreground'
                   : 'text-muted-foreground hover:bg-accent hover:text-foreground'
               }`}
-              title={showHiddenFolders ? 'Hide hidden folders' : 'Show hidden folders'}
+              title={showHiddenFolders ? t('folderBrowser.hideHiddenFolders') : t('folderBrowser.showHiddenFolders')}
             >
               {showHiddenFolders ? <Eye className="h-5 w-5" strokeWidth={1.75} /> : <EyeOff className="h-5 w-5" strokeWidth={1.75} />}
             </button>
@@ -127,14 +129,14 @@ export default function FolderBrowserModal({
                   ? 'bg-accent text-foreground'
                   : 'text-muted-foreground hover:bg-accent hover:text-foreground'
               }`}
-              title="Create new folder"
+              title={t('folderBrowser.createNewFolder')}
             >
               <Plus className="h-5 w-5" strokeWidth={1.75} />
             </button>
             <button
               onClick={handleClose}
               className="rounded-md p-2 text-muted-foreground hover:bg-accent hover:text-foreground"
-              aria-label="Close"
+              aria-label={t('folderBrowser.close')}
             >
               <X className="h-5 w-5" strokeWidth={1.75} />
             </button>
@@ -148,7 +150,7 @@ export default function FolderBrowserModal({
                 type="text"
                 value={newFolderName}
                 onChange={(event) => setNewFolderName(event.target.value)}
-                placeholder="New folder name"
+                placeholder={t('folderBrowser.newFolderName')}
                 className="flex-1"
                 onKeyDown={(event) => {
                   if (event.key === 'Enter') {
@@ -168,10 +170,10 @@ export default function FolderBrowserModal({
                 onClick={handleCreateFolder}
                 disabled={!newFolderName.trim() || creatingFolder}
               >
-                {creatingFolder ? <Loader2 className="h-4 w-4 animate-spin" /> : 'Create'}
+                {creatingFolder ? <Loader2 className="h-4 w-4 animate-spin" /> : t('folderBrowser.create')}
               </Button>
               <Button size="sm" variant="ghost" onClick={resetNewFolderState}>
-                Cancel
+                {t('folderBrowser.cancel')}
               </Button>
             </div>
           </div>
@@ -202,7 +204,7 @@ export default function FolderBrowserModal({
 
               {visibleFolders.length === 0 ? (
                 <div className="py-8 text-center text-muted-foreground">
-                  No subfolders found
+                  {t('folderBrowser.noSubfoldersFound')}
                 </div>
               ) : (
                 visibleFolders.map((folder) => (
@@ -222,7 +224,7 @@ export default function FolderBrowserModal({
                       onClick={() => onFolderSelected(folder.path, autoAdvanceOnSelect)}
                       className="px-3 text-xs"
                     >
-                      Select
+                      {t('folderBrowser.select')}
                     </Button>
                   </div>
                 ))
@@ -233,20 +235,20 @@ export default function FolderBrowserModal({
 
         <div className="border-t border-border">
           <div className="flex items-center gap-2 bg-muted/40 px-4 py-3">
-            <span className="text-sm text-muted-foreground">Path:</span>
+            <span className="text-sm text-muted-foreground">{t('folderBrowser.path')}</span>
             <code className="flex-1 truncate font-mono text-sm text-foreground">
               {currentPath}
             </code>
           </div>
           <div className="flex items-center justify-end gap-2 p-4">
             <Button variant="outline" onClick={handleClose}>
-              Cancel
+              {t('folderBrowser.cancel')}
             </Button>
             <Button
               variant="outline"
               onClick={() => onFolderSelected(currentPath, autoAdvanceOnSelect)}
             >
-              Use this folder
+              {t('folderBrowser.useThisFolder')}
             </Button>
           </div>
         </div>

--- a/ui/src/components/project-creation-wizard/components/WorkspacePathField.tsx
+++ b/ui/src/components/project-creation-wizard/components/WorkspacePathField.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { FolderOpen } from 'lucide-react';
 import { Button, Input } from '../../../shared/view/ui';
 import { browseFilesystemFolders } from '../data/workspaceApi';
@@ -21,6 +22,7 @@ export default function WorkspacePathField({
   onChange,
   onAdvanceToConfirm,
 }: WorkspacePathFieldProps) {
+  const { t } = useTranslation();
   const [pathSuggestions, setPathSuggestions] = useState<FolderSuggestion[]>([]);
   const [showPathDropdown, setShowPathDropdown] = useState(false);
   const [showFolderBrowser, setShowFolderBrowser] = useState(false);
@@ -118,7 +120,7 @@ export default function WorkspacePathField({
           variant="outline"
           onClick={() => setShowFolderBrowser(true)}
           className="px-3"
-          title="Browse folders"
+          title={t('buttons.browse')}
           disabled={disabled}
         >
           <FolderOpen className="h-4 w-4" />

--- a/ui/src/components/provider-auth/view/ProviderLoginModal.tsx
+++ b/ui/src/components/provider-auth/view/ProviderLoginModal.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import { ExternalLink, KeyRound, X } from 'lucide-react';
 import StandaloneShell from '../../standalone-shell/view/StandaloneShell';
 import { IS_PLATFORM } from '../../../constants/config';
@@ -82,6 +83,7 @@ export default function ProviderLoginModal({
   customCommand,
   isAuthenticated = false,
 }: ProviderLoginModalProps) {
+  const { t } = useTranslation();
   if (!isOpen) {
     return null;
   }
@@ -103,7 +105,7 @@ export default function ProviderLoginModal({
           <button
             onClick={onClose}
             className="text-gray-400 transition-colors hover:text-gray-600 dark:hover:text-gray-300"
-            aria-label="Close login modal"
+            aria-label={t('providerLogin.closeLoginModal')}
           >
             <X className="h-6 w-6" />
           </button>
@@ -145,7 +147,7 @@ export default function ProviderLoginModal({
                       2
                     </div>
                     <div>
-                      <p className="mb-1 text-sm font-medium text-gray-900 dark:text-white">Run configuration</p>
+                      <p className="mb-1 text-sm font-medium text-gray-900 dark:text-white">{t('providerLogin.runConfiguration')}</p>
                       <p className="mb-2 text-sm text-gray-600 dark:text-gray-400">Open your terminal and run:</p>
                       <code className="block rounded bg-gray-100 px-3 py-2 font-mono text-sm text-pink-600 dark:bg-gray-900 dark:text-pink-400">
                         gemini config set api_key YOUR_KEY

--- a/ui/src/components/settings/view/tabs/PilotDeckConfigTab.tsx
+++ b/ui/src/components/settings/view/tabs/PilotDeckConfigTab.tsx
@@ -188,13 +188,15 @@ const SECTIONS: Array<{ id: SectionId; labelKey: string; descriptionKey: string 
 // ── Reload-status presentation (kept identical to legacy raw view) ──────
 
 type SubsystemKey = 'processEnv' | 'memory' | 'router' | 'gateway' | 'proxy';
-const SUBSYSTEM_LABELS: Record<SubsystemKey, string> = {
-  processEnv: 'Process Env',
-  memory: 'Memory',
-  router: 'PilotDeck Router',
-  gateway: 'Gateway',
-  proxy: 'Proxy',
-};
+function getSubsystemLabels(t: (key: string) => string): Record<SubsystemKey, string> {
+  return {
+    processEnv: t('pilotDeckConfig.subsystemLabels.processEnv'),
+    memory: t('pilotDeckConfig.subsystemLabels.memory'),
+    router: t('pilotDeckConfig.subsystemLabels.router'),
+    gateway: t('pilotDeckConfig.subsystemLabels.gateway'),
+    proxy: t('pilotDeckConfig.subsystemLabels.proxy'),
+  };
+}
 
 type SubsystemResult = {
   reloaded?: boolean;
@@ -227,21 +229,23 @@ function SubsystemIcon({ state }: { state: 'ok' | 'skipped' | 'error' | 'unknown
 }
 
 function ReloadSummary({ reload }: { reload: ConfigReload | null }) {
+  const { t } = useTranslation('settings');
   if (!reload) {
-    return <div className="text-sm text-muted-foreground">No reload has run yet.</div>;
+    return <div className="text-sm text-muted-foreground">{t('pilotDeckConfig.noReloadYet')}</div>;
   }
   const keys: SubsystemKey[] = ['processEnv', 'memory', 'router', 'gateway', 'proxy'];
+  const labels = getSubsystemLabels(t);
   return (
     <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5">
       {keys.map((key) => {
         const result = reload[key] as SubsystemResult | undefined;
         const state = classifySubsystem(result);
-        const detail = result?.error || result?.reason || result?.note || (state === 'ok' ? 'Reloaded' : state === 'unknown' ? 'No data' : '');
+        const detail = result?.error || result?.reason || result?.note || (state === 'ok' ? t('pilotDeckConfig.reloadSummary.reloaded') : state === 'unknown' ? t('pilotDeckConfig.reloadSummary.noData') : '');
         return (
           <div key={key} className={`flex flex-col gap-1 rounded-lg border px-3 py-2 text-xs ${subsystemBadgeClasses(state)}`}>
             <div className="flex items-center gap-1.5 font-medium">
               <SubsystemIcon state={state} />
-              <span>{SUBSYSTEM_LABELS[key]}</span>
+              <span>{labels[key]}</span>
             </div>
             {detail && <div className="text-[11px] opacity-80">{detail}</div>}
           </div>
@@ -251,12 +255,12 @@ function ReloadSummary({ reload }: { reload: ConfigReload | null }) {
   );
 }
 
-function sourceLabel(source: string): string {
+function sourceLabel(source: string, t: (key: string) => string): string {
   switch (source) {
-    case 'ui-save':   return 'UI save';
-    case 'ui-reload': return 'UI reload';
-    case 'watcher':   return 'External file edit';
-    case 'refresh':   return 'Manual refresh';
+    case 'ui-save':   return t('pilotDeckConfig.sourceLabels.uiSave');
+    case 'ui-reload': return t('pilotDeckConfig.sourceLabels.uiReload');
+    case 'watcher':   return t('pilotDeckConfig.sourceLabels.watcher');
+    case 'refresh':   return t('pilotDeckConfig.sourceLabels.refresh');
     default:          return source;
   }
 }
@@ -417,12 +421,13 @@ function SecretTextInput({
   className?: string;
   monospace?: boolean;
 }) {
+  const { t } = useTranslation('settings');
   const masked = isMaskedSecret(value);
   return (
     <TextInput
       type="password"
       value={secretDisplayValue(value)}
-      placeholder={placeholder ?? (masked ? 'Existing key kept — type to replace' : emptyPlaceholder)}
+      placeholder={placeholder ?? (masked ? t('pilotDeckConfig.existingKeyKept') : emptyPlaceholder)}
       monospace={monospace}
       className={className}
       onChange={onChange}
@@ -496,6 +501,7 @@ function ModelRefInput({
   options: Array<{ value: string; label: string }>;
   placeholder?: string;
 }) {
+  const { t } = useTranslation('settings');
   const [id] = useState(() => `model-ref-dl-${++_datalistCounter}`);
   return (
     <>
@@ -504,7 +510,7 @@ function ModelRefInput({
         list={id}
         value={value ?? ''}
         onChange={(e) => onChange(e.target.value)}
-        placeholder={placeholder ?? 'provider/model-name'}
+        placeholder={placeholder ?? t('pilotDeckConfig.modelRef.placeholder')}
         spellCheck={false}
         className="w-full rounded-md border border-border bg-background px-2 py-1.5 font-mono text-xs text-foreground outline-none focus:ring-1 focus:ring-ring"
       />
@@ -680,7 +686,7 @@ function ProviderCard({
             {containsActive && (
               <span className="inline-flex items-center gap-1 rounded-full border border-foreground/30 bg-foreground/5 px-1.5 py-0.5 text-[10px] font-medium text-foreground">
                 <Star className="h-2.5 w-2.5 fill-current" strokeWidth={0} />
-                Main agent
+                {t('pilotDeckConfig.mainAgent')}
               </span>
             )}
           </div>
@@ -705,7 +711,7 @@ function ProviderCard({
 
       {/* API key — the only required field */}
       <label className="block text-xs text-muted-foreground">
-        <span className="mb-1 block">API key</span>
+        <span className="mb-1 block">{t('pilotDeckConfig.apiKeyLabel')}</span>
         <SecretTextInput
           value={provider.apiKey}
           emptyPlaceholder="sk-..."
@@ -714,7 +720,7 @@ function ProviderCard({
         {isMaskedKey && (
           <span className="mt-1 inline-flex items-center gap-1 text-[11px] text-muted-foreground">
             <Info className="h-3 w-3" />
-            Key hidden; leave as-is to keep, retype to replace.
+            {t('pilotDeckConfig.apiKeyHidden')}
           </span>
         )}
       </label>
@@ -725,12 +731,12 @@ function ProviderCard({
           body to enable/disable; click the star to set as main. */}
       <div>
         <div className="mb-1.5 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-xs text-muted-foreground">
-          <span>Enabled models</span>
+          <span>{t('pilotDeckConfig.enabledModels')}</span>
           <span className="text-[10px] text-muted-foreground/60">
-            click <Star className="inline h-2.5 w-2.5" /> to set main agent
+            {t('pilotDeckConfig.clickStarToSetMain')}
           </span>
           <span className="text-[10px] text-muted-foreground/60">
-            · <ImageIcon className="inline h-2.5 w-2.5" /> supports image input
+            · <ImageIcon className="inline h-2.5 w-2.5" /> {t('pilotDeckConfig.supportsImageInput')}
           </span>
         </div>
         {catalogEntry && catalogEntry.models.length > 0 && (
@@ -755,7 +761,7 @@ function ProviderCard({
                     type="button"
                     onClick={() => toggleCatalogModel(m.id)}
                     className="inline-flex items-center gap-1 px-2 py-1"
-                    title={on ? 'Click to disable' : 'Click to enable'}
+                    title={on ? t('pilotDeckConfig.catalogChip.clickToDisable') : t('pilotDeckConfig.catalogChip.clickToEnable')}
                   >
                     {isActive && <Check className="h-3 w-3 text-primary" strokeWidth={2.5} />}
                     {m.displayName}
@@ -770,7 +776,7 @@ function ProviderCard({
                     <button
                       type="button"
                       onClick={() => onSetActive(ref)}
-                      title={isActive ? 'Currently the main agent model' : 'Set as main agent model'}
+                      title={isActive ? t('pilotDeckConfig.starButton.currentMain') : t('pilotDeckConfig.starButton.setMain')}
                       className={cn(
                         'border-l px-1.5 py-1 transition-opacity',
                         isActive ? 'border-primary/30 text-primary opacity-100' : 'border-current/20 opacity-30 hover:opacity-100',
@@ -797,7 +803,7 @@ function ProviderCard({
               <button
                 type="button"
                 onClick={() => onSetActive(ref)}
-                title={isActive ? 'Currently the main agent model' : 'Set as main agent model'}
+                title={isActive ? t('pilotDeckConfig.starButton.currentMain') : t('pilotDeckConfig.starButton.setMain')}
                 className={cn(
                   'transition-opacity',
                   isActive ? 'text-primary opacity-100' : 'text-muted-foreground opacity-40 hover:opacity-100',
@@ -821,13 +827,13 @@ function ProviderCard({
           <input
             value={newModelId}
             onChange={(e) => setNewModelId(e.target.value)}
-            placeholder="Custom model ID"
+            placeholder={t('pilotDeckConfig.customModelPlaceholder')}
             className="min-w-0 flex-1 rounded-md border border-border bg-background px-2 py-1 font-mono text-[11px] text-foreground outline-none focus:ring-1 focus:ring-ring"
             onKeyDown={(e) => { if (e.key === 'Enter' && !isImeEnterEvent(e)) addModel(newModelId); }}
           />
           <Button variant="outline" size="sm" className="shrink-0" onClick={() => addModel(newModelId)} disabled={!newModelId.trim()}>
             <Plus className="mr-1 h-3 w-3" />
-            Add
+            {t('pilotDeckConfig.actions.add')}
           </Button>
         </div>
       </div>
@@ -841,7 +847,7 @@ function ProviderCard({
         <div className="border-t border-border/60 pt-3">
           <div className="mb-2 flex items-center gap-1.5 text-[11px] font-medium text-foreground">
             <Settings2 className="h-3 w-3" />
-            Per-model max output tokens
+            {t('pilotDeckConfig.perModelMaxOutputTokens')}
           </div>
           <div className="space-y-1.5">
             {enabledModels.map((mid) => {
@@ -891,7 +897,7 @@ function ProviderCard({
                         ? 'opacity-30'
                         : 'hover:bg-muted hover:text-foreground',
                     )}
-                    title={current === undefined ? 'Already using default' : 'Reset to catalog/protocol default'}
+                    title={current === undefined ? t('pilotDeckConfig.alreadyDefault') : t('pilotDeckConfig.resetToDefault')}
                   >
                     <RefreshCw className="h-3 w-3" />
                   </button>
@@ -900,7 +906,7 @@ function ProviderCard({
             })}
           </div>
           <p className="mt-2 text-[10px] leading-relaxed text-muted-foreground">
-            Cap on tokens each model may generate per turn (sent as <code className="font-mono">max_tokens</code>). Leave blank to fall back to the protocol default (~8k for openai, ~4k for anthropic). 32k is a safe modern recommendation; raise it for long-form / thinking models — too small a value cuts the response off mid-stream.
+            {t('pilotDeckConfig.perModelMaxOutputTokensDesc')}
           </p>
         </div>
       )}
@@ -912,12 +918,12 @@ function ProviderCard({
           onClick={() => setShowAdvanced(!showAdvanced)}
           className="text-[11px] text-muted-foreground hover:text-foreground"
         >
-          {showAdvanced ? 'Hide' : 'Show'} advanced (protocol &amp; URL)
+          {showAdvanced ? t('pilotDeckConfig.hideAdvanced') : t('pilotDeckConfig.showAdvanced')}
         </button>
         {showAdvanced && (
           <div className="mt-2 grid grid-cols-1 gap-2 sm:grid-cols-[140px_1fr]">
             <label className="text-[11px] text-muted-foreground">
-              <span className="mb-1 block">Protocol</span>
+              <span className="mb-1 block">{t('pilotDeckConfig.protocol')}</span>
               <Select
                 value={protocol}
                 onChange={(v) => update({ protocol: v as 'openai' | 'anthropic' })}
@@ -928,7 +934,7 @@ function ProviderCard({
               />
             </label>
             <label className="text-[11px] text-muted-foreground">
-              <span className="mb-1 block">Base URL</span>
+              <span className="mb-1 block">{t('pilotDeckConfig.baseUrl')}</span>
               <TextInput
                 value={provider.url}
                 placeholder={catalogEntry?.defaultUrl || 'https://api.example.com/v1'}
@@ -937,13 +943,13 @@ function ProviderCard({
               />
               {!provider.url && catalogEntry && (
                 <span className="mt-0.5 block text-[10px] text-muted-foreground/70">
-                  Defaults to <code className="font-mono">{catalogEntry.defaultUrl}</code> from catalog.
+                  {t('pilotDeckConfig.advancedSection.defaultsTo', { url: catalogEntry.defaultUrl })}
                 </span>
               )}
             </label>
             {effectiveUrl && (
               <div className="col-span-full text-[10px] text-muted-foreground">
-                Effective: <code className="font-mono">{effectiveUrl}</code>
+                {t('pilotDeckConfig.advancedSection.effective')} <code className="font-mono">{effectiveUrl}</code>
               </div>
             )}
           </div>
@@ -962,21 +968,22 @@ function CatalogPicker({
   onPick: (catalog: CatalogProvider) => void;
   onCustom: () => void;
 }) {
+  const { t } = useTranslation('settings');
   const [open, setOpen] = useState(false);
   const available = CATALOG_PROVIDERS.filter((p) => !existingIds.has(p.id));
   if (!open) {
     return (
       <Button variant="outline" size="sm" onClick={() => setOpen(true)}>
         <Plus className="mr-1 h-3.5 w-3.5" />
-        Add provider
+        {t('pilotDeckConfig.addProvider')}
       </Button>
     );
   }
   return (
     <div className="space-y-3 rounded-lg border border-border bg-muted/30 p-4">
       <div className="flex items-center justify-between">
-        <div className="text-sm font-medium text-foreground">Add a provider</div>
-        <Button variant="ghost" size="sm" onClick={() => setOpen(false)}>Cancel</Button>
+        <div className="text-sm font-medium text-foreground">{t('pilotDeckConfig.addAProvider')}</div>
+        <Button variant="ghost" size="sm" onClick={() => setOpen(false)}>{t('pilotDeckConfig.cancel')}</Button>
       </div>
       <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
         {available.map((p) => (
@@ -987,7 +994,7 @@ function CatalogPicker({
             className="rounded-md border border-border bg-background px-3 py-2 text-left text-sm transition-colors hover:border-foreground/40 hover:bg-muted"
           >
             <div className="font-medium text-foreground">{p.displayName}</div>
-            <div className="mt-0.5 text-[10px] text-muted-foreground">{p.models.length} models</div>
+            <div className="mt-0.5 text-[10px] text-muted-foreground">{t('pilotDeckConfig.providerCard.modelsCount', { count: p.models.length })}</div>
           </button>
         ))}
         <button
@@ -995,8 +1002,8 @@ function CatalogPicker({
           onClick={() => { onCustom(); setOpen(false); }}
           className="rounded-md border border-dashed border-border bg-background px-3 py-2 text-left text-sm transition-colors hover:border-foreground/40 hover:bg-muted"
         >
-          <div className="font-medium text-foreground">+ Custom</div>
-          <div className="mt-0.5 text-[10px] text-muted-foreground">Manual setup</div>
+          <div className="font-medium text-foreground">+ {t('pilotDeckConfig.custom')}</div>
+          <div className="mt-0.5 text-[10px] text-muted-foreground">{t('pilotDeckConfig.manualSetup')}</div>
         </button>
       </div>
     </div>
@@ -1071,7 +1078,7 @@ function ModelsSection({ config, onChange }: { config: PilotDeckConfig; onChange
       <div className="space-y-3">
         {ids.length === 0 && (
           <div className="rounded-md border border-dashed border-border px-3 py-6 text-center text-xs text-muted-foreground">
-            No providers configured yet. Click "Add provider" to get started.
+            {t('pilotDeckConfig.noProvidersYet')}
           </div>
         )}
         {ids.map((id) => (
@@ -1165,11 +1172,11 @@ function AgentsSection({ config, onChange }: { config: PilotDeckConfig; onChange
   const [showSubagents, setShowSubagents] = useState(subDefault !== 'inherit');
 
   const mainOptions = [
-    { value: '', label: '— pick a model —' },
+    { value: '', label: t('pilotDeckConfig.agentSection.pickModel') },
     ...refOptions,
   ];
   const subOptions = [
-    { value: 'inherit', label: 'inherit (use main agent\'s model)' },
+    { value: 'inherit', label: t('pilotDeckConfig.agentSection.inheritModel') },
     ...refOptions,
   ];
 
@@ -1431,12 +1438,14 @@ function AgentsSection({ config, onChange }: { config: PilotDeckConfig; onChange
   );
 }
 
-const WELL_KNOWN_ENV_KEYS = [
-  { key: 'TAVILY_API_KEY', hint: 'Tavily web search API key' },
-  { key: 'FIRECRAWL_API_KEY', hint: 'Firecrawl web scraping API key' },
-  { key: 'SERPER_API_KEY', hint: 'Serper search API key' },
-  { key: 'BROWSERBASE_API_KEY', hint: 'Browserbase API key' },
-];
+function getWellKnownEnvKeys(t: (key: string) => string) {
+  return [
+    { key: 'TAVILY_API_KEY', hint: t('pilotDeckConfig.envKeys.tavily') },
+    { key: 'FIRECRAWL_API_KEY', hint: t('pilotDeckConfig.envKeys.firecrawl') },
+    { key: 'SERPER_API_KEY', hint: t('pilotDeckConfig.envKeys.serper') },
+    { key: 'BROWSERBASE_API_KEY', hint: t('pilotDeckConfig.envKeys.browserbase') },
+  ];
+}
 
 function CustomEnvSection({ config, onChange }: { config: PilotDeckConfig; onChange: (next: PilotDeckConfig) => void }) {
   const { t } = useTranslation('settings');
@@ -1465,7 +1474,7 @@ function CustomEnvSection({ config, onChange }: { config: PilotDeckConfig; onCha
     onChange(patch(config, ['customEnv', key], ''));
   };
 
-  const unusedWellKnown = WELL_KNOWN_ENV_KEYS.filter((wk) => envMap[wk.key] === undefined);
+  const unusedWellKnown = getWellKnownEnvKeys(t).filter((wk) => envMap[wk.key] === undefined);
 
   return (
     <SettingsSection
@@ -1491,7 +1500,7 @@ function CustomEnvSection({ config, onChange }: { config: PilotDeckConfig; onCha
                 <span className="text-muted-foreground">=</span>
                 <SecretTextInput
                   value={value}
-                  placeholder={isMasked ? t('pilotDeckConfig.panels.customEnv.existingValueKept') : 'value'}
+                  placeholder={isMasked ? t('pilotDeckConfig.panels.customEnv.existingValueKept') : t('pilotDeckConfig.customEnv.valuePlaceholder')}
                   monospace
                   className="min-w-0 flex-1"
                   onChange={(v) => setEnv(key, v)}
@@ -1663,8 +1672,8 @@ function AlwaysOnSection({
                     value={trigger.preferChannel}
                     onChange={(value) => onChange(patch(config, ['alwaysOn', 'trigger', 'preferChannel'], value))}
                     options={[
-                      { value: 'web', label: 'Web UI' },
-                      { value: 'tui', label: 'TUI' },
+                      { value: 'web', label: t('pilotDeckConfig.alwaysOnSection.webUI') },
+                      { value: 'tui', label: t('pilotDeckConfig.alwaysOnSection.tui') },
                     ]}
                   />
                 </FormRow>
@@ -1800,7 +1809,7 @@ function AlwaysOnSection({
                     >
                       <SettingsToggle
                         checked={isAlwaysOnProjectEnabled(config, project)}
-                        ariaLabel={`Toggle Always-On for ${project.displayName || project.name}`}
+                        ariaLabel={t('pilotDeckConfig.alwaysOnSection.toggleLabel', { project: project.displayName || project.name })}
                         onChange={(en) => onChange(setAlwaysOnProjectEnabled(config, project, en))}
                       />
                     </SettingsRow>
@@ -2008,7 +2017,7 @@ function ToolsSection({ config, onChange }: { config: PilotDeckConfig; onChange:
           {isMaskedSecret(apiKey) && (
             <p className="mt-1 flex items-center gap-1 text-[11px] text-muted-foreground">
               <Info className="h-3 w-3" />
-              Key hidden; leave as-is to keep, retype to replace.
+              {t('pilotDeckConfig.apiKeyHidden')}
             </p>
           )}
         </FormRow>
@@ -2031,7 +2040,7 @@ function ToolsSection({ config, onChange }: { config: PilotDeckConfig; onChange:
             >
               <TextInput
                 value={custom.name ?? ''}
-                placeholder="My Search"
+                placeholder={t('pilotDeckConfig.customSearchPlaceholder')}
                 onChange={(v) => setCustomField('name', v)}
               />
             </FormRow>
@@ -2278,7 +2287,7 @@ function RouterScenarioEditor({ config, onChange }: { config: PilotDeckConfig; o
           <input
             value={newKey}
             onChange={(e) => setNewKey(e.target.value)}
-            placeholder="scenario name"
+            placeholder={t('pilotDeckConfig.searchConfig.scenarioName')}
             className="min-w-0 flex-1 rounded-md border border-border bg-background px-2 py-1.5 font-mono text-xs text-foreground outline-none focus:ring-1 focus:ring-ring"
             onKeyDown={(e) => { if (e.key === 'Enter' && !isImeEnterEvent(e)) addScenario(); }}
           />
@@ -2380,7 +2389,7 @@ function RouterFallbackEditor({ config, onChange }: { config: PilotDeckConfig; o
           <input
             value={newKey}
             onChange={(e) => setNewKey(e.target.value)}
-            placeholder="scenario name (e.g. default)"
+            placeholder={t('pilotDeckConfig.searchConfig.scenarioNameDefault')}
             className="min-w-0 flex-1 rounded-md border border-border bg-background px-2 py-1.5 font-mono text-xs text-foreground outline-none focus:ring-1 focus:ring-ring"
             onKeyDown={(e) => { if (e.key === 'Enter' && !isImeEnterEvent(e)) addChain(); }}
           />
@@ -2394,19 +2403,23 @@ function RouterFallbackEditor({ config, onChange }: { config: PilotDeckConfig; o
   );
 }
 
-const DEFAULT_TIERS: Record<string, { description: string }> = {
-  simple: { description: 'Simple greetings, confirmations, single-step Q&A, trivial file writes, remembering rules' },
-  medium: { description: 'Single tool call, short text generation, 1-2 file read/write, code generation' },
-  complex: { description: 'Needs sub-agent orchestration: parallel workstreams, delegation to specialized agents' },
-  reasoning: { description: 'Deep single-agent work: multi-file operations, data analysis, multi-step workflows, web research, structured reports from many sources' },
-};
+function getDefaultTiers(t: (key: string) => string): Record<string, { description: string }> {
+  return {
+    simple: { description: t('pilotDeckConfig.tierDescriptions.simple') },
+    medium: { description: t('pilotDeckConfig.tierDescriptions.medium') },
+    complex: { description: t('pilotDeckConfig.tierDescriptions.complex') },
+    reasoning: { description: t('pilotDeckConfig.tierDescriptions.reasoning') },
+  };
+}
 
-const DEFAULT_RULES: string[] = [
-  'complex is ONLY for tasks that need sub-agent orchestration or parallel delegation — do NOT use it for single-agent multi-step work',
-  'Multi-file operations, data analysis, and multi-step workflows without orchestration should be reasoning',
-  'Simple file creation (1-2 files) or single code generation is medium',
-  'Trivial greetings, confirmations, remembering rules, or reading one file and answering a short question is simple',
-];
+function getDefaultRules(t: (key: string) => string): string[] {
+  return [
+    t('pilotDeckConfig.tierRules.complex'),
+    t('pilotDeckConfig.tierRules.reasoning'),
+    t('pilotDeckConfig.tierRules.medium'),
+    t('pilotDeckConfig.tierRules.simple'),
+  ];
+}
 
 function TokenSaverTierEditor({ config, onChange }: { config: PilotDeckConfig; onChange: (next: PilotDeckConfig) => void }) {
   const { t } = useTranslation('settings');
@@ -2425,7 +2438,7 @@ function TokenSaverTierEditor({ config, onChange }: { config: PilotDeckConfig; o
   const addTier = () => {
     const key = newKey.trim();
     if (!key || tiers[key]) return;
-    const preset = DEFAULT_TIERS[key];
+    const preset = getDefaultTiers(t)[key];
     onChange(patch(config, ['router', 'tokenSaver', 'tiers', key], {
       model: modelOpts[0]?.value ?? '',
       description: preset?.description ?? '',
@@ -2471,7 +2484,7 @@ function TokenSaverTierEditor({ config, onChange }: { config: PilotDeckConfig; o
           <input
             value={newKey}
             onChange={(e) => setNewKey(e.target.value)}
-            placeholder="tier name (e.g. simple, medium, complex)"
+            placeholder={t('pilotDeckConfig.searchConfig.tierName')}
             className="min-w-0 flex-1 rounded-md border border-border bg-background px-2 py-1.5 font-mono text-xs text-foreground outline-none focus:ring-1 focus:ring-ring"
             onKeyDown={(e) => { if (e.key === 'Enter' && !isImeEnterEvent(e)) addTier(); }}
           />
@@ -2699,8 +2712,8 @@ function RouterSection({ config, onChange }: { config: PilotDeckConfig; onChange
                     <Select
                       value={ts.subagent?.policy ?? 'judge'}
                       options={[
-                        { value: 'judge', label: 'judge' },
-                        { value: 'inherit', label: 'inherit' },
+                        { value: 'judge', label: t('pilotDeckConfig.subagentPolicy.judge') },
+                        { value: 'inherit', label: t('pilotDeckConfig.subagentPolicy.inherit') },
                       ]}
                       onChange={(v) => onChange(patch(config, ['router', 'tokenSaver', 'subagent', 'policy'], v))}
                     />
@@ -3136,7 +3149,7 @@ export default function PilotDeckConfigTab({ projects = [] }: { projects?: Setti
         title={t('pilotDeckConfig.panels.subsystemReload.title')}
         description={lastReloadInfo
           ? t('pilotDeckConfig.panels.subsystemReload.lastReload', {
-              source: sourceLabel(lastReloadInfo.source),
+              source: sourceLabel(lastReloadInfo.source, t),
               time: new Date(lastReloadInfo.at).toLocaleTimeString(),
             })
           : t('pilotDeckConfig.panels.subsystemReload.fallbackDescription')}

--- a/ui/src/components/standalone-shell/view/subcomponents/StandaloneShellEmptyState.tsx
+++ b/ui/src/components/standalone-shell/view/subcomponents/StandaloneShellEmptyState.tsx
@@ -1,8 +1,11 @@
+import { useTranslation } from 'react-i18next';
+
 type StandaloneShellEmptyStateProps = {
   className: string;
 };
 
 export default function StandaloneShellEmptyState({ className }: StandaloneShellEmptyStateProps) {
+  const { t } = useTranslation();
   return (
     <div className={`flex h-full items-center justify-center ${className}`}>
       <div className="text-center text-gray-500 dark:text-gray-400">
@@ -16,8 +19,8 @@ export default function StandaloneShellEmptyState({ className }: StandaloneShell
             />
           </svg>
         </div>
-        <h3 className="mb-2 text-lg font-semibold">No Project Selected</h3>
-        <p>A project is required to open a shell</p>
+        <h3 className="mb-2 text-lg font-semibold">{t('alwaysOn:standaloneShell.noProject')}</h3>
+        <p>{t('alwaysOn:standaloneShell.projectRequired')}</p>
       </div>
     </div>
   );

--- a/ui/src/components/standalone-shell/view/subcomponents/StandaloneShellHeader.tsx
+++ b/ui/src/components/standalone-shell/view/subcomponents/StandaloneShellHeader.tsx
@@ -1,3 +1,5 @@
+import { useTranslation } from 'react-i18next';
+
 type StandaloneShellHeaderProps = {
   title: string;
   isCompleted: boolean;
@@ -9,16 +11,17 @@ export default function StandaloneShellHeader({
   isCompleted,
   onClose = null,
 }: StandaloneShellHeaderProps) {
+  const { t } = useTranslation();
   return (
     <div className="flex-shrink-0 border-b border-gray-700 bg-gray-800 px-4 py-2">
       <div className="flex items-center justify-between">
         <div className="flex items-center space-x-2">
           <h3 className="text-sm font-medium text-gray-200">{title}</h3>
-          {isCompleted && <span className="text-xs text-green-400">(Completed)</span>}
+          {isCompleted && <span className="text-xs text-green-400">{t('alwaysOn:standaloneShell.completed')}</span>}
         </div>
 
         {onClose && (
-          <button onClick={onClose} className="text-gray-400 hover:text-white" title="Close">
+          <button onClick={onClose} className="text-gray-400 hover:text-white" title={t('buttons.close')}>
             <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
             </svg>

--- a/ui/src/i18n/locales/en/auth.json
+++ b/ui/src/i18n/locales/en/auth.json
@@ -33,5 +33,20 @@
     "title": "Sign Out",
     "confirm": "Are you sure you want to sign out?",
     "button": "Sign Out"
+  },
+  "setup": {
+    "title": "Welcome to PilotDeck",
+    "description": "Set up your account to get started",
+    "footerText": "This is a single-user system. Only one account can be created.",
+    "username": "Username",
+    "password": "Password",
+    "confirmPassword": "Confirm Password",
+    "placeholders": {
+      "username": "Enter your username",
+      "password": "Enter your password",
+      "confirmPassword": "Confirm your password"
+    },
+    "submit": "Create Account",
+    "loading": "Setting up..."
   }
 }

--- a/ui/src/i18n/locales/en/chat.json
+++ b/ui/src/i18n/locales/en/chat.json
@@ -110,7 +110,52 @@
     "readFile": "Read file",
     "updateTodo": "Update todo list",
     "readTodo": "Read todo list",
-    "searchResults": "results"
+    "searchResults": "results",
+    "unknownError": "Unknown error",
+    "backgroundTaskUpdate": "Background task update",
+    "processSummary": "Process summary",
+    "unableToLoad": "Unable to load conversation messages.",
+    "failedToFetchCommands": "Failed to fetch commands",
+    "toolOutputError": "Tool output could not be rendered.",
+    "details": "Details",
+    "rawParams": "raw params",
+    "copyToClipboard": "Copy to clipboard",
+    "edit": "Edit",
+    "new": "New",
+    "patch": "Patch",
+    "foundFiles": "Found {{count}} {{fileType}}",
+    "foundSingular": "file",
+    "foundPlural": "files",
+    "updatingTodo": "Updating todo list",
+    "todoUpdated": "Todo list updated",
+    "readingList": "reading list",
+    "scheduleJob": "schedule job",
+    "scheduledJob": "Scheduled job",
+    "scheduled": "Scheduled",
+    "cancelJob": "cancel scheduled job",
+    "cancelledJob": "Cancelled scheduled job",
+    "cancelled": "Cancelled",
+    "listingJobs": "listing scheduled jobs",
+    "jobCount": "{{count}} scheduled {{jobType}}",
+    "jobSingular": "job",
+    "jobPlural": "jobs",
+    "creatingTask": "Creating task",
+    "updating": "updating",
+    "listingTasks": "listing tasks",
+    "taskList": "Task list",
+    "fetching": "fetching",
+    "taskDetails": "Task details",
+    "runningTask": "Running task",
+    "subagentPrefix": "Subagent / ",
+    "subagentResult": "Subagent result",
+    "noResponseText": "No response text",
+    "noResponse": "No response",
+    "question": "Question",
+    "questionPayload": "Question payload",
+    "questionsAnswered": "questions — answered",
+    "questions": "questions",
+    "implementationPlan": "Implementation Plan",
+    "parameters": "Parameters"
   },
   "search": {
     "found": "Found {{count}} {{type}}",
@@ -387,6 +432,80 @@
   },
   "composer": {
     "placeholder": "Tell PilotDeck what you want to get done…",
-    "welcomePlaceholder": "Tell PilotDeck what you want to get done…"
+    "welcomePlaceholder": "Tell PilotDeck what you want to get done…",
+    "askBeforeRisky": "Ask before risky operations",
+    "skipConfirmations": "Skip confirmations and allow full access"
+  },
+  "thinkingModes": {
+    "standard": { "name": "Standard", "description": "Regular response" },
+    "think": { "name": "Think", "description": "Basic extended thinking" },
+    "thinkHard": { "name": "Think Hard", "description": "More thorough evaluation" },
+    "thinkHarder": { "name": "Think Harder", "description": "Deep analysis with alternatives" },
+    "ultrathink": { "name": "Ultrathink", "description": "Maximum thinking budget" }
+  },
+  "subagent": {
+    "running": "Running subagent...",
+    "currently": "Currently:",
+    "failed": "Failed ({{count}} {{toolType}})",
+    "completed": "Completed ({{count}} {{toolType}})",
+    "viewHistory": "View tool history ({{count}})",
+    "toolSingular": "tool",
+    "toolPlural": "tools"
+  },
+  "askUser": {
+    "agentNeedsInput": "Agent needs your input",
+    "selectApply": "Select all that apply",
+    "other": "Other...",
+    "typeAnswer": "Type your answer...",
+    "skip": "Skip",
+    "skipAll": "Skip all",
+    "back": "Back",
+    "submit": "Submit",
+    "next": "Next"
+  },
+  "permission": {
+    "allowSaved": "Allow (saved)",
+    "allowRemember": "Allow & remember",
+    "required": "Permission required",
+    "toolLabel": "Tool: ",
+    "allowRule": "Allow rule: ",
+    "viewInput": "View tool input",
+    "viewInputs": "View {{count}} tool inputs",
+    "allowOnce": "Allow once",
+    "denied": "User denied tool use",
+    "deny": "Deny"
+  },
+  "imagePreview": {
+    "preview": "Image preview",
+    "close": "Close preview",
+    "previous": "Previous image",
+    "next": "Next image",
+    "remove": "Remove attachment"
+  },
+  "questionContent": {
+    "renderError": "Question payload could not be rendered.",
+    "custom": "(custom)",
+    "skipped": "Skipped",
+    "noAnswer": "No answer provided"
+  },
+  "taskContent": {
+    "completed": "{{completed}}/{{total}} completed"
+  },
+  "todoContent": {
+    "todoList": "Todo List (",
+    "itemSingular": "item",
+    "itemPlural": "items"
+  },
+  "imageAlt": {
+    "uploaded": "Uploaded image",
+    "toolResult": "Tool result image"
+  },
+  "processTrace": {
+    "working": "Working",
+    "step": "Step"
+  },
+  "messageRow": {
+    "copied": "Copied",
+    "copy": "Copy"
   }
 }

--- a/ui/src/i18n/locales/en/common.json
+++ b/ui/src/i18n/locales/en/common.json
@@ -309,6 +309,85 @@
     "cron": {
       "title": "Scheduled cron jobs",
       "description": "Existing durable and session-scoped cron tasks for this project."
+    },
+    "deleteProject": {
+      "title": "Delete project?",
+      "description": "This removes the project from PilotDeck and deletes its session metadata.",
+      "sessionWarning": "{{count}} session(s) will also be removed.",
+      "diskNote": "Files on disk are not deleted -- only PilotDeck's reference to them.",
+      "cancel": "Cancel",
+      "deleting": "Deleting...",
+      "confirm": "Delete project"
+    },
+    "deleteConversation": {
+      "title": "Delete conversation?",
+      "description": "This removes the conversation from {{projectName}}.",
+      "cancel": "Cancel",
+      "deleting": "Deleting...",
+      "confirm": "Delete conversation"
+    },
+    "shell": {
+      "noProject": "Pick a project to open a shell.",
+      "shellName": "zsh "
+    },
+    "gitV2": {
+      "noProject": "Pick a project to view source control.",
+      "fetch": "Fetch",
+      "loading": "Loading git status...",
+      "clean": "Working tree clean.",
+      "staged": "Staged",
+      "changes": "Changes",
+      "commit": "Commit",
+      "aiSuggest": "AI suggest commit message",
+      "push": "Push",
+      "dismiss": "Dismiss"
+    },
+    "tasksV2": {
+      "title": "Tasks",
+      "taskCount": "{{count}} tasks",
+      "inProgress": "in progress",
+      "refresh": "Refresh",
+      "noTasks": "No tasks yet. Initialize Task Master from the legacy tasks panel to get started.",
+      "notStarted": "Not started",
+      "done": "Done",
+      "inReview": "In review",
+      "blocked": "Blocked",
+      "deferred": "Deferred",
+      "cancelled": "Cancelled"
+    },
+    "filesV2": {
+      "open": "Open"
+    },
+    "standaloneShell": {
+      "noProject": "No Project Selected",
+      "projectRequired": "A project is required to open a shell",
+      "completed": "(Completed)"
+    },
+    "codeEditorBinary": {
+      "close": "Close",
+      "pdfTitle": "PDF: {{fileName}}",
+      "exitFullscreen": "Exit fullscreen",
+      "fullscreen": "Fullscreen"
+    },
+    "codeEditorSidebar": {
+      "dragToResize": "Drag to resize"
+    },
+    "editorToolbar": {
+      "openInModal": "Open in modal"
+    },
+    "markdownCode": {
+      "copied": "Copied!",
+      "copy": "Copy"
+    },
+    "authLoading": {
+      "loading": "Loading..."
+    },
+    "memoryPanel": {
+      "emptyProject": "Select a project to inspect memory.",
+      "unavailable": "Memory dashboard is unavailable until auth and project context are ready."
+    },
+    "errorBoundary": {
+      "errorDetails": "Error Details"
     }
   },
   "fileTree": {
@@ -480,5 +559,32 @@
       "updateAvailable": "Update available",
       "closeSidebar": "Close sidebar"
     }
+  },
+  "git": {
+    "commitMessage": "Commit message"
+  },
+  "providerLogin": {
+    "runConfiguration": "Run configuration",
+    "closeLoginModal": "Close login modal"
+  },
+  "folderBrowser": {
+    "selectFolder": "Select Folder",
+    "select": "Select",
+    "path": "Path:",
+    "cancel": "Cancel",
+    "useThisFolder": "Use this folder",
+    "newFolderName": "New folder name",
+    "create": "Create",
+    "createNewFolder": "Create new folder",
+    "showHiddenFolders": "Show hidden folders",
+    "hideHiddenFolders": "Hide hidden folders",
+    "close": "Close",
+    "noSubfoldersFound": "No subfolders found"
+  },
+  "errorBoundary": {
+    "somethingWentWrong": "Something went wrong"
+  },
+  "dashboard": {
+    "tierBreakdown": "Tier breakdown"
   }
 }

--- a/ui/src/i18n/locales/en/settings.json
+++ b/ui/src/i18n/locales/en/settings.json
@@ -486,6 +486,33 @@
       "add": "Add",
       "dismiss": "Dismiss"
     },
+    "enabledModels": "Enabled models",
+    "clickStarToSetMain": "click ★ to set main agent",
+    "supportsImageInput": "supports image input",
+    "addProvider": "Add provider",
+    "addAProvider": "Add a provider",
+    "cancel": "Cancel",
+    "custom": "Custom",
+    "manualSetup": "Manual setup",
+    "modelsCount": "{{count}} models",
+    "customModelPlaceholder": "Custom model ID",
+    "searchPlaceholder": "My Search",
+    "perModelMaxOutputTokens": "Per-model max output tokens",
+    "perModelMaxOutputTokensDesc": "Cap on tokens each model may generate per turn (sent as max_tokens). Leave blank to fall back to the protocol default (~8k for openai, ~4k for anthropic). 32k is a safe modern recommendation; raise it for long-form / thinking models — too small a value cuts the response off mid-stream.",
+    "showAdvanced": "Show advanced (protocol & URL)",
+    "hideAdvanced": "Hide advanced (protocol & URL)",
+    "apiKeyHidden": "Key hidden; leave as-is to keep, retype to replace.",
+    "alreadyDefault": "Already using default",
+    "resetToDefault": "Reset to catalog/protocol default",
+    "noProvidersYet": "No providers configured yet. Click \"Add provider\" to get started.",
+    "protocol": "Protocol",
+    "baseUrl": "Base URL",
+    "noReloadYet": "No reload has run yet.",
+    "customSearchPlaceholder": "My Search",
+    "apiKeyLabel": "API key",
+    "searchPlaceholder": "My Search",
+    "mainAgent": "Main agent",
+    "existingKeyKept": "Existing key kept — type to replace",
     "rawYaml": {
       "configValid": "Config is valid",
       "unsaved": "(unsaved)",
@@ -496,6 +523,93 @@
       "yamlParseError": "YAML on disk failed to parse — switch to Raw YAML to fix it.",
       "cannotParse": "Could not parse the YAML on disk. Switch to {{rawYaml}} to inspect and fix it.",
       "rawYaml": "Raw YAML"
+    },
+    "subsystemLabels": {
+      "processEnv": "Process Env",
+      "memory": "Memory",
+      "router": "PilotDeck Router",
+      "gateway": "Gateway",
+      "proxy": "Proxy"
+    },
+    "reloadSummary": {
+      "reloaded": "Reloaded",
+      "noData": "No data"
+    },
+    "sourceLabels": {
+      "uiSave": "UI save",
+      "uiReload": "UI reload",
+      "externalEdit": "External file edit",
+      "manualRefresh": "Manual refresh"
+    },
+    "modelRef": {
+      "placeholder": "provider/model-name"
+    },
+    "catalogChip": {
+      "clickToDisable": "Click to disable",
+      "clickToEnable": "Click to enable"
+    },
+    "starButton": {
+      "currentMain": "Currently the main agent model",
+      "setMain": "Set as main agent model"
+    },
+    "advancedSection": {
+      "defaultsTo": "Defaults to",
+      "fromCatalog": "from catalog.",
+      "effective": "Effective:"
+    },
+    "providerCard": {
+      "modelsCount": "{{count}} models"
+    },
+    "agentSection": {
+      "pickModel": "— pick a model —",
+      "inheritModel": "inherit (use main agent's model)"
+    },
+    "envKeys": {
+      "tavilyHint": "Tavily web search API key",
+      "firecrawlHint": "Firecrawl web scraping API key",
+      "serperHint": "Serper search API key",
+      "browserbaseHint": "Browserbase API key"
+    },
+    "customEnv": {
+      "valuePlaceholder": "value"
+    },
+    "alwaysOnSection": {
+      "webUI": "Web UI",
+      "tui": "TUI",
+      "toggleLabel": "Toggle Always-On for {{project}}"
+    },
+    "searchConfig": {
+      "query": "query",
+      "apiKey": "api_key",
+      "dataItems": "data.items",
+      "titleField": "title",
+      "urlField": "url",
+      "snippet": "snippet",
+      "sourceField": "source",
+      "publishedAt": "publishedAt",
+      "scenarioName": "scenario name",
+      "scenarioExample": "scenario name (e.g. default)",
+      "tierName": "tier name (e.g. simple, medium, complex)"
+    },
+    "tierDescriptions": {
+      "simple": "Simple greetings, confirmations, single-step Q&A, trivial file writes, remembering rules",
+      "medium": "Single tool call, short text generation, 1-2 file read/write, code generation",
+      "complex": "Needs sub-agent orchestration: parallel workstreams, delegation to specialized agents",
+      "reasoning": "Deep single-agent work: multi-file operations, data analysis, multi-step workflows, web research, structured reports from many sources"
+    },
+    "tierRules": {
+      "complexOnly": "complex is ONLY for tasks that need sub-agent orchestration or parallel delegation — do NOT use it for single-agent multi-step work",
+      "reasoningRule": "Multi-file operations, data analysis, and multi-step workflows without orchestration should be reasoning",
+      "mediumRule": "Simple file creation (1-2 files) or single code generation is medium",
+      "simpleRule": "Trivial greetings, confirmations, remembering rules, or reading one file and answering a short question is simple"
+    },
+    "subagentPolicy": {
+      "judge": "judge",
+      "inherit": "inherit"
+    },
+    "toolsSection": {
+      "providerLabel": "Provider",
+      "bearerHeader": "Bearer header"
     },
     "sections": {
       "runtime": {

--- a/ui/src/i18n/locales/zh-CN/alwaysOn.json
+++ b/ui/src/i18n/locales/zh-CN/alwaysOn.json
@@ -1,5 +1,5 @@
 {
-  "emptyProject": "选择一个项目以查看 Always-On。",
+  "emptyProject": "选择一个项目以查看常驻。",
   "actions": {
     "refresh": "刷新"
   },
@@ -8,10 +8,10 @@
     "plansCron": "计划与定时任务"
   },
   "dashboard": {
-    "title": "Always-On 仪表盘",
+    "title": "常驻仪表盘",
     "subtitle": "所有工作区的活动动态。",
     "loading": "正在加载事件…",
-    "empty": "暂无 Always-On 事件记录。",
+    "empty": "暂无常驻事件记录。",
     "stats": {
       "todayEvents": "今日事件",
       "activeProjects": "活跃项目",

--- a/ui/src/i18n/locales/zh-CN/auth.json
+++ b/ui/src/i18n/locales/zh-CN/auth.json
@@ -33,5 +33,20 @@
     "title": "退出登录",
     "confirm": "确定要退出登录吗？",
     "button": "退出登录"
+  },
+  "setup": {
+    "title": "欢迎使用 PilotDeck",
+    "description": "设置您的账户以开始使用",
+    "footerText": "这是一个单用户系统，只能创建一个账户。",
+    "username": "用户名",
+    "password": "密码",
+    "confirmPassword": "确认密码",
+    "placeholders": {
+      "username": "输入您的用户名",
+      "password": "输入您的密码",
+      "confirmPassword": "确认您的密码"
+    },
+    "submit": "创建账户",
+    "loading": "设置中..."
   }
 }

--- a/ui/src/i18n/locales/zh-CN/chat.json
+++ b/ui/src/i18n/locales/zh-CN/chat.json
@@ -110,7 +110,52 @@
     "readFile": "读取文件",
     "updateTodo": "更新待办列表",
     "readTodo": "读取待办列表",
-    "searchResults": "结果"
+    "searchResults": "结果",
+    "unknownError": "未知错误",
+    "backgroundTaskUpdate": "后台任务更新",
+    "processSummary": "处理摘要",
+    "unableToLoad": "无法加载对话消息。",
+    "failedToFetchCommands": "获取命令失败",
+    "toolOutputError": "工具输出无法渲染。",
+    "details": "详情",
+    "rawParams": "原始参数",
+    "copyToClipboard": "复制到剪贴板",
+    "edit": "编辑",
+    "new": "新增",
+    "patch": "补丁",
+    "foundFiles": "找到 {{count}} 个{{fileType}}",
+    "foundSingular": "文件",
+    "foundPlural": "文件",
+    "updatingTodo": "正在更新待办列表",
+    "todoUpdated": "待办列表已更新",
+    "readingList": "读取列表",
+    "scheduleJob": "调度任务",
+    "scheduledJob": "已调度任务",
+    "scheduled": "已调度",
+    "cancelJob": "取消调度任务",
+    "cancelledJob": "已取消调度任务",
+    "cancelled": "已取消",
+    "listingJobs": "列出调度任务",
+    "jobCount": "{{count}} 个已调度{{jobType}}",
+    "jobSingular": "任务",
+    "jobPlural": "任务",
+    "creatingTask": "创建任务",
+    "updating": "更新中",
+    "listingTasks": "列出任务",
+    "taskList": "任务列表",
+    "fetching": "获取中",
+    "taskDetails": "任务详情",
+    "runningTask": "运行任务",
+    "subagentPrefix": "子智能体 / ",
+    "subagentResult": "子智能体结果",
+    "noResponseText": "无响应文本",
+    "noResponse": "无响应",
+    "question": "问题",
+    "questionPayload": "问题内容",
+    "questionsAnswered": "个问题 — 已回答",
+    "questions": "个问题",
+    "implementationPlan": "实施计划",
+    "parameters": "参数"
   },
   "search": {
     "found": "找到 {{count}} 个{{type}}",
@@ -189,6 +234,24 @@
       "plan": "计划模式 - 不执行任何命令"
     },
     "technicalDetails": "技术细节"
+  },
+  "gemini": {
+    "permissionMode": "Gemini 权限模式",
+    "description": "控制 Gemini CLI 处理操作审批的方式。",
+    "modes": {
+      "default": {
+        "title": "标准模式（请求审批）",
+        "description": "Gemini 在执行命令、写入文件和获取网络资源前会请求审批。"
+      },
+      "autoEdit": {
+        "title": "自动编辑（跳过文件审批）",
+        "description": "Gemini 会自动批准文件编辑和网络请求，但 Shell 命令仍需审批。"
+      },
+      "yolo": {
+        "title": "YOLO（跳过所有权限）",
+        "description": "Gemini 将不经审批直接执行所有操作。请谨慎使用。"
+      }
+    }
   },
   "input": {
     "placeholder": "输入 / 调用命令，@ 选择文件，或向 {{provider}} 提问...",
@@ -338,29 +401,29 @@
   },
   "pilotdeckStatus": {
     "actions": {
-      "thinking": "Thinking",
-      "processing": "Processing",
-      "analyzing": "Analyzing",
-      "working": "Working",
-      "computing": "Computing",
-      "reasoning": "Reasoning"
+      "thinking": "思考中",
+      "processing": "处理中",
+      "analyzing": "分析中",
+      "working": "工作中",
+      "computing": "计算中",
+      "reasoning": "推理中"
     },
     "state": {
-      "live": "Live",
-      "paused": "Paused"
+      "live": "运行中",
+      "paused": "已暂停"
     },
     "elapsed": {
-      "seconds": "{{count}}s",
-      "minutesSeconds": "{{minutes}}m {{seconds}}s",
-      "label": "{{time}} elapsed",
-      "startingNow": "Starting now"
+      "seconds": "{{count}}秒",
+      "minutesSeconds": "{{minutes}}分 {{seconds}}秒",
+      "label": "已用时 {{time}}",
+      "startingNow": "正在启动"
     },
     "controls": {
-      "stopGeneration": "Stop Generation",
-      "pressEscToStop": "Press Esc anytime to stop"
+      "stopGeneration": "停止生成",
+      "pressEscToStop": "随时按 Esc 停止"
     },
     "providers": {
-      "assistant": "Assistant"
+      "assistant": "助手"
     }
   },
   "projectSelection": {
@@ -371,10 +434,84 @@
   },
   "composer": {
     "placeholder": "告诉 PilotDeck 你想完成什么…",
-    "welcomePlaceholder": "告诉 PilotDeck 你想完成什么…"
+    "welcomePlaceholder": "告诉 PilotDeck 你想完成什么…",
+    "askBeforeRisky": "风险操作前询问",
+    "skipConfirmations": "跳过确认并允许完全访问"
   },
   "welcome": {
     "greetingWithProject": "今天想做点什么？",
     "noProject": "从左侧选择一个项目开始"
+  },
+  "thinkingModes": {
+    "standard": { "name": "标准", "description": "普通回复" },
+    "think": { "name": "思考", "description": "基础扩展思考" },
+    "thinkHard": { "name": "深度思考", "description": "更全面的评估" },
+    "thinkHarder": { "name": "超深度思考", "description": "带备选方案的深度分析" },
+    "ultrathink": { "name": "极致思考", "description": "最大思考预算" }
+  },
+  "subagent": {
+    "running": "正在运行子智能体...",
+    "currently": "当前：",
+    "failed": "失败（{{count}} 个{{toolType}}）",
+    "completed": "已完成（{{count}} 个{{toolType}}）",
+    "viewHistory": "查看工具历史（{{count}}）",
+    "toolSingular": "工具",
+    "toolPlural": "工具"
+  },
+  "askUser": {
+    "agentNeedsInput": "智能体需要您的输入",
+    "selectApply": "选择所有适用项",
+    "other": "其他...",
+    "typeAnswer": "输入您的回答...",
+    "skip": "跳过",
+    "skipAll": "全部跳过",
+    "back": "返回",
+    "submit": "提交",
+    "next": "下一步"
+  },
+  "permission": {
+    "allowSaved": "允许（已保存）",
+    "allowRemember": "允许并记住",
+    "required": "需要权限",
+    "toolLabel": "工具：",
+    "allowRule": "允许规则：",
+    "viewInput": "查看工具输入",
+    "viewInputs": "查看 {{count}} 个工具输入",
+    "allowOnce": "允许一次",
+    "denied": "用户拒绝了工具使用",
+    "deny": "拒绝"
+  },
+  "imagePreview": {
+    "preview": "图片预览",
+    "close": "关闭预览",
+    "previous": "上一张图片",
+    "next": "下一张图片",
+    "remove": "移除附件"
+  },
+  "questionContent": {
+    "renderError": "问题内容无法渲染。",
+    "custom": "（自定义）",
+    "skipped": "已跳过",
+    "noAnswer": "未提供答案"
+  },
+  "taskContent": {
+    "completed": "{{completed}}/{{total}} 已完成"
+  },
+  "todoContent": {
+    "todoList": "待办列表（",
+    "itemSingular": "项",
+    "itemPlural": "项"
+  },
+  "imageAlt": {
+    "uploaded": "上传的图片",
+    "toolResult": "工具结果图片"
+  },
+  "processTrace": {
+    "working": "处理中",
+    "step": "步骤"
+  },
+  "messageRow": {
+    "copied": "已复制",
+    "copy": "复制"
   }
 }

--- a/ui/src/i18n/locales/zh-CN/codeEditor.json
+++ b/ui/src/i18n/locales/zh-CN/codeEditor.json
@@ -27,7 +27,9 @@
     "fullscreen": "全屏",
     "expand": "展开为全宽",
     "collapse": "收起为分栏视图",
-    "close": "关闭"
+    "close": "关闭",
+    "previewMarkdown": "预览 Markdown",
+    "editMarkdown": "编辑 Markdown"
   },
   "footer": {
     "lines": "行数：",

--- a/ui/src/i18n/locales/zh-CN/common.json
+++ b/ui/src/i18n/locales/zh-CN/common.json
@@ -104,6 +104,8 @@
     "create": "创建技能",
     "creating": "创建中…"
   },
+  "newSessionInProject": "新建会话",
+  "deleteProject": "删除项目",
   "status": {
     "loading": "加载中...",
     "success": "成功",
@@ -176,10 +178,10 @@
     "projectFiles": "项目文件"
   },
   "alwaysOn": {
-    "title": "Always-On 总览",
+    "title": "常驻总览",
     "description": "在一个界面里查看当前项目的 discovery 计划和定时 cron 任务。",
     "lastUpdated": "最近更新：{{timestamp}}",
-    "loadingTitle": "正在加载 Always-On 数据",
+    "loadingTitle": "正在加载常驻数据",
     "loadingDescription": "正在读取当前项目的 discovery 计划和定时任务。",
     "emptyTitle": "还没有定时任务",
     "emptyDescription": "当前项目暂时没有可显示的持久化 cron 或本会话任务。",
@@ -254,13 +256,13 @@
       "alreadyRunning": "任务 {{id}} 正在运行中。"
     },
     "errors": {
-      "loadFailed": "加载 Always-On 数据失败。",
+      "loadFailed": "加载常驻数据失败。",
       "deleteFailed": "删除 cron job 失败。",
       "runNowFailed": "立即执行 cron job 失败。"
     },
     "discovery": {
       "title": "Discovery 计划",
-      "description": "由 Always-On discovery 生成、在执行前可审阅的结构化计划。",
+      "description": "由常驻 discovery 生成、在执行前可审阅的结构化计划。",
       "emptyTitle": "还没有 discovery 计划",
       "emptyDescription": "运行 discovery 后，这里会出现可执行的结构化计划。",
       "summary": {
@@ -307,6 +309,85 @@
     "cron": {
       "title": "定时 cron 任务",
       "description": "当前项目里已有的持久化和本会话 cron 任务。"
+    },
+    "deleteProject": {
+      "title": "删除项目？",
+      "description": "这将从 PilotDeck 中移除该项目并删除其会话元数据。",
+      "sessionWarning": "{{count}} 个会话也将被移除。",
+      "diskNote": "磁盘上的文件不会被删除——仅删除 PilotDeck 对它们的引用。",
+      "cancel": "取消",
+      "deleting": "删除中...",
+      "confirm": "删除项目"
+    },
+    "deleteConversation": {
+      "title": "删除对话？",
+      "description": "这将从 {{projectName}} 中移除该对话。",
+      "cancel": "取消",
+      "deleting": "删除中...",
+      "confirm": "删除对话"
+    },
+    "shell": {
+      "noProject": "选择一个项目以打开终端。",
+      "shellName": "zsh "
+    },
+    "gitV2": {
+      "noProject": "选择一个项目以查看版本控制。",
+      "fetch": "拉取",
+      "loading": "正在加载 Git 状态...",
+      "clean": "工作区干净。",
+      "staged": "已暂存",
+      "changes": "更改",
+      "commit": "提交",
+      "aiSuggest": "AI 建议提交信息",
+      "push": "推送",
+      "dismiss": "忽略"
+    },
+    "tasksV2": {
+      "title": "任务",
+      "taskCount": "{{count}} 个任务",
+      "inProgress": "进行中",
+      "refresh": "刷新",
+      "noTasks": "暂无任务。请从旧版任务面板初始化 Task Master 以开始使用。",
+      "notStarted": "未开始",
+      "done": "已完成",
+      "inReview": "审核中",
+      "blocked": "已阻塞",
+      "deferred": "已延迟",
+      "cancelled": "已取消"
+    },
+    "filesV2": {
+      "open": "打开"
+    },
+    "standaloneShell": {
+      "noProject": "未选择项目",
+      "projectRequired": "需要选择一个项目才能打开终端",
+      "completed": "（已完成）"
+    },
+    "codeEditorBinary": {
+      "close": "关闭",
+      "pdfTitle": "PDF：{{fileName}}",
+      "exitFullscreen": "退出全屏",
+      "fullscreen": "全屏"
+    },
+    "codeEditorSidebar": {
+      "dragToResize": "拖拽调整大小"
+    },
+    "editorToolbar": {
+      "openInModal": "在弹窗中打开"
+    },
+    "markdownCode": {
+      "copied": "已复制！",
+      "copy": "复制"
+    },
+    "authLoading": {
+      "loading": "加载中..."
+    },
+    "memoryPanel": {
+      "emptyProject": "选择一个项目以查看记忆。",
+      "unavailable": "记忆面板在认证和项目上下文就绪前不可用。"
+    },
+    "errorBoundary": {
+      "errorDetails": "错误详情"
     }
   },
   "fileTree": {
@@ -478,5 +559,32 @@
       "updateAvailable": "有可用更新",
       "closeSidebar": "关闭侧边栏"
     }
+  },
+  "git": {
+    "commitMessage": "提交信息"
+  },
+  "providerLogin": {
+    "runConfiguration": "运行配置",
+    "closeLoginModal": "关闭登录窗口"
+  },
+  "folderBrowser": {
+    "selectFolder": "选择文件夹",
+    "select": "选择",
+    "path": "路径：",
+    "cancel": "取消",
+    "useThisFolder": "使用此文件夹",
+    "newFolderName": "新文件夹名称",
+    "create": "创建",
+    "createNewFolder": "新建文件夹",
+    "showHiddenFolders": "显示隐藏文件夹",
+    "hideHiddenFolders": "隐藏隐藏文件夹",
+    "close": "关闭",
+    "noSubfoldersFound": "未找到子文件夹"
+  },
+  "errorBoundary": {
+    "somethingWentWrong": "出了点问题"
+  },
+  "dashboard": {
+    "tierBreakdown": "层级分布"
   }
 }

--- a/ui/src/i18n/locales/zh-CN/routing.json
+++ b/ui/src/i18n/locales/zh-CN/routing.json
@@ -34,14 +34,14 @@
       "title": "按项目"
     },
     "projectCard": {
-      "summary": "{{requests}} 次请求 · {{tokens}} tokens · {{sessions}} 个会话"
+      "summary": "{{requests}} 次请求 · {{tokens}} Token · {{sessions}} 个会话"
     },
     "units": {
       "requestsShort_one": "{{count}} 次",
       "requestsShort_other": "{{count}} 次",
       "queries_one": "{{count}} 条请求",
       "queries_other": "{{count}} 条请求",
-      "tokens": "{{value}} tokens"
+      "tokens": "{{value}} Token"
     },
     "session": {
       "orchestrated": "已编排",
@@ -74,7 +74,7 @@
       "savedLower": "节省",
       "extra": "多花",
       "extraLower": "多花",
-      "summary": "{{sessions}} 个会话 · {{requests}} 次请求 · {{tokens}} tokens",
+      "summary": "{{sessions}} 个会话 · {{requests}} 次请求 · {{tokens}} Token",
       "baselineHint": "按所有路由 token 都交给主模型估算。",
       "savedHint": "相对基准 {{rate}}%",
       "missingBaseline": "这些会话还没有配置基准成本。",

--- a/ui/src/i18n/locales/zh-CN/settings.json
+++ b/ui/src/i18n/locales/zh-CN/settings.json
@@ -486,6 +486,33 @@
       "add": "添加",
       "dismiss": "忽略"
     },
+    "enabledModels": "已启用的模型",
+    "clickStarToSetMain": "点击 ★ 设为主代理",
+    "supportsImageInput": "支持图片输入",
+    "addProvider": "添加供应商",
+    "addAProvider": "添加供应商",
+    "cancel": "取消",
+    "custom": "自定义",
+    "manualSetup": "手动配置",
+    "modelsCount": "{{count}} 个模型",
+    "customModelPlaceholder": "自定义模型 ID",
+    "searchPlaceholder": "我的搜索",
+    "perModelMaxOutputTokens": "每个模型的最大输出 Token 数",
+    "perModelMaxOutputTokensDesc": "每个模型每轮可生成的最大 Token 数（作为 max_tokens 发送）。留空则使用协议默认值（OpenAI 约 8k，Anthropic 约 4k）。32k 是安全的现代推荐值；对于长文本/推理模型可适当调高——过小会导致响应中途截断。",
+    "showAdvanced": "显示高级选项（协议和 URL）",
+    "hideAdvanced": "隐藏高级选项（协议和 URL）",
+    "apiKeyHidden": "密钥已隐藏；保持原样以保留，重新输入以替换。",
+    "alreadyDefault": "已使用默认值",
+    "resetToDefault": "重置为目录/协议默认值",
+    "noProvidersYet": "尚未配置供应商。点击「添加供应商」开始。",
+    "protocol": "协议",
+    "baseUrl": "基础 URL",
+    "noReloadYet": "尚未执行重新加载。",
+    "customSearchPlaceholder": "我的搜索",
+    "apiKeyLabel": "API 密钥",
+    "searchPlaceholder": "我的搜索",
+    "mainAgent": "主智能体",
+    "existingKeyKept": "已保留现有密钥 —— 输入以替换",
     "rawYaml": {
       "configValid": "配置有效",
       "unsaved": "（未保存）",
@@ -496,6 +523,93 @@
       "yamlParseError": "磁盘上的 YAML 解析失败——切换到原始 YAML 以修复。",
       "cannotParse": "无法解析磁盘上的 YAML。切换到{{rawYaml}}以检查和修复。",
       "rawYaml": "原始 YAML"
+    },
+    "subsystemLabels": {
+      "processEnv": "进程环境",
+      "memory": "记忆",
+      "router": "PilotDeck 路由器",
+      "gateway": "网关",
+      "proxy": "代理"
+    },
+    "reloadSummary": {
+      "reloaded": "已重新加载",
+      "noData": "无数据"
+    },
+    "sourceLabels": {
+      "uiSave": "UI 保存",
+      "uiReload": "UI 重新加载",
+      "externalEdit": "外部文件编辑",
+      "manualRefresh": "手动刷新"
+    },
+    "modelRef": {
+      "placeholder": "提供商/模型名"
+    },
+    "catalogChip": {
+      "clickToDisable": "点击禁用",
+      "clickToEnable": "点击启用"
+    },
+    "starButton": {
+      "currentMain": "当前主智能体模型",
+      "setMain": "设为主智能体模型"
+    },
+    "advancedSection": {
+      "defaultsTo": "默认为",
+      "fromCatalog": "（来自目录）。",
+      "effective": "实际值："
+    },
+    "providerCard": {
+      "modelsCount": "{{count}} 个模型"
+    },
+    "agentSection": {
+      "pickModel": "— 选择模型 —",
+      "inheritModel": "继承（使用主智能体模型）"
+    },
+    "envKeys": {
+      "tavilyHint": "Tavily 网络搜索 API 密钥",
+      "firecrawlHint": "Firecrawl 网页抓取 API 密钥",
+      "serperHint": "Serper 搜索 API 密钥",
+      "browserbaseHint": "Browserbase API 密钥"
+    },
+    "customEnv": {
+      "valuePlaceholder": "值"
+    },
+    "alwaysOnSection": {
+      "webUI": "Web UI",
+      "tui": "终端",
+      "toggleLabel": "切换 {{project}} 的常驻模式"
+    },
+    "searchConfig": {
+      "query": "查询",
+      "apiKey": "api_key",
+      "dataItems": "data.items",
+      "titleField": "title",
+      "urlField": "url",
+      "snippet": "摘要",
+      "sourceField": "source",
+      "publishedAt": "publishedAt",
+      "scenarioName": "场景名称",
+      "scenarioExample": "场景名称（如 default）",
+      "tierName": "层级名称（如 simple, medium, complex）"
+    },
+    "tierDescriptions": {
+      "simple": "简单问候、确认、单步问答、简单文件写入、记住规则",
+      "medium": "单次工具调用、短文本生成、1-2 次文件读写、代码生成",
+      "complex": "需要子智能体编排：并行工作流、委派给专门的智能体",
+      "reasoning": "深度单智能体工作：多文件操作、数据分析、多步骤工作流、网络调研、多来源结构化报告"
+    },
+    "tierRules": {
+      "complexOnly": "complex 仅用于需要子智能体编排或并行委派的任务 — 不要用于单智能体多步骤工作",
+      "reasoningRule": "无编排的多文件操作、数据分析和多步骤工作流应使用 reasoning",
+      "mediumRule": "简单文件创建（1-2 个文件）或单次代码生成使用 medium",
+      "simpleRule": "简单问候、确认、记住规则，或读取一个文件回答简短问题使用 simple"
+    },
+    "subagentPolicy": {
+      "judge": "判断",
+      "inherit": "继承"
+    },
+    "toolsSection": {
+      "providerLabel": "提供商",
+      "bearerHeader": "Bearer 请求头"
     },
     "sections": {
       "runtime": {
@@ -599,7 +713,7 @@
         "add": "添加"
       },
       "alwaysOn": {
-        "title": "Always-On",
+        "title": "常驻模式",
         "description": "配置全局自动发现，并按工作区单独开关。",
         "enabled": { "label": "启用", "description": "常驻后台智能体的总开关。" },
         "trigger": {
@@ -658,16 +772,16 @@
         "title": "搜索",
         "description": "智能体的 web_search 工具背后的搜索提供商。只能选择一个提供商，未选中的提供商不会生效。",
         "provider": {
-          "label": "Provider",
+          "label": "提供商",
           "description": "选择智能体使用的唯一搜索提供商。",
           "glm": "GLM / Z.AI Web Search",
           "tavily": "Tavily",
           "custom": "自定义"
         },
         "apiKey": {
-          "label": "API Key",
+          "label": "API 密钥",
           "description": "保存到 pilotdeck.yaml 的 tools.webSearch.apiKey，作用于当前选择的提供商。",
-          "placeholder": "provider API key"
+          "placeholder": "供应商 API 密钥"
         },
         "endpoint": {
           "label": "接口地址",
@@ -682,7 +796,7 @@
           "auth": {
             "label": "鉴权方式",
             "description": "自定义提供商接收 API Key 的方式。",
-            "bearer": "Bearer header",
+            "bearer": "Bearer 请求头",
             "bodyApiKey": "API Key 放在 JSON body",
             "queryApiKey": "API Key 放在 query string",
             "none": "不使用 API Key"
@@ -709,7 +823,7 @@
         }
       },
       "router": {
-        "title": "PilotDeck Router",
+        "title": "PilotDeck 路由器",
         "description": "内嵌路由器，跨提供商路由分发（按层级分流、Token 节省、自动编排）。",
         "enabled": { "label": "启用", "description": "启用后，智能体通过路由器而非直接使用配置的提供商。" },
         "zeroUsageRetry": {
@@ -802,6 +916,7 @@
     "installFailed": "安装失败",
     "uninstallFailed": "卸载失败",
     "toggleFailed": "切换失败",
+    "starterPluginLabel": "入门插件",
     "buildYourOwn": "构建您自己的插件",
     "starter": "入门模板",
     "docs": "文档",
@@ -809,6 +924,12 @@
       "name": "项目统计",
       "badge": "入门",
       "description": "查看项目的文件数、代码行数、文件类型分布以及最近活动。",
+      "install": "安装"
+    },
+    "terminalPlugin": {
+      "name": "终端",
+      "badge": "官方",
+      "description": "在界面中直接集成终端，提供完整的 Shell 访问。",
       "install": "安装"
     },
     "morePlugins": "更多",

--- a/ui/src/shared/view/ui/DarkModeToggle.tsx
+++ b/ui/src/shared/view/ui/DarkModeToggle.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import { Moon, Sun } from 'lucide-react';
 import { useTheme } from '../../../contexts/ThemeContext';
 import { cn } from '../../../lib/utils';
@@ -11,9 +12,11 @@ type DarkModeToggleProps = {
 function DarkModeToggle({
   checked,
   onToggle,
-  ariaLabel = 'Toggle dark mode',
+  ariaLabel,
 }: DarkModeToggleProps) {
+  const { t } = useTranslation();
   const { isDarkMode, toggleDarkMode } = useTheme();
+  const effectiveAriaLabel = ariaLabel ?? t('common:common.darkMode');
   const isControlled = typeof checked === 'boolean' && typeof onToggle === 'function';
   const isEnabled = isControlled ? checked : isDarkMode;
 
@@ -36,9 +39,9 @@ function DarkModeToggle({
       )}
       role="switch"
       aria-checked={isEnabled}
-      aria-label={ariaLabel}
+      aria-label={effectiveAriaLabel}
     >
-      <span className="sr-only">{ariaLabel}</span>
+      <span className="sr-only">{effectiveAriaLabel}</span>
       <span
         className={cn(
           'flex h-5 w-5 transform items-center justify-center rounded-full shadow-sm transition-transform duration-200',


### PR DESCRIPTION
- Add missing zh-CN translations for common, settings, chat, codeEditor, auth, alwaysOn namespaces
- Translate pilotdeckStatus section (Thinking→思考中, Live→运行中, etc.)
- Add gemini permission mode translations
- Fix hardcoded English in components: SetupForm, PilotDeckConfigTab, GitV2, ProviderLoginModal, ErrorBoundary, FolderBrowserModal, LlmConfigurationStep
- Fix i18n key exposure bug (pilotDeckConfig.add → pilotDeckConfig.actions.add)
- Translate "Always-On" → "常驻" across all zh-CN locale files
- Fix JSON syntax errors in locale files (missing commas, Chinese quotes)