### PR TITLE
feat(telemetry): add UI toggle and YAML-driven hot-reload for telemetry

### DIFF
--- a/src/cli/pilotdeck.ts
+++ b/src/cli/pilotdeck.ts
@@ -26,7 +26,10 @@ async function main(argv = process.argv.slice(2)): Promise<void> {
     const env = process.env;
     const pilotHome = resolvePilotHome(env);
     const snapshot = loadPilotConfig({ projectRoot, env });
-    const telemetry = createTelemetryCollector({ env, pilotHome });
+    const telemetry = createTelemetryCollector({
+      env, pilotHome,
+      enabled: snapshot.config.telemetry?.enabled,
+    });
 
     let alwaysOn: AlwaysOnManager | undefined;
     let cron: CronRuntime | undefined;
@@ -128,6 +131,10 @@ async function main(argv = process.argv.slice(2)): Promise<void> {
     let reloadChain = Promise.resolve();
 
     configStore.subscribe((event) => {
+      if (event.changedPaths.some((p) => p.startsWith("telemetry."))) {
+        telemetry.setEnabled(event.nextSnapshot.config.telemetry?.enabled ?? false);
+      }
+
       const aoChanged = event.changedPaths.some((p) => p.startsWith("alwaysOn."));
       const cronChanged = event.changedPaths.some((p) => p.startsWith("cron."));
       if (!aoChanged && !cronChanged) return;

--- a/src/pilot/config/loadPilotConfig.ts
+++ b/src/pilot/config/loadPilotConfig.ts
@@ -299,11 +299,11 @@ function validateTopLevel(rawConfig: PilotRawConfig, diagnostics: PilotConfigDia
     "alwaysOn",
     "cron",
     "tools",
-    // Reserved namespace for ui/server (Web UI Express bridge). The PilotDeck
-    // gateway does not parse `webui.*` itself but tolerates it so a single
-    // ~/.pilotdeck/pilotdeck.yaml can carry both gateway-side and ui-side
-    // config without producing diagnostic noise.
+    // Reserved namespaces for ui/server. The PilotDeck gateway does not parse
+    // these itself but tolerates them so a single ~/.pilotdeck/pilotdeck.yaml
+    // can carry both gateway-side and ui-side config without diagnostic noise.
     "webui",
+    "telemetry",
   ]);
   for (const key of Object.keys(rawConfig)) {
     if (!allowedKeys.has(key)) {

--- a/src/pilot/config/loadPilotConfig.ts
+++ b/src/pilot/config/loadPilotConfig.ts
@@ -23,6 +23,7 @@ import {
   type PilotConfigSnapshot,
   type PilotConfigSource,
   type PilotRawConfig,
+  type PilotTelemetryConfig,
 } from "./types.js";
 
 const SUPPORTED_SCHEMA_VERSION = 1;
@@ -122,6 +123,7 @@ export function loadPilotConfig(options: PilotConfigLoadOptions = {}): PilotConf
   const alwaysOn = parseAlwaysOnConfig(rawConfig.alwaysOn, diagnostics);
   const cron = parseCronConfig(rawConfig.cron, diagnostics);
   const tools = parseToolsConfig(rawConfig.tools, diagnostics);
+  const telemetry = parseTelemetryConfig(rawConfig.telemetry);
   throwConfigErrorIfFatal(diagnostics);
 
   const redactedSnapshotConfig = redactConfig({
@@ -135,6 +137,7 @@ export function loadPilotConfig(options: PilotConfigLoadOptions = {}): PilotConf
     alwaysOn,
     cron,
     tools,
+    telemetry,
   });
   return deepFreeze({
     version: options.version ?? 1,
@@ -154,6 +157,7 @@ export function loadPilotConfig(options: PilotConfigLoadOptions = {}): PilotConf
       ...(alwaysOn ? { alwaysOn } : {}),
       ...(cron ? { cron } : {}),
       ...(tools ? { tools } : {}),
+      telemetry,
     },
   });
 }
@@ -611,6 +615,12 @@ function parseRouterSection(
     });
   }
   return result.config;
+}
+
+function parseTelemetryConfig(raw: unknown): PilotTelemetryConfig {
+  return {
+    enabled: isRecord(raw) && (raw as Record<string, unknown>).enabled === true,
+  };
 }
 
 function deepFreeze<T>(value: T): T {

--- a/src/pilot/config/types.ts
+++ b/src/pilot/config/types.ts
@@ -45,6 +45,7 @@ export type PilotRawConfig = {
   alwaysOn?: unknown;
   cron?: unknown;
   tools?: unknown;
+  telemetry?: unknown;
 };
 
 export type PilotExtensionConfig = {

--- a/src/pilot/config/types.ts
+++ b/src/pilot/config/types.ts
@@ -194,6 +194,10 @@ export type PilotAdaptersConfig = {
   webhook?: PilotPlatformAdapterConfig;
 };
 
+export type PilotTelemetryConfig = {
+  enabled: boolean;
+};
+
 export type PilotConfig = {
   agent: PilotAgentConfig;
   model: ModelConfig;
@@ -205,6 +209,7 @@ export type PilotConfig = {
   alwaysOn?: AlwaysOnConfig;
   cron?: CronConfig;
   tools?: PilotToolsConfig;
+  telemetry?: PilotTelemetryConfig;
 };
 
 export type PilotConfigSnapshot = {

--- a/src/telemetry/collector.ts
+++ b/src/telemetry/collector.ts
@@ -26,6 +26,8 @@ type CreateTelemetryCollectorInput = {
   env?: Record<string, string | undefined>;
   pilotHome?: string;
   fetchImpl?: typeof fetch;
+  /** Explicit override for the enabled flag; takes precedence over env. */
+  enabled?: boolean;
 };
 
 const DEFAULT_BASE_URL = "http://tele.pilotdeck.cn";
@@ -38,6 +40,9 @@ export function createTelemetryCollector(
 ): TelemetryClient {
   const env = input.env ?? process.env;
   const config = resolveTelemetryConfig(env, input.pilotHome);
+  if (input.enabled != null) {
+    config.enabled = input.enabled;
+  }
   const runtimeContext = resolveTelemetryRuntimeContext({ env, pilotHome: input.pilotHome });
   const sender = new TelemetrySender(config, { fetchImpl: input.fetchImpl });
 
@@ -108,6 +113,10 @@ export function createTelemetryCollector(
         sessionId: inputError.sessionId,
         metadata: sanitizeProperties(pickErrorFeatureMetadata(code, inputError.toolName, inputError.metadata)),
       });
+    },
+    setEnabled(enabled: boolean) {
+      config.enabled = enabled;
+      sender.setEnabled(enabled);
     },
     flush() {
       return sender.flush();

--- a/src/telemetry/sender.ts
+++ b/src/telemetry/sender.ts
@@ -27,7 +27,7 @@ export class TelemetrySender {
   private flushing = false;
 
   constructor(
-    private readonly config: TelemetryConfig,
+    private config: TelemetryConfig,
     deps: TelemetrySenderDeps = {},
   ) {
     this.fetchImpl = deps.fetchImpl ?? fetch;
@@ -37,6 +37,25 @@ export class TelemetrySender {
         void this.flush();
       }, this.config.flushIntervalMs);
       this.timer.unref();
+    }
+  }
+
+  setEnabled(enabled: boolean): void {
+    if (this.config.enabled === enabled) return;
+    this.config = { ...this.config, enabled };
+    if (enabled) {
+      if (!this.timer) {
+        this.timer = setInterval(() => {
+          void this.flush();
+        }, this.config.flushIntervalMs);
+        this.timer.unref();
+      }
+    } else {
+      if (this.timer) {
+        clearInterval(this.timer);
+        this.timer = undefined;
+      }
+      void this.flush();
     }
   }
 

--- a/src/telemetry/types.ts
+++ b/src/telemetry/types.ts
@@ -145,6 +145,7 @@ export type TelemetryClient = {
   trackFeatureUsed(input: TelemetryFeatureUsedInput): void;
   trackFeatureLoopStage(input: TelemetryFeatureUsedInput): void;
   trackError(error: unknown, input?: TelemetryErrorInput): void;
+  setEnabled(enabled: boolean): void;
   flush(): Promise<void>;
   shutdown(): Promise<void>;
   snapshot(): TelemetrySenderMetrics;

--- a/ui/server/services/pilotdeckConfig.js
+++ b/ui/server/services/pilotdeckConfig.js
@@ -92,6 +92,9 @@ export function buildDefaultPilotDeckConfig() {
         workspacesRoot: os.homedir(),
       },
     },
+    telemetry: {
+      enabled: false,
+    },
   };
 }
 
@@ -369,6 +372,9 @@ export function buildRuntimeEnv(config) {
     env.PILOTDECK_MEMORY_API_TYPE = normalizeString(normalized.memory?.apiType)
       || providerProtocolToMemoryApi(memory.provider.protocol);
   }
+
+  // Telemetry opt-in (default off).
+  env.ANALYTICS_ENABLED = normalized.telemetry?.enabled ? '1' : '0';
 
   // Pass through customEnv (UI-managed escape hatch).
   if (isRecord(normalized.customEnv)) {

--- a/ui/server/services/pilotdeckConfig.js
+++ b/ui/server/services/pilotdeckConfig.js
@@ -373,9 +373,6 @@ export function buildRuntimeEnv(config) {
       || providerProtocolToMemoryApi(memory.provider.protocol);
   }
 
-  // Telemetry opt-in (default off).
-  env.ANALYTICS_ENABLED = normalized.telemetry?.enabled ? '1' : '0';
-
   // Pass through customEnv (UI-managed escape hatch).
   if (isRecord(normalized.customEnv)) {
     for (const [key, value] of Object.entries(normalized.customEnv)) {

--- a/ui/src/components/settings/view/Settings.tsx
+++ b/ui/src/components/settings/view/Settings.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useState, type ReactNode } from 'react';
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react';
 import {
+  Activity,
   ArrowUpDown,
   ChevronLeft,
   ChevronRight,
@@ -14,10 +15,12 @@ import {
   type LucideIcon,
 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
+import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
 import { Button } from '../../../shared/view/ui';
 import { useTheme } from '../../../contexts/ThemeContext';
 import { languages } from '../../../i18n/languages';
 import { useUiPreferences } from '../../../hooks/useUiPreferences';
+import { usePilotDeckConfig } from '../../../hooks/usePilotDeckConfig';
 import { useSettingsController } from '../hooks/useSettingsController';
 import type {
   CodeEditorSettingsState,
@@ -147,6 +150,28 @@ function SettingsHome({ projectSortOrder, onProjectSortOrderChange, onOpenPage }
     themeMode?: ThemeMode;
     setThemeMode?: (mode: ThemeMode) => void;
   };
+  const { raw, setRaw, save, loading } = usePilotDeckConfig();
+
+  const telemetryEnabled = useMemo(() => {
+    try {
+      const config = parseYaml(raw);
+      return config?.telemetry?.enabled === true;
+    } catch {
+      return false;
+    }
+  }, [raw]);
+
+  const handleTelemetryToggle = useCallback((value: boolean) => {
+    try {
+      const config = parseYaml(raw) ?? {};
+      config.telemetry = { ...config.telemetry, enabled: value };
+      const next = stringifyYaml(config, { indent: 2, lineWidth: 0 });
+      setRaw(next);
+      void save();
+    } catch {
+      // YAML parse/stringify failure — ignore silently.
+    }
+  }, [raw, setRaw, save]);
 
   const currentLanguage = languages.some((language) => language.value === i18n.language)
     ? i18n.language
@@ -240,13 +265,25 @@ function SettingsHome({ projectSortOrder, onProjectSortOrderChange, onOpenPage }
       </SettingsGroup>
 
       <SettingsGroup title={t('settingsHome.advanced')}>
-        <GroupedCard>
+        <GroupedCard divided>
           <NavigationRow
             icon={Shield}
             title={t('mainTabs.permissions')}
             detail={t('settingsHome.permissions.detail')}
             onClick={() => onOpenPage('permissions')}
           />
+          <MenuRow
+            icon={Activity}
+            title={t('settingsHome.telemetry.title')}
+            detail={t('settingsHome.telemetry.detail')}
+          >
+            <SettingsToggle
+              checked={telemetryEnabled}
+              onChange={handleTelemetryToggle}
+              ariaLabel={t('settingsHome.telemetry.title')}
+              disabled={loading}
+            />
+          </MenuRow>
         </GroupedCard>
       </SettingsGroup>
     </div>

--- a/ui/src/hooks/usePilotDeckConfig.ts
+++ b/ui/src/hooks/usePilotDeckConfig.ts
@@ -110,6 +110,7 @@ export function usePilotDeckConfig() {
   }, []);
 
   const updateRaw = useCallback((value: string) => {
+    rawRef.current = value;
     setRaw(value);
     scheduleValidation(value);
   }, [scheduleValidation]);

--- a/ui/src/i18n/locales/en/settings.json
+++ b/ui/src/i18n/locales/en/settings.json
@@ -131,6 +131,10 @@
     },
     "permissions": {
       "detail": "Manage allowed and blocked tool rules"
+    },
+    "telemetry": {
+      "title": "Telemetry",
+      "detail": "Send anonymous usage data to help improve the product"
     }
   },
   "notifications": {

--- a/ui/src/i18n/locales/zh-CN/settings.json
+++ b/ui/src/i18n/locales/zh-CN/settings.json
@@ -131,6 +131,10 @@
     },
     "permissions": {
       "detail": "管理允许和禁用的工具规则"
+    },
+    "telemetry": {
+      "title": "遥测",
+      "detail": "发送匿名使用数据以帮助改进产品"
     }
   },
   "notifications": {


### PR DESCRIPTION
## Summary

- Add a Telemetry toggle in Settings > Advanced section, allowing users to enable/disable telemetry from the Web UI without restarting the process.
- Introduce `telemetry.enabled` as a first-class field in `pilotdeck.yaml`, parsed by the gateway config store.
- Wire up a hot-reload path: `configStore.subscribe` detects `telemetry.*` changes and calls `telemetry.setEnabled()` at runtime, starting/stopping the flush timer accordingly.
- Remove the `ANALYTICS_ENABLED` environment variable intermediate layer — telemetry is now driven directly by YAML config.
- Fix a `rawRef` race condition in `usePilotDeckConfig` where `save()` could read stale YAML when called immediately after `setRaw()`.

## Changes (11 files, +109/−8)

| Layer | Files | What |
|-------|-------|------|
| Telemetry module | `types.ts`, `collector.ts`, `sender.ts` | Add `setEnabled()` API with timer start/stop |
| Gateway config | `config/types.ts`, `loadPilotConfig.ts` | Parse `telemetry` section, add `PilotTelemetryConfig` |
| Gateway entry | `pilotdeck.ts` | Pass initial value, subscribe for hot-reload |
| UI server | `pilotdeckConfig.js` | Add default, remove env var mapping |
| UI frontend | `Settings.tsx`, `usePilotDeckConfig.ts` | Toggle row + rawRef race fix |
| i18n | `en/settings.json`, `zh-CN/settings.json` | Translations |

## Test plan

- [ ] Start PilotDeck, open Settings > Advanced, verify Telemetry toggle appears (default OFF)
- [ ] Toggle ON, verify shutdown log shows non-zero `queued`/`sent` counts after some activity
- [ ] Toggle OFF while running, verify flush completes and no further events are queued
- [ ] Edit `pilotdeck.yaml` externally to set `telemetry.enabled: true`, verify gateway picks up the change without restart
- [ ] Verify gateway produces no `CONFIG_UNKNOWN_FIELD` warning for the `telemetry` key

Made with [Cursor](https://cursor.com)