### PR TITLE
chore: fix dependabot config — remove non-existent directory

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,6 @@ updates:
     directories:
       - "/"
       - "/ui"
-      - "/apps/desktop"
       - "/src/context/memory/edgeclaw-memory-core"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
Removes `/apps/desktop` from the dependabot npm directories list — this directory does not exist in the repo and causes Dependabot to fail.

Fixes dependabot configuration so automated dependency updates work correctly.