### PR TITLE
fix(dev-launcher): make npm run dev work on Windows

### DIFF
--- a/scripts/dev-launcher.mjs
+++ b/scripts/dev-launcher.mjs
@@ -119,10 +119,19 @@ async function main() {
     PILOTDECK_SKIP_DEFAULT_PROJECT: '1',
   };
 
+  // On Windows the npm executable is a `npm.cmd` shim. Recent Node.js releases
+  // refuse to spawn `.cmd`/`.bat` files without a shell (they throw EINVAL, a
+  // hardening change from CVE-2024-27980), and the bare `npm` name cannot be
+  // resolved by `spawn` at all (ENOENT). Launch through the platform shell on
+  // Windows so `npm run dev` works out of the box; other platforms keep the
+  // plain, shell-free spawn. The arguments here are fixed literals with no
+  // user input, so enabling the shell carries no injection risk.
+  const isWindows = process.platform === 'win32';
+  const npmCommand = isWindows ? 'npm.cmd' : 'npm';
   const child = spawn(
-    'npm',
+    npmCommand,
     ['--workspace', 'ui', 'run', 'dev:concurrent'],
-    { cwd: repoRoot, env, stdio: 'inherit' },
+    { cwd: repoRoot, env, stdio: 'inherit', shell: isWindows },
   );
 
   const forward = (signal) => {


### PR DESCRIPTION
## Summary

`npm run dev` fails immediately on Windows because `scripts/dev-launcher.mjs`
spawns `npm` without a shell. This PR makes the launcher cross-platform so the
documented "From source (for developers)" quick-start works out of the box on
Windows, while leaving the macOS/Linux behavior unchanged.

## Problem

On a fresh clone, following the README quick-start (`npm install` then
`npm run dev`) on Windows produces:

```
[dev-launcher] resolved dev ports:
  server (express/ws)  →  3001
  gateway (pilotdeck)  →  18789
  vite client          →  5173

Error: spawn npm ENOENT
    ...
  syscall: 'spawn npm',
  path: 'npm',
  spawnargs: [ '--workspace', 'ui', 'run', 'dev:concurrent' ]
```

Root cause:

- On Windows the `npm` executable is a `npm.cmd` shim. `child_process.spawn('npm', ...)`
  without a shell cannot resolve it, so it throws `ENOENT`.
- Simply switching to the `npm.cmd` name is not enough: recent Node.js releases
  refuse to spawn `.cmd`/`.bat` files without a shell and throw `spawn EINVAL`
  (a security hardening change related to CVE-2024-27980).

## Fix

In `scripts/dev-launcher.mjs`, on `win32` only:

- use `npm.cmd` as the command, and
- pass `shell: true`.

macOS/Linux keep the original plain, shell-free `spawn('npm', ...)`.

The spawn arguments here are fixed string literals (`--workspace`, `ui`, `run`,
`dev:concurrent`) with no user input, so enabling the shell on Windows carries
no command-injection risk.

```js
const isWindows = process.platform === 'win32';
const npmCommand = isWindows ? 'npm.cmd' : 'npm';
const child = spawn(
  npmCommand,
  ['--workspace', 'ui', 'run', 'dev:concurrent'],
  { cwd: repoRoot, env, stdio: 'inherit', shell: isWindows },
);
```

## Testing

Verified on Windows (PowerShell, Node.js v22.14.0, npm 10.9.2):

- `npm run dev` now boots all three processes successfully:
  - vite client → `http://localhost:5173` (HTTP 200)
  - server (express/ws) → `http://localhost:3001` (HTTP 200, "PilotDeck Server - Ready")
  - gateway (pilotdeck) → `ws://127.0.0.1:18789/ws` (listening)
- No `ENOENT` / `EINVAL` in stderr.

macOS/Linux code path is unchanged (still plain `spawn('npm', ...)` with no shell).

## Scope

This PR intentionally fixes only the developer quick-start entry point
(`dev-launcher.mjs`), which is the one blocker that prevents `npm run dev` from
starting at all on Windows. Other `spawn('npm'|'npx', ...)` call sites in
runtime/optional feature paths are out of scope here and can be addressed
separately if desired.
