### PR TITLE
fix(ui): display user's selected answer in ask_user_question tool block

### DIFF
--- a/ui/server/pilotdeck-bridge.js
+++ b/ui/server/pilotdeck-bridge.js
@@ -399,6 +399,9 @@ export function gatewayEventToFrames(event, sessionId, provider) {
                               planSummary: event.data.planSummary,
                           }
                         : {}),
+                    ...(event.toolName === 'ask_user_question' && event.data
+                        ? { toolUseResult: event.data }
+                        : {}),
                 }),
             ];
         }

--- a/ui/src/components/chat/tools/ToolRenderer.tsx
+++ b/ui/src/components/chat/tools/ToolRenderer.tsx
@@ -202,7 +202,7 @@ const ToolRendererInner: React.FC<ToolRendererProps> = ({
         'title getter',
         toolName,
         () => typeof displayConfig.title === 'function'
-          ? displayConfig.title(parsedData)
+          ? displayConfig.title(parsedData, { toolResult })
           : displayConfig.title,
         'Details',
       ),
@@ -219,7 +219,8 @@ const ToolRendererInner: React.FC<ToolRendererProps> = ({
       () => displayConfig.getContentProps?.(parsedData, {
         selectedProject,
         createDiff,
-        onFileOpen
+        onFileOpen,
+        toolResult,
       }),
       {},
     ));

--- a/ui/src/components/chat/tools/configs/toolConfigs.ts
+++ b/ui/src/components/chat/tools/configs/toolConfigs.ts
@@ -626,14 +626,16 @@ export const TOOL_CONFIGS: Record<string, ToolDisplayConfig> = {
   AskUserQuestion: {
     input: {
       type: 'collapsible',
-      title: (input: any) => {
+      title: (input: any, helpers?: any) => {
         const questions = Array.isArray(input.questions) ? input.questions : [];
         const count = questions.length;
+        const resultAnswers = helpers?.toolResult?.toolUseResult?.answers;
+        const answers = input.answers || resultAnswers;
         const hasAnswers =
-          input.answers &&
-          typeof input.answers === 'object' &&
-          !Array.isArray(input.answers) &&
-          Object.keys(input.answers).length > 0;
+          answers &&
+          typeof answers === 'object' &&
+          !Array.isArray(answers) &&
+          Object.keys(answers).length > 0;
         if (count === 1) {
           const header = questions[0]?.header || 'Question';
           return hasAnswers ? `${header} — answered` : header;
@@ -645,10 +647,13 @@ export const TOOL_CONFIGS: Record<string, ToolDisplayConfig> = {
       },
       defaultOpen: true,
       contentType: 'question-answer',
-      getContentProps: (input: any) => ({
-        questions: input.questions,
-        answers: input.answers || {}
-      }),
+      getContentProps: (input: any, helpers?: any) => {
+        const resultAnswers = helpers?.toolResult?.toolUseResult?.answers;
+        return {
+          questions: input.questions,
+          answers: input.answers || resultAnswers || {},
+        };
+      },
     },
     result: {
       hideOnSuccess: true


### PR DESCRIPTION
## Summary

- **Bug**: 用户在 `ask_user_question` 面板中选择选项并提交后，工具详情展开时所有选项显示为未选中状态，底部显示 "Skipped"
- **Root cause**: 用户答案存在于 `tool_call_finished.data` 中，但 bridge 仅对 `exit_plan_mode` 提取 `data` 字段，`ask_user_question` 的结构化答案被丢弃；同时 UI 从 `toolInput`（不含 answers）读取，而 `toolResult` 被 `hideOnSuccess` 隐藏
- **Fix**: 在 bridge 中为 `ask_user_question` 传递 `event.data` 到 `toolUseResult`，在 ToolRenderer 中将 `toolResult` 注入 helpers，在 toolConfigs 中从 `helpers.toolResult.toolUseResult.answers` 读取用户选择作为 fallback

## Changes (3 files)

1. `ui/server/pilotdeck-bridge.js` — forward `event.data` as `toolUseResult` for `ask_user_question` in `tool_call_finished`
2. `ui/src/components/chat/tools/ToolRenderer.tsx` — pass `toolResult` in helpers to `title()` and `getContentProps()`
3. `ui/src/components/chat/tools/configs/toolConfigs.ts` — `AskUserQuestion` title/getContentProps read answers from `helpers.toolResult.toolUseResult.answers` as fallback

## Test plan

- [ ] 触发 agent 调用 `ask_user_question`，在面板中选择一个选项并提交
- [ ] 确认工具详情标题显示 "— answered" 后缀
- [ ] 展开工具详情，确认选中的选项正确高亮，不再显示 "Skipped"
- [ ] 测试 Skip 按钮跳过问题，确认仍正确显示 "Skipped"
- [ ] 刷新页面后重新加载历史消息，确认选择结果仍然回显


Made with [Cursor](https://cursor.com)