### PR TITLE
fix(read_file): normalize empty pages string to prevent validation loop

### DIFF
--- a/src/tool/builtin/readFile.ts
+++ b/src/tool/builtin/readFile.ts
@@ -94,6 +94,10 @@ export function createReadFileTool(): PilotDeckToolDefinition<ReadFileInput> {
           issues: [{ path: "limit", code: "invalid_schema", message: "limit must be greater than or equal to 0." }],
         };
       }
+      if (typeof input.pages === "string" && input.pages.trim().length === 0) {
+        const { pages: _pages, ...rest } = input;
+        input = rest as ReadFileInput;
+      }
       if (input.pages !== undefined) {
         const parsed = parsePdfPageRange(input.pages);
         if (!parsed) {


### PR DESCRIPTION
## Summary

- Normalize empty/blank `pages` values (`""`, `"  "`) to omitted before validation in `read_file`, preventing `invalid_tool_input` rejections that lead to `agent_tool_error_loop` termination.
- Some models/providers emit `pages: ""` instead of omitting the optional field for non-PDF files; `parsePdfPageRange` rejects the empty string, and after 3 consecutive failures the circuit breaker kills the session.

Closes #108

## Changes

**`src/tool/builtin/readFile.ts`** — added 4 lines in `validateInput` before the existing `pages` check:

```typescript
if (typeof input.pages === "string" && input.pages.trim().length === 0) {
  const { pages: _pages, ...rest } = input;
  input = rest as ReadFileInput;
}
```

## Test plan

- [ ] Verify `read_file` with `pages: ""` on a non-PDF file no longer returns `invalid_tool_input`
- [ ] Verify `read_file` with `pages: "1-5"` on a PDF still works correctly
- [ ] Verify `tsc --noEmit` passes with no type errors

Made with [Cursor](https://cursor.com)