### PR TITLE
feat(feishu): add reaction support for message processing status

### DIFF
--- a/src/adapters/channel/feishu/FeishuChannel.ts
+++ b/src/adapters/channel/feishu/FeishuChannel.ts
@@ -21,8 +21,17 @@ async function loadLarkSdk(): Promise<any> {
 
 const TENANT_TOKEN_URL = "https://open.feishu.cn/open-apis/auth/v3/tenant_access_token/internal";
 const SEND_MESSAGE_URL = "https://open.feishu.cn/open-apis/im/v1/messages?receive_id_type=chat_id";
+const MESSAGE_REACTIONS_URL = (messageId: string) =>
+  `https://open.feishu.cn/open-apis/im/v1/messages/${messageId}/reactions`;
+const MESSAGE_DETAIL_URL = (messageId: string) =>
+  `https://open.feishu.cn/open-apis/im/v1/messages/${messageId}`;
 const TOKEN_REFRESH_BUFFER_MS = 5 * 60 * 1000;
 const SEEN_EVENTS_MAX = 2000;
+
+// Reaction constants (借鉴 hermes-agent)
+const FEISHU_REACTION_IN_PROGRESS = "Typing";  // 处理中状态
+const FEISHU_REACTION_FAILURE = "CrossMark";    // 处理失败状态
+const FEISHU_PROCESSING_REACTION_CACHE_SIZE = 1024;
 
 export type FeishuOutboundMessage = {
   chatId: string;
@@ -55,7 +64,8 @@ export type FeishuChannelOptions = {
 
 type ParsedEvent =
   | { kind: "url_verification"; challenge: string }
-  | { kind: "message"; eventId: string; chatId: string; text: string }
+  | { kind: "message"; eventId: string; chatId: string; text: string; messageId?: string }
+  | { kind: "reaction"; eventId: string; action: "created" | "deleted"; messageId: string; emojiType: string; operatorType: string }
   | { kind: "ignore" };
 
 export class FeishuChannel implements ChannelAdapter {
@@ -78,6 +88,10 @@ export class FeishuChannel implements ChannelAdapter {
   private tokenInflight?: Promise<string>;
   private readonly seenEvents = new Set<string>();
   private readonly activeChats = new Set<string>();
+
+  // Reaction 相关状态
+  private readonly _sentMessageIds = new Map<string, string>(); // message_id → chat_id
+  private readonly _pendingProcessingReactions = new Map<string, string>(); // message_id → reaction_id
 
   private wsClient: any = null;
 
@@ -155,6 +169,18 @@ export class FeishuChannel implements ChannelAdapter {
             this.logger?.error?.(`feishu: stream event handler error: ${e}`);
           });
         },
+        "im.message.reaction.created_v1": (data: unknown) => {
+          this.logger?.info?.("feishu: ★ im.message.reaction.created_v1 fired");
+          void this._onReactionEvent("created", data as Record<string, unknown>).catch((e: unknown) => {
+            this.logger?.error?.(`feishu: reaction event handler error: ${e}`);
+          });
+        },
+        "im.message.reaction.deleted_v1": (data: unknown) => {
+          this.logger?.info?.("feishu: ★ im.message.reaction.deleted_v1 fired");
+          void this._onReactionEvent("deleted", data as Record<string, unknown>).catch((e: unknown) => {
+            this.logger?.error?.(`feishu: reaction event handler error: ${e}`);
+          });
+        },
       });
 
       const domain =
@@ -191,11 +217,12 @@ export class FeishuChannel implements ChannelAdapter {
 
     const text = extractTextContent(message.content);
     const eventId = message.message_id ?? `stream:${chatId}:${Date.now()}`;
+    const messageId = message.message_id;
 
     if (this.seenEvents.has(eventId)) return;
     this.rememberEvent(eventId);
 
-    await this.processInboundMessage(chatId, text);
+    await this.processInboundMessage(chatId, text, messageId);
   }
 
   async handleWebhook(request: IncomingMessage, response: ServerResponse, body: string): Promise<boolean> {
@@ -223,13 +250,24 @@ export class FeishuChannel implements ChannelAdapter {
     this.rememberEvent(parsed.eventId);
 
     respondJson(response, 200, { ok: true });
-    void this.processInboundMessage(parsed.chatId, parsed.text).catch((e) => {
-      this.logger?.error?.(`feishu: processInboundMessage error: ${e}`);
-    });
+
+    if (parsed.kind === "reaction") {
+      void this._onReactionEvent(parsed.action, {
+        message_id: parsed.messageId,
+        emoji_type: parsed.emojiType,
+        operator_type: parsed.operatorType,
+      }).catch((e) => {
+        this.logger?.error?.(`feishu: reaction event handler error: ${e}`);
+      });
+    } else {
+      void this.processInboundMessage(parsed.chatId, parsed.text, parsed.messageId).catch((e) => {
+        this.logger?.error?.(`feishu: processInboundMessage error: ${e}`);
+      });
+    }
     return true;
   }
 
-  private async processInboundMessage(chatId: string, text: string): Promise<void> {
+  private async processInboundMessage(chatId: string, text: string, messageId?: string): Promise<void> {
     if (!this.gateway) return;
 
     const mapped = this.mapper.resolve({ chatId, text });
@@ -245,6 +283,17 @@ export class FeishuChannel implements ChannelAdapter {
     }
 
     this.activeChats.add(chatId);
+    
+    // 添加 Typing reaction 表示正在处理
+    let processingReactionId: string | undefined;
+    if (messageId) {
+      processingReactionId = await this._addReaction(messageId, FEISHU_REACTION_IN_PROGRESS) ?? undefined;
+      if (processingReactionId) {
+        this._pendingProcessingReactions.set(messageId, processingReactionId);
+      }
+    }
+
+    let success = false;
     try {
       let buffer = "";
       try {
@@ -263,20 +312,32 @@ export class FeishuChannel implements ChannelAdapter {
       const reply = buffer.trim();
       if (reply) {
         await this.send({ chatId, text: reply });
+        success = true;
       }
     } finally {
+      // 移除 Typing reaction
+      if (messageId && processingReactionId) {
+        await this._removeReaction(messageId, processingReactionId);
+        this._pendingProcessingReactions.delete(messageId);
+      }
+
+      // 如果处理失败，添加 CrossMark reaction
+      if (!success && messageId) {
+        await this._addReaction(messageId, FEISHU_REACTION_FAILURE);
+      }
+
       this.activeChats.delete(chatId);
     }
   }
 
-  private async send(message: FeishuOutboundMessage): Promise<void> {
+  private async send(message: FeishuOutboundMessage): Promise<string | undefined> {
     if (this.explicitSend) {
       await this.explicitSend(message);
-      return;
+      return undefined;
     }
     if (!this.appId || !this.appSecret) {
       this.logger?.warn?.("feishu: cannot send — appId/appSecret missing");
-      return;
+      return undefined;
     }
 
     try {
@@ -293,15 +354,26 @@ export class FeishuChannel implements ChannelAdapter {
           content: JSON.stringify({ text: message.text }),
         }),
       });
-      const json = (await res.json().catch(() => ({}))) as { code?: number; msg?: string };
+      const json = (await res.json().catch(() => ({}))) as {
+        code?: number;
+        msg?: string;
+        data?: { message_id?: string };
+      };
       if (!res.ok || (json.code !== undefined && json.code !== 0)) {
         if (json.code === 99991663 || json.code === 99991664) {
           this.tokenCache = undefined;
         }
         this.logger?.error?.(`feishu: send failed code=${json.code} msg=${json.msg}`);
+        return undefined;
       }
+      const sentMessageId = json.data?.message_id;
+      if (sentMessageId) {
+        this._sentMessageIds.set(sentMessageId, message.chatId);
+      }
+      return sentMessageId;
     } catch (e) {
       this.logger?.error?.(`feishu: send threw: ${e}`);
+      return undefined;
     }
   }
 
@@ -389,6 +461,91 @@ export class FeishuChannel implements ChannelAdapter {
       if (first) this.seenEvents.delete(first);
     }
   }
+
+  // ────────────────────────────────────────────────────────────────
+  // Reaction helpers (借鉴 hermes-agent)
+  // ────────────────────────────────────────────────────────────────
+
+  private async _addReaction(messageId: string, emojiType: string): Promise<string | null> {
+    try {
+      const token = await this.getTenantAccessToken();
+      const res = await fetch(MESSAGE_REACTIONS_URL(messageId), {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json; charset=utf-8",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ reaction_type: { emoji_type: emojiType } }),
+      });
+      const json = (await res.json().catch(() => ({}))) as {
+        code?: number;
+        msg?: string;
+        data?: { reaction_id?: string };
+      };
+      if (!res.ok || (json.code !== undefined && json.code !== 0)) {
+        this.logger?.warn?.(
+          `feishu: addReaction(${emojiType}) failed on ${messageId}: code=${json.code} msg=${json.msg}`,
+        );
+        return null;
+      }
+      return json.data?.reaction_id ?? null;
+    } catch (e) {
+      this.logger?.warn?.(`feishu: addReaction(${emojiType}) threw on ${messageId}: ${e}`);
+      return null;
+    }
+  }
+
+  private async _removeReaction(messageId: string, reactionId: string): Promise<boolean> {
+    try {
+      const token = await this.getTenantAccessToken();
+      const res = await fetch(`${MESSAGE_REACTIONS_URL(messageId)}/${reactionId}`, {
+        method: "DELETE",
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      const json = (await res.json().catch(() => ({}))) as { code?: number; msg?: string };
+      if (!res.ok || (json.code !== undefined && json.code !== 0)) {
+        this.logger?.warn?.(
+          `feishu: removeReaction failed on ${messageId}/${reactionId}: code=${json.code} msg=${json.msg}`,
+        );
+        return false;
+      }
+      return true;
+    } catch (e) {
+      this.logger?.warn?.(`feishu: removeReaction threw on ${messageId}/${reactionId}: ${e}`);
+      return false;
+    }
+  }
+
+  /**
+   * 处理收到的 reaction 事件（用户对消息添加/删除表情回应）。
+   * 参考 hermes-agent: 过滤 bot 自身的 reaction，记录用户操作。
+   */
+  private async _onReactionEvent(
+    action: "created" | "deleted",
+    data: Record<string, unknown>,
+  ): Promise<void> {
+    const messageId = data.message_id as string | undefined;
+    const emojiType = (data as { emoji_type?: string; reaction_type?: { emoji_type?: string } }).emoji_type
+      ?? (data as { reaction_type?: { emoji_type?: string } }).reaction_type?.emoji_type;
+    const operatorType = data.operator_type as string | undefined;
+
+    if (!messageId) {
+      this.logger?.warn?.("feishu: reaction event missing message_id");
+      return;
+    }
+
+    // 过滤 bot/app 自身的 reaction（避免循环）
+    if (operatorType === "app" || operatorType === "bot") {
+      return;
+    }
+
+    this.logger?.info?.(
+      `feishu: reaction ${action} on ${messageId}: emoji=${emojiType} by ${operatorType ?? "unknown"}`,
+    );
+
+    // TODO: 未来可以将用户 reaction 路由为合成消息事件，类似 hermes-agent 的
+    // "reaction:added:THUMBSUP" → 进入 agent 处理流程
+  }
 }
 
 function parseDirectShape(raw: Record<string, unknown>): ParsedEvent | undefined {
@@ -405,20 +562,52 @@ function parseDirectShape(raw: Record<string, unknown>): ParsedEvent | undefined
 
 function parseV2Event(raw: Record<string, unknown>): ParsedEvent | undefined {
   const header = raw.header as { event_id?: string; event_type?: string } | undefined;
-  const event = raw.event as
-    | { message?: { chat_id?: string; content?: string; message_type?: string } }
-    | undefined;
+  const event = raw.event as Record<string, unknown> | undefined;
 
-  if (!header?.event_id || !event?.message) return undefined;
+  if (!header?.event_id || !event) return undefined;
+
+  // 处理 reaction 事件
+  if (
+    header.event_type === "im.message.reaction.created_v1" ||
+    header.event_type === "im.message.reaction.deleted_v1"
+  ) {
+    const action = header.event_type === "im.message.reaction.created_v1" ? "created" : "deleted";
+    const reactionEvent = event as {
+      message_id?: string;
+      operator_type?: string;
+      reaction_type?: { emoji_type?: string };
+    };
+    const messageId = reactionEvent.message_id;
+    const emojiType = reactionEvent.reaction_type?.emoji_type;
+    const operatorType = reactionEvent.operator_type;
+
+    if (!messageId) return undefined;
+
+    return {
+      kind: "reaction",
+      eventId: header.event_id,
+      action,
+      messageId,
+      emojiType: emojiType ?? "unknown",
+      operatorType: operatorType ?? "unknown",
+    };
+  }
+
+  // 处理消息事件
   if (header.event_type !== "im.message.receive_v1") return { kind: "ignore" };
-  if (event.message.message_type !== "text") return { kind: "ignore" };
 
-  const chatId = event.message.chat_id;
-  const content = event.message.content;
+  const messageEvent = event as {
+    message?: { chat_id?: string; content?: string; message_type?: string; message_id?: string };
+  };
+  if (!messageEvent.message) return undefined;
+  if (messageEvent.message.message_type !== "text") return { kind: "ignore" };
+
+  const chatId = messageEvent.message.chat_id;
+  const content = messageEvent.message.content;
   if (!chatId || content === undefined) return undefined;
 
   const text = extractTextContent(content);
-  return { kind: "message", eventId: header.event_id, chatId, text };
+  return { kind: "message", eventId: header.event_id, chatId, text, messageId: messageEvent.message.message_id };
 }
 
 function parseV1Event(raw: Record<string, unknown>): ParsedEvent | undefined {


### PR DESCRIPTION
## 概述

为飞书通道添加了 Reaction 支持，用于显示消息处理状态。

## 功能特性

### 1. 处理状态指示
- 收到用户消息后，自动添加 **Typing** reaction 表示正在处理
- 处理完成后自动移除 Typing reaction
- 处理失败时添加 **CrossMark** reaction 表示处理失败

### 2. Reaction 事件订阅
- 订阅 `im.message.reaction.created_v1` 和 `im.message.reaction.deleted_v1` 事件
- 支持通过 Webhook 和 WebSocket 两种方式接收 reaction 事件
- 自动过滤 bot/app 自身的 reaction，避免循环

### 3. 消息 ID 追踪
- `send()` 方法现在返回发送的消息 ID
- 维护 `_sentMessageIds` 映射，用于管理已发送消息的 reaction

## 技术实现

### 新增方法
- `_addReaction(messageId, emojiType)`: 为消息添加 reaction
- `_removeReaction(messageId, reactionId)`: 移除指定 reaction
- `_onReactionEvent(action, data)`: 处理收到的 reaction 事件

### 修改的函数
- `processInboundMessage()`: 添加 Typing reaction 和失败时的 CrossMark reaction
- `send()`: 返回消息 ID
- `parseV2Event()`: 支持解析 reaction 事件类型
- `handleWebhook()`: 处理 reaction 事件的 webhook 回调

### 常量定义
```typescript
const FEISHU_REACTION_IN_PROGRESS = "Typing"
const FEISHU_REACTION_FAILURE = "CrossMark"
```

## 参考来源

借鉴了 [hermes-agent](https://github.com/NousResearch/hermes-agent) 的实现思路。

## 测试

- [x] 收到消息时显示 Typing reaction
- [x] 处理完成后移除 Typing reaction
- [x] 处理失败时显示 CrossMark reaction
- [x] 支持接收用户添加/删除 reaction 的事件

## 截图/演示

（可添加飞书聊天截图展示 reaction 效果）

---

**Breaking Changes**: 无

**依赖更新**: 无
