### PR TITLE
fix(onboarding): validate LLM test response shape

### DIFF
--- a/ui/server/routes/config.js
+++ b/ui/server/routes/config.js
@@ -217,6 +217,7 @@ router.post('/test-connection', async (req, res) => {
   // onboarding values ('openai-chat' | 'anthropic') for compatibility.
   const normalizedType = String(providerType || '').toLowerCase();
   const isAnthropic = normalizedType === 'anthropic';
+  const normalizedBaseUrl = String(baseUrl).trim().replace(/\/+$/, '');
   const timeout = 10_000;
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeout);
@@ -226,7 +227,7 @@ router.post('/test-connection', async (req, res) => {
     let fetchOptions;
 
     if (isAnthropic) {
-      url = `${baseUrl.replace(/\/+$/, '')}/v1/messages`;
+      url = `${normalizedBaseUrl}/v1/messages`;
       fetchOptions = {
         method: 'POST',
         headers: {
@@ -242,9 +243,7 @@ router.post('/test-connection', async (req, res) => {
         signal: controller.signal,
       };
     } else {
-      const base = baseUrl.replace(/\/+$/, '');
-      const hasV1 = /\/v1\/?$/i.test(base);
-      url = hasV1 ? `${base}/chat/completions` : `${base}/v1/chat/completions`;
+      url = `${normalizedBaseUrl}/chat/completions`;
       fetchOptions = {
         method: 'POST',
         headers: {
@@ -262,14 +261,35 @@ router.post('/test-connection', async (req, res) => {
 
     const response = await fetch(url, fetchOptions);
     clearTimeout(timer);
+    const responseText = await response.text();
 
     if (response.ok) {
+      let body;
+      try {
+        body = JSON.parse(responseText);
+      } catch {
+        return res.json({
+          ok: false,
+          error: `Expected a JSON completion response but received non-JSON content from ${url}. For OpenAI-compatible endpoints, the base URL usually ends with /v1.`,
+        });
+      }
+
+      const hasCompletionShape = isAnthropic
+        ? Array.isArray(body?.content) || body?.type === 'message'
+        : Array.isArray(body?.choices);
+      if (!hasCompletionShape) {
+        return res.json({
+          ok: false,
+          error: `Endpoint returned HTTP ${response.status}, but the response was not a valid ${isAnthropic ? 'Anthropic message' : 'OpenAI chat completion'}. Check the base URL path.`,
+        });
+      }
+
       return res.json({ ok: true, message: `Connected successfully — Model ${model} is available.` });
     }
 
     let detail = `${response.status} ${response.statusText}`;
     try {
-      const body = await response.json();
+      const body = JSON.parse(responseText);
       if (body?.error?.message) detail = body.error.message;
       else if (body?.error?.type) detail = `${body.error.type}: ${body.error.message || ''}`;
     } catch { /* ignore parse errors */ }

--- a/ui/src/components/onboarding/view/subcomponents/LlmConfigurationStep.tsx
+++ b/ui/src/components/onboarding/view/subcomponents/LlmConfigurationStep.tsx
@@ -332,6 +332,11 @@ export default function LlmConfigurationStep({ onSaved }: LlmConfigurationStepPr
                     autoComplete="off"
                     spellCheck={false}
                   />
+                {customProtocol === 'openai' && (
+                  <p className="mt-1 text-[11px] text-muted-foreground">
+                    OpenAI-compatible base URLs should include the API version path, for example ending in <span className="font-mono">/v1</span>.
+                  </p>
+                )}
                 </div>
               </div>
             </div>
@@ -426,6 +431,11 @@ export default function LlmConfigurationStep({ onSaved }: LlmConfigurationStepPr
                     autoComplete="off"
                     spellCheck={false}
                   />
+                  {(selectedProvider?.protocol ?? customProtocol) === 'openai' && (
+                    <p className="mt-1 text-[11px] text-muted-foreground">
+                      OpenAI-compatible base URLs should include the API version path, for example ending in <span className="font-mono">/v1</span>.
+                    </p>
+                  )}
                 </div>
                 <div className="text-[11px] text-muted-foreground">
                   Protocol: <span className="font-mono">{selectedProvider?.protocol ?? customProtocol}</span> &middot; Default URL: <span className="font-mono">{selectedDefaultUrl}</span>


### PR DESCRIPTION
## Summary
- Stop auto-appending `/v1` for OpenAI-compatible onboarding connection tests.
- Require successful test responses to parse as provider completion JSON, so HTTP 200 HTML pages no longer pass.
- Add onboarding helper text that OpenAI-compatible base URLs usually include `/v1`.

## Test plan
- Manually compared the provided endpoint with and without `/v1`; the non-`/v1` URL returned HTML while `/v1` returned chat completion JSON.
- Ran IDE lints on the edited files; remaining diagnostics are pre-existing `lucide-react` JSX type issues in the onboarding component.


Made with [Cursor](https://cursor.com)