### PR TITLE
feat(feishu): improve IM channel with project switching, clean replies, and reaction feedback

### DIFF
--- a/scripts/bootstrap-pilotdeck-config.mjs
+++ b/scripts/bootstrap-pilotdeck-config.mjs
@@ -8,8 +8,10 @@
  * Behaviour:
  *   1. Every run: discover repo skills and copy missing slugs into
  *      $PILOT_HOME/skills, skipping existing targets.
- *   2. If $PILOT_HOME/pilotdeck.yaml already exists -> skip config bootstrap.
- *   3. Otherwise write a minimal V2 yaml that:
+ *   2. Every run: if pilotdeck.yaml exists but is missing known sections
+ *      (e.g. adapters), append the default snippet so new features are
+ *      discoverable without requiring users to recreate the config.
+ *   3. If $PILOT_HOME/pilotdeck.yaml does not exist, write a minimal V2 yaml that:
  *        - has a valid agent.model that resolves to a catalog provider/model,
  *          so the engine's parseModelConfig won't crash on startup
  *        - uses a sentinel apiKey ("PLACEHOLDER_RUN_ONBOARDING_TO_REPLACE")
@@ -19,7 +21,7 @@
  * Override the target via $PILOT_HOME (same env var the engine reads).
  * Skip the whole step via $PILOTDECK_SKIP_BOOTSTRAP=1.
  */
