### PR TITLE
fix(always-on): tolerate H1 section headers in report markdown

### DIFF
--- a/src/always-on/contracts/ReportContract.ts
+++ b/src/always-on/contracts/ReportContract.ts
@@ -90,6 +90,7 @@ export function parseReportMarkdown(
   metadata: ReportMetadata,
 ): ReportParseResult {
   const fallbacks: string[] = [];
+  const requiredSet = new Set<string>(REPORT_REQUIRED_SECTIONS);
   const normalized = content.replace(/\r\n/g, "\n");
   const lines = normalized.split("\n");
 
@@ -98,8 +99,14 @@ export function parseReportMarkdown(
   const titleLine = lines[cursor] ?? "";
   let title: string;
   if (titleLine.startsWith("# ")) {
-    title = titleLine.slice(2).trim();
-    cursor += 1;
+    const titleCandidate = titleLine.slice(2).trim();
+    if (requiredSet.has(titleCandidate)) {
+      title = "Always-On Discovery Run";
+      fallbacks.push("title-missing");
+    } else {
+      title = titleCandidate;
+      cursor += 1;
+    }
   } else {
     title = "Always-On Discovery Run";
     fallbacks.push("title-missing");
@@ -130,6 +137,16 @@ export function parseReportMarkdown(
       currentSection = line.slice(3).trim();
       buffer = [];
       continue;
+    }
+    if (!line.startsWith("## ") && line.startsWith("# ")) {
+      const candidate = line.slice(2).trim();
+      if (requiredSet.has(candidate)) {
+        flush();
+        currentSection = candidate;
+        buffer = [];
+        fallbacks.push(`h1-downgraded(${candidate})`);
+        continue;
+      }
     }
     if (currentSection !== null) {
       buffer.push(line);

--- a/src/always-on/runtime/discoveryPrompts.ts
+++ b/src/always-on/runtime/discoveryPrompts.ts
@@ -224,7 +224,8 @@ export function buildReportPrompt(input: BuildReportPromptInput): string {
     "2. Summarize the execution: what steps were performed, which files were changed, command outputs, and verification results.",
     `3. Call \`${ALWAYS_ON_REPORT_TOOL_NAME}\` exactly once with the full work-report markdown.`,
     "",
-    "Required report sections in order: Plan Reference, Steps Performed, Files Changed, Command Output, Verification Results, Follow-ups, Notes.",
+    "Each section MUST use `##` (h2) headers — e.g. `## Plan Reference`, `## Steps Performed`, etc.",
+    "Required sections in order: Plan Reference, Steps Performed, Files Changed, Command Output, Verification Results, Follow-ups, Notes.",
     "Missing sections will be filled by the runtime fallback.",
   ].join("\n");
 }

--- a/src/always-on/runtime/discoveryPrompts.zh.ts
+++ b/src/always-on/runtime/discoveryPrompts.zh.ts
@@ -172,6 +172,7 @@ export function buildReportPromptZh(input: BuildReportPromptInput): string {
     "2. 总结执行情况: 执行了哪些步骤、修改了哪些文件、命令输出、验证结果。",
     `3. 调用 \`${ALWAYS_ON_REPORT_TOOL_NAME}\` 恰好一次, 提交完整的工作报告 markdown。`,
     "",
+    "每个章节必须使用 `##`（h2）标题——例如 `## Plan Reference`、`## Steps Performed` 等。",
     "报告章节按以下顺序排列: Plan Reference, Steps Performed, Files Changed, Command Output, Verification Results, Follow-ups, Notes。",
     "缺失的章节将由运行时自动补全。",
   ].join("\n");


### PR DESCRIPTION
## Summary

- LLM 在调用 `always_on_report` 工具时，有时使用 `# Plan Reference`（H1）而非 `## Plan Reference`（H2）作为章节标题，导致 `parseReportMarkdown` 无法识别任何 section，所有章节被填充为 `(empty)`，实际详尽的 report 内容被完全丢弃。
- `parseReportMarkdown` 现在会将 `# SectionName`（当 SectionName 匹配 required section 名称时）自动降级为 `## SectionName`，并在 fallbacks 中记录 `h1-downgraded(...)` 便于追踪。
- Title 解析不再把匹配 required section 名称的 H1 行误消费为标题。
- Report prompt（英文 + 中文）现在明确要求使用 `##`（h2）标题。

## Test plan

- [ ] 触发一次 Always-On run，观察 report 正常使用 `##` 时行为不变
- [ ] 手动构造一份使用 `#`（H1）章节标题的 report content，验证 `parseReportMarkdown` 能正确提取所有 section 内容，且 fallbacks 包含 `h1-downgraded` 条目
- [ ] 验证第一行为 `# Plan Reference`（无独立标题行）时，title 回退为默认值 `Always-On Discovery Run`，且 `Plan Reference` section 内容被正确提取

Made with [Cursor](https://cursor.com)