### PR TITLE
fix(channels): suppress tool_call noise in all IM channel replies

### DIFF
--- a/src/adapters/channel/bluebubbles/bluebubbles-render.ts
+++ b/src/adapters/channel/bluebubbles/bluebubbles-render.ts
@@ -7,11 +7,15 @@ export function renderBlueBubblesEvent(event: GatewayEvent): string | undefined 
     case "assistant_thinking_delta":
       return "";
     case "tool_call_started":
-      return `\n[${event.name} running]\n`;
+      return "";
     case "tool_call_finished":
-      return `\n[${event.toolName ?? event.toolCallId} ${event.ok ? "done" : "failed"}]\n`;
+      if (!event.ok) {
+        const name = event.toolName ?? event.toolCallId;
+        return `\n⚠️ ${name} failed\n`;
+      }
+      return "";
     case "error":
-      return `\nError: ${event.message}\n`;
+      return `\n❌ ${event.message}\n`;
     default:
       return undefined;
   }

--- a/src/adapters/channel/dingtalk/dingtalk-render.ts
+++ b/src/adapters/channel/dingtalk/dingtalk-render.ts
@@ -7,11 +7,15 @@ export function renderDingTalkEvent(event: GatewayEvent): string | undefined {
     case "assistant_thinking_delta":
       return "";
     case "tool_call_started":
-      return `\n[${event.name} running]\n`;
+      return "";
     case "tool_call_finished":
-      return `\n[${event.toolName ?? event.toolCallId} ${event.ok ? "done" : "failed"}]\n`;
+      if (!event.ok) {
+        const name = event.toolName ?? event.toolCallId;
+        return `\n⚠️ ${name} 执行失败\n`;
+      }
+      return "";
     case "error":
-      return `\nError: ${event.message}\n`;
+      return `\n❌ ${event.message}\n`;
     default:
       return undefined;
   }

--- a/src/adapters/channel/discord/discord-render.ts
+++ b/src/adapters/channel/discord/discord-render.ts
@@ -7,11 +7,15 @@ export function renderDiscordEvent(event: GatewayEvent): string | undefined {
     case "assistant_thinking_delta":
       return "";
     case "tool_call_started":
-      return `\n[${event.name} running]\n`;
+      return "";
     case "tool_call_finished":
-      return `\n[${event.toolName ?? event.toolCallId} ${event.ok ? "done" : "failed"}]\n`;
+      if (!event.ok) {
+        const name = event.toolName ?? event.toolCallId;
+        return `\n⚠️ ${name} failed\n`;
+      }
+      return "";
     case "error":
-      return `\nError: ${event.message}\n`;
+      return `\n❌ ${event.message}\n`;
     default:
       return undefined;
   }

--- a/src/adapters/channel/email/email-render.ts
+++ b/src/adapters/channel/email/email-render.ts
@@ -7,11 +7,15 @@ export function renderEmailEvent(event: GatewayEvent): string | undefined {
     case "assistant_thinking_delta":
       return "";
     case "tool_call_started":
-      return `\n[${event.name} running]\n`;
+      return "";
     case "tool_call_finished":
-      return `\n[${event.toolName ?? event.toolCallId} ${event.ok ? "done" : "failed"}]\n`;
+      if (!event.ok) {
+        const name = event.toolName ?? event.toolCallId;
+        return `\n⚠️ ${name} failed\n`;
+      }
+      return "";
     case "error":
-      return `\nError: ${event.message}\n`;
+      return `\n❌ ${event.message}\n`;
     default:
       return undefined;
   }

--- a/src/adapters/channel/homeassistant/homeassistant-render.ts
+++ b/src/adapters/channel/homeassistant/homeassistant-render.ts
@@ -7,11 +7,15 @@ export function renderHomeAssistantEvent(event: GatewayEvent): string | undefine
     case "assistant_thinking_delta":
       return "";
     case "tool_call_started":
-      return `\n[${event.name} running]\n`;
+      return "";
     case "tool_call_finished":
-      return `\n[${event.toolName ?? event.toolCallId} ${event.ok ? "done" : "failed"}]\n`;
+      if (!event.ok) {
+        const name = event.toolName ?? event.toolCallId;
+        return `\n⚠️ ${name} failed\n`;
+      }
+      return "";
     case "error":
-      return `\nError: ${event.message}\n`;
+      return `\n❌ ${event.message}\n`;
     default:
       return undefined;
   }

--- a/src/adapters/channel/matrix/matrix-render.ts
+++ b/src/adapters/channel/matrix/matrix-render.ts
@@ -7,11 +7,15 @@ export function renderMatrixEvent(event: GatewayEvent): string | undefined {
     case "assistant_thinking_delta":
       return "";
     case "tool_call_started":
-      return `\n[${event.name} running]\n`;
+      return "";
     case "tool_call_finished":
-      return `\n[${event.toolName ?? event.toolCallId} ${event.ok ? "done" : "failed"}]\n`;
+      if (!event.ok) {
+        const name = event.toolName ?? event.toolCallId;
+        return `\n⚠️ ${name} failed\n`;
+      }
+      return "";
     case "error":
-      return `\nError: ${event.message}\n`;
+      return `\n❌ ${event.message}\n`;
     default:
       return undefined;
   }

--- a/src/adapters/channel/mattermost/mattermost-render.ts
+++ b/src/adapters/channel/mattermost/mattermost-render.ts
@@ -7,11 +7,15 @@ export function renderMattermostEvent(event: GatewayEvent): string | undefined {
     case "assistant_thinking_delta":
       return "";
     case "tool_call_started":
-      return `\n[${event.name} running]\n`;
+      return "";
     case "tool_call_finished":
-      return `\n[${event.toolName ?? event.toolCallId} ${event.ok ? "done" : "failed"}]\n`;
+      if (!event.ok) {
+        const name = event.toolName ?? event.toolCallId;
+        return `\n⚠️ ${name} failed\n`;
+      }
+      return "";
     case "error":
-      return `\nError: ${event.message}\n`;
+      return `\n❌ ${event.message}\n`;
     default:
       return undefined;
   }

--- a/src/adapters/channel/qq/qq-render.ts
+++ b/src/adapters/channel/qq/qq-render.ts
@@ -7,11 +7,15 @@ export function renderQQEvent(event: GatewayEvent): string | undefined {
     case "assistant_thinking_delta":
       return "";
     case "tool_call_started":
-      return `\n[${event.name} running]\n`;
+      return "";
     case "tool_call_finished":
-      return `\n[${event.toolName ?? event.toolCallId} ${event.ok ? "done" : "failed"}]\n`;
+      if (!event.ok) {
+        const name = event.toolName ?? event.toolCallId;
+        return `\n⚠️ ${name} 执行失败\n`;
+      }
+      return "";
     case "error":
-      return `\n错误：${event.message}\n`;
+      return `\n❌ ${event.message}\n`;
     default:
       return undefined;
   }

--- a/src/adapters/channel/signal/signal-render.ts
+++ b/src/adapters/channel/signal/signal-render.ts
@@ -7,11 +7,15 @@ export function renderSignalEvent(event: GatewayEvent): string | undefined {
     case "assistant_thinking_delta":
       return "";
     case "tool_call_started":
-      return `\n[${event.name} running]\n`;
+      return "";
     case "tool_call_finished":
-      return `\n[${event.toolName ?? event.toolCallId} ${event.ok ? "done" : "failed"}]\n`;
+      if (!event.ok) {
+        const name = event.toolName ?? event.toolCallId;
+        return `\n⚠️ ${name} failed\n`;
+      }
+      return "";
     case "error":
-      return `\nError: ${event.message}\n`;
+      return `\n❌ ${event.message}\n`;
     default:
       return undefined;
   }

--- a/src/adapters/channel/slack/slack-render.ts
+++ b/src/adapters/channel/slack/slack-render.ts
@@ -7,11 +7,15 @@ export function renderSlackEvent(event: GatewayEvent): string | undefined {
     case "assistant_thinking_delta":
       return "";
     case "tool_call_started":
-      return `\n[${event.name} running]\n`;
+      return "";
     case "tool_call_finished":
-      return `\n[${event.toolName ?? event.toolCallId} ${event.ok ? "done" : "failed"}]\n`;
+      if (!event.ok) {
+        const name = event.toolName ?? event.toolCallId;
+        return `\n⚠️ ${name} failed\n`;
+      }
+      return "";
     case "error":
-      return `\nError: ${event.message}\n`;
+      return `\n❌ ${event.message}\n`;
     default:
       return undefined;
   }

--- a/src/adapters/channel/sms/sms-render.ts
+++ b/src/adapters/channel/sms/sms-render.ts
@@ -7,11 +7,15 @@ export function renderSmsEvent(event: GatewayEvent): string | undefined {
     case "assistant_thinking_delta":
       return "";
     case "tool_call_started":
-      return `\n[${event.name} running]\n`;
+      return "";
     case "tool_call_finished":
-      return `\n[${event.toolName ?? event.toolCallId} ${event.ok ? "done" : "failed"}]\n`;
+      if (!event.ok) {
+        const name = event.toolName ?? event.toolCallId;
+        return `\n⚠️ ${name} failed\n`;
+      }
+      return "";
     case "error":
-      return `\nError: ${event.message}\n`;
+      return `\n❌ ${event.message}\n`;
     default:
       return undefined;
   }

--- a/src/adapters/channel/telegram/telegram-render.ts
+++ b/src/adapters/channel/telegram/telegram-render.ts
@@ -7,11 +7,15 @@ export function renderTelegramEvent(event: GatewayEvent): string | undefined {
     case "assistant_thinking_delta":
       return "";
     case "tool_call_started":
-      return `\n[${event.name} running]\n`;
+      return "";
     case "tool_call_finished":
-      return `\n[${event.toolName ?? event.toolCallId} ${event.ok ? "done" : "failed"}]\n`;
+      if (!event.ok) {
+        const name = event.toolName ?? event.toolCallId;
+        return `\n⚠️ ${name} failed\n`;
+      }
+      return "";
     case "error":
-      return `\nError: ${event.message}\n`;
+      return `\n❌ ${event.message}\n`;
     default:
       return undefined;
   }

--- a/src/adapters/channel/wecom-callback/wecom-callback-render.ts
+++ b/src/adapters/channel/wecom-callback/wecom-callback-render.ts
@@ -7,11 +7,15 @@ export function renderWeComCallbackEvent(event: GatewayEvent): string | undefine
     case "assistant_thinking_delta":
       return "";
     case "tool_call_started":
-      return `\n[${event.name} running]\n`;
+      return "";
     case "tool_call_finished":
-      return `\n[${event.toolName ?? event.toolCallId} ${event.ok ? "done" : "failed"}]\n`;
+      if (!event.ok) {
+        const name = event.toolName ?? event.toolCallId;
+        return `\n⚠️ ${name} failed\n`;
+      }
+      return "";
     case "error":
-      return `\nError: ${event.message}\n`;
+      return `\n❌ ${event.message}\n`;
     default:
       return undefined;
   }

--- a/src/adapters/channel/wecom/wecom-render.ts
+++ b/src/adapters/channel/wecom/wecom-render.ts
@@ -7,11 +7,15 @@ export function renderWeComEvent(event: GatewayEvent): string | undefined {
     case "assistant_thinking_delta":
       return "";
     case "tool_call_started":
-      return `\n[${event.name} running]\n`;
+      return "";
     case "tool_call_finished":
-      return `\n[${event.toolName ?? event.toolCallId} ${event.ok ? "done" : "failed"}]\n`;
+      if (!event.ok) {
+        const name = event.toolName ?? event.toolCallId;
+        return `\n⚠️ ${name} failed\n`;
+      }
+      return "";
     case "error":
-      return `\nError: ${event.message}\n`;
+      return `\n❌ ${event.message}\n`;
     default:
       return undefined;
   }

--- a/src/adapters/channel/weixin/weixin-render.ts
+++ b/src/adapters/channel/weixin/weixin-render.ts
@@ -7,11 +7,15 @@ export function renderWeixinEvent(event: GatewayEvent): string | undefined {
     case "assistant_thinking_delta":
       return "";
     case "tool_call_started":
-      return `\n[${event.name} running]\n`;
+      return "";
     case "tool_call_finished":
-      return `\n[${event.toolName ?? event.toolCallId} ${event.ok ? "done" : "failed"}]\n`;
+      if (!event.ok) {
+        const name = event.toolName ?? event.toolCallId;
+        return `\n⚠️ ${name} 执行失败\n`;
+      }
+      return "";
     case "error":
-      return `\n错误：${event.message}\n`;
+      return `\n❌ ${event.message}\n`;
     default:
       return undefined;
   }

--- a/src/adapters/channel/whatsapp/whatsapp-render.ts
+++ b/src/adapters/channel/whatsapp/whatsapp-render.ts
@@ -7,11 +7,15 @@ export function renderWhatsAppEvent(event: GatewayEvent): string | undefined {
     case "assistant_thinking_delta":
       return "";
     case "tool_call_started":
-      return `\n[${event.name} running]\n`;
+      return "";
     case "tool_call_finished":
-      return `\n[${event.toolName ?? event.toolCallId} ${event.ok ? "done" : "failed"}]\n`;
+      if (!event.ok) {
+        const name = event.toolName ?? event.toolCallId;
+        return `\n⚠️ ${name} failed\n`;
+      }
+      return "";
     case "error":
-      return `\nError: ${event.message}\n`;
+      return `\n❌ ${event.message}\n`;
     default:
       return undefined;
   }


### PR DESCRIPTION
## Summary

All IM channel render functions were dumping `[tool_name running]` / `[tool_call_id done]` events into user-facing replies, producing garbled output. This PR fixes all 16 remaining channels (Feishu was fixed in #100).

**Before:** users see `[bash running]\n[call_00_xxx done]\n[bash running]\n...` interleaved with the actual answer.

**After:** only the final assistant text and error summaries are sent.

## Commits (by channel group)

1. **weixin, qq, dingtalk** — Chinese IM channels
2. **wecom, wecom-callback** — WeCom channels
3. **telegram, discord, slack** — major international platforms
4. **whatsapp, signal, matrix, mattermost, bluebubbles** — messaging protocols
5. **email, sms, homeassistant** — utility channels

## Change pattern (identical across all files)

```diff
- case "tool_call_started":
-   return `\n[${event.name} running]\n`;
- case "tool_call_finished":
-   return `\n[${event.toolName ?? event.toolCallId} ${event.ok ? "done" : "failed"}]\n`;
+ case "tool_call_started":
+   return "";
+ case "tool_call_finished":
+   if (!event.ok) {
+     const name = event.toolName ?? event.toolCallId;
+     return `\n⚠️ ${name} failed\n`;
+   }
+   return "";
```

## Test plan

- [ ] Verify clean output on any IM channel (no `[xxx running/done]` in replies)
- [ ] Verify tool failures still surface as `⚠️ tool_name failed`
- [ ] `npx tsc --noEmit` (note: pre-existing error in `src/telemetry/sender.ts` from upstream, unrelated)


Made with [Cursor](https://cursor.com)