-import { cpSync, existsSync, mkdirSync, readdirSync, writeFileSync } from 'node:fs';
+import { appendFileSync, cpSync, existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { basename, dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -46,6 +48,13 @@ model:
         _placeholder:
           capabilities:
             maxOutputTokens: 16384
+adapters:
+  feishu:
+    enabled: false
+    appId: ""
+    appSecret: ""
+    # connectionMode: stream
+    # domainName: feishu
 router:
   enabled: true
   scenarios:
@@ -173,6 +182,49 @@ function syncRepoSkillsToPilotHome(pilotHome) {
   return { created, skippedExisting, skippedDuplicateSlug };
 }
 
+const DEFAULT_ADAPTERS_SNIPPET = `
+adapters:
+  feishu:
+    enabled: false
+    appId: ""
+    appSecret: ""
+    # connectionMode: stream
+    # domainName: feishu
+`;
+
+const PATCH_SECTIONS = [
+  { key: 'adapters', snippet: DEFAULT_ADAPTERS_SNIPPET },
+];
+
+function patchMissingSections(configPath) {
+  let content;
+  try {
+    content = readFileSync(configPath, 'utf8');
+  } catch {
+    return;
+  }
+
+  let patched = false;
+  for (const { key, snippet } of PATCH_SECTIONS) {
+    const pattern = new RegExp(`^${key}\\s*:`, 'm');
+    if (!pattern.test(content)) {
+      try {
+        appendFileSync(configPath, snippet, 'utf8');
+        patched = true;
+        console.log(`[pilotdeck] Appended missing "${key}" section to ${configPath}.`);
+      } catch (error) {
+        console.warn(
+          `[pilotdeck] Could not append "${key}" to ${configPath}: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      }
+    }
+  }
+
+  return patched;
+}
+
 function main() {
   if (process.env.PILOTDECK_SKIP_BOOTSTRAP === '1') {
     return;
@@ -190,6 +242,7 @@ function main() {
   }
 
   if (existsSync(configPath)) {
+    patchMissingSections(configPath);
     return;
   }
 

--- a/src/adapters/channel/feishu/FeishuChannel.ts
+++ b/src/adapters/channel/feishu/FeishuChannel.ts
@@ -3,7 +3,6 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import type { Gateway } from "../../../gateway/index.js";
 import type { ChannelAdapter, ChannelHandle, ChannelLogger, ChannelStartDeps } from "../protocol/ChannelAdapter.js";
 import { FeishuSessionMapper } from "./FeishuSessionMapper.js";
-import { renderFeishuEvent } from "./feishu-render.js";
 
 let Lark: any = null;
 let larkLoadAttempted = false;
@@ -21,6 +20,8 @@ async function loadLarkSdk(): Promise<any> {
 
 const TENANT_TOKEN_URL = "https://open.feishu.cn/open-apis/auth/v3/tenant_access_token/internal";
 const SEND_MESSAGE_URL = "https://open.feishu.cn/open-apis/im/v1/messages?receive_id_type=chat_id";
+const REACTION_URL = "https://open.feishu.cn/open-apis/im/v1/messages";
+const PROCESSING_EMOJI = "OnIt";
 const TOKEN_REFRESH_BUFFER_MS = 5 * 60 * 1000;
 const SEEN_EVENTS_MAX = 2000;
 
@@ -55,7 +56,7 @@ export type FeishuChannelOptions = {
 
 type ParsedEvent =
   | { kind: "url_verification"; challenge: string }
-  | { kind: "message"; eventId: string; chatId: string; text: string }
+  | { kind: "message"; eventId: string; chatId: string; text: string; messageId?: string }
   | { kind: "ignore" };
 
 export class FeishuChannel implements ChannelAdapter {
@@ -190,12 +191,13 @@ export class FeishuChannel implements ChannelAdapter {
     if (!chatId || message.content === undefined) return;
 
     const text = extractTextContent(message.content);
-    const eventId = message.message_id ?? `stream:${chatId}:${Date.now()}`;
+    const messageId = message.message_id;
+    const eventId = messageId ?? `stream:${chatId}:${Date.now()}`;
 
     if (this.seenEvents.has(eventId)) return;
     this.rememberEvent(eventId);
 
-    await this.processInboundMessage(chatId, text);
+    await this.processInboundMessage(chatId, text, messageId);
   }
 
   async handleWebhook(request: IncomingMessage, response: ServerResponse, body: string): Promise<boolean> {
@@ -223,20 +225,32 @@ export class FeishuChannel implements ChannelAdapter {
     this.rememberEvent(parsed.eventId);
 
     respondJson(response, 200, { ok: true });
-    void this.processInboundMessage(parsed.chatId, parsed.text).catch((e) => {
+    void this.processInboundMessage(parsed.chatId, parsed.text, parsed.messageId).catch((e) => {
       this.logger?.error?.(`feishu: processInboundMessage error: ${e}`);
     });
     return true;
   }
 
-  private async processInboundMessage(chatId: string, text: string): Promise<void> {
+  private async processInboundMessage(chatId: string, text: string, messageId?: string): Promise<void> {
     if (!this.gateway) return;
 
     const mapped = this.mapper.resolve({ chatId, text });
+
     if (mapped.command === "new" && !mapped.message) {
       await this.send({ chatId, text: "已创建新会话。" });
       return;
     }
+
+    if (mapped.command === "projects") {
+      await this.handleListProjects(chatId);
+      return;
+    }
+
+    if (mapped.command === "switch-project") {
+      await this.handleSwitchProject(chatId, mapped.commandArg);
+      return;
+    }
+
     if (!mapped.message) return;
 
     if (this.activeChats.has(chatId)) {
@@ -244,28 +258,114 @@ export class FeishuChannel implements ChannelAdapter {
       return;
     }
 
+    const reactionId = messageId ? await this.addReaction(messageId) : undefined;
+
     this.activeChats.add(chatId);
     try {
-      let buffer = "";
+      let lastTextSegment = "";
+      let errorMessages = "";
+      let inToolCall = false;
       try {
         for await (const event of this.gateway.submitTurn({
           sessionKey: mapped.sessionKey,
           channelKey: "feishu",
           message: mapped.message,
+          ...(mapped.projectKey ? { projectKey: mapped.projectKey } : {}),
         })) {
-          buffer += renderFeishuEvent(event) ?? "";
+          switch (event.type) {
+            case "assistant_text_delta":
+              if (!inToolCall) lastTextSegment += event.text;
+              break;
+            case "tool_call_started":
+              inToolCall = true;
+              lastTextSegment = "";
+              break;
+            case "tool_call_finished":
+              inToolCall = false;
+              if (!event.ok) {
+                const name = event.toolName ?? event.toolCallId;
+                errorMessages += `⚠️ ${name} 执行失败\n`;
+              }
+              break;
+            case "error":
+              errorMessages += `❌ ${event.message}\n`;
+              break;
+          }
         }
       } catch (e) {
         this.logger?.error?.(`feishu: submitTurn error: ${e}`);
-        buffer = "处理消息时发生错误，请重试。";
+        lastTextSegment = "处理消息时发生错误，请重试。";
       }
 
-      const reply = buffer.trim();
+      const reply = (lastTextSegment.trim() || errorMessages.trim());
       if (reply) {
         await this.send({ chatId, text: reply });
       }
     } finally {
+      if (reactionId && messageId) {
+        await this.removeReaction(messageId, reactionId);
+      }
       this.activeChats.delete(chatId);
+    }
+  }
+
+  private async handleListProjects(chatId: string): Promise<void> {
+    if (!this.gateway) return;
+    try {
+      const result = await this.gateway.listProjects();
+      const projects = result.projects;
+      if (projects.length === 0) {
+        await this.send({ chatId, text: "暂无项目。使用 Web UI 创建 WorkSpace 后即可在此切换。" });
+        return;
+      }
+
+      const currentProject = this.mapper.getProject(chatId);
+      const lines = ["📂 项目列表：", ""];
+      for (const p of projects) {
+        const marker = currentProject === p.projectKey ? " ✅" : "";
+        lines.push(`• ${p.name}${marker}`);
+      }
+      lines.push("", '发送 /switch-project <项目名> 切换 WorkSpace');
+      await this.send({ chatId, text: lines.join("\n") });
+    } catch (e) {
+      this.logger?.error?.(`feishu: listProjects error: ${e}`);
+      await this.send({ chatId, text: "获取项目列表失败，请重试。" });
+    }
+  }
+
+  private async handleSwitchProject(chatId: string, projectName?: string): Promise<void> {
+    if (!this.gateway) return;
+
+    if (!projectName) {
+      await this.send({ chatId, text: "用法：/switch-project <项目名>\n\n发送 /projects 查看可用项目。" });
+      return;
+    }
+
+    try {
+      const result = await this.gateway.listProjects();
+      const lower = projectName.toLowerCase();
+      const target =
+        result.projects.find((p) => p.name === projectName) ??
+        result.projects.find((p) => p.name.toLowerCase() === lower) ??
+        result.projects.find((p) => p.name.toLowerCase().includes(lower));
+
+      if (!target) {
+        await this.send({
+          chatId,
+          text: `未找到匹配「${projectName}」的项目。\n\n发送 /projects 查看可用项目。`,
+        });
+        return;
+      }
+
+      this.mapper.bindProject(chatId, target.projectKey);
+      const sessionKey = `feishu:chat=${chatId}:s_${Date.now().toString(36)}`;
+      await this.send({
+        chatId,
+        text: `已切换到项目：${target.name}\n路径：${target.fullPath}`,
+      });
+    } catch (e) {
+      this.logger?.error?.(`feishu: switchProject error: ${e}`);
+      await this.send({ chatId, text: "切换项目失败，请重试。" });
     }
   }
 
@@ -302,6 +402,45 @@ export class FeishuChannel implements ChannelAdapter {
       }
     } catch (e) {
       this.logger?.error?.(`feishu: send threw: ${e}`);
+    }
+  }
+
+  private async addReaction(messageId: string): Promise<string | undefined> {
+    if (!this.appId || !this.appSecret) return undefined;
+    try {
+      const token = await this.getTenantAccessToken();
+      const res = await fetch(`${REACTION_URL}/${messageId}/reactions`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json; charset=utf-8",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ reaction_type: { emoji_type: PROCESSING_EMOJI } }),
+      });
+      const json = (await res.json().catch(() => ({}))) as {
+        code?: number;
+        data?: { reaction_id?: string };
+      };
+      if (json.code === 0 && json.data?.reaction_id) {
+        return json.data.reaction_id;
+      }
+      this.logger?.info?.(`feishu: addReaction non-zero code=${json.code}`);
+    } catch (e) {
+      this.logger?.info?.(`feishu: addReaction failed: ${e}`);
+    }
+    return undefined;
+  }
+
+  private async removeReaction(messageId: string, reactionId: string): Promise<void> {
+    if (!this.appId || !this.appSecret) return;
+    try {
+      const token = await this.getTenantAccessToken();
+      await fetch(`${REACTION_URL}/${messageId}/reactions/${reactionId}`, {
+        method: "DELETE",
+        headers: { Authorization: `Bearer ${token}` },
+      });
+    } catch (e) {
+      this.logger?.info?.(`feishu: removeReaction failed: ${e}`);
     }
   }
 
@@ -406,7 +545,7 @@ function parseDirectShape(raw: Record<string, unknown>): ParsedEvent | undefined
 function parseV2Event(raw: Record<string, unknown>): ParsedEvent | undefined {
   const header = raw.header as { event_id?: string; event_type?: string } | undefined;
   const event = raw.event as
-    | { message?: { chat_id?: string; content?: string; message_type?: string } }
+    | { message?: { chat_id?: string; content?: string; message_type?: string; message_id?: string } }
     | undefined;
 
   if (!header?.event_id || !event?.message) return undefined;
@@ -418,7 +557,7 @@ function parseV2Event(raw: Record<string, unknown>): ParsedEvent | undefined {
   if (!chatId || content === undefined) return undefined;
 
   const text = extractTextContent(content);
-  return { kind: "message", eventId: header.event_id, chatId, text };
+  return { kind: "message", eventId: header.event_id, chatId, text, messageId: event.message.message_id };
 }
 
 function parseV1Event(raw: Record<string, unknown>): ParsedEvent | undefined {

--- a/src/adapters/channel/feishu/FeishuSessionMapper.ts
+++ b/src/adapters/channel/feishu/FeishuSessionMapper.ts
@@ -2,33 +2,81 @@ import { randomUUID } from "node:crypto";
 
 export type FeishuSessionMapperState = {
   activeByChatId: Record<string, string>;
+  projectByChatId: Record<string, string>;
+};
+
+export type FeishuResolveResult = {
+  sessionKey: string;
+  projectKey?: string;
+  command?: "new" | "projects" | "switch-project";
+  /** For /switch-project: the requested project name. */
+  commandArg?: string;
+  message: string;
 };
 
 export class FeishuSessionMapper {
   constructor(
-    private readonly state: FeishuSessionMapperState = { activeByChatId: {} },
+    private readonly state: FeishuSessionMapperState = { activeByChatId: {}, projectByChatId: {} },
     private readonly uuid: () => string = randomUUID,
   ) {}
 
-  resolve(input: { chatId: string; text: string }): { sessionKey: string; command?: "new"; message: string } {
+  resolve(input: { chatId: string; text: string }): FeishuResolveResult {
     const trimmed = input.text.trim();
+
     if (trimmed === "/new" || trimmed.startsWith("/new ")) {
       const sessionKey = `feishu:chat=${input.chatId}:s_${this.uuid()}`;
       this.state.activeByChatId[input.chatId] = sessionKey;
       return {
         sessionKey,
+        projectKey: this.state.projectByChatId[input.chatId],
         command: "new",
         message: trimmed.slice("/new".length).trim(),
       };
     }
 
+    if (trimmed === "/projects") {
+      return {
+        sessionKey: this.currentSessionKey(input.chatId),
+        projectKey: this.state.projectByChatId[input.chatId],
+        command: "projects",
+        message: "",
+      };
+    }
+
+    if (trimmed === "/switch-project" || trimmed.startsWith("/switch-project ")) {
+      const arg = trimmed.slice("/switch-project".length).trim();
+      return {
+        sessionKey: this.currentSessionKey(input.chatId),
+        projectKey: this.state.projectByChatId[input.chatId],
+        command: "switch-project",
+        commandArg: arg || undefined,
+        message: "",
+      };
+    }
+
     return {
-      sessionKey: this.state.activeByChatId[input.chatId] ?? `feishu:chat=${input.chatId}:general`,
+      sessionKey: this.currentSessionKey(input.chatId),
+      projectKey: this.state.projectByChatId[input.chatId],
       message: trimmed,
     };
   }
 
+  bindProject(chatId: string, projectKey: string): void {
+    this.state.projectByChatId[chatId] = projectKey;
+  }
+
+  getProject(chatId: string): string | undefined {
+    return this.state.projectByChatId[chatId];
+  }
+
+  private currentSessionKey(chatId: string): string {
+    return this.state.activeByChatId[chatId] ?? `feishu:chat=${chatId}:general`;
+  }
+
   snapshot(): FeishuSessionMapperState {
-    return { activeByChatId: { ...this.state.activeByChatId } };
+    return {
+      activeByChatId: { ...this.state.activeByChatId },
+      projectByChatId: { ...this.state.projectByChatId },
+    };
   }
 }

--- a/src/adapters/channel/feishu/feishu-render.ts
+++ b/src/adapters/channel/feishu/feishu-render.ts
@@ -7,11 +7,15 @@ export function renderFeishuEvent(event: GatewayEvent): string | undefined {
     case "assistant_thinking_delta":
       return "";
     case "tool_call_started":
-      return `\n[${event.name} running]\n`;
+      return "";
     case "tool_call_finished":
-      return `\n[${event.toolCallId} ${event.ok ? "done" : "failed"}]\n`;
+      if (!event.ok) {
+        const name = event.toolName ?? event.toolCallId;
+        return `\n⚠️ ${name} 执行失败\n`;
+      }
+      return "";
     case "error":
-      return `\n错误：${event.message}\n`;
+      return `\n❌ ${event.message}\n`;
     default:
       return undefined;
   }


### PR DESCRIPTION
## Summary

- **飞书 /projects & /switch-project 命令**：在 FeishuChannel 层拦截，调用 `gateway.listProjects()` 实现项目列表和切换，不再依赖 Web UI 独有的 commands.js 路径
- **干净回复**：只发送 agent 最终回复文本，过滤掉所有 `[tool_call running/done]` 中间事件，解决飞书收到大量乱码的问题
- **表情反馈**：收到消息后立即给用户消息加 "OnIt" emoji reaction 表示处理中，回复完成后自动删除
- **projectKey 透传**：FeishuSessionMapper 新增 `projectByChatId` 状态，`submitTurn` 现在会携带 `projectKey`，让 agent 在正确的 workspace 中工作
- **Bootstrap 自动补 adapters**：`bootstrap-pilotdeck-config.mjs` 不再仅在配置文件不存在时生成，还会检测已有配置缺失 `adapters` 段并自动追加

## Changed files

| File | Change |
|------|--------|
| `src/adapters/channel/feishu/FeishuChannel.ts` | /projects, /switch-project handlers; reaction lifecycle; clean reply buffering; projectKey passthrough |
| `src/adapters/channel/feishu/FeishuSessionMapper.ts` | New command types, projectKey binding, resolve result type |
| `src/adapters/channel/feishu/feishu-render.ts` | Suppress tool_call events, only surface errors |
| `scripts/bootstrap-pilotdeck-config.mjs` | patchMissingSections() for existing configs; adapters in bootstrap template |

## Test plan

- [ ] 飞书发送普通消息 → 收到干净的纯文本回复，无 `[xxx running/done]`
- [ ] 飞书发送 `/projects` → 收到项目列表
- [ ] 飞书发送 `/switch-project <name>` → 切换成功，后续消息在目标 workspace 中执行
- [ ] 飞书发送消息后 → 消息上出现 "OnIt" 表情，回复后表情消失
- [ ] 删除 `~/.pilotdeck/pilotdeck.yaml` 中 adapters 段 → `npm run dev` 后自动补回
- [ ] TypeScript 编译通过 (`npx tsc --noEmit`)


Made with [Cursor](https://cursor.com)