### PR TITLE
fix(telemetry): replace hardcoded IP with tele.pilotdeck.cn domain

### DIFF
--- a/src/telemetry/collector.ts
+++ b/src/telemetry/collector.ts
@@ -28,7 +28,7 @@ type CreateTelemetryCollectorInput = {
   fetchImpl?: typeof fetch;
 };
 
-const DEFAULT_BASE_URL = "http://123.56.15.233:3000";
+const DEFAULT_BASE_URL = "http://tele.pilotdeck.cn";
 
 const PATH_LIKE_KEY = /path|cwd|root|dir|file/i;
 const ABSOLUTE_PATH_VALUE = /^([A-Za-z]:)?[/\\]/;


### PR DESCRIPTION
## Summary
- 将遥测数据采集模块中硬编码的 IP 地址 `http://123.56.15.233:3000` 替换为域名形式 `http://tele.pilotdeck.cn`
- 数据仍然 POST 到 `/collect` 路径（由 `TelemetrySender` 自动拼接）
- 环境变量 `ANALYTICS_BASE_URL` 覆盖机制不受影响

## Test plan
- [ ] 验证遥测数据正确发送到 `http://tele.pilotdeck.cn/collect`
- [ ] 验证 `ANALYTICS_BASE_URL` 环境变量仍可覆盖默认地址


Made with [Cursor](https://cursor.com)