### PR TITLE
feat(docker): add docker-entrypoint.d/ support for user init scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,13 +69,15 @@ COPY --from=builder /build/ui/vite.config.js ui/vite.config.js
 
 # Create PilotDeck state/workspace directories used by the gateway, UI server,
 # permissions, skills/plugins, memory, auth, and router stats.
+# Also create docker-entrypoint.d/ for user-provided init scripts.
 RUN mkdir -p \
     /root/.pilotdeck/projects \
     /root/.pilotdeck/router \
     /root/.pilotdeck/skills \
     /root/.pilotdeck/plugins \
     /root/.pilotdeck/memory \
-    /workspace
+    /workspace \
+    /docker-entrypoint.d
 
 # Entrypoint
 COPY docker-entrypoint.sh /docker-entrypoint.sh

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -146,6 +146,17 @@ echo "[pilotdeck-docker] Starting PilotDeck (gateway + UI server)..."
 echo "[pilotdeck-docker] Config: $CONFIG_FILE"
 echo "[pilotdeck-docker] UI will be available at http://0.0.0.0:${SERVER_PORT:-3001}"
 
+# ── Run user-provided init scripts from /docker-entrypoint.d/ ─────────
+if [ -d /docker-entrypoint.d ]; then
+  for f in $(find /docker-entrypoint.d -maxdepth 1 -type f \( -name '*.sh' -o -perm /u+x,g+x,o+x \) | sort); do
+    if [ -f "$f" ] && [ -r "$f" ]; then
+      echo "[pilotdeck-docker] Running init script: $f"
+      # shellcheck disable=SC1090
+      . "$f"
+    fi
+  done
+fi
+
 # ── Start gateway + UI server via concurrently ────────────────────────
 cd /app
 


### PR DESCRIPTION
Create /docker-entrypoint.d/ directory in the Dockerfile and update docker-entrypoint.sh to scan and execute user-provided init scripts (sorted by filename) before starting the main PilotDeck processes.

This allows users to customize container initialization (e.g. install additional deps, fix mount permissions, generate dynamic keys) by mounting scripts without forking the repository.