### PR TITLE
fix(openai-stream): ignore empty tool-call name in streamed deltas (#107)

### DIFF
--- a/src/model/providers/openai/stream.ts
+++ b/src/model/providers/openai/stream.ts
@@ -183,8 +183,13 @@ function toolCallEvents(
     if (typeof record.id === "string") {
       current.id = record.id;
     }
-    if (typeof fn.name === "string") {
-      current.name = fn.name;
+    // Only adopt a non-empty name. Some providers send the real name in the
+    // first chunk, then `function.name: ""` in later argument-only chunks;
+    // overwriting with the empty string would emit a nameless tool call and
+    // trigger a `tool_not_found: Tool "" does not exist` loop.
+    const name = readNonEmptyString(fn.name);
+    if (name !== undefined) {
+      current.name = name;
     }
 
     if (!state.toolCalls.has(index)) {


### PR DESCRIPTION
## Summary

Fixes #107 — streamed tool calls intermittently emitted with an empty name, causing a `tool_not_found: Tool  does not exist.` loop.

## Root cause

Some OpenAI-compatible providers send the real `function.name` in the **first** tool-call chunk, then `function.name: ""` in later **argument-only** chunks. In `src/model/providers/openai/stream.ts`, `toolCallEvents()` updated the stored name on *any* string value:

```ts
if (typeof fn.name === "string") {
  current.name = fn.name;   // "" overwrites the good name
}
```

So the accumulated tool call ended up with `name: ""`, and the downstream agent looped on `tool_not_found`.

## Fix

Guard the assignment with the **existing** `readNonEmptyString()` helper (already used in this file for tool-call ids), so an empty/whitespace name never clobbers a previously-captured one:

```ts
const name = readNonEmptyString(fn.name);
if (name !== undefined) {
  current.name = name;
}
```

A name that legitimately arrives only in a later chunk is still captured.

## Testing

- `tsc --noEmit` passes.
- Verified the name-handling control flow against three scenarios:
  - **Empty name in a later chunk** (the #107 case) → name preserved. ✅
  - **Normal single-chunk name** → unchanged. ✅
  - **Name arriving only in the 2nd chunk** → still captured. ✅

The repo currently ships no tests under `tests/` for this module, so verification was done via standalone reproduction of the parser's name-merge logic.
