### PR TITLE
fix(always-on): extract report from LLM text when report tool is not invoked

### DIFF
--- a/src/always-on/runtime/DiscoveryFire.ts
+++ b/src/always-on/runtime/DiscoveryFire.ts
@@ -5,7 +5,7 @@ import type { Gateway, GatewayChannelKey, GatewayEvent } from "../../gateway/ind
 import { getPilotProjectChatDir } from "../../pilot/paths.js";
 import { buildChatDigest } from "../context/ChatDigestBuilder.js";
 import type { AlwaysOnConfig } from "../config/parseAlwaysOnConfig.js";
-import { buildFallbackReport, type ReportMetadata } from "../contracts/ReportContract.js";
+import { buildFallbackReport, parseReportMarkdown, type ReportMetadata } from "../contracts/ReportContract.js";
 import { AlwaysOnError } from "../protocol/errors.js";
 import type {
   AlwaysOnDiscoveryOutcome,
@@ -458,9 +458,10 @@ export class DiscoveryFire {
     };
     this.deps.runContexts.register(reportCtx);
 
+    let reportEvents: GatewayEvent[] = [];
     let reportError: { code?: string; message: string } | undefined;
     try {
-      const events = await this.drainTurn({
+      reportEvents = await this.drainTurn({
         sessionKey: reportSessionKey,
         channelKey: REPORT_CHANNEL,
         runId: `${runId}.report`,
@@ -468,7 +469,7 @@ export class DiscoveryFire {
         mode: "bypassPermissions",
         persistEvents: true,
       });
-      reportError = pickFirstError(events);
+      reportError = pickFirstError(reportEvents);
     } finally {
       this.deps.runContexts.unregister(reportSessionKey);
       this.deps.sessionOverrides.delete(reportSessionKey);
@@ -476,6 +477,25 @@ export class DiscoveryFire {
     }
 
     const finishedAt = this.deps.now();
+
+    if (!reportCtx.report && !reportError) {
+      const assistantText = extractAssistantText(reportEvents);
+      if (assistantText) {
+        const metadata: ReportMetadata = {
+          runId,
+          planId,
+          startedAt: startedAt.toISOString(),
+          finishedAt: finishedAt.toISOString(),
+          outcome: "executed",
+          workspaceStrategy: workspace.strategy === "git-worktree" ? "git-worktree" : "snapshot-copy",
+          workspaceHandle: workspace.cwd,
+        };
+        const parsed = parseReportMarkdown(assistantText, metadata);
+        const filePath = await this.deps.reportStore.writeReport(runId, parsed.rawContent);
+        reportCtx.report = { markdown: parsed.rawContent, filePath, finishedAt };
+      }
+    }
+
     const outcome: AlwaysOnDiscoveryOutcome = reportCtx.report && !reportError ? "executed" : "failed";
 
     if (reportCtx.report && !reportError) {
@@ -801,9 +821,10 @@ export class DiscoveryFire {
     };
     this.deps.runContexts.register(reportCtx);
 
+    let reportEvents: GatewayEvent[] = [];
     let reportError: { code?: string; message: string } | undefined;
     try {
-      const events = await this.drainTurn({
+      reportEvents = await this.drainTurn({
         sessionKey: reportSessionKey,
         channelKey: REPORT_CHANNEL,
         runId: `${runId}.report`,
@@ -817,7 +838,7 @@ export class DiscoveryFire {
         mode: "bypassPermissions",
         persistEvents: true,
       });
-      reportError = pickFirstError(events);
+      reportError = pickFirstError(reportEvents);
     } finally {
       this.deps.runContexts.unregister(reportSessionKey);
       this.deps.sessionOverrides.delete(reportSessionKey);
@@ -827,6 +848,25 @@ export class DiscoveryFire {
     }
 
     const finishedAt = this.deps.now();
+
+    if (!reportCtx.report && !reportError) {
+      const assistantText = extractAssistantText(reportEvents);
+      if (assistantText) {
+        const metadata: ReportMetadata = {
+          runId,
+          planId: planRecord.id,
+          startedAt: startedAt.toISOString(),
+          finishedAt: finishedAt.toISOString(),
+          outcome: "executed",
+          workspaceStrategy: workspace.strategy === "git-worktree" ? "git-worktree" : "snapshot-copy",
+          workspaceHandle: workspace.cwd,
+        };
+        const parsed = parseReportMarkdown(assistantText, metadata);
+        const filePath = await this.deps.reportStore.writeReport(runId, parsed.rawContent);
+        reportCtx.report = { markdown: parsed.rawContent, filePath, finishedAt };
+      }
+    }
+
     const outcome: AlwaysOnDiscoveryOutcome = reportCtx.report && !reportError ? "executed" : "failed";
 
     if (reportCtx.report && !reportError) {
@@ -1115,4 +1155,14 @@ function pickFirstError(events: GatewayEvent[]): { code?: string; message: strin
     }
   }
   return undefined;
+}
+
+function extractAssistantText(events: GatewayEvent[]): string {
+  let text = "";
+  for (const event of events) {
+    if (event.type === "assistant_text_delta") {
+      text += event.text;
+    }
+  }
+  return text.trim();
 }


### PR DESCRIPTION
## Summary

- When the report-phase agent produces text but does not call `always_on_report`, the run was incorrectly marked as `failed` with reason `report_tool_not_invoked`. Now the runtime extracts `assistant_text_delta` events from the report session, runs them through `parseReportMarkdown` for validation/completion, and persists the result — so the outcome reflects the actual execution success rather than a missed tool call.
- The existing tool-call path is completely unchanged; the new logic only activates as a fallback when `reportCtx.report` is unset and there is no `reportError`.

## Changes

**File:** `src/always-on/runtime/DiscoveryFire.ts`

1. Added `extractAssistantText()` helper that concatenates all `assistant_text_delta` events into a single string.
2. In both `fire()` and `run()` methods, after `drainTurn` completes and before outcome determination: if the report tool was not called and there is no error, attempt to extract LLM text from events. If non-empty, parse it via `parseReportMarkdown` and write to disk, setting `reportCtx.report` so the outcome resolves to `"executed"`.
3. If the LLM produced no text output either, the original `writeFallbackReport` path is preserved (outcome = `"failed"`).

## Priority: tool call > LLM text > fallback template

| Scenario | Outcome |
|---|---|
| Tool called successfully | `executed` (unchanged) |
| Tool not called, LLM text present | `executed` (new) |
| Tool not called, no LLM text | `failed` (unchanged) |

Closes #148

Made with [Cursor](https://cursor.com)