### PR TITLE
fix(ui): add missing prestart script to auto-generate config in production mode

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -22,6 +22,7 @@
     "lint:fix": "eslint src/ --fix",
     "test": "vitest run",
     "test:watch": "vitest",
+    "prestart": "node ../scripts/bootstrap-pilotdeck-config.mjs",
     "start": "npm run build && npm run start:built",
     "start:built": "concurrently --kill-others-on-fail --names gateway,server \"npm:gateway\" \"npm:server\"",
     "postinstall": "node scripts/fix-node-pty.js"


### PR DESCRIPTION
**Describe the bug**
Running `npm run start` in a fresh environment fails with a fatal error: `Config must contain an agent section.`. 
This happens because `start` mode is missing the initialization hook (`bootstrap-pilotdeck-config.mjs`) that generates the initial `~/.pilotdeck/pilotdeck.yaml` file, which is present in `dev` mode (`predev`).

**To Reproduce**
1. Clone the repo in a fresh environment (without `~/.pilotdeck/pilotdeck.yaml`).
2. Run `cd ui && npm run start`.
3. Gateway crashes due to missing config.

**Solution**
Added a `prestart` hook in `ui/package.json` matching the existing `predev` hook, ensuring the `bootstrap-pilotdeck-config.mjs` script runs before starting the production server, fixing the OOTB experience.