### PR TITLE
fix(proxy): bypass localhost, promote to top-level config, and fix race condition

### DIFF
--- a/src/cli/pilotdeck.ts
+++ b/src/cli/pilotdeck.ts
@@ -17,7 +17,7 @@ import { installGlobalProxy } from "./proxy.js";
 import { createShutdownAndExit } from "./shutdownCoordinator.js";
 import { createTelemetryCollector } from "../telemetry/index.js";
 
-installGlobalProxy();
+await installGlobalProxy();
 
 async function main(argv = process.argv.slice(2)): Promise<void> {
   const command = argv[0];

--- a/src/cli/pilotdeck.ts
+++ b/src/cli/pilotdeck.ts
@@ -13,7 +13,7 @@ import {
 import { loadPilotConfig, resolvePilotHome } from "../pilot/index.js";
 import { createLocalGateway } from "./createLocalGateway.js";
 import { startPilotDeckServer } from "./pilotdeckServer.js";
-import { installGlobalProxy } from "./proxy.js";
+import { installGlobalProxy, reinstallGlobalProxy } from "./proxy.js";
 import { createShutdownAndExit } from "./shutdownCoordinator.js";
 import { createTelemetryCollector } from "../telemetry/index.js";
 
@@ -27,6 +27,12 @@ async function main(argv = process.argv.slice(2)): Promise<void> {
     const pilotHome = resolvePilotHome(env);
     const snapshot = loadPilotConfig({ projectRoot, env });
     const telemetry = createTelemetryCollector({ env, pilotHome });
+
+    // Apply proxy from config (env-based proxy from top-level installGlobalProxy
+    // takes precedence; this fills in when only pilotdeck.yaml has a proxy).
+    if (snapshot.config.proxy?.url) {
+      await installGlobalProxy(snapshot.config.proxy.url);
+    }
 
     let alwaysOn: AlwaysOnManager | undefined;
     let cron: CronRuntime | undefined;
@@ -130,6 +136,13 @@ async function main(argv = process.argv.slice(2)): Promise<void> {
     configStore.subscribe((event) => {
       const aoChanged = event.changedPaths.some((p) => p.startsWith("alwaysOn."));
       const cronChanged = event.changedPaths.some((p) => p.startsWith("cron."));
+      const proxyChanged = event.changedPaths.some((p) => p.startsWith("proxy.") || p === "proxy");
+
+      if (proxyChanged) {
+        const proxyConfig = event.nextSnapshot.config.proxy;
+        void reinstallGlobalProxy(proxyConfig?.url, proxyConfig?.noProxy);
+      }
+
       if (!aoChanged && !cronChanged) return;
 
       reloadChain = reloadChain

--- a/src/cli/proxy.ts
+++ b/src/cli/proxy.ts
@@ -15,30 +15,43 @@ export function getProxyUrl(env: EnvLike = process.env): string | undefined {
 }
 
 /**
- * Install a global undici ProxyAgent so that all native `fetch()` calls
- * in the process are routed through the configured HTTP/HTTPS proxy.
+ * Install a global undici EnvHttpProxyAgent so that all native
+ * `fetch()` and `WebSocket` calls in the process are routed through
+ * the configured HTTP/HTTPS proxy, while respecting `NO_PROXY`.
  *
- * Node.js native fetch (backed by undici) does NOT respect the standard
- * HTTPS_PROXY / HTTP_PROXY env vars — unlike curl or Python requests.
- * This function bridges that gap by calling `setGlobalDispatcher`.
+ * `127.0.0.1` and `localhost` are always excluded — the gateway
+ * WebSocket lives on loopback and must never be routed through an
+ * external proxy.
+ *
+ * Node.js native fetch (backed by undici) does NOT respect the
+ * standard HTTPS_PROXY / HTTP_PROXY env vars — unlike curl or Python
+ * requests. This function bridges that gap via `setGlobalDispatcher`.
  *
  * Safe to call multiple times; only the first effective call installs.
  * Returns the proxy URL that was activated, or undefined if none.
  */
 let installed = false;
 
-export function installGlobalProxy(explicitUrl?: string): string | undefined {
+export async function installGlobalProxy(explicitUrl?: string): Promise<string | undefined> {
   if (installed) return undefined;
 
   const proxyUrl = explicitUrl ?? getProxyUrl();
   if (!proxyUrl) return undefined;
 
   try {
-    const { ProxyAgent, setGlobalDispatcher } = require("undici") as typeof import("undici");
-    const agent = new ProxyAgent(proxyUrl);
+    const { EnvHttpProxyAgent, setGlobalDispatcher } = await import("undici");
+    const userNoProxy = process.env.no_proxy || process.env.NO_PROXY || "";
+    const noProxy = [userNoProxy, "127.0.0.1", "localhost"]
+      .filter(Boolean)
+      .join(",");
+    const agent = new EnvHttpProxyAgent({
+      httpProxy: proxyUrl,
+      httpsProxy: proxyUrl,
+      noProxy,
+    });
     setGlobalDispatcher(agent);
     installed = true;
-    console.log(`[proxy] Global fetch proxy → ${proxyUrl}`);
+    console.log(`[proxy] Global fetch proxy → ${proxyUrl} (noProxy: ${noProxy})`);
     return proxyUrl;
   } catch (error) {
     console.warn(

--- a/src/cli/proxy.ts
+++ b/src/cli/proxy.ts
@@ -32,14 +32,19 @@ export function getProxyUrl(env: EnvLike = process.env): string | undefined {
  * Returns the proxy URL that was activated, or undefined if none.
  */
 let installed = false;
+let pendingInstall: Promise<string | undefined> | null = null;
 
 export async function installGlobalProxy(explicitUrl?: string): Promise<string | undefined> {
   if (installed) return undefined;
+  if (pendingInstall) return pendingInstall;
 
   const proxyUrl = explicitUrl ?? getProxyUrl();
   if (!proxyUrl) return undefined;
 
-  return applyGlobalProxy(proxyUrl);
+  pendingInstall = applyGlobalProxy(proxyUrl).finally(() => {
+    pendingInstall = null;
+  });
+  return pendingInstall;
 }
 
 /**
@@ -52,6 +57,8 @@ export async function reinstallGlobalProxy(
   proxyUrl: string | undefined,
   extraNoProxy?: string,
 ): Promise<string | undefined> {
+  if (pendingInstall) await pendingInstall;
+
   if (!proxyUrl) {
     try {
       const { Agent, setGlobalDispatcher } = await import("undici");

--- a/src/cli/proxy.ts
+++ b/src/cli/proxy.ts
@@ -28,6 +28,7 @@ export function getProxyUrl(env: EnvLike = process.env): string | undefined {
  * requests. This function bridges that gap via `setGlobalDispatcher`.
  *
  * Safe to call multiple times; only the first effective call installs.
+ * Use {@link reinstallGlobalProxy} when the proxy URL changes at runtime.
  * Returns the proxy URL that was activated, or undefined if none.
  */
 let installed = false;
@@ -38,10 +39,41 @@ export async function installGlobalProxy(explicitUrl?: string): Promise<string |
   const proxyUrl = explicitUrl ?? getProxyUrl();
   if (!proxyUrl) return undefined;
 
+  return applyGlobalProxy(proxyUrl);
+}
+
+/**
+ * Unconditionally (re-)install the global proxy dispatcher.
+ * Called by hot-reload paths when `proxy.*` config changes at runtime.
+ * Passing `undefined` or empty string removes the proxy (resets to
+ * a no-op agent so outbound requests go direct).
+ */
+export async function reinstallGlobalProxy(
+  proxyUrl: string | undefined,
+  extraNoProxy?: string,
+): Promise<string | undefined> {
+  if (!proxyUrl) {
+    try {
+      const { Agent, setGlobalDispatcher } = await import("undici");
+      setGlobalDispatcher(new Agent());
+      installed = false;
+      console.log("[proxy] Global fetch proxy removed");
+    } catch {
+      // best effort
+    }
+    return undefined;
+  }
+  return applyGlobalProxy(proxyUrl, extraNoProxy);
+}
+
+async function applyGlobalProxy(
+  proxyUrl: string,
+  extraNoProxy?: string,
+): Promise<string | undefined> {
   try {
     const { EnvHttpProxyAgent, setGlobalDispatcher } = await import("undici");
     const userNoProxy = process.env.no_proxy || process.env.NO_PROXY || "";
-    const noProxy = [userNoProxy, "127.0.0.1", "localhost"]
+    const noProxy = [userNoProxy, extraNoProxy, "127.0.0.1", "localhost"]
       .filter(Boolean)
       .join(",");
     const agent = new EnvHttpProxyAgent({

--- a/src/pilot/config/classifyChanges.ts
+++ b/src/pilot/config/classifyChanges.ts
@@ -39,6 +39,9 @@ function classifyPath(path: string): PilotConfigChangeClass {
   if (path.startsWith("tools.")) {
     return "next-runtime";
   }
+  if (path.startsWith("proxy.") || path === "proxy") {
+    return "runtime-live";
+  }
   return "next-runtime";
 }
 

--- a/src/pilot/config/index.ts
+++ b/src/pilot/config/index.ts
@@ -27,6 +27,7 @@ export {
   type PilotAdaptersConfig,
   type PilotGatewayConfig,
   type PilotRouterConfig,
+  type PilotProxyConfig,
   type PilotToolsConfig,
   type PilotWebSearchConfig,
 } from "./types.js";

--- a/src/pilot/config/loadPilotConfig.ts
+++ b/src/pilot/config/loadPilotConfig.ts
@@ -19,6 +19,7 @@ import {
   type PilotAgentModelSelection,
   type PilotConfigDiagnostic,
   type PilotExtensionConfig,
+  type PilotProxyConfig,
   type PilotConfigLoadOptions,
   type PilotConfigSnapshot,
   type PilotConfigSource,
@@ -122,6 +123,7 @@ export function loadPilotConfig(options: PilotConfigLoadOptions = {}): PilotConf
   const alwaysOn = parseAlwaysOnConfig(rawConfig.alwaysOn, diagnostics);
   const cron = parseCronConfig(rawConfig.cron, diagnostics);
   const tools = parseToolsConfig(rawConfig.tools, diagnostics);
+  const proxy = parseProxyConfig(rawConfig, diagnostics);
   throwConfigErrorIfFatal(diagnostics);
 
   const redactedSnapshotConfig = redactConfig({
@@ -135,6 +137,7 @@ export function loadPilotConfig(options: PilotConfigLoadOptions = {}): PilotConf
     alwaysOn,
     cron,
     tools,
+    proxy,
   });
   return deepFreeze({
     version: options.version ?? 1,
@@ -154,6 +157,7 @@ export function loadPilotConfig(options: PilotConfigLoadOptions = {}): PilotConf
       ...(alwaysOn ? { alwaysOn } : {}),
       ...(cron ? { cron } : {}),
       ...(tools ? { tools } : {}),
+      ...(proxy ? { proxy } : {}),
     },
   });
 }
@@ -299,6 +303,7 @@ function validateTopLevel(rawConfig: PilotRawConfig, diagnostics: PilotConfigDia
     "alwaysOn",
     "cron",
     "tools",
+    "proxy",
     // Reserved namespace for ui/server (Web UI Express bridge). The PilotDeck
     // gateway does not parse `webui.*` itself but tolerates it so a single
     // ~/.pilotdeck/pilotdeck.yaml can carry both gateway-side and ui-side
@@ -611,6 +616,64 @@ function parseRouterSection(
     });
   }
   return result.config;
+}
+
+function parseProxyConfig(
+  rawConfig: PilotRawConfig,
+  diagnostics: PilotConfigDiagnostic[],
+): PilotProxyConfig | undefined {
+  let raw = rawConfig.proxy;
+
+  // Backward-compat: migrate webui.runtime.httpsProxy → proxy.url
+  if (raw === undefined && isRecord(rawConfig.webui)) {
+    const webui = rawConfig.webui as Record<string, unknown>;
+    if (isRecord(webui.runtime)) {
+      const runtime = webui.runtime as Record<string, unknown>;
+      if (typeof runtime.httpsProxy === "string" && runtime.httpsProxy) {
+        raw = { url: runtime.httpsProxy };
+        diagnostics.push({
+          code: "CONFIG_PROXY_MIGRATED",
+          severity: "info",
+          message:
+            "webui.runtime.httpsProxy has been migrated to the top-level proxy.url field. " +
+            "Please update your pilotdeck.yaml to use proxy.url instead.",
+          path: "webui.runtime.httpsProxy",
+          recoverable: true,
+        });
+      }
+    }
+  }
+
+  if (raw === undefined) return undefined;
+
+  if (typeof raw === "string") {
+    return { url: raw };
+  }
+
+  if (!isRecord(raw)) {
+    diagnostics.push({
+      code: "CONFIG_PROXY_INVALID",
+      severity: "warning",
+      message: "proxy must be a string or an object with a url field.",
+      path: "proxy",
+      recoverable: true,
+    });
+    return undefined;
+  }
+
+  if (typeof raw.url !== "string" || !raw.url) {
+    diagnostics.push({
+      code: "CONFIG_PROXY_URL_MISSING",
+      severity: "warning",
+      message: "proxy.url must be a non-empty string.",
+      path: "proxy.url",
+      recoverable: true,
+    });
+    return undefined;
+  }
+
+  const noProxy = typeof raw.noProxy === "string" ? raw.noProxy : undefined;
+  return { url: raw.url, ...(noProxy ? { noProxy } : {}) };
 }
 
 function deepFreeze<T>(value: T): T {

--- a/src/pilot/config/types.ts
+++ b/src/pilot/config/types.ts
@@ -45,6 +45,8 @@ export type PilotRawConfig = {
   alwaysOn?: unknown;
   cron?: unknown;
   tools?: unknown;
+  proxy?: unknown;
+  webui?: unknown;
 };
 
 export type PilotExtensionConfig = {
@@ -149,6 +151,11 @@ export type PilotToolsConfig = {
   webSearch?: PilotWebSearchConfig;
 };
 
+export type PilotProxyConfig = {
+  url: string;
+  noProxy?: string;
+};
+
 export type PilotPlatformAdapterConfig = {
   enabled: boolean;
   token?: string;
@@ -204,6 +211,7 @@ export type PilotConfig = {
   alwaysOn?: AlwaysOnConfig;
   cron?: CronConfig;
   tools?: PilotToolsConfig;
+  proxy?: PilotProxyConfig;
 };
 
 export type PilotConfigSnapshot = {

--- a/ui/server/index.js
+++ b/ui/server/index.js
@@ -9,7 +9,7 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { dirname } from 'path';
-import net from 'net';
+
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -139,111 +139,6 @@ const alwaysOnHeartbeat = createAlwaysOnHeartbeatManager({
 });
 registerAlwaysOnNotificationForwarding(connectedClients);
 let isGetProjectsRunning = false; // Flag to prevent reentrant calls
-let pilotDeckProxyProcess = null;
-
-function resolveBunExecutable() {
-    const candidates = [
-        process.env.BUN_BIN,
-        process.env.BUN,
-        process.env.BUN_INSTALL ? path.join(process.env.BUN_INSTALL, 'bin', 'bun') : null,
-        path.join(os.homedir(), '.bun', 'bin', 'bun'),
-        '/opt/homebrew/bin/bun',
-        '/usr/local/bin/bun',
-        'bun',
-    ].filter(Boolean);
-
-    for (const candidate of candidates) {
-        if (candidate === 'bun' || fs.existsSync(candidate)) {
-            return candidate;
-        }
-    }
-
-    return 'bun';
-}
-
-function isLocalPortListening(port, host = '127.0.0.1', timeoutMs = 400) {
-    return new Promise(resolve => {
-        const socket = net.createConnection({ port, host });
-        const finalize = (isOpen) => {
-            socket.destroy();
-            resolve(isOpen);
-        };
-
-        socket.setTimeout(timeoutMs);
-        socket.once('connect', () => finalize(true));
-        socket.once('timeout', () => finalize(false));
-        socket.once('error', () => finalize(false));
-    });
-}
-
-async function waitForLocalPort(port, host = '127.0.0.1', timeoutMs = 4000) {
-    const deadline = Date.now() + timeoutMs;
-    while (Date.now() < deadline) {
-        if (await isLocalPortListening(port, host)) {
-            return true;
-        }
-        await new Promise(resolve => setTimeout(resolve, 120));
-    }
-    return false;
-}
-
-async function ensurePilotDeckProxyRunning() {
-    // The legacy in-process proxy bootstrap was tied to a bundled CCR pipeline
-    // that we removed during the PilotDeck-only migration.
-    // Model traffic now flows through `src/gateway` directly. Returning
-    // immediately keeps any callers happy without touching dead code.
-    return;
-    // The unreachable body below is left as historical scaffolding.
-    // eslint-disable-next-line no-unreachable
-    const proxyPort = parseInt(process.env.PROXY_PORT || process.env.PILOTDECK_PROXY_PORT || '18080', 10);
-    if (!proxyPort) return;
-    if (await isLocalPortListening(proxyPort)) {
-        console.log(`${c.info('[INFO]')} Reusing existing PilotDeck-friendly proxy on http://127.0.0.1:${proxyPort}`);
-        return;
-    }
-
-    console.error(`[ERROR] PilotDeck proxy did not become ready on http://127.0.0.1:${proxyPort}`);
-}
-
-async function stopPilotDeckProxy() {
-    if (!pilotDeckProxyProcess) {
-        return;
-    }
-
-    const proxyProcess = pilotDeckProxyProcess;
-    pilotDeckProxyProcess = null;
-
-    if (proxyProcess.exitCode !== null || proxyProcess.signalCode !== null) {
-        return;
-    }
-
-    await new Promise(resolve => {
-        const timeout = setTimeout(() => {
-            proxyProcess.kill('SIGKILL');
-        }, 2000);
-
-        proxyProcess.once('exit', () => {
-            clearTimeout(timeout);
-            resolve();
-        });
-
-        proxyProcess.kill('SIGTERM');
-    });
-}
-
-process.on('pilotdeck:restart-proxy', async (done) => {
-    try {
-        await stopPilotDeckProxy();
-        await ensurePilotDeckProxyRunning();
-        if (typeof done === 'function') {
-            done(null);
-        }
-    } catch (error) {
-        if (typeof done === 'function') {
-            done(error);
-        }
-    }
-});
 
 // Broadcast progress to all connected WebSocket clients
 function broadcastProgress(progress) {
@@ -3059,8 +2954,6 @@ async function startServer() {
                     // Start watching the projects folder for changes
                     await setupProjectsWatcher();
 
-                    await ensurePilotDeckProxyRunning();
-
                     // Start background memory scheduler for auto index/dream.
                     startMemoryScheduler();
 
@@ -3092,7 +2985,6 @@ async function startServer() {
                     stopMemoryScheduler();
                     closeMemoryServices();
                     stopPilotDeckConfigWatcher();
-                    await stopPilotDeckProxy();
                     await stopAllPlugins();
                     // helpers were retired with the four-provider runtime.
                     try {

--- a/ui/server/pilotdeck-bridge.js
+++ b/ui/server/pilotdeck-bridge.js
@@ -45,7 +45,7 @@ import { promises as fsPromises } from 'node:fs';
 import { randomUUID } from 'node:crypto';
 
 import { installGlobalProxy } from '../../src/cli/proxy.js';
-installGlobalProxy();
+await installGlobalProxy();
 
 import { resolvePilotHome, createProjectId, sanitizeSessionIdForPath } from './utils/pilotPaths.js';
 // Read the gateway client straight from TypeScript source via tsx — the UI

--- a/ui/server/services/cron-daemon-startup.js
+++ b/ui/server/services/cron-daemon-startup.js
@@ -15,8 +15,6 @@ function resolvePilotDeckMainRoot() {
 const DEFAULT_RETRY_ATTEMPTS = 20;
 const DEFAULT_RETRY_DELAY_MS = 250;
 const START_LOCK_STALE_MS = 30000;
-const CCR_SENTINEL = 'http://ccr.local';
-const CCR_DAEMON_FETCH_INTERCEPTOR = 'CCR_DAEMON_FETCH_INTERCEPTOR';
 
 function getPilotDeckConfigHomeDir() {
   return process.env.PILOTDECK_CONFIG_DIR || process.env.PILOT_HOME || path.join(os.homedir(), '.pilotdeck');
@@ -73,11 +71,7 @@ export function isCronDaemonUnavailableError(error) {
 }
 
 export function buildCronDaemonEnv(baseEnv = process.env) {
-  const env = { ...baseEnv };
-  if (env.ANTHROPIC_BASE_URL === CCR_SENTINEL) {
-    env[CCR_DAEMON_FETCH_INTERCEPTOR] = '1';
-  }
-  return env;
+  return { ...baseEnv };
 }
 
 export function buildCronDaemonSpawnCommand({

--- a/ui/server/services/pilotdeckConfig.js
+++ b/ui/server/services/pilotdeckConfig.js
@@ -12,7 +12,7 @@ import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
 //   agent:    { model: "provider/model", params, subagents }
 //   model:    { providers: { [pid]: { protocol, url, apiKey, models, headers, timeoutMs } } }
 //   memory:   { enabled, model, apiType?, reasoningMode, ... }
-//   webui:    { runtime: { host, serverPort, vitePort, proxyPort, ... } }
+//   webui:    { runtime: { host, serverPort, vitePort, ... } }
 //   router:   { enabled, stats: { enabled, modelPricing }, ... }
 //   gateway:  { enabled, home, ... }
 //   alwaysOn: { enabled, trigger, dormancy, workspace, execution, projects }
@@ -85,7 +85,6 @@ export function buildDefaultPilotDeckConfig() {
         host: '0.0.0.0',
         serverPort: 3001,
         vitePort: 5173,
-        proxyPort: 18080,
         apiTimeoutMs: 120000,
         httpsProxy: '',
         databasePath: path.join(PILOT_HOME_DIR, 'auth.db'),
@@ -306,11 +305,8 @@ export function buildRuntimeEnv(config) {
   const normalized = normalizePilotDeckConfig(config);
   const main = resolveModel(normalized, normalized.agent.model, { allowMissing: true });
   const runtime = normalized.webui?.runtime ?? {};
-  const proxyPort = String(runtime.proxyPort ?? 18080);
 
   const env = {
-    PILOTDECK_PROXY_PORT: process.env.PILOTDECK_PROXY_PORT || proxyPort,
-    PROXY_PORT: process.env.PROXY_PORT || proxyPort,
     SERVER_PORT: process.env.SERVER_PORT || String(runtime.serverPort ?? 3001),
     VITE_PORT: process.env.VITE_PORT || String(runtime.vitePort ?? 5173),
     HOST: process.env.HOST || String(runtime.host ?? '0.0.0.0'),
@@ -335,7 +331,6 @@ export function buildRuntimeEnv(config) {
     env.ANTHROPIC_API_KEY = main.provider.apiKey || '';
     env.ANTHROPIC_MODEL = main.model;
   }
-  env.ANTHROPIC_BASE_URL = `http://127.0.0.1:${proxyPort}`;
 
   // Reasoning models (DeepSeek-R1, MiniMax-M2.7, etc.) need a generous
   // output token cap; honor agent.params.maxOutputTokens / max_tokens.

--- a/ui/server/services/pilotdeckConfig.js
+++ b/ui/server/services/pilotdeckConfig.js
@@ -86,7 +86,6 @@ export function buildDefaultPilotDeckConfig() {
         serverPort: 3001,
         vitePort: 5173,
         apiTimeoutMs: 120000,
-        httpsProxy: '',
         databasePath: path.join(PILOT_HOME_DIR, 'auth.db'),
         workspacesRoot: os.homedir(),
       },
@@ -316,9 +315,12 @@ export function buildRuntimeEnv(config) {
 
   if (runtime.databasePath) env.DATABASE_PATH = expandTilde(runtime.databasePath);
   if (runtime.workspacesRoot) env.WORKSPACES_ROOT = expandTilde(runtime.workspacesRoot);
-  if (runtime.httpsProxy) {
-    env.HTTPS_PROXY = runtime.httpsProxy;
-    env.https_proxy = runtime.httpsProxy;
+  const proxyUrl = normalized.proxy?.url
+    || (typeof normalized.proxy === 'string' ? normalized.proxy : '')
+    || runtime.httpsProxy || '';
+  if (proxyUrl) {
+    env.HTTPS_PROXY = proxyUrl;
+    env.https_proxy = proxyUrl;
   }
 
   if (main) {

--- a/ui/server/services/pilotdeckConfigReloader.js
+++ b/ui/server/services/pilotdeckConfigReloader.js
@@ -9,7 +9,6 @@ export async function reloadPilotDeckConfig(config) {
   const result = {
     processEnv: { reloaded: false },
     memory: { reloaded: false },
-    proxy: { reloaded: false, skipped: false },
   };
 
   applyConfigToProcessEnv(config);
@@ -21,19 +20,6 @@ export async function reloadPilotDeckConfig(config) {
   }
   result.memory.reloaded = true;
   result.memory.scheduler = config.memory?.enabled ? 'started' : 'stopped';
-
-  result.proxy = await new Promise((resolve) => {
-    const handled = process.emit('pilotdeck:restart-proxy', (error) => {
-      if (error) {
-        resolve({ reloaded: false, error: error instanceof Error ? error.message : String(error) });
-      } else {
-        resolve({ reloaded: true });
-      }
-    });
-    if (!handled) {
-      resolve({ reloaded: false, skipped: true, reason: 'proxy restart hook is not registered in this process' });
-    }
-  });
 
   return result;
 }

--- a/ui/server/utils/proxy.js
+++ b/ui/server/utils/proxy.js
@@ -1,13 +1,19 @@
 /**
  * Pure-JS port of `src/cli/proxy.ts` — installs a global undici
- * ProxyAgent so Node native `fetch()` honors `PILOTDECK_PROXY` /
- * `HTTPS_PROXY` / `HTTP_PROXY`. Node's native fetch does NOT respect
- * those env vars by default; this closes the gap.
+ * proxy agent so Node native `fetch()` and `WebSocket` honor
+ * `PILOTDECK_PROXY` / `HTTPS_PROXY` / `HTTP_PROXY`. Node's native
+ * fetch does NOT respect those env vars by default; this closes the
+ * gap.
+ *
+ * Uses `EnvHttpProxyAgent` instead of bare `ProxyAgent` so that
+ * `NO_PROXY` / `no_proxy` is honored. `127.0.0.1` and `localhost`
+ * are always excluded — the gateway WebSocket lives on loopback and
+ * must never be routed through an external proxy.
  *
  * Living in `ui/server/utils/` lets the express bridge run from
  * source without depending on `dist/src/cli/proxy.js`.
  */
-import { ProxyAgent, setGlobalDispatcher } from 'undici';
+import { EnvHttpProxyAgent, setGlobalDispatcher } from 'undici';
 
 function getProxyUrl(env = process.env) {
     return (
@@ -22,9 +28,9 @@ function getProxyUrl(env = process.env) {
 let installed = false;
 
 /**
- * Install a global undici ProxyAgent. Safe to call multiple times —
- * only the first effective call wins. Returns the proxy URL that was
- * activated, or undefined if no proxy is configured.
+ * Install a global undici EnvHttpProxyAgent. Safe to call multiple
+ * times — only the first effective call wins. Returns the proxy URL
+ * that was activated, or undefined if no proxy is configured.
  *
  * @param {string} [explicitUrl] Override the env-driven proxy URL.
  * @returns {string | undefined} The activated proxy URL.
@@ -34,10 +40,18 @@ export function installGlobalProxy(explicitUrl) {
     const proxyUrl = explicitUrl ?? getProxyUrl();
     if (!proxyUrl) return undefined;
     try {
-        const agent = new ProxyAgent(proxyUrl);
+        const userNoProxy = process.env.no_proxy || process.env.NO_PROXY || '';
+        const noProxy = [userNoProxy, '127.0.0.1', 'localhost']
+            .filter(Boolean)
+            .join(',');
+        const agent = new EnvHttpProxyAgent({
+            httpProxy: proxyUrl,
+            httpsProxy: proxyUrl,
+            noProxy,
+        });
         setGlobalDispatcher(agent);
         installed = true;
-        console.log(`[proxy] Global fetch proxy → ${proxyUrl}`);
+        console.log(`[proxy] Global fetch proxy → ${proxyUrl} (noProxy: ${noProxy})`);
         return proxyUrl;
     } catch (error) {
         console.warn(

--- a/ui/src/components/settings/view/tabs/PilotDeckConfigTab.tsx
+++ b/ui/src/components/settings/view/tabs/PilotDeckConfigTab.tsx
@@ -92,7 +92,6 @@ type PilotDeckConfig = {
       host?: string;
       serverPort?: number;
       vitePort?: number;
-      proxyPort?: number;
       apiTimeoutMs?: number;
       httpsProxy?: string;
       databasePath?: string;
@@ -632,9 +631,6 @@ function ServiceSection({ config, onChange }: { config: PilotDeckConfig; onChang
           </FormRow>
           <FormRow label={t('pilotDeckConfig.panels.runtime.fields.serverPort.label')} description={t('pilotDeckConfig.panels.runtime.fields.serverPort.description')}>
             <NumberInput value={r.serverPort} placeholder="3001" onChange={(v) => set('serverPort', v)} />
-          </FormRow>
-          <FormRow label={t('pilotDeckConfig.panels.runtime.fields.proxyPort.label')} description={t('pilotDeckConfig.panels.runtime.fields.proxyPort.description')}>
-            <NumberInput value={r.proxyPort} placeholder="18080" onChange={(v) => set('proxyPort', v)} />
           </FormRow>
           <FormRow label={t('pilotDeckConfig.panels.runtime.fields.workspacesRoot.label')} description={t('pilotDeckConfig.panels.runtime.fields.workspacesRoot.description')}>
             <TextInput value={r.workspacesRoot} placeholder="~" monospace onChange={(v) => set('workspacesRoot', v)} />

--- a/ui/src/components/settings/view/tabs/PilotDeckConfigTab.tsx
+++ b/ui/src/components/settings/view/tabs/PilotDeckConfigTab.tsx
@@ -87,13 +87,16 @@ type PilotDeckConfig = {
     maxMessageChars?: number;
     heartbeatBatchSize?: number;
   };
+  proxy?: {
+    url?: string;
+    noProxy?: string;
+  };
   webui?: {
     runtime?: {
       host?: string;
       serverPort?: number;
       vitePort?: number;
       apiTimeoutMs?: number;
-      httpsProxy?: string;
       databasePath?: string;
       workspacesRoot?: string;
     };
@@ -658,8 +661,11 @@ function ServiceSection({ config, onChange }: { config: PilotDeckConfig; onChang
             <FormRow label={t('pilotDeckConfig.panels.runtime.fields.databasePath.label')} description={t('pilotDeckConfig.panels.runtime.fields.databasePath.description')}>
               <TextInput value={r.databasePath} placeholder="~/.pilotdeck/auth.db" monospace onChange={(v) => set('databasePath', v)} />
             </FormRow>
-            <FormRow label={t('pilotDeckConfig.panels.runtime.fields.httpsProxy.label')} description={t('pilotDeckConfig.panels.runtime.fields.httpsProxy.description')}>
-              <TextInput value={r.httpsProxy} placeholder="http://127.0.0.1:7890" monospace onChange={(v) => set('httpsProxy', v)} />
+            <FormRow label={t('pilotDeckConfig.panels.runtime.fields.proxyUrl.label')} description={t('pilotDeckConfig.panels.runtime.fields.proxyUrl.description')}>
+              <TextInput value={config.proxy?.url} placeholder="http://127.0.0.1:7890" monospace onChange={(v) => onChange(patch(config, ['proxy', 'url'], v))} />
+            </FormRow>
+            <FormRow label={t('pilotDeckConfig.panels.runtime.fields.proxyNoProxy.label')} description={t('pilotDeckConfig.panels.runtime.fields.proxyNoProxy.description')}>
+              <TextInput value={config.proxy?.noProxy} placeholder="127.0.0.1,localhost" monospace onChange={(v) => onChange(patch(config, ['proxy', 'noProxy'], v))} />
             </FormRow>
           </div>
         )}

--- a/ui/src/i18n/locales/en/settings.json
+++ b/ui/src/i18n/locales/en/settings.json
@@ -658,7 +658,6 @@
           "host": { "label": "Host", "description": "Bind interface for the HTTP/WebSocket server." },
           "serverPort": { "label": "Server port", "description": "Express + WebSocket port." },
           "vitePort": { "label": "Vite port", "description": "Frontend dev server (only used when running `npm run dev`)." },
-          "proxyPort": { "label": "Proxy port", "description": "Local LLM proxy (PilotDeck agent target)." },
           "apiTimeout": { "label": "API timeout (ms)", "description": "Per-request upstream timeout." },
           "databasePath": { "label": "Database path", "description": "SQLite auth/projects database (~ expands to home)." },
           "workspacesRoot": { "label": "Workspaces root", "description": "Directory under which projects are scanned." },

--- a/ui/src/i18n/locales/en/settings.json
+++ b/ui/src/i18n/locales/en/settings.json
@@ -661,7 +661,8 @@
           "apiTimeout": { "label": "API timeout (ms)", "description": "Per-request upstream timeout." },
           "databasePath": { "label": "Database path", "description": "SQLite auth/projects database (~ expands to home)." },
           "workspacesRoot": { "label": "Workspaces root", "description": "Directory under which projects are scanned." },
-          "httpsProxy": { "label": "HTTPS proxy", "description": "Outbound HTTPS proxy URL (HTTPS_PROXY / https_proxy)." }
+          "proxyUrl": { "label": "HTTPS proxy", "description": "Outbound HTTPS proxy URL. Applies to both Gateway and UI Server (proxy.url in pilotdeck.yaml)." },
+          "proxyNoProxy": { "label": "No-proxy list", "description": "Comma-separated hostnames/IPs that bypass the proxy (proxy.noProxy in pilotdeck.yaml). 127.0.0.1 and localhost are always excluded." }
         }
       },
       "models": {

--- a/ui/src/i18n/locales/zh-CN/settings.json
+++ b/ui/src/i18n/locales/zh-CN/settings.json
@@ -658,7 +658,6 @@
           "host": { "label": "主机", "description": "HTTP/WebSocket 服务器的绑定接口。" },
           "serverPort": { "label": "服务器端口", "description": "Express + WebSocket 端口。" },
           "vitePort": { "label": "Vite 端口", "description": "前端开发服务器（仅在运行 npm run dev 时使用）。" },
-          "proxyPort": { "label": "代理端口", "description": "本地 LLM 代理（PilotDeck 智能体目标）。" },
           "apiTimeout": { "label": "API 超时（毫秒）", "description": "每次请求的上游超时。" },
           "databasePath": { "label": "数据库路径", "description": "SQLite 认证/项目数据库（~ 展开为主目录）。" },
           "workspacesRoot": { "label": "工作区根目录", "description": "项目扫描的根目录。" },

--- a/ui/src/i18n/locales/zh-CN/settings.json
+++ b/ui/src/i18n/locales/zh-CN/settings.json
@@ -661,7 +661,8 @@
           "apiTimeout": { "label": "API 超时（毫秒）", "description": "每次请求的上游超时。" },
           "databasePath": { "label": "数据库路径", "description": "SQLite 认证/项目数据库（~ 展开为主目录）。" },
           "workspacesRoot": { "label": "工作区根目录", "description": "项目扫描的根目录。" },
-          "httpsProxy": { "label": "HTTPS 代理", "description": "出站 HTTPS 代理 URL（HTTPS_PROXY / https_proxy）。" }
+          "proxyUrl": { "label": "HTTPS 代理", "description": "出站 HTTPS 代理 URL，同时作用于 Gateway 和 UI Server（对应 pilotdeck.yaml 中的 proxy.url）。" },
+          "proxyNoProxy": { "label": "代理排除列表", "description": "逗号分隔的主机名/IP，这些地址不走代理（对应 pilotdeck.yaml 中的 proxy.noProxy）。127.0.0.1 和 localhost 始终排除。" }
         }
       },
       "models": {


### PR DESCRIPTION
## Summary

- **Bypass proxy for Gateway WebSocket**: Exclude `127.0.0.1` and `localhost` from the global proxy so the Gateway loopback WebSocket is never routed through an external proxy. Remove dead `proxyPort` / legacy proxy-process code.
- **Promote proxy config to top-level field**: Move proxy configuration from `webui.runtime.httpsProxy` to a top-level `proxy.url` / `proxy.noProxy` field in `pilotdeck.yaml`, enabling Gateway hot-reload via `reinstallGlobalProxy()` and `configStore.subscribe`. Includes backward-compat migration from the old location.
- **Fix race condition in `installGlobalProxy`** (#137): Use a Promise lock (`pendingInstall`) so concurrent async callers share the same in-flight install instead of racing past the `installed` guard during the dynamic `import("undici")` await gap.

Closes #137

## Test plan

- [ ] Configure `proxy.url` in Web UI settings, save, and verify the field appears in `~/.pilotdeck/pilotdeck.yaml`
- [ ] Start PilotDeck with `HTTPS_PROXY` env var set; verify `[proxy] Global fetch proxy →` log and that outbound API calls succeed
- [ ] Verify Gateway WebSocket (`127.0.0.1`) is not routed through the proxy (agent conversations work normally)
- [ ] Hot-reload: edit `proxy.url` in YAML while running; verify proxy is reinstalled without restart
- [ ] Remove `proxy.url` from config; verify `[proxy] Global fetch proxy removed` log


Made with [Cursor](https://cursor.com)