### PR TITLE
fix: handle cross-device skill upload imports

### DIFF
--- a/tests/ui-server/skills-import-upload.test.ts
+++ b/tests/ui-server/skills-import-upload.test.ts
@@ -1,0 +1,85 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { createRequire } from "node:module";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+const require = createRequire(import.meta.url);
+const { moveDirectoryAcrossDevicesSafe } = require(
+  join(process.cwd(), "ui/server/utils/fileMoves.js"),
+) as {
+  moveDirectoryAcrossDevicesSafe: (
+    sourceDir: string,
+    targetDir: string,
+    fsImpl?: {
+      rename: (sourceDir: string, targetDir: string) => Promise<void>;
+      cp: (sourceDir: string, targetDir: string, options: unknown) => Promise<void>;
+      rm: (sourceDir: string, options: unknown) => Promise<void>;
+    },
+  ) => Promise<void>;
+};
+
+test("moveDirectoryAcrossDevicesSafe moves a staged skill directory", async () => {
+  const root = await mkdtemp(join(tmpdir(), "pilotdeck-skill-move-"));
+  const sourceDir = join(root, "source");
+  const nestedDir = join(sourceDir, "assets");
+  const targetDir = join(root, "target-skill");
+
+  try {
+    await mkdir(nestedDir, { recursive: true });
+    await writeFile(join(sourceDir, "SKILL.md"), "---\nname: test\n---\n");
+    await writeFile(join(nestedDir, "example.txt"), "asset");
+
+    await moveDirectoryAcrossDevicesSafe(sourceDir, targetDir);
+
+    assert.equal(await readFile(join(targetDir, "SKILL.md"), "utf8"), "---\nname: test\n---\n");
+    assert.equal(await readFile(join(targetDir, "assets", "example.txt"), "utf8"), "asset");
+    await assert.rejects(readFile(join(sourceDir, "SKILL.md"), "utf8"), { code: "ENOENT" });
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("moveDirectoryAcrossDevicesSafe falls back to copy/remove on EXDEV", async () => {
+  const calls: string[] = [];
+  const exdev = Object.assign(new Error("cross-device link not permitted"), { code: "EXDEV" });
+  const fsImpl = {
+    async rename() {
+      calls.push("rename");
+      throw exdev;
+    },
+    async cp(_sourceDir: string, _targetDir: string, options: unknown) {
+      calls.push("cp");
+      assert.deepEqual(options, { recursive: true, force: false, errorOnExist: true });
+    },
+    async rm(_sourceDir: string, options: unknown) {
+      calls.push("rm");
+      assert.deepEqual(options, { recursive: true, force: true });
+    },
+  };
+
+  await moveDirectoryAcrossDevicesSafe("/tmp/skill-upload-x", "/root/.pilotdeck/skills/demo", fsImpl);
+
+  assert.deepEqual(calls, ["rename", "cp", "rm"]);
+});
+
+test("moveDirectoryAcrossDevicesSafe rethrows non-EXDEV rename errors", async () => {
+  const permissionError = Object.assign(new Error("permission denied"), { code: "EACCES" });
+  const fsImpl = {
+    async rename() {
+      throw permissionError;
+    },
+    async cp() {
+      assert.fail("cp should not run for non-EXDEV errors");
+    },
+    async rm() {
+      assert.fail("rm should not run for non-EXDEV errors");
+    },
+  };
+
+  await assert.rejects(
+    moveDirectoryAcrossDevicesSafe("/tmp/skill-upload-x", "/root/.pilotdeck/skills/demo", fsImpl),
+    { code: "EACCES" },
+  );
+});

--- a/ui/server/routes/skills.js
+++ b/ui/server/routes/skills.js
@@ -10,7 +10,7 @@
  * onto a single gateway RPC:
  *
  *   - `/import-upload` — multipart browser folder picker. We stream the
- *     buffers into the project skill dir directly, then ask the gateway
+ *     buffers into a staging dir next to the target skill root, then ask the gateway
  *     to refresh its in-memory caches via a follow-up `skill_validate`
  *     call to compute the validation result. A future revision can lift
  *     this onto a gateway RPC that accepts base64 chunks.
@@ -34,6 +34,7 @@ import { promisify } from 'util';
 import multer from 'multer';
 import { getPilotDeckGateway } from '../pilotdeck-bridge.js';
 import { resolvePilotHome } from '../utils/pilotPaths.js';
+import { moveDirectoryAcrossDevicesSafe } from '../utils/fileMoves.js';
 
 const execFileAsync = promisify(execFile);
 const router = express.Router();
@@ -417,7 +418,8 @@ router.post('/import-upload', upload.array('files', 500), async (req, res) => {
       }
     }
 
-    stagingDir = await fs.mkdtemp(path.join(os.tmpdir(), 'skill-upload-'));
+    await fs.mkdir(root, { recursive: true });
+    stagingDir = await fs.mkdtemp(path.join(root, '.tmp-skill-upload-'));
     for (const m of manifest) {
       const rel =
         stripPrefix && m.relativePath.startsWith(stripPrefix)
@@ -428,9 +430,8 @@ router.post('/import-upload', upload.array('files', 500), async (req, res) => {
       await fs.mkdir(path.dirname(out), { recursive: true });
       await fs.writeFile(out, m.buffer);
     }
-    await fs.mkdir(root, { recursive: true });
     if (exists) await fs.rm(targetDir, { recursive: true, force: true });
-    await fs.rename(stagingDir, targetDir);
+    await moveDirectoryAcrossDevicesSafe(stagingDir, targetDir);
     stagingDir = null;
 
     // Round-trip through the gateway once more so the response shape

--- a/ui/server/utils/fileMoves.js
+++ b/ui/server/utils/fileMoves.js
@@ -1,0 +1,13 @@
+import { promises as fs } from 'fs';
+
+async function moveDirectoryAcrossDevicesSafe(sourceDir, targetDir, fsImpl = fs) {
+  try {
+    await fsImpl.rename(sourceDir, targetDir);
+  } catch (e) {
+    if (e?.code !== 'EXDEV') throw e;
+    await fsImpl.cp(sourceDir, targetDir, { recursive: true, force: false, errorOnExist: true });
+    await fsImpl.rm(sourceDir, { recursive: true, force: true });
+  }
+}
+
+export { moveDirectoryAcrossDevicesSafe };


### PR DESCRIPTION
## Summary\n- stage uploaded skill folders under the target skills root instead of /tmp\n- add an EXDEV fallback that copies then removes the staging directory when rename crosses devices\n- add regression coverage for normal moves, EXDEV fallback, and non-EXDEV errors\n\nFixes #93\n\n## Tests\n- npm test