### PR TITLE
fix(docker): enable cron tools by default in generated config

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -98,6 +98,8 @@ model:
         ${LIGHT_MODEL_ID}:
           capabilities:
             maxOutputTokens: 16384
+cron:
+  enabled: true
 ${ROUTER_SECTION}
 YAML
   else
@@ -126,6 +128,8 @@ model:
         ${LIGHT_MODEL_ID}:
           capabilities:
             maxOutputTokens: 16384
+cron:
+  enabled: true
 ${ROUTER_SECTION}
 YAML
   fi


### PR DESCRIPTION
## Summary

- Docker entrypoint 自动生成的 `pilotdeck.yaml` 中缺失 `cron:` 段，导致 `parseCronConfig(undefined)` 返回 `undefined`，`CronRuntime` 从未创建，`cron_create`/`cron_list`/`cron_delete`/`cron_stop` 四个内置工具不会注册到 agent session
- 在两个 YAML 生成分支（same-provider / cross-provider）中均添加 `cron: { enabled: true }`，使 Docker 部署默认启用 cron 工具，与 `defaultCronConfig()` 的设计意图一致

## Test plan

- [ ] 使用 Docker 构建镜像并启动容器（不挂载自定义 YAML）
- [ ] 验证生成的 `/root/.pilotdeck/pilotdeck.yaml` 包含 `cron: enabled: true`
- [ ] 在 Web UI 中发起对话，确认 agent 可以调用 `cron_create` 工具创建定时任务
- [ ] 验证 `cron_list` 能列出已创建的任务


Made with [Cursor](https://cursor.com)