### PR TITLE
feat(channels): add elicitation (ask_user_question) support to all IM channels

### DIFF
--- a/src/adapters/channel/bluebubbles/BlueBubblesChannel.ts
+++ b/src/adapters/channel/bluebubbles/BlueBubblesChannel.ts
@@ -4,6 +4,7 @@ import type { Gateway, GatewayChannelKey } from "../../../gateway/index.js";
 import type { ChannelAdapter, ChannelHandle, ChannelLogger, ChannelStartDeps } from "../protocol/ChannelAdapter.js";
 import { BlueBubblesSessionMapper } from "./BlueBubblesSessionMapper.js";
 import { renderBlueBubblesEvent } from "./bluebubbles-render.js";
+import { ImElicitationHelper } from "../protocol/ImElicitationHelper.js";
 
 const POLL_MS = 2500;
 const MESSAGE_LIMIT = 50;
@@ -41,6 +42,7 @@ export class BlueBubblesChannel implements ChannelAdapter {
   private lastTimestamp = 0;
   private seenGuids = new Set<string>();
   private activeChats = new Set<string>();
+  private readonly elicitation = new ImElicitationHelper();
   private running = false;
 
   constructor(options: BlueBubblesChannelOptions = {}) {
@@ -137,6 +139,16 @@ export class BlueBubblesChannel implements ChannelAdapter {
     );
     if (!chatGuid || !text) return;
 
+    if (this.elicitation.hasPending(chatGuid) && this.gateway) {
+      try {
+        const confirmation = await this.elicitation.answer(chatGuid, text, this.gateway);
+        if (confirmation) await this.sendReply(chatGuid, confirmation);
+      } catch (e) {
+        this.logger?.error?.(`bluebubbles: elicitation answer error: ${e}`);
+      }
+      return;
+    }
+
     if (this.activeChats.has(chatGuid)) {
       this.logger?.info?.(`bluebubbles: chat ${chatGuid} already active, skipping`);
       return;
@@ -167,6 +179,11 @@ export class BlueBubblesChannel implements ChannelAdapter {
         channelKey: "bluebubbles",
         message,
       })) {
+        if (event.type === "elicitation_request") {
+          const questionText = this.elicitation.capture(chatGuid, sessionKey, event);
+          await this.sendReply(chatGuid, questionText);
+          continue;
+        }
         const fragment = renderBlueBubblesEvent(event);
         if (fragment != null) replyText += fragment;
       }
@@ -174,6 +191,8 @@ export class BlueBubblesChannel implements ChannelAdapter {
       this.logger?.error?.(`bluebubbles: submitTurn error: ${e}`);
       replyText = "处理消息时发生错误，请重试。";
     }
+
+    this.elicitation.clear(chatGuid);
 
     const finalText = replyText.trim();
     if (finalText) {

--- a/src/adapters/channel/bluebubbles/bluebubbles-render.ts
+++ b/src/adapters/channel/bluebubbles/bluebubbles-render.ts
@@ -14,6 +14,17 @@ export function renderBlueBubblesEvent(event: GatewayEvent): string | undefined 
         return `\n⚠️ ${name} failed\n`;
       }
       return "";
+    case "elicitation_request": {
+      const lines: string[] = [];
+      for (const q of event.questions) {
+        if (q.header) lines.push(`**${q.header}**`);
+        if (q.question) lines.push(q.question);
+        for (let i = 0; i < q.options.length; i++) {
+          lines.push(`${i + 1}. ${q.options[i].label}`);
+        }
+      }
+      return lines.length > 0 ? `\n${lines.join("\n")}\n` : "";
+    }
     case "error":
       return `\n❌ ${event.message}\n`;
     default:

--- a/src/adapters/channel/dingtalk/DingTalkChannel.ts
+++ b/src/adapters/channel/dingtalk/DingTalkChannel.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import type { Gateway, GatewayChannelKey } from "../../../gateway/index.js";
 import type { ChannelAdapter, ChannelHandle, ChannelLogger, ChannelStartDeps } from "../protocol/ChannelAdapter.js";
+import { ImElicitationHelper } from "../protocol/ImElicitationHelper.js";
 import { DingTalkSessionMapper } from "./DingTalkSessionMapper.js";
 import { renderDingTalkEvent } from "./dingtalk-render.js";
 
@@ -34,6 +35,7 @@ export class DingTalkChannel implements ChannelAdapter {
   private logger?: ChannelLogger;
   private client: any = null;
   private activeChats = new Set<string>();
+  private readonly elicitation = new ImElicitationHelper();
   private sessionWebhooks = new Map<string, string>();
   private seenIds = new Set<string>();
 
@@ -122,6 +124,16 @@ export class DingTalkChannel implements ChannelAdapter {
       this.rememberWebhook(chatId, webhook);
     }
 
+    if (this.elicitation.hasPending(chatId) && this.gateway) {
+      try {
+        const confirmation = await this.elicitation.answer(chatId, text.trim(), this.gateway);
+        if (confirmation) await this.sendReply(chatId, confirmation);
+      } catch (e) {
+        this.logger?.error?.(`dingtalk: elicitation answer error: ${e}`);
+      }
+      return;
+    }
+
     if (this.activeChats.has(chatId)) {
       this.logger?.info?.(`dingtalk: chat ${chatId} already active, skipping`);
       return;
@@ -178,6 +190,11 @@ export class DingTalkChannel implements ChannelAdapter {
         channelKey: "dingtalk",
         message,
       })) {
+        if (event.type === "elicitation_request") {
+          const questionText = this.elicitation.capture(chatId, sessionKey, event);
+          await this.sendReply(chatId, questionText);
+          continue;
+        }
         const fragment = renderDingTalkEvent(event);
         if (fragment != null) replyText += fragment;
       }
@@ -186,6 +203,7 @@ export class DingTalkChannel implements ChannelAdapter {
       replyText = "处理消息时发生错误，请重试。";
     }
 
+    this.elicitation.clear(chatId);
     const finalText = replyText.trim();
     if (finalText) {
       await this.sendReply(chatId, finalText);

--- a/src/adapters/channel/dingtalk/dingtalk-render.ts
+++ b/src/adapters/channel/dingtalk/dingtalk-render.ts
@@ -14,6 +14,17 @@ export function renderDingTalkEvent(event: GatewayEvent): string | undefined {
         return `\n⚠️ ${name} 执行失败\n`;
       }
       return "";
+    case "elicitation_request": {
+      const lines: string[] = [];
+      for (const q of event.questions) {
+        if (q.header) lines.push(`**${q.header}**`);
+        if (q.question) lines.push(q.question);
+        for (let i = 0; i < q.options.length; i++) {
+          lines.push(`${i + 1}. ${q.options[i].label}`);
+        }
+      }
+      return lines.length > 0 ? `\n${lines.join("\n")}\n` : "";
+    }
     case "error":
       return `\n❌ ${event.message}\n`;
     default:

--- a/src/adapters/channel/discord/DiscordChannel.ts
+++ b/src/adapters/channel/discord/DiscordChannel.ts
@@ -1,5 +1,6 @@
 import type { Gateway, GatewayChannelKey } from "../../../gateway/index.js";
 import type { ChannelAdapter, ChannelHandle, ChannelLogger, ChannelStartDeps } from "../protocol/ChannelAdapter.js";
+import { ImElicitationHelper } from "../protocol/ImElicitationHelper.js";
 import { DiscordSessionMapper } from "./DiscordSessionMapper.js";
 import { renderDiscordEvent } from "./discord-render.js";
 
@@ -29,6 +30,7 @@ export class DiscordChannel implements ChannelAdapter {
   private client: any = null;
   private botUserId: string | null = null;
   private activeChats = new Set<string>();
+  private readonly elicitation = new ImElicitationHelper();
 
   constructor(options: DiscordChannelOptions = {}) {
     this.mapper = options.mapper ?? new DiscordSessionMapper();
@@ -105,6 +107,16 @@ export class DiscordChannel implements ChannelAdapter {
     const chatId = String(message.channel?.id ?? "");
     if (!chatId) return;
 
+    if (this.elicitation.hasPending(chatId) && this.gateway) {
+      try {
+        const confirmation = await this.elicitation.answer(chatId, text, this.gateway);
+        if (confirmation) await this.sendReply(chatId, confirmation);
+      } catch (e) {
+        this.logger?.error?.(`discord: elicitation answer error: ${e}`);
+      }
+      return;
+    }
+
     if (this.activeChats.has(chatId)) {
       this.logger?.info?.(`discord: chat ${chatId} already active, skipping`);
       return;
@@ -137,6 +149,11 @@ export class DiscordChannel implements ChannelAdapter {
         channelKey: "discord",
         message,
       })) {
+        if (event.type === "elicitation_request") {
+          const questionText = this.elicitation.capture(chatId, sessionKey, event);
+          await this.sendReply(chatId, questionText);
+          continue;
+        }
         const fragment = renderDiscordEvent(event);
         if (fragment != null) replyText += fragment;
       }
@@ -145,6 +162,7 @@ export class DiscordChannel implements ChannelAdapter {
       replyText = "处理消息时发生错误，请重试。";
     }
 
+    this.elicitation.clear(chatId);
     const finalText = replyText.trim();
     if (finalText) {
       await this.sendReply(chatId, finalText);

--- a/src/adapters/channel/discord/discord-render.ts
+++ b/src/adapters/channel/discord/discord-render.ts
@@ -14,6 +14,17 @@ export function renderDiscordEvent(event: GatewayEvent): string | undefined {
         return `\n⚠️ ${name} failed\n`;
       }
       return "";
+    case "elicitation_request": {
+      const lines: string[] = [];
+      for (const q of event.questions) {
+        if (q.header) lines.push(`**${q.header}**`);
+        if (q.question) lines.push(q.question);
+        for (let i = 0; i < q.options.length; i++) {
+          lines.push(`${i + 1}. ${q.options[i].label}`);
+        }
+      }
+      return lines.length > 0 ? `\n${lines.join("\n")}\n` : "";
+    }
     case "error":
       return `\n❌ ${event.message}\n`;
     default:

--- a/src/adapters/channel/email/EmailChannel.ts
+++ b/src/adapters/channel/email/EmailChannel.ts
@@ -2,6 +2,7 @@ import type { Gateway, GatewayChannelKey } from "../../../gateway/index.js";
 import type { ChannelAdapter, ChannelHandle, ChannelLogger, ChannelStartDeps } from "../protocol/ChannelAdapter.js";
 import { EmailSessionMapper } from "./EmailSessionMapper.js";
 import { renderEmailEvent } from "./email-render.js";
+import { ImElicitationHelper } from "../protocol/ImElicitationHelper.js";
 
 let ImapFlow: any;
 let nodemailer: any;
@@ -40,6 +41,7 @@ export class EmailChannel implements ChannelAdapter {
   private ownAddress = "";
   private defaultSubject = "Message";
   private activeChats = new Set<string>();
+  private readonly elicitation = new ImElicitationHelper();
   private stopped = false;
 
   constructor(options: EmailChannelOptions = {}) {
@@ -206,6 +208,16 @@ export class EmailChannel implements ChannelAdapter {
   private async handleIncoming(chatId: string, text: string): Promise<void> {
     if (!chatId || chatId === "unknown") return;
 
+    if (this.elicitation.hasPending(chatId) && this.gateway) {
+      try {
+        const confirmation = await this.elicitation.answer(chatId, text, this.gateway);
+        if (confirmation) await this.sendReply(chatId, confirmation);
+      } catch (e) {
+        this.logger?.error?.(`email: elicitation answer error: ${e}`);
+      }
+      return;
+    }
+
     if (this.activeChats.has(chatId)) {
       this.logger?.info?.(`email: chat ${chatId} already active, skipping`);
       return;
@@ -236,6 +248,11 @@ export class EmailChannel implements ChannelAdapter {
         channelKey: "email",
         message,
       })) {
+        if (event.type === "elicitation_request") {
+          const questionText = this.elicitation.capture(chatId, sessionKey, event);
+          await this.sendReply(chatId, questionText);
+          continue;
+        }
         const fragment = renderEmailEvent(event);
         if (fragment != null) replyText += fragment;
       }
@@ -243,6 +260,8 @@ export class EmailChannel implements ChannelAdapter {
       this.logger?.error?.(`email: submitTurn error: ${e}`);
       replyText = "处理消息时发生错误，请重试。";
     }
+
+    this.elicitation.clear(chatId);
 
     const finalText = replyText.trim();
     if (finalText) {

--- a/src/adapters/channel/email/email-render.ts
+++ b/src/adapters/channel/email/email-render.ts
@@ -14,6 +14,17 @@ export function renderEmailEvent(event: GatewayEvent): string | undefined {
         return `\n⚠️ ${name} failed\n`;
       }
       return "";
+    case "elicitation_request": {
+      const lines: string[] = [];
+      for (const q of event.questions) {
+        if (q.header) lines.push(`**${q.header}**`);
+        if (q.question) lines.push(q.question);
+        for (let i = 0; i < q.options.length; i++) {
+          lines.push(`${i + 1}. ${q.options[i].label}`);
+        }
+      }
+      return lines.length > 0 ? `\n${lines.join("\n")}\n` : "";
+    }
     case "error":
       return `\n❌ ${event.message}\n`;
     default:

--- a/src/adapters/channel/feishu/FeishuChannel.ts
+++ b/src/adapters/channel/feishu/FeishuChannel.ts
@@ -2,6 +2,7 @@ import { createDecipheriv, createHash } from "node:crypto";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import type { Gateway } from "../../../gateway/index.js";
 import type { ChannelAdapter, ChannelHandle, ChannelLogger, ChannelStartDeps } from "../protocol/ChannelAdapter.js";
+import { ImElicitationHelper } from "../protocol/ImElicitationHelper.js";
 import { FeishuSessionMapper } from "./FeishuSessionMapper.js";
 
 let Lark: any = null;
@@ -79,6 +80,7 @@ export class FeishuChannel implements ChannelAdapter {
   private tokenInflight?: Promise<string>;
   private readonly seenEvents = new Set<string>();
   private readonly activeChats = new Set<string>();
+  private readonly elicitation = new ImElicitationHelper();
 
   private wsClient: any = null;
 
@@ -234,6 +236,16 @@ export class FeishuChannel implements ChannelAdapter {
   private async processInboundMessage(chatId: string, text: string, messageId?: string): Promise<void> {
     if (!this.gateway) return;
 
+    if (this.elicitation.hasPending(chatId)) {
+      try {
+        const confirmation = await this.elicitation.answer(chatId, text, this.gateway);
+        if (confirmation) await this.send({ chatId, text: confirmation });
+      } catch (e) {
+        this.logger?.error?.(`feishu: elicitation answer error: ${e}`);
+      }
+      return;
+    }
+
     const mapped = this.mapper.resolve({ chatId, text });
 
     if (mapped.command === "new" && !mapped.message) {
@@ -287,6 +299,11 @@ export class FeishuChannel implements ChannelAdapter {
                 errorMessages += `⚠️ ${name} 执行失败\n`;
               }
               break;
+            case "elicitation_request": {
+              const questionText = this.elicitation.capture(chatId, mapped.sessionKey, event);
+              await this.send({ chatId, text: questionText });
+              break;
+            }
             case "error":
               errorMessages += `❌ ${event.message}\n`;
               break;
@@ -297,6 +314,7 @@ export class FeishuChannel implements ChannelAdapter {
         lastTextSegment = "处理消息时发生错误，请重试。";
       }
 
+      this.elicitation.clear(chatId);
       const reply = (lastTextSegment.trim() || errorMessages.trim());
       if (reply) {
         await this.send({ chatId, text: reply });

--- a/src/adapters/channel/feishu/feishu-render.ts
+++ b/src/adapters/channel/feishu/feishu-render.ts
@@ -14,6 +14,17 @@ export function renderFeishuEvent(event: GatewayEvent): string | undefined {
         return `\n⚠️ ${name} 执行失败\n`;
       }
       return "";
+    case "elicitation_request": {
+      const lines: string[] = [];
+      for (const q of event.questions) {
+        if (q.header) lines.push(`**${q.header}**`);
+        if (q.question) lines.push(q.question);
+        for (let i = 0; i < q.options.length; i++) {
+          lines.push(`${i + 1}. ${q.options[i].label}`);
+        }
+      }
+      return lines.length > 0 ? `\n${lines.join("\n")}\n` : "";
+    }
     case "error":
       return `\n❌ ${event.message}\n`;
     default:

--- a/src/adapters/channel/homeassistant/HomeAssistantChannel.ts
+++ b/src/adapters/channel/homeassistant/HomeAssistantChannel.ts
@@ -2,6 +2,7 @@ import type { Gateway, GatewayChannelKey } from "../../../gateway/index.js";
 import type { ChannelAdapter, ChannelHandle, ChannelLogger, ChannelStartDeps } from "../protocol/ChannelAdapter.js";
 import { HomeAssistantSessionMapper } from "./HomeAssistantSessionMapper.js";
 import { renderHomeAssistantEvent } from "./homeassistant-render.js";
+import { ImElicitationHelper } from "../protocol/ImElicitationHelper.js";
 
 let WebSocketImpl: any;
 try {
@@ -47,6 +48,7 @@ export class HomeAssistantChannel implements ChannelAdapter {
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private authSettle: ((ok: boolean) => void) | null = null;
   private activeChats = new Set<string>();
+  private readonly elicitation = new ImElicitationHelper();
 
   constructor(options: HomeAssistantChannelOptions = {}) {
     this.mapper = options.mapper ?? new HomeAssistantSessionMapper();
@@ -220,6 +222,16 @@ export class HomeAssistantChannel implements ChannelAdapter {
   }
 
   private async handleIncoming(chatId: string, text: string): Promise<void> {
+    if (this.elicitation.hasPending(chatId) && this.gateway) {
+      try {
+        const confirmation = await this.elicitation.answer(chatId, text, this.gateway);
+        if (confirmation) await this.sendReply(chatId, confirmation);
+      } catch (e) {
+        this.logger?.error?.(`homeassistant: elicitation answer error: ${e}`);
+      }
+      return;
+    }
+
     if (this.activeChats.has(chatId)) {
       this.logger?.info?.(`homeassistant: chat ${chatId} already active, skipping`);
       return;
@@ -250,6 +262,11 @@ export class HomeAssistantChannel implements ChannelAdapter {
         channelKey: "homeassistant",
         message,
       })) {
+        if (event.type === "elicitation_request") {
+          const questionText = this.elicitation.capture(chatId, sessionKey, event);
+          await this.sendReply(chatId, questionText);
+          continue;
+        }
         const fragment = renderHomeAssistantEvent(event);
         if (fragment != null) replyText += fragment;
       }
@@ -257,6 +274,8 @@ export class HomeAssistantChannel implements ChannelAdapter {
       this.logger?.error?.(`homeassistant: submitTurn error: ${e}`);
       replyText = "处理消息时发生错误，请重试。";
     }
+
+    this.elicitation.clear(chatId);
 
     const finalText = replyText.trim();
     if (finalText) {

--- a/src/adapters/channel/homeassistant/homeassistant-render.ts
+++ b/src/adapters/channel/homeassistant/homeassistant-render.ts
@@ -14,6 +14,17 @@ export function renderHomeAssistantEvent(event: GatewayEvent): string | undefine
         return `\n⚠️ ${name} failed\n`;
       }
       return "";
+    case "elicitation_request": {
+      const lines: string[] = [];
+      for (const q of event.questions) {
+        if (q.header) lines.push(`**${q.header}**`);
+        if (q.question) lines.push(q.question);
+        for (let i = 0; i < q.options.length; i++) {
+          lines.push(`${i + 1}. ${q.options[i].label}`);
+        }
+      }
+      return lines.length > 0 ? `\n${lines.join("\n")}\n` : "";
+    }
     case "error":
       return `\n❌ ${event.message}\n`;
     default:

--- a/src/adapters/channel/matrix/MatrixChannel.ts
+++ b/src/adapters/channel/matrix/MatrixChannel.ts
@@ -3,6 +3,7 @@ import type { Gateway, GatewayChannelKey } from "../../../gateway/index.js";
 import type { ChannelAdapter, ChannelHandle, ChannelLogger, ChannelStartDeps } from "../protocol/ChannelAdapter.js";
 import { MatrixSessionMapper } from "./MatrixSessionMapper.js";
 import { renderMatrixEvent } from "./matrix-render.js";
+import { ImElicitationHelper } from "../protocol/ImElicitationHelper.js";
 
 let MatrixSdk: any;
 try {
@@ -36,6 +37,7 @@ export class MatrixChannel implements ChannelAdapter {
   private client: any = null;
   private userId: string | null = null;
   private activeChats = new Set<string>();
+  private readonly elicitation = new ImElicitationHelper();
 
   constructor(options: MatrixChannelOptions = {}) {
     this.mapper = options.mapper ?? new MatrixSessionMapper();
@@ -123,6 +125,16 @@ export class MatrixChannel implements ChannelAdapter {
     const text = String(content.body ?? "").trim();
     if (!text) return;
 
+    if (this.elicitation.hasPending(roomId) && this.gateway) {
+      try {
+        const confirmation = await this.elicitation.answer(roomId, text, this.gateway);
+        if (confirmation) await this.sendReply(roomId, confirmation);
+      } catch (e) {
+        this.logger?.error?.(`matrix: elicitation answer error: ${e}`);
+      }
+      return;
+    }
+
     if (this.activeChats.has(roomId)) {
       this.logger?.info?.(`matrix: room ${roomId} already active, skipping`);
       return;
@@ -153,6 +165,11 @@ export class MatrixChannel implements ChannelAdapter {
         channelKey: "matrix",
         message,
       })) {
+        if (event.type === "elicitation_request") {
+          const questionText = this.elicitation.capture(roomId, sessionKey, event);
+          await this.sendReply(roomId, questionText);
+          continue;
+        }
         const fragment = renderMatrixEvent(event);
         if (fragment != null) replyText += fragment;
       }
@@ -160,6 +177,8 @@ export class MatrixChannel implements ChannelAdapter {
       this.logger?.error?.(`matrix: submitTurn error: ${e}`);
       replyText = "处理消息时发生错误，请重试。";
     }
+
+    this.elicitation.clear(roomId);
 
     const finalText = replyText.trim();
     if (finalText) {

--- a/src/adapters/channel/matrix/matrix-render.ts
+++ b/src/adapters/channel/matrix/matrix-render.ts
@@ -14,6 +14,17 @@ export function renderMatrixEvent(event: GatewayEvent): string | undefined {
         return `\n⚠️ ${name} failed\n`;
       }
       return "";
+    case "elicitation_request": {
+      const lines: string[] = [];
+      for (const q of event.questions) {
+        if (q.header) lines.push(`**${q.header}**`);
+        if (q.question) lines.push(q.question);
+        for (let i = 0; i < q.options.length; i++) {
+          lines.push(`${i + 1}. ${q.options[i].label}`);
+        }
+      }
+      return lines.length > 0 ? `\n${lines.join("\n")}\n` : "";
+    }
     case "error":
       return `\n❌ ${event.message}\n`;
     default:

--- a/src/adapters/channel/mattermost/MattermostChannel.ts
+++ b/src/adapters/channel/mattermost/MattermostChannel.ts
@@ -2,6 +2,7 @@ import type { Gateway, GatewayChannelKey } from "../../../gateway/index.js";
 import type { ChannelAdapter, ChannelHandle, ChannelLogger, ChannelStartDeps } from "../protocol/ChannelAdapter.js";
 import { MattermostSessionMapper } from "./MattermostSessionMapper.js";
 import { renderMattermostEvent } from "./mattermost-render.js";
+import { ImElicitationHelper } from "../protocol/ImElicitationHelper.js";
 
 let WebSocketImpl: any;
 try {
@@ -38,6 +39,7 @@ export class MattermostChannel implements ChannelAdapter {
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private closed = false;
   private activeChats = new Set<string>();
+  private readonly elicitation = new ImElicitationHelper();
 
   constructor(options: MattermostChannelOptions = {}) {
     this.mapper = options.mapper ?? new MattermostSessionMapper();
@@ -158,6 +160,16 @@ export class MattermostChannel implements ChannelAdapter {
     // Treat each thread as its own session bucket (channel root vs thread reply).
     const chatId = rootId ? `${channelId}:${rootId}` : channelId;
 
+    if (this.elicitation.hasPending(chatId) && this.gateway) {
+      try {
+        const confirmation = await this.elicitation.answer(chatId, text, this.gateway);
+        if (confirmation) await this.sendReply({ channelId, rootId }, confirmation);
+      } catch (e) {
+        this.logger?.error?.(`mattermost: elicitation answer error: ${e}`);
+      }
+      return;
+    }
+
     if (this.activeChats.has(chatId)) {
       this.logger?.info?.(`mattermost: chat ${chatId} already active, skipping`);
       return;
@@ -194,6 +206,12 @@ export class MattermostChannel implements ChannelAdapter {
         channelKey: "mattermost",
         message,
       })) {
+        if (event.type === "elicitation_request") {
+          const chatId = ctx.rootId ? `${ctx.channelId}:${ctx.rootId}` : ctx.channelId;
+          const questionText = this.elicitation.capture(chatId, sessionKey, event);
+          await this.sendReply(ctx, questionText);
+          continue;
+        }
         const fragment = renderMattermostEvent(event);
         if (fragment != null) replyText += fragment;
       }
@@ -201,6 +219,9 @@ export class MattermostChannel implements ChannelAdapter {
       this.logger?.error?.(`mattermost: submitTurn error: ${e}`);
       replyText = "处理消息时发生错误，请重试。";
     }
+
+    const chatId = ctx.rootId ? `${ctx.channelId}:${ctx.rootId}` : ctx.channelId;
+    this.elicitation.clear(chatId);
 
     const finalText = replyText.trim();
     if (finalText) {

--- a/src/adapters/channel/mattermost/mattermost-render.ts
+++ b/src/adapters/channel/mattermost/mattermost-render.ts
@@ -14,6 +14,17 @@ export function renderMattermostEvent(event: GatewayEvent): string | undefined {
         return `\n⚠️ ${name} failed\n`;
       }
       return "";
+    case "elicitation_request": {
+      const lines: string[] = [];
+      for (const q of event.questions) {
+        if (q.header) lines.push(`**${q.header}**`);
+        if (q.question) lines.push(q.question);
+        for (let i = 0; i < q.options.length; i++) {
+          lines.push(`${i + 1}. ${q.options[i].label}`);
+        }
+      }
+      return lines.length > 0 ? `\n${lines.join("\n")}\n` : "";
+    }
     case "error":
       return `\n❌ ${event.message}\n`;
     default:

--- a/src/adapters/channel/protocol/ImElicitationHelper.ts
+++ b/src/adapters/channel/protocol/ImElicitationHelper.ts
@@ -1,0 +1,110 @@
+import type { Gateway, GatewayEvent } from "../../../gateway/index.js";
+
+/**
+ * Lightweight helper that manages pending elicitation state for IM channels.
+ *
+ * IM channels process one turn at a time per chat (`activeChats` guard), so
+ * user replies arrive through the normal inbound handler. When the agent emits
+ * an `elicitation_request` the event stream blocks until `respondElicitation`
+ * is called. This helper:
+ *
+ *   1. Captures the pending request when the channel sees an elicitation event.
+ *   2. Formats the question(s) as a numbered-option text message.
+ *   3. When the user's next message arrives, resolves the pending elicitation
+ *      by mapping the reply (a number or label) back to the original option.
+ */
+
+type PendingElicitation = {
+  sessionKey: string;
+  requestId: string;
+  questions: Array<{
+    question: string;
+    header: string;
+    options: Array<{ label: string; description: string }>;
+    multiSelect?: boolean;
+  }>;
+};
+
+export class ImElicitationHelper {
+  private readonly pending = new Map<string, PendingElicitation>();
+
+  /**
+   * Call when the event stream yields an `elicitation_request`.
+   * Returns the formatted question text to send to the user.
+   */
+  capture(chatId: string, sessionKey: string, event: GatewayEvent & { type: "elicitation_request" }): string {
+    this.pending.set(chatId, {
+      sessionKey,
+      requestId: event.requestId,
+      questions: event.questions,
+    });
+
+    const lines: string[] = [];
+    for (const q of event.questions) {
+      if (q.header) lines.push(`**${q.header}**`);
+      if (q.question) lines.push(q.question);
+      for (let i = 0; i < q.options.length; i++) {
+        const opt = q.options[i];
+        lines.push(`${i + 1}. ${opt.label}${opt.description ? ` — ${opt.description}` : ""}`);
+      }
+    }
+    lines.push("", "回复数字选择（多选用逗号分隔），回复 0 取消。");
+    return lines.join("\n");
+  }
+
+  hasPending(chatId: string): boolean {
+    return this.pending.has(chatId);
+  }
+
+  /**
+   * Call when the user sends a message while an elicitation is pending.
+   * Parses the reply, calls `gateway.respondElicitation`, and clears state.
+   * Returns a confirmation string to send back, or undefined if nothing to say.
+   */
+  async answer(chatId: string, text: string, gateway: Gateway): Promise<string | undefined> {
+    const entry = this.pending.get(chatId);
+    if (!entry) return undefined;
+    this.pending.delete(chatId);
+
+    const trimmed = text.trim();
+
+    if (trimmed === "0") {
+      await gateway.respondElicitation({
+        sessionKey: entry.sessionKey,
+        requestId: entry.requestId,
+        answer: { type: "cancelled", reason: "user cancelled" },
+      });
+      return "已取消。";
+    }
+
+    const answers: Record<string, string | string[]> = {};
+
+    for (const q of entry.questions) {
+      const indices = trimmed.split(/[,，\s]+/).map((s) => Number.parseInt(s, 10)).filter((n) => !Number.isNaN(n));
+
+      const selected: string[] = [];
+      for (const idx of indices) {
+        if (idx >= 1 && idx <= q.options.length) {
+          selected.push(q.options[idx - 1].label);
+        }
+      }
+
+      if (selected.length === 0) {
+        selected.push(trimmed);
+      }
+
+      answers[q.question] = q.multiSelect ? selected : (selected[0] ?? trimmed);
+    }
+
+    await gateway.respondElicitation({
+      sessionKey: entry.sessionKey,
+      requestId: entry.requestId,
+      answer: { type: "answered", answers },
+    });
+    return undefined;
+  }
+
+  clear(chatId: string): void {
+    this.pending.delete(chatId);
+  }
+}

--- a/src/adapters/channel/qq/QQChannel.ts
+++ b/src/adapters/channel/qq/QQChannel.ts
@@ -1,6 +1,7 @@
 import type { Gateway, GatewayChannelKey } from "../../../gateway/index.js";
 import type { ChannelAdapter, ChannelHandle, ChannelLogger, ChannelStartDeps } from "../protocol/ChannelAdapter.js";
 import { QQBotGateway, type QQBotCredentials, type QQGroupMessageEvent, type QQC2CMessageEvent } from "./qqbot-gateway.js";
+import { ImElicitationHelper } from "../protocol/ImElicitationHelper.js";
 import { QQSessionMapper } from "./QQSessionMapper.js";
 import { renderQQEvent } from "./qq-render.js";
 
@@ -29,6 +30,7 @@ export class QQChannel implements ChannelAdapter {
   private logger?: ChannelLogger;
   private botGateway?: QQBotGateway;
   private activeChats = new Set<string>();
+  private readonly elicitation = new ImElicitationHelper();
 
   constructor(options: QQChannelOptions = {}) {
     this.credentials = {
@@ -120,6 +122,17 @@ export class QQChannel implements ChannelAdapter {
     if (!text) return;
 
     const chatKey = `${groupOpenId}:${userOpenId}`;
+
+    if (this.elicitation.hasPending(chatKey) && this.gateway) {
+      try {
+        const confirmation = await this.elicitation.answer(chatKey, text, this.gateway);
+        if (confirmation) await this.sendReply(groupOpenId, confirmation);
+      } catch (e) {
+        this.logger?.error?.(`qq: elicitation answer error: ${e}`);
+      }
+      return;
+    }
+
     if (this.activeChats.has(chatKey)) {
       this.logger?.info?.(`qq: chat ${chatKey} already active, skipping`);
       return;
@@ -150,6 +163,17 @@ export class QQChannel implements ChannelAdapter {
     if (!rawText) return;
 
     const chatKey = `c2c:${userOpenId}`;
+
+    if (this.elicitation.hasPending(chatKey) && this.gateway) {
+      try {
+        const confirmation = await this.elicitation.answer(chatKey, rawText, this.gateway);
+        if (confirmation) await this.sendC2CReply(userOpenId, confirmation);
+      } catch (e) {
+        this.logger?.error?.(`qq: elicitation answer error (c2c): ${e}`);
+      }
+      return;
+    }
+
     if (this.activeChats.has(chatKey)) {
       this.logger?.info?.(`qq: c2c ${chatKey} already active, skipping`);
       return;
@@ -171,6 +195,7 @@ export class QQChannel implements ChannelAdapter {
     msgId: string,
   ): Promise<void> {
     if (!this.gateway) return;
+    const chatKey = `c2c:${userOpenId}`;
 
     let replyText = "";
     try {
@@ -179,6 +204,11 @@ export class QQChannel implements ChannelAdapter {
         channelKey: "qq",
         message,
       })) {
+        if (event.type === "elicitation_request") {
+          const questionText = this.elicitation.capture(chatKey, sessionKey, event);
+          await this.sendC2CReplyChunked(userOpenId, questionText, msgId);
+          continue;
+        }
         const fragment = renderQQEvent(event);
         if (fragment != null) replyText += fragment;
       }
@@ -187,6 +217,7 @@ export class QQChannel implements ChannelAdapter {
       replyText = "处理消息时发生错误，请重试。";
     }
 
+    this.elicitation.clear(chatKey);
     const finalText = replyText.trim();
     if (finalText) {
       await this.sendC2CReplyChunked(userOpenId, finalText, msgId);
@@ -238,6 +269,11 @@ export class QQChannel implements ChannelAdapter {
         channelKey: "qq",
         message,
       })) {
+        if (event.type === "elicitation_request") {
+          const questionText = this.elicitation.capture(groupOpenId, sessionKey, event);
+          await this.sendReplyChunked(groupOpenId, questionText, msgId);
+          continue;
+        }
         const fragment = renderQQEvent(event);
         if (fragment != null) replyText += fragment;
       }
@@ -246,6 +282,7 @@ export class QQChannel implements ChannelAdapter {
       replyText = "处理消息时发生错误，请重试。";
     }
 
+    this.elicitation.clear(groupOpenId);
     const finalText = replyText.trim();
     if (finalText) {
       await this.sendReplyChunked(groupOpenId, finalText, msgId);

--- a/src/adapters/channel/qq/qq-render.ts
+++ b/src/adapters/channel/qq/qq-render.ts
@@ -14,6 +14,17 @@ export function renderQQEvent(event: GatewayEvent): string | undefined {
         return `\n⚠️ ${name} 执行失败\n`;
       }
       return "";
+    case "elicitation_request": {
+      const lines: string[] = [];
+      for (const q of event.questions) {
+        if (q.header) lines.push(`**${q.header}**`);
+        if (q.question) lines.push(q.question);
+        for (let i = 0; i < q.options.length; i++) {
+          lines.push(`${i + 1}. ${q.options[i].label}`);
+        }
+      }
+      return lines.length > 0 ? `\n${lines.join("\n")}\n` : "";
+    }
     case "error":
       return `\n❌ ${event.message}\n`;
     default:

--- a/src/adapters/channel/signal/SignalChannel.ts
+++ b/src/adapters/channel/signal/SignalChannel.ts
@@ -2,6 +2,7 @@ import type { Gateway, GatewayChannelKey } from "../../../gateway/index.js";
 import type { ChannelAdapter, ChannelHandle, ChannelLogger, ChannelStartDeps } from "../protocol/ChannelAdapter.js";
 import { SignalSessionMapper } from "./SignalSessionMapper.js";
 import { renderSignalEvent } from "./signal-render.js";
+import { ImElicitationHelper } from "../protocol/ImElicitationHelper.js";
 
 const MAX_MESSAGE_LENGTH = 2000;
 const DEFAULT_REST_URL = "http://127.0.0.1:8080";
@@ -70,6 +71,7 @@ export class SignalChannel implements ChannelAdapter {
   private receivePromise: Promise<void> | null = null;
   private running = false;
   private activeChats = new Set<string>();
+  private readonly elicitation = new ImElicitationHelper();
   private recipientByChat = new Map<string, string>();
 
   constructor(options: SignalChannelOptions = {}) {
@@ -172,6 +174,16 @@ export class SignalChannel implements ChannelAdapter {
     const recipient = sourceNumber ?? sessionChatId.replace(/^(dm:|group:)/, "");
     if (recipient) this.recipientByChat.set(sessionChatId, recipient);
 
+    if (this.elicitation.hasPending(sessionChatId) && this.gateway) {
+      try {
+        const confirmation = await this.elicitation.answer(sessionChatId, text, this.gateway);
+        if (confirmation) await this.sendReply(sessionChatId, confirmation);
+      } catch (e) {
+        this.logger?.error?.(`signal: elicitation answer error: ${e}`);
+      }
+      return;
+    }
+
     if (this.activeChats.has(sessionChatId)) {
       this.logger?.info?.(`signal: chat ${sessionChatId} already active, skipping`);
       return;
@@ -202,6 +214,11 @@ export class SignalChannel implements ChannelAdapter {
         channelKey: "signal",
         message,
       })) {
+        if (event.type === "elicitation_request") {
+          const questionText = this.elicitation.capture(chatId, sessionKey, event);
+          await this.sendReply(chatId, questionText);
+          continue;
+        }
         const fragment = renderSignalEvent(event);
         if (fragment != null) replyText += fragment;
       }
@@ -209,6 +226,8 @@ export class SignalChannel implements ChannelAdapter {
       this.logger?.error?.(`signal: submitTurn error: ${e}`);
       replyText = "处理消息时发生错误，请重试。";
     }
+
+    this.elicitation.clear(chatId);
 
     const finalText = replyText.trim();
     if (finalText) {

--- a/src/adapters/channel/signal/signal-render.ts
+++ b/src/adapters/channel/signal/signal-render.ts
@@ -14,6 +14,17 @@ export function renderSignalEvent(event: GatewayEvent): string | undefined {
         return `\n⚠️ ${name} failed\n`;
       }
       return "";
+    case "elicitation_request": {
+      const lines: string[] = [];
+      for (const q of event.questions) {
+        if (q.header) lines.push(`**${q.header}**`);
+        if (q.question) lines.push(q.question);
+        for (let i = 0; i < q.options.length; i++) {
+          lines.push(`${i + 1}. ${q.options[i].label}`);
+        }
+      }
+      return lines.length > 0 ? `\n${lines.join("\n")}\n` : "";
+    }
     case "error":
       return `\n❌ ${event.message}\n`;
     default:

--- a/src/adapters/channel/slack/SlackChannel.ts
+++ b/src/adapters/channel/slack/SlackChannel.ts
@@ -1,5 +1,6 @@
 import type { Gateway, GatewayChannelKey } from "../../../gateway/index.js";
 import type { ChannelAdapter, ChannelHandle, ChannelLogger, ChannelStartDeps } from "../protocol/ChannelAdapter.js";
+import { ImElicitationHelper } from "../protocol/ImElicitationHelper.js";
 import { SlackSessionMapper } from "./SlackSessionMapper.js";
 import { renderSlackEvent } from "./slack-render.js";
 
@@ -31,6 +32,7 @@ export class SlackChannel implements ChannelAdapter {
   private app: any = null;
   private botUserId: string | null = null;
   private activeChats = new Set<string>();
+  private readonly elicitation = new ImElicitationHelper();
 
   constructor(options: SlackChannelOptions = {}) {
     this.mapper = options.mapper ?? new SlackSessionMapper();
@@ -116,6 +118,16 @@ export class SlackChannel implements ChannelAdapter {
 
     if (!text) return;
 
+    if (this.elicitation.hasPending(chatId) && this.gateway) {
+      try {
+        const confirmation = await this.elicitation.answer(chatId, text, this.gateway);
+        if (confirmation) await this.sendReply({ channelId, threadTs }, confirmation);
+      } catch (e) {
+        this.logger?.error?.(`slack: elicitation answer error: ${e}`);
+      }
+      return;
+    }
+
     if (this.activeChats.has(chatId)) {
       this.logger?.info?.(`slack: chat ${chatId} already active, skipping`);
       return;
@@ -144,6 +156,7 @@ export class SlackChannel implements ChannelAdapter {
     message: string,
   ): Promise<void> {
     if (!this.gateway) return;
+    const chatId = ctx.threadTs ? `${ctx.channelId}:${ctx.threadTs}` : ctx.channelId;
 
     let replyText = "";
     try {
@@ -152,6 +165,11 @@ export class SlackChannel implements ChannelAdapter {
         channelKey: "slack",
         message,
       })) {
+        if (event.type === "elicitation_request") {
+          const questionText = this.elicitation.capture(chatId, sessionKey, event);
+          await this.sendReply(ctx, questionText);
+          continue;
+        }
         const fragment = renderSlackEvent(event);
         if (fragment != null) replyText += fragment;
       }
@@ -160,6 +178,7 @@ export class SlackChannel implements ChannelAdapter {
       replyText = "处理消息时发生错误，请重试。";
     }
 
+    this.elicitation.clear(chatId);
     const finalText = replyText.trim();
     if (finalText) {
       await this.sendReply(ctx, finalText);

--- a/src/adapters/channel/slack/slack-render.ts
+++ b/src/adapters/channel/slack/slack-render.ts
@@ -14,6 +14,17 @@ export function renderSlackEvent(event: GatewayEvent): string | undefined {
         return `\n⚠️ ${name} failed\n`;
       }
       return "";
+    case "elicitation_request": {
+      const lines: string[] = [];
+      for (const q of event.questions) {
+        if (q.header) lines.push(`**${q.header}**`);
+        if (q.question) lines.push(q.question);
+        for (let i = 0; i < q.options.length; i++) {
+          lines.push(`${i + 1}. ${q.options[i].label}`);
+        }
+      }
+      return lines.length > 0 ? `\n${lines.join("\n")}\n` : "";
+    }
     case "error":
       return `\n❌ ${event.message}\n`;
     default:

--- a/src/adapters/channel/sms/SmsChannel.ts
+++ b/src/adapters/channel/sms/SmsChannel.ts
@@ -4,6 +4,7 @@ import type { Gateway, GatewayChannelKey } from "../../../gateway/index.js";
 import type { ChannelAdapter, ChannelHandle, ChannelLogger, ChannelStartDeps } from "../protocol/ChannelAdapter.js";
 import { SmsSessionMapper } from "./SmsSessionMapper.js";
 import { renderSmsEvent } from "./sms-render.js";
+import { ImElicitationHelper } from "../protocol/ImElicitationHelper.js";
 
 let twilioFactory: any;
 try {
@@ -42,6 +43,7 @@ export class SmsChannel implements ChannelAdapter {
   private port = DEFAULT_PORT;
   private path = DEFAULT_PATH;
   private activeChats = new Set<string>();
+  private readonly elicitation = new ImElicitationHelper();
 
   constructor(options: SmsChannelOptions = {}) {
     this.mapper = options.mapper ?? new SmsSessionMapper();
@@ -194,6 +196,16 @@ export class SmsChannel implements ChannelAdapter {
   }
 
   private async handleIncoming(chatId: string, text: string): Promise<void> {
+    if (this.elicitation.hasPending(chatId) && this.gateway) {
+      try {
+        const confirmation = await this.elicitation.answer(chatId, text, this.gateway);
+        if (confirmation) await this.sendReply(chatId, confirmation);
+      } catch (e) {
+        this.logger?.error?.(`sms: elicitation answer error: ${e}`);
+      }
+      return;
+    }
+
     if (this.activeChats.has(chatId)) {
       this.logger?.info?.(`sms: chat ${chatId} already active, skipping`);
       return;
@@ -224,6 +236,11 @@ export class SmsChannel implements ChannelAdapter {
         channelKey: "sms",
         message,
       })) {
+        if (event.type === "elicitation_request") {
+          const questionText = this.elicitation.capture(chatId, sessionKey, event);
+          await this.sendReply(chatId, questionText);
+          continue;
+        }
         const fragment = renderSmsEvent(event);
         if (fragment != null) replyText += fragment;
       }
@@ -231,6 +248,8 @@ export class SmsChannel implements ChannelAdapter {
       this.logger?.error?.(`sms: submitTurn error: ${e}`);
       replyText = "处理消息时发生错误，请重试。";
     }
+
+    this.elicitation.clear(chatId);
 
     const finalText = replyText.trim();
     if (finalText) {

--- a/src/adapters/channel/sms/sms-render.ts
+++ b/src/adapters/channel/sms/sms-render.ts
@@ -14,6 +14,17 @@ export function renderSmsEvent(event: GatewayEvent): string | undefined {
         return `\n⚠️ ${name} failed\n`;
       }
       return "";
+    case "elicitation_request": {
+      const lines: string[] = [];
+      for (const q of event.questions) {
+        if (q.header) lines.push(`**${q.header}**`);
+        if (q.question) lines.push(q.question);
+        for (let i = 0; i < q.options.length; i++) {
+          lines.push(`${i + 1}. ${q.options[i].label}`);
+        }
+      }
+      return lines.length > 0 ? `\n${lines.join("\n")}\n` : "";
+    }
     case "error":
       return `\n❌ ${event.message}\n`;
     default:

--- a/src/adapters/channel/telegram/TelegramChannel.ts
+++ b/src/adapters/channel/telegram/TelegramChannel.ts
@@ -1,5 +1,6 @@
 import type { Gateway, GatewayChannelKey } from "../../../gateway/index.js";
 import type { ChannelAdapter, ChannelHandle, ChannelLogger, ChannelStartDeps } from "../protocol/ChannelAdapter.js";
+import { ImElicitationHelper } from "../protocol/ImElicitationHelper.js";
 import { TelegramSessionMapper } from "./TelegramSessionMapper.js";
 import { renderTelegramEvent } from "./telegram-render.js";
 
@@ -30,6 +31,7 @@ export class TelegramChannel implements ChannelAdapter {
   private logger?: ChannelLogger;
   private bot: any = null;
   private activeChats = new Set<string>();
+  private readonly elicitation = new ImElicitationHelper();
 
   constructor(options: TelegramChannelOptions = {}) {
     this.mapper = options.mapper ?? new TelegramSessionMapper();
@@ -89,6 +91,16 @@ export class TelegramChannel implements ChannelAdapter {
     if (!msg?.text) return;
     const chatId = String(msg.chat.id);
 
+    if (this.elicitation.hasPending(chatId) && this.gateway) {
+      try {
+        const confirmation = await this.elicitation.answer(chatId, msg.text, this.gateway);
+        if (confirmation) await this.sendReply(chatId, confirmation);
+      } catch (e) {
+        this.logger?.error?.(`telegram: elicitation answer error: ${e}`);
+      }
+      return;
+    }
+
     if (this.activeChats.has(chatId)) {
       this.logger?.info?.(`telegram: chat ${chatId} already active, skipping`);
       return;
@@ -121,6 +133,11 @@ export class TelegramChannel implements ChannelAdapter {
         channelKey: "telegram",
         message,
       })) {
+        if (event.type === "elicitation_request") {
+          const questionText = this.elicitation.capture(chatId, sessionKey, event);
+          await this.sendReply(chatId, questionText);
+          continue;
+        }
         const fragment = renderTelegramEvent(event);
         if (fragment != null) replyText += fragment;
       }
@@ -129,6 +146,7 @@ export class TelegramChannel implements ChannelAdapter {
       replyText = "处理消息时发生错误，请重试。";
     }
 
+    this.elicitation.clear(chatId);
     const finalText = replyText.trim();
     if (finalText) {
       await this.sendReply(chatId, finalText);

--- a/src/adapters/channel/telegram/telegram-render.ts
+++ b/src/adapters/channel/telegram/telegram-render.ts
@@ -14,6 +14,17 @@ export function renderTelegramEvent(event: GatewayEvent): string | undefined {
         return `\n⚠️ ${name} failed\n`;
       }
       return "";
+    case "elicitation_request": {
+      const lines: string[] = [];
+      for (const q of event.questions) {
+        if (q.header) lines.push(`**${q.header}**`);
+        if (q.question) lines.push(q.question);
+        for (let i = 0; i < q.options.length; i++) {
+          lines.push(`${i + 1}. ${q.options[i].label}`);
+        }
+      }
+      return lines.length > 0 ? `\n${lines.join("\n")}\n` : "";
+    }
     case "error":
       return `\n❌ ${event.message}\n`;
     default:

--- a/src/adapters/channel/wecom-callback/WeComCallbackChannel.ts
+++ b/src/adapters/channel/wecom-callback/WeComCallbackChannel.ts
@@ -5,6 +5,7 @@ import type { Gateway, GatewayChannelKey } from "../../../gateway/index.js";
 import type { ChannelAdapter, ChannelHandle, ChannelLogger, ChannelStartDeps } from "../protocol/ChannelAdapter.js";
 import { WeComCallbackSessionMapper } from "./WeComCallbackSessionMapper.js";
 import { renderWeComCallbackEvent } from "./wecom-callback-render.js";
+import { ImElicitationHelper } from "../protocol/ImElicitationHelper.js";
 
 const QYAPI = "https://qyapi.weixin.qq.com/cgi-bin";
 const DEFAULT_PORT = 8780;
@@ -88,6 +89,7 @@ export class WeComCallbackChannel implements ChannelAdapter {
   private accessToken: string | null = null;
   private accessTokenExpires = 0;
   private activeChats = new Set<string>();
+  private readonly elicitation = new ImElicitationHelper();
 
   constructor(options: WeComCallbackChannelOptions = {}) {
     this.mapper = options.mapper ?? new WeComCallbackSessionMapper();
@@ -203,6 +205,16 @@ export class WeComCallbackChannel implements ChannelAdapter {
 
     const chatId = from;
 
+    if (this.elicitation.hasPending(chatId) && this.gateway) {
+      try {
+        const confirmation = await this.elicitation.answer(chatId, text, this.gateway);
+        if (confirmation) await this.sendReply(chatId, confirmation);
+      } catch (e) {
+        this.logger?.error?.(`wecom_callback: elicitation answer error: ${e}`);
+      }
+      return;
+    }
+
     if (this.activeChats.has(chatId)) {
       this.logger?.info?.(`wecom_callback: chat ${chatId} already active, skipping`);
       return;
@@ -233,6 +245,11 @@ export class WeComCallbackChannel implements ChannelAdapter {
         channelKey: "wecom_callback",
         message,
       })) {
+        if (event.type === "elicitation_request") {
+          const questionText = this.elicitation.capture(chatId, sessionKey, event);
+          await this.sendReply(chatId, questionText);
+          continue;
+        }
         const fragment = renderWeComCallbackEvent(event);
         if (fragment != null) replyText += fragment;
       }
@@ -240,6 +257,8 @@ export class WeComCallbackChannel implements ChannelAdapter {
       this.logger?.error?.(`wecom_callback: submitTurn error: ${e}`);
       replyText = "处理消息时发生错误，请重试。";
     }
+
+    this.elicitation.clear(chatId);
 
     const finalText = replyText.trim();
     if (finalText) {

--- a/src/adapters/channel/wecom-callback/wecom-callback-render.ts
+++ b/src/adapters/channel/wecom-callback/wecom-callback-render.ts
@@ -14,6 +14,17 @@ export function renderWeComCallbackEvent(event: GatewayEvent): string | undefine
         return `\n⚠️ ${name} failed\n`;
       }
       return "";
+    case "elicitation_request": {
+      const lines: string[] = [];
+      for (const q of event.questions) {
+        if (q.header) lines.push(`**${q.header}**`);
+        if (q.question) lines.push(q.question);
+        for (let i = 0; i < q.options.length; i++) {
+          lines.push(`${i + 1}. ${q.options[i].label}`);
+        }
+      }
+      return lines.length > 0 ? `\n${lines.join("\n")}\n` : "";
+    }
     case "error":
       return `\n❌ ${event.message}\n`;
     default:

--- a/src/adapters/channel/wecom/WeComChannel.ts
+++ b/src/adapters/channel/wecom/WeComChannel.ts
@@ -3,6 +3,7 @@ import type { Gateway, GatewayChannelKey } from "../../../gateway/index.js";
 import type { ChannelAdapter, ChannelHandle, ChannelLogger, ChannelStartDeps } from "../protocol/ChannelAdapter.js";
 import { WeComSessionMapper } from "./WeComSessionMapper.js";
 import { renderWeComEvent } from "./wecom-render.js";
+import { ImElicitationHelper } from "../protocol/ImElicitationHelper.js";
 
 let WebSocketCtor: any = null;
 try {
@@ -47,6 +48,7 @@ export class WeComChannel implements ChannelAdapter {
   private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
   private listenStopped = false;
   private activeChats = new Set<string>();
+  private readonly elicitation = new ImElicitationHelper();
 
   constructor(options: WeComChannelOptions = {}) {
     this.mapper = options.mapper ?? new WeComSessionMapper();
@@ -219,6 +221,16 @@ export class WeComChannel implements ChannelAdapter {
     const text = this.extractText(body);
     if (!text.trim()) return;
 
+    if (this.elicitation.hasPending(chatId) && this.gateway) {
+      try {
+        const confirmation = await this.elicitation.answer(chatId, text, this.gateway);
+        if (confirmation) await this.sendReply(chatId, confirmation);
+      } catch (e) {
+        this.logger?.error?.(`wecom: elicitation answer error: ${e}`);
+      }
+      return;
+    }
+
     if (this.activeChats.has(chatId)) {
       this.logger?.info?.(`wecom: chat ${chatId} already active, skipping`);
       return;
@@ -274,6 +286,11 @@ export class WeComChannel implements ChannelAdapter {
         channelKey: "wecom",
         message,
       })) {
+        if (event.type === "elicitation_request") {
+          const questionText = this.elicitation.capture(chatId, sessionKey, event);
+          await this.sendReply(chatId, questionText);
+          continue;
+        }
         const fragment = renderWeComEvent(event);
         if (fragment != null) replyText += fragment;
       }
@@ -281,6 +298,8 @@ export class WeComChannel implements ChannelAdapter {
       this.logger?.error?.(`wecom: submitTurn error: ${e}`);
       replyText = "处理消息时发生错误，请重试。";
     }
+
+    this.elicitation.clear(chatId);
 
     const finalText = replyText.trim();
     if (finalText) {

--- a/src/adapters/channel/wecom/wecom-render.ts
+++ b/src/adapters/channel/wecom/wecom-render.ts
@@ -14,6 +14,17 @@ export function renderWeComEvent(event: GatewayEvent): string | undefined {
         return `\n⚠️ ${name} failed\n`;
       }
       return "";
+    case "elicitation_request": {
+      const lines: string[] = [];
+      for (const q of event.questions) {
+        if (q.header) lines.push(`**${q.header}**`);
+        if (q.question) lines.push(q.question);
+        for (let i = 0; i < q.options.length; i++) {
+          lines.push(`${i + 1}. ${q.options[i].label}`);
+        }
+      }
+      return lines.length > 0 ? `\n${lines.join("\n")}\n` : "";
+    }
     case "error":
       return `\n❌ ${event.message}\n`;
     default:

--- a/src/adapters/channel/weixin/WeixinChannel.ts
+++ b/src/adapters/channel/weixin/WeixinChannel.ts
@@ -5,6 +5,7 @@ import { ILinkClient, loginWithQR, MessageItemType } from "weixin-ilink";
 import type { WeixinMessage, LoginResult } from "weixin-ilink";
 import type { Gateway, GatewayChannelKey } from "../../../gateway/index.js";
 import type { ChannelAdapter, ChannelHandle, ChannelLogger, ChannelStartDeps } from "../protocol/ChannelAdapter.js";
+import { ImElicitationHelper } from "../protocol/ImElicitationHelper.js";
 import { WeixinSessionMapper } from "./WeixinSessionMapper.js";
 import { renderWeixinEvent } from "./weixin-render.js";
 
@@ -34,6 +35,7 @@ export class WeixinChannel implements ChannelAdapter {
   private loopAbort = new AbortController();
   private pollPromise: Promise<void> | null = null;
   private activeChats = new Set<string>();
+  private readonly elicitation = new ImElicitationHelper();
   private contextTokens = new Map<string, string>();
 
   constructor(options: WeixinChannelOptions = {}) {
@@ -166,6 +168,16 @@ export class WeixinChannel implements ChannelAdapter {
 
     if (!text.trim()) return;
 
+    if (this.elicitation.hasPending(fromUser) && this.gateway) {
+      try {
+        const confirmation = await this.elicitation.answer(fromUser, text, this.gateway);
+        if (confirmation) await this.sendReply(fromUser, confirmation);
+      } catch (e) {
+        this.logger?.error?.(`weixin: elicitation answer error: ${e}`);
+      }
+      return;
+    }
+
     if (this.activeChats.has(fromUser)) {
       this.logger?.info?.(`weixin: chat ${fromUser} already active, skipping`);
       return;
@@ -203,6 +215,11 @@ export class WeixinChannel implements ChannelAdapter {
         channelKey: "weixin",
         message,
       })) {
+        if (event.type === "elicitation_request") {
+          const questionText = this.elicitation.capture(userId, sessionKey, event);
+          await this.sendReply(userId, questionText);
+          continue;
+        }
         const fragment = renderWeixinEvent(event);
         if (fragment != null) replyText += fragment;
       }
@@ -211,6 +228,7 @@ export class WeixinChannel implements ChannelAdapter {
       replyText = "处理消息时发生错误，请重试。";
     }
 
+    this.elicitation.clear(userId);
     const finalText = replyText.trim();
     if (finalText) {
       await this.sendReply(userId, finalText);

--- a/src/adapters/channel/weixin/weixin-render.ts
+++ b/src/adapters/channel/weixin/weixin-render.ts
@@ -14,6 +14,17 @@ export function renderWeixinEvent(event: GatewayEvent): string | undefined {
         return `\n⚠️ ${name} 执行失败\n`;
       }
       return "";
+    case "elicitation_request": {
+      const lines: string[] = [];
+      for (const q of event.questions) {
+        if (q.header) lines.push(`**${q.header}**`);
+        if (q.question) lines.push(q.question);
+        for (let i = 0; i < q.options.length; i++) {
+          lines.push(`${i + 1}. ${q.options[i].label}`);
+        }
+      }
+      return lines.length > 0 ? `\n${lines.join("\n")}\n` : "";
+    }
     case "error":
       return `\n❌ ${event.message}\n`;
     default:

--- a/src/adapters/channel/whatsapp/WhatsAppChannel.ts
+++ b/src/adapters/channel/whatsapp/WhatsAppChannel.ts
@@ -1,6 +1,7 @@
 import { spawn, type ChildProcess } from "node:child_process";
 import type { Gateway, GatewayChannelKey } from "../../../gateway/index.js";
 import type { ChannelAdapter, ChannelHandle, ChannelLogger, ChannelStartDeps } from "../protocol/ChannelAdapter.js";
+import { ImElicitationHelper } from "../protocol/ImElicitationHelper.js";
 import { WhatsAppSessionMapper } from "./WhatsAppSessionMapper.js";
 import { renderWhatsAppEvent } from "./whatsapp-render.js";
 
@@ -38,6 +39,7 @@ export class WhatsAppChannel implements ChannelAdapter {
   private pollAbort = new AbortController();
   private seenIds = new Set<string>();
   private activeChats = new Set<string>();
+  private readonly elicitation = new ImElicitationHelper();
   private running = false;
 
   constructor(options: WhatsAppChannelOptions = {}) {
@@ -187,6 +189,16 @@ export class WhatsAppChannel implements ChannelAdapter {
   private async dispatch(msg: InboundMessage): Promise<void> {
     if (!msg.text) return;
 
+    if (this.elicitation.hasPending(msg.chatId) && this.gateway) {
+      try {
+        const confirmation = await this.elicitation.answer(msg.chatId, msg.text, this.gateway);
+        if (confirmation) await this.sendReply(msg.chatId, confirmation);
+      } catch (e) {
+        this.logger?.error?.(`whatsapp: elicitation answer error: ${e}`);
+      }
+      return;
+    }
+
     if (this.activeChats.has(msg.chatId)) {
       this.logger?.info?.(`whatsapp: chat ${msg.chatId} already active, skipping`);
       return;
@@ -217,6 +229,11 @@ export class WhatsAppChannel implements ChannelAdapter {
         channelKey: "whatsapp",
         message,
       })) {
+        if (event.type === "elicitation_request") {
+          const questionText = this.elicitation.capture(chatId, sessionKey, event);
+          await this.sendReply(chatId, questionText);
+          continue;
+        }
         const fragment = renderWhatsAppEvent(event);
         if (fragment != null) replyText += fragment;
       }
@@ -225,6 +242,7 @@ export class WhatsAppChannel implements ChannelAdapter {
       replyText = "处理消息时发生错误，请重试。";
     }
 
+    this.elicitation.clear(chatId);
     const finalText = replyText.trim();
     if (finalText) {
       await this.sendReply(chatId, finalText);

--- a/src/adapters/channel/whatsapp/whatsapp-render.ts
+++ b/src/adapters/channel/whatsapp/whatsapp-render.ts
@@ -14,6 +14,17 @@ export function renderWhatsAppEvent(event: GatewayEvent): string | undefined {
         return `\n⚠️ ${name} failed\n`;
       }
       return "";
+    case "elicitation_request": {
+      const lines: string[] = [];
+      for (const q of event.questions) {
+        if (q.header) lines.push(`**${q.header}**`);
+        if (q.question) lines.push(q.question);
+        for (let i = 0; i < q.options.length; i++) {
+          lines.push(`${i + 1}. ${q.options[i].label}`);
+        }
+      }
+      return lines.length > 0 ? `\n${lines.join("\n")}\n` : "";
+    }
     case "error":
       return `\n❌ ${event.message}\n`;
     default:


### PR DESCRIPTION
## Summary

- Introduce `ImElicitationHelper` — a shared utility that manages pending elicitation state across IM channels
- When the agent calls `ask_user_question`, the channel renders a numbered-option list, waits for the user's reply, and calls `gateway.respondElicitation()` to unblock the agent
- All 17 IM render functions also gain an `elicitation_request` case
- Reply `0` to cancel; multi-select uses comma-separated numbers

## Changed files

- **New:** `src/adapters/channel/protocol/ImElicitationHelper.ts`
- **Modified:** 17 Channel classes + 17 render files (feishu, weixin, qq, dingtalk, wecom, wecom-callback, telegram, discord, slack, whatsapp, signal, matrix, mattermost, bluebubbles, email, sms, homeassistant)

## Test plan

- [ ] Trigger `ask_user_question` from agent in Feishu — verify numbered options appear
- [ ] Reply with a number — verify agent receives the selection and continues
- [ ] Reply `0` — verify cancellation
- [ ] Verify normal messages still work when no elicitation is pending


Made with [Cursor](https://cursor.com)