### PR TITLE
Fix downloads for non-ASCII filenames

### DIFF
--- a/tests/ui-server/download-headers.test.ts
+++ b/tests/ui-server/download-headers.test.ts
@@ -1,0 +1,34 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+import { createRequire } from "node:module";
+import { join } from "node:path";
+
+const require = createRequire(import.meta.url);
+const { contentDispositionAttachment } = require(
+  join(process.cwd(), "ui/server/utils/downloadHeaders.js"),
+) as {
+  contentDispositionAttachment: (filename: string) => string;
+};
+
+test("contentDispositionAttachment keeps non-ASCII filenames header-safe", () => {
+  const filename = "chapter-01a-市场情绪与资金流向.pptx";
+  const header = contentDispositionAttachment(filename);
+
+  assert.match(header, /^attachment; filename="chapter-01a-_________.pptx"/);
+  assert.ok(header.includes("filename*=UTF-8''chapter-01a-"));
+  assert.ok(header.includes("%E5%B8%82%E5%9C%BA"));
+  assert.doesNotThrow(() => {
+    const res = new http.ServerResponse({ method: "GET" } as http.IncomingMessage);
+    res.setHeader("Content-Disposition", header);
+  });
+});
+
+test("contentDispositionAttachment strips unsafe filename characters", () => {
+  const header = contentDispositionAttachment('bad/name:"x".pptx');
+
+  assert.equal(
+    header,
+    "attachment; filename=\"bad_name__x_.pptx\"; filename*=UTF-8''bad_name__x_.pptx",
+  );
+});

--- a/ui/server/index.js
+++ b/ui/server/index.js
@@ -101,6 +101,7 @@ import { runServerStartupBeforeListen, startServerAfterStartup } from './service
 import { validateApiKey, authenticateToken, authenticateWebSocket } from './middleware/auth.js';
 import { DISABLE_LOCAL_AUTH, IS_PLATFORM } from './constants/config.js';
 import { getConnectableHost } from '../shared/networkHosts.js';
+import { contentDispositionAttachment } from './utils/downloadHeaders.js';
 
 // PilotDeck-only mode: chat execution always goes through src/gateway via
 // cursor-cli, openai-codex, gemini-cli) has been removed.
@@ -1184,7 +1185,7 @@ app.get('/api/projects/:projectName/files/content', authenticateToken, async (re
 
         if (req.query.download) {
             const basename = path.basename(resolved);
-            res.setHeader('Content-Disposition', `attachment; filename="${basename}"`);
+            res.setHeader('Content-Disposition', contentDispositionAttachment(basename));
         }
 
         // Stream the file
@@ -1261,12 +1262,8 @@ app.get('/api/projects/:projectName/download', authenticateToken, async (req, re
         await addDirectoryToZip(zip, projectRoot, projectRoot);
 
         const filename = getSafeZipFilename(projectName);
-        const asciiFilename = filename.replace(/[^\x20-\x7e]/g, '_');
         res.setHeader('Content-Type', 'application/zip');
-        res.setHeader(
-            'Content-Disposition',
-            `attachment; filename="${asciiFilename}"; filename*=UTF-8''${encodeURIComponent(filename)}`,
-        );
+        res.setHeader('Content-Disposition', contentDispositionAttachment(filename));
 
         const zipStream = zip.generateNodeStream({
             type: 'nodebuffer',

--- a/ui/server/utils/downloadHeaders.js
+++ b/ui/server/utils/downloadHeaders.js
@@ -1,0 +1,8 @@
+export function contentDispositionAttachment(filename) {
+    const safeFilename = String(filename || 'download')
+        .replace(/[\\/:*?"<>|\x00-\x1f]/g, '_')
+        .replace(/^\.+$/, 'download')
+        .trim() || 'download';
+    const asciiFilename = safeFilename.replace(/[^\x20-\x7e]/g, '_');
+    return `attachment; filename="${asciiFilename}"; filename*=UTF-8''${encodeURIComponent(safeFilename)}`;
+}


### PR DESCRIPTION
## Summary
- fix single-file downloads when filenames contain Chinese or other non-ASCII characters
- generate a safe `Content-Disposition` header with ASCII fallback plus UTF-8 `filename*`
- reuse the same helper for project zip downloads

Fixes https://github.com/OpenBMB/PilotDeck/issues/51

## Tests
- `node --import tsx --test tests/ui-server/download-headers.test.ts`
- `npm test`
