### PR TITLE
fix(settings): clarify model base URL format

### DIFF
--- a/ui/src/components/settings/view/tabs/PilotDeckConfigTab.tsx
+++ b/ui/src/components/settings/view/tabs/PilotDeckConfigTab.tsx
@@ -805,6 +805,9 @@ function ProviderCard({
             monospace
             onChange={(v) => update({ url: v })}
           />
+          <span className="mt-0.5 block text-[10px] text-muted-foreground/70">
+            {t('pilotDeckConfig.panels.models.baseUrlHint')}
+          </span>
           {!provider.url && catalogEntry && (
             <span className="mt-0.5 block text-[10px] text-muted-foreground/70">
               {t('pilotDeckConfig.panels.models.defaultsTo')}{' '}

--- a/ui/src/i18n/locales/en/settings.json
+++ b/ui/src/i18n/locales/en/settings.json
@@ -683,6 +683,7 @@
           "anthropic": "anthropic (messages API)"
         },
         "baseUrl": "Base URL",
+        "baseUrlHint": "For OpenAI-compatible providers, include the /v1 suffix, for example https://api.example.com/v1.",
         "defaultsTo": "Defaults to",
         "fromCatalog": "from catalog.",
         "effective": "Effective:",

--- a/ui/src/i18n/locales/zh-CN/settings.json
+++ b/ui/src/i18n/locales/zh-CN/settings.json
@@ -683,6 +683,7 @@
           "anthropic": "anthropic（消息 API）"
         },
         "baseUrl": "接口地址",
+        "baseUrlHint": "OpenAI 兼容接口请填到 /v1，例如 https://api.example.com/v1。",
         "defaultsTo": "默认使用目录中的",
         "fromCatalog": "。",
         "effective": "实际地址：",


### PR DESCRIPTION
## Summary
- Add a localized hint below the model provider Base URL field reminding users to include the `/v1` suffix for OpenAI-compatible providers.

## Test plan
- `npx tsc -p tsconfig.json --noEmit`
- Parsed English and Chinese settings locale JSON successfully.


Made with [Cursor](https://cursor.com)