### PR TITLE
feat(bootstrap): auto-patch cron section into existing pilotdeck.yaml

### DIFF
--- a/scripts/bootstrap-pilotdeck-config.mjs
+++ b/scripts/bootstrap-pilotdeck-config.mjs
@@ -102,6 +102,10 @@ router:
     subagentMaxTokens: 48000
   stats:
     enabled: true
+cron:
+  enabled: true
+  timezone: Asia/Shanghai
+  maxConcurrentRuns: 2
 `;
 
 function resolvePilotHome() {
@@ -192,8 +196,16 @@ adapters:
     # domainName: feishu
 `;
 
+const DEFAULT_CRON_SNIPPET = `
+cron:
+  enabled: true
+  timezone: Asia/Shanghai
+  maxConcurrentRuns: 2
+`;
+
 const PATCH_SECTIONS = [
   { key: 'adapters', snippet: DEFAULT_ADAPTERS_SNIPPET },
+  { key: 'cron', snippet: DEFAULT_CRON_SNIPPET },
 ];
 
 function patchMissingSections(configPath) {


### PR DESCRIPTION
## Summary

- Bootstrap 脚本在启动时自动检测已有的 `pilotdeck.yaml`，如果缺少 `cron` 段则自动追加默认配置
- 新用户的模板也包含 `cron` 默认段
- 复用 #100 中引入的 `patchMissingSections` 机制，逻辑一致

## Default cron config

```yaml
cron:
  enabled: true
  timezone: Asia/Shanghai
  maxConcurrentRuns: 2
```

## Test plan

- [ ] 删除 `pilotdeck.yaml` 中 `cron` 段 → `npm run dev` 后自动补回
- [ ] 删除整个 `pilotdeck.yaml` → 重新生成的模板包含 `cron` 段


Made with [Cursor](https://cursor.com)