### PR TITLE
fix(install): avoid zsh nomatch error when checking Playwright dirs

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -361,11 +361,11 @@ ensure_lfs_assets() {
 }
 
 has_playwright_chrome_for_testing() {
-  local candidate
-  for candidate in \
-    "$HOME/Library/Caches/ms-playwright"/mcp-chrome-for-testing-* \
-    "$HOME/.cache/ms-playwright"/mcp-chrome-for-testing-*; do
-    if [[ -d "$candidate" ]]; then
+  local base
+  for base in \
+    "$HOME/Library/Caches/ms-playwright" \
+    "$HOME/.cache/ms-playwright"; do
+    if find "$base" -maxdepth 1 -name "mcp-chrome-for-testing-*" -type d 2>/dev/null | grep -q .; then
       return 0
     fi
   done


### PR DESCRIPTION
**Problem**  
In the `has_playwright_chrome_for_testing()` function in `install.sh`, the original glob pattern could fail when `NOMATCH` is enabled in `zsh`. If no files matched, it would throw `zsh: no matches found`, causing the installation script to stop.

**Fix**  
Replaced the glob pattern with a POSIX-compatible `find + grep -q .` approach, ensuring consistent behavior across `bash`, `zsh`, `dash`, and other shells.

**Changed File**  
`install.sh` — `has_playwright_chrome_for_testing()` function.