### PR TITLE
feat: auto-update with unified command registry

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,9 @@ services:
       - PILOT_HOME=/root/.pilotdeck
       - SERVER_PORT=3001
       - PILOTDECK_GATEWAY_PORT=18789
+      # ── Authentication (uncomment to require login) ──
+      # - PILOTDECK_DISABLE_LOCAL_AUTH=0
+      #
       # ── Proxy (uncomment if behind corporate proxy) ──
       # - https_proxy=http://host.docker.internal:7890
       # - PILOTDECK_PROXY=http://host.docker.internal:7890

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# PilotDeck self-update script.
+# Pulls latest code, rebuilds, and signals the parent process to restart.
+#
+# Usage:
+#   scripts/update.sh [--restart]
+#
+# Exit codes:
+#   0 = update successful (caller should restart services)
+#   1 = error during update
+#   2 = already up-to-date (no changes pulled)
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+RED='\033[0;31m'
+DIM='\033[2m'
+RESET='\033[0m'
+
+log()  { printf "${GREEN}[update]${RESET} %s\n" "$1"; }
+warn() { printf "${YELLOW}[update]${RESET} %s\n" "$1"; }
+fail() { printf "${RED}[update]${RESET} %s\n" "$1" >&2; exit 1; }
+
+DO_RESTART=0
+for arg in "$@"; do
+  case "$arg" in
+    --restart) DO_RESTART=1 ;;
+  esac
+done
+
+cd "$PROJECT_ROOT"
+
+if [[ ! -d ".git" ]]; then
+  fail "Not a git repository. Cannot update."
+fi
+
+CURRENT_BRANCH="$(git branch --show-current 2>/dev/null || echo "unknown")"
+log "Current branch: $CURRENT_BRANCH"
+
+log "Fetching latest changes..."
+git fetch origin "$CURRENT_BRANCH" 2>&1
+
+LOCAL_HEAD="$(git rev-parse HEAD)"
+REMOTE_HEAD="$(git rev-parse "origin/$CURRENT_BRANCH" 2>/dev/null || echo "")"
+
+if [[ -z "$REMOTE_HEAD" ]]; then
+  fail "Cannot determine remote HEAD for branch $CURRENT_BRANCH"
+fi
+
+if [[ "$LOCAL_HEAD" == "$REMOTE_HEAD" ]]; then
+  log "Already up-to-date (${LOCAL_HEAD:0:8})"
+  exit 2
+fi
+
+log "Updating from ${LOCAL_HEAD:0:8} to ${REMOTE_HEAD:0:8}..."
+
+if [[ -n "$(git status --porcelain 2>/dev/null)" ]]; then
+  warn "Working directory has uncommitted changes. Stashing..."
+  git stash push -m "pilotdeck-auto-update-$(date +%Y%m%d-%H%M%S)" 2>&1
+fi
+
+git pull --ff-only origin "$CURRENT_BRANCH" 2>&1 || {
+  warn "Fast-forward pull failed, attempting reset..."
+  git reset --hard "origin/$CURRENT_BRANCH" 2>&1
+}
+
+log "Installing dependencies..."
+if command -v pnpm >/dev/null 2>&1; then
+  HUSKY=0 pnpm install --frozen-lockfile 2>&1 || HUSKY=0 pnpm install 2>&1
+else
+  HUSKY=0 npm install --no-audit --no-fund 2>&1
+fi
+
+log "Building gateway (TypeScript)..."
+npm run build 2>&1
+
+log "Building UI frontend..."
+cd ui
+npm run build 2>&1
+cd "$PROJECT_ROOT"
+
+NEW_HEAD="$(git rev-parse HEAD)"
+log "Update complete: ${NEW_HEAD:0:8}"
+
+COMMIT_MSG="$(git log --oneline -1 HEAD)"
+log "Latest commit: $COMMIT_MSG"
+
+if [[ "$DO_RESTART" -eq 1 ]]; then
+  log "Restarting PilotDeck..."
+  if [[ -n "${PILOTDECK_PID:-}" ]] && kill -0 "$PILOTDECK_PID" 2>/dev/null; then
+    kill -SIGUSR2 "$PILOTDECK_PID" 2>/dev/null || true
+  fi
+fi
+
+exit 0

--- a/src/adapters/channel/feishu/FeishuChannel.ts
+++ b/src/adapters/channel/feishu/FeishuChannel.ts
@@ -2,6 +2,7 @@ import { createDecipheriv, createHash } from "node:crypto";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import type { Gateway } from "../../../gateway/index.js";
 import type { ChannelAdapter, ChannelHandle, ChannelLogger, ChannelStartDeps } from "../protocol/ChannelAdapter.js";
+import { executeChannelCommand, resolveCommand } from "../protocol/ChannelCommandRegistry.js";
 import { ImElicitationHelper } from "../protocol/ImElicitationHelper.js";
 import { FeishuSessionMapper } from "./FeishuSessionMapper.js";
 
@@ -253,14 +254,19 @@ export class FeishuChannel implements ChannelAdapter {
       return;
     }
 
-    if (mapped.command === "projects") {
-      await this.handleListProjects(chatId);
-      return;
-    }
-
-    if (mapped.command === "switch-project") {
-      await this.handleSwitchProject(chatId, mapped.commandArg);
-      return;
+    // Delegate system-level commands (e.g. /projects, /update, /status) to
+    // the centralized registry — no need to handle them individually here.
+    if (text.trim().startsWith("/")) {
+      const handled = await executeChannelCommand(text, {
+        gateway: this.gateway,
+        chatId,
+        channelKey: "feishu",
+        reply: (msg) => this.send({ chatId, text: msg }),
+        bindProject: (projectKey) => this.mapper.bindProject(chatId, projectKey),
+        getProject: () => this.mapper.getProject(chatId),
+        logger: this.logger as any,
+      });
+      if (handled) return;
     }
 
     if (!mapped.message) return;
@@ -324,66 +330,6 @@ export class FeishuChannel implements ChannelAdapter {
         await this.removeReaction(messageId, reactionId);
       }
       this.activeChats.delete(chatId);
-    }
-  }
-
-  private async handleListProjects(chatId: string): Promise<void> {
-    if (!this.gateway) return;
-    try {
-      const result = await this.gateway.listProjects();
-      const projects = result.projects;
-      if (projects.length === 0) {
-        await this.send({ chatId, text: "暂无项目。使用 Web UI 创建 WorkSpace 后即可在此切换。" });
-        return;
-      }
-
-      const currentProject = this.mapper.getProject(chatId);
-      const lines = ["📂 项目列表：", ""];
-      for (const p of projects) {
-        const marker = currentProject === p.projectKey ? " ✅" : "";
-        lines.push(`• ${p.name}${marker}`);
-      }
-      lines.push("", '发送 /switch-project <项目名> 切换 WorkSpace');
-      await this.send({ chatId, text: lines.join("\n") });
-    } catch (e) {
-      this.logger?.error?.(`feishu: listProjects error: ${e}`);
-      await this.send({ chatId, text: "获取项目列表失败，请重试。" });
-    }
-  }
-
-  private async handleSwitchProject(chatId: string, projectName?: string): Promise<void> {
-    if (!this.gateway) return;
-
-    if (!projectName) {
-      await this.send({ chatId, text: "用法：/switch-project <项目名>\n\n发送 /projects 查看可用项目。" });
-      return;
-    }
-
-    try {
-      const result = await this.gateway.listProjects();
-      const lower = projectName.toLowerCase();
-      const target =
-        result.projects.find((p) => p.name === projectName) ??
-        result.projects.find((p) => p.name.toLowerCase() === lower) ??
-        result.projects.find((p) => p.name.toLowerCase().includes(lower));
-
-      if (!target) {
-        await this.send({
-          chatId,
-          text: `未找到匹配「${projectName}」的项目。\n\n发送 /projects 查看可用项目。`,
-        });
-        return;
-      }
-
-      this.mapper.bindProject(chatId, target.projectKey);
-      const sessionKey = `feishu:chat=${chatId}:s_${Date.now().toString(36)}`;
-      await this.send({
-        chatId,
-        text: `已切换到项目：${target.name}\n路径：${target.fullPath}`,
-      });
-    } catch (e) {
-      this.logger?.error?.(`feishu: switchProject error: ${e}`);
-      await this.send({ chatId, text: "切换项目失败，请重试。" });
     }
   }
 

--- a/src/adapters/channel/protocol/ChannelAdapter.ts
+++ b/src/adapters/channel/protocol/ChannelAdapter.ts
@@ -5,3 +5,11 @@ export type {
   ChannelMessage,
   ChannelStartDeps,
 } from "./types.js";
+
+export {
+  executeChannelCommand,
+  resolveCommand,
+  getRegisteredCommands,
+  type ChannelCommand,
+  type CommandExecContext,
+} from "./ChannelCommandRegistry.js";

--- a/src/adapters/channel/protocol/ChannelCommandRegistry.ts
+++ b/src/adapters/channel/protocol/ChannelCommandRegistry.ts
@@ -1,0 +1,300 @@
+/**
+ * Centralized IM channel command registry.
+ *
+ * All IM channels (Feishu, Weixin, QQ, Telegram, Slack, etc.) share this
+ * single command definition list. To add a new slash command that works
+ * across all channels, just add an entry here — no need to touch individual
+ * channel implementations.
+ *
+ * Commands marked `systemLevel: true` are handled by the channel directly
+ * (without entering the AI agent loop). Commands marked `systemLevel: false`
+ * are passed through to the gateway as normal messages.
+ */
+
+import type { Gateway } from "../../../gateway/index.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type CommandExecContext = {
+  gateway: Gateway;
+  chatId: string;
+  channelKey: string;
+  /** Send a text reply back to the same chat. */
+  reply: (text: string) => Promise<void>;
+  /** Bind a project to this chat (for project-scoped channels). */
+  bindProject?: (projectKey: string) => void;
+  /** Get the currently bound project for this chat. */
+  getProject?: () => string | undefined;
+  logger?: {
+    info?(msg: string): void;
+    warn?(msg: string): void;
+    error?(msg: string): void;
+  };
+};
+
+export type ChannelCommand = {
+  /** The slash command name without leading `/` (e.g. "update", "projects") */
+  name: string;
+  /** Aliases (e.g. "升级" for Chinese users) */
+  aliases?: string[];
+  /** Short description */
+  description: string;
+  /**
+   * If true, this command is handled directly by the channel (system-level)
+   * and does NOT enter the agent session. If false, the text is forwarded
+   * as a normal user message to the gateway.
+   */
+  systemLevel: boolean;
+  /**
+   * Handler function. Only called for systemLevel commands.
+   * `arg` is everything after the command name.
+   */
+  handler?: (ctx: CommandExecContext, arg: string) => Promise<void>;
+};
+
+// ---------------------------------------------------------------------------
+// Command definitions
+// ---------------------------------------------------------------------------
+
+const commands: ChannelCommand[] = [
+  {
+    name: "new",
+    description: "Create a new conversation session",
+    systemLevel: true,
+    // Handled by the session mapper in each channel (creates a new session key)
+    // so no handler here — the mapper returns `command: "new"` and the channel
+    // sends an ack directly.
+  },
+
+  {
+    name: "projects",
+    aliases: ["项目列表"],
+    description: "List available projects",
+    systemLevel: true,
+    handler: async (ctx, _arg) => {
+      const result = await ctx.gateway.listProjects();
+      const projects = result.projects;
+      if (projects.length === 0) {
+        await ctx.reply("暂无项目。使用 Web UI 创建 WorkSpace 后即可在此切换。");
+        return;
+      }
+      const currentProject = ctx.getProject?.();
+      const lines = ["📂 项目列表：", ""];
+      for (const p of projects) {
+        const marker = currentProject === p.projectKey ? " ✅" : "";
+        lines.push(`• ${p.name}${marker}`);
+      }
+      lines.push("", "发送 /switch-project <项目名> 切换 WorkSpace");
+      await ctx.reply(lines.join("\n"));
+    },
+  },
+
+  {
+    name: "switch-project",
+    aliases: ["切换项目"],
+    description: "Switch active project for this chat",
+    systemLevel: true,
+    handler: async (ctx, arg) => {
+      if (!arg) {
+        await ctx.reply("用法：/switch-project <项目名>\n\n发送 /projects 查看可用项目。");
+        return;
+      }
+      const result = await ctx.gateway.listProjects();
+      const lower = arg.toLowerCase();
+      const target =
+        result.projects.find((p) => p.name === arg) ??
+        result.projects.find((p) => p.name.toLowerCase() === lower) ??
+        result.projects.find((p) => p.name.toLowerCase().includes(lower));
+
+      if (!target) {
+        await ctx.reply(`未找到匹配「${arg}」的项目。\n\n发送 /projects 查看可用项目。`);
+        return;
+      }
+      ctx.bindProject?.(target.projectKey);
+      await ctx.reply(`已切换到项目：${target.name}\n路径：${target.fullPath}`);
+    },
+  },
+
+  {
+    name: "update",
+    aliases: ["升级", "更新"],
+    description: "Pull latest code, rebuild, and restart PilotDeck",
+    systemLevel: true,
+    handler: async (ctx, arg) => {
+      const { execFile } = await import("node:child_process");
+      const { resolve: resolvePath, dirname } = await import("node:path");
+      const { promisify } = await import("node:util");
+      const { fileURLToPath } = await import("node:url");
+      const execFileAsync = promisify(execFile);
+
+      const thisFile = fileURLToPath(import.meta.url);
+      const projectRoot = resolvePath(dirname(thisFile), "..", "..", "..", "..");
+      const scriptPath = resolvePath(projectRoot, "scripts", "update.sh");
+
+      const subcommand = arg?.trim() || "";
+
+      if (subcommand === "check") {
+        await ctx.reply("⏳ 正在检查更新...");
+        try {
+          const { stdout: branch } = await execFileAsync("git", ["branch", "--show-current"], { cwd: projectRoot });
+          const currentBranch = branch.trim() || "main";
+          await execFileAsync("git", ["fetch", "origin", currentBranch], { cwd: projectRoot });
+          const { stdout: localH } = await execFileAsync("git", ["rev-parse", "HEAD"], { cwd: projectRoot });
+          const { stdout: remoteH } = await execFileAsync("git", ["rev-parse", `origin/${currentBranch}`], { cwd: projectRoot });
+          if (localH.trim() === remoteH.trim()) {
+            await ctx.reply(`✅ 已是最新版本 (${localH.trim().slice(0, 8)})，无需更新。`);
+          } else {
+            const { stdout: countStr } = await execFileAsync(
+              "git", ["rev-list", "--count", `HEAD..origin/${currentBranch}`], { cwd: projectRoot },
+            );
+            const { stdout: logStr } = await execFileAsync(
+              "git", ["log", "--oneline", `HEAD..origin/${currentBranch}`, "-5"], { cwd: projectRoot },
+            );
+            const lines = [
+              `🆕 有 ${countStr.trim()} 个新提交可用`,
+              `当前: ${localH.trim().slice(0, 8)} → 最新: ${remoteH.trim().slice(0, 8)}`,
+              "",
+              "最近提交:",
+              logStr.trim(),
+              "",
+              "发送 /update 执行更新",
+            ];
+            await ctx.reply(lines.join("\n"));
+          }
+        } catch (e) {
+          await ctx.reply(`❌ 检查更新失败: ${e instanceof Error ? e.message : String(e)}`);
+        }
+        return;
+      }
+
+      // Execute the update
+      await ctx.reply("🚀 开始更新 PilotDeck...\n正在拉取最新代码、重新构建...");
+      try {
+        const { stdout, stderr } = await execFileAsync("bash", [scriptPath, "--restart"], {
+          cwd: projectRoot,
+          env: { ...process.env, FORCE_COLOR: "0" },
+          timeout: 300_000,
+        });
+
+        const output = (stdout || "").trim();
+        const lastLines = output.split("\n").slice(-5).join("\n");
+        await ctx.reply(`✅ 更新完成！\n\n${lastLines}\n\n服务即将重启...`);
+
+        // Exit so the process manager (docker/systemd) restarts us.
+        // In local dev without a process manager, the user must restart manually.
+        setTimeout(() => process.exit(0), 2000);
+      } catch (e: unknown) {
+        const err = e as { code?: number; stdout?: string; stderr?: string };
+        if (err.code === 2) {
+          await ctx.reply("✅ 已是最新版本，无需更新。");
+          return;
+        }
+        const detail = err.stderr?.trim().split("\n").slice(-3).join("\n") || "";
+        await ctx.reply(`❌ 更新失败\n\n${detail || (e instanceof Error ? e.message : String(e))}`);
+      }
+    },
+  },
+
+  {
+    name: "status",
+    aliases: ["状态"],
+    description: "Show PilotDeck status and version",
+    systemLevel: true,
+    handler: async (ctx, _arg) => {
+      const { execFile } = await import("node:child_process");
+      const { resolve: resolvePath, dirname } = await import("node:path");
+      const { promisify } = await import("node:util");
+      const { fileURLToPath } = await import("node:url");
+      const execFileAsync = promisify(execFile);
+
+      const thisFile = fileURLToPath(import.meta.url);
+      const projectRoot = resolvePath(dirname(thisFile), "..", "..", "..", "..");
+
+      try {
+        const { stdout: branch } = await execFileAsync("git", ["branch", "--show-current"], { cwd: projectRoot });
+        const { stdout: commit } = await execFileAsync("git", ["log", "--oneline", "-1", "HEAD"], { cwd: projectRoot });
+        const uptime = process.uptime();
+        const uptimeMin = Math.floor(uptime / 60);
+        const uptimeH = Math.floor(uptimeMin / 60);
+        const uptimeStr = uptimeH > 0 ? `${uptimeH}h ${uptimeMin % 60}m` : `${uptimeMin}m`;
+
+        const lines = [
+          "📊 PilotDeck Status",
+          "",
+          `分支: ${branch.trim()}`,
+          `提交: ${commit.trim()}`,
+          `运行时间: ${uptimeStr}`,
+          `Node: ${process.version}`,
+          `平台: ${process.platform}`,
+        ];
+        await ctx.reply(lines.join("\n"));
+      } catch (e) {
+        await ctx.reply(`获取状态失败: ${e instanceof Error ? e.message : String(e)}`);
+      }
+    },
+  },
+
+  {
+    name: "help",
+    aliases: ["帮助"],
+    description: "Show available commands",
+    systemLevel: true,
+    handler: async (ctx, _arg) => {
+      const lines = ["📋 可用命令：", ""];
+      for (const cmd of commands) {
+        const aliases = cmd.aliases?.length ? ` (${cmd.aliases.map((a) => "/" + a).join(", ")})` : "";
+        lines.push(`/${cmd.name}${aliases} — ${cmd.description}`);
+      }
+      await ctx.reply(lines.join("\n"));
+    },
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Registry API
+// ---------------------------------------------------------------------------
+
+/** Look up command by name or alias. Returns undefined if not a registered command. */
+export function resolveCommand(text: string): { command: ChannelCommand; arg: string } | undefined {
+  const trimmed = text.trim();
+  if (!trimmed.startsWith("/")) return undefined;
+
+  const spaceIdx = trimmed.indexOf(" ");
+  const name = (spaceIdx > 0 ? trimmed.slice(1, spaceIdx) : trimmed.slice(1)).toLowerCase();
+  const arg = spaceIdx > 0 ? trimmed.slice(spaceIdx + 1).trim() : "";
+
+  for (const cmd of commands) {
+    if (cmd.name === name) return { command: cmd, arg };
+    if (cmd.aliases?.some((a) => a.toLowerCase() === name)) return { command: cmd, arg };
+  }
+  return undefined;
+}
+
+/** Get all registered commands. */
+export function getRegisteredCommands(): readonly ChannelCommand[] {
+  return commands;
+}
+
+/**
+ * Execute a system-level command. Returns true if the command was handled,
+ * false if it should be forwarded to the gateway.
+ */
+export async function executeChannelCommand(
+  text: string,
+  ctx: CommandExecContext,
+): Promise<boolean> {
+  const resolved = resolveCommand(text);
+  if (!resolved) return false;
+  if (!resolved.command.systemLevel) return false;
+  if (!resolved.command.handler) return false;
+
+  try {
+    await resolved.command.handler(ctx, resolved.arg);
+  } catch (e) {
+    ctx.logger?.error?.(`command /${resolved.command.name} failed: ${e}`);
+    await ctx.reply(`命令执行失败: ${e instanceof Error ? e.message : String(e)}`);
+  }
+  return true;
+}

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -90,3 +90,11 @@ export type {
   ChannelMessage,
   ChannelStartDeps,
 } from "./channel/protocol/ChannelAdapter.js";
+
+export {
+  executeChannelCommand,
+  resolveCommand,
+  getRegisteredCommands,
+  type ChannelCommand,
+  type CommandExecContext,
+} from "./channel/protocol/ChannelAdapter.js";

--- a/src/cli/pilotdeck.ts
+++ b/src/cli/pilotdeck.ts
@@ -261,6 +261,11 @@ async function main(argv = process.argv.slice(2)): Promise<void> {
     return;
   }
 
+  if (command === "update") {
+    await handleUpdateCommand(argv.slice(1));
+    return;
+  }
+
   if (command === "skills") {
     await handleSkillsCommand(argv.slice(1));
     return;
@@ -297,6 +302,64 @@ async function main(argv = process.argv.slice(2)): Promise<void> {
 
   const { gateway: fallbackGateway } = createLocalGateway({ projectRoot: process.cwd() });
   await new CliChannel({ argv, projectKey: process.cwd() }).start({ gateway: fallbackGateway });
+}
+
+async function handleUpdateCommand(argv: string[]): Promise<void> {
+  const { execFileSync } = await import("node:child_process");
+  const { resolve: resolvePath, dirname } = await import("node:path");
+  const { fileURLToPath } = await import("node:url");
+
+  const __filename = fileURLToPath(import.meta.url);
+  const projectRoot = resolvePath(dirname(__filename), "..", "..", "..");
+  const scriptPath = resolvePath(projectRoot, "scripts", "update.sh");
+
+  const doRestart = argv.includes("--restart");
+  const checkOnly = argv.includes("--check");
+
+  if (checkOnly) {
+    try {
+      const branch = execFileSync("git", ["branch", "--show-current"], { cwd: projectRoot, encoding: "utf-8" }).trim() || "main";
+      execFileSync("git", ["fetch", "origin", branch], { cwd: projectRoot, encoding: "utf-8", stdio: "pipe" });
+      const local = execFileSync("git", ["rev-parse", "HEAD"], { cwd: projectRoot, encoding: "utf-8" }).trim();
+      const remote = execFileSync("git", ["rev-parse", `origin/${branch}`], { cwd: projectRoot, encoding: "utf-8" }).trim();
+
+      if (local === remote) {
+        console.log(`Already up-to-date (${local.slice(0, 8)}) on branch ${branch}`);
+      } else {
+        const countStr = execFileSync("git", ["rev-list", "--count", `HEAD..origin/${branch}`], { cwd: projectRoot, encoding: "utf-8" }).trim();
+        console.log(`Update available: ${countStr} new commit(s) on branch ${branch}`);
+        console.log(`  local:  ${local.slice(0, 8)}`);
+        console.log(`  remote: ${remote.slice(0, 8)}`);
+        const log = execFileSync("git", ["log", "--oneline", `HEAD..origin/${branch}`, "-5"], { cwd: projectRoot, encoding: "utf-8" }).trim();
+        if (log) {
+          console.log("\nRecent commits:");
+          console.log(log);
+        }
+      }
+    } catch (e: unknown) {
+      console.error(`Failed to check for updates: ${e instanceof Error ? e.message : String(e)}`);
+      process.exitCode = 1;
+    }
+    return;
+  }
+
+  const args = doRestart ? [scriptPath, "--restart"] : [scriptPath];
+
+  try {
+    execFileSync("bash", args, {
+      cwd: projectRoot,
+      stdio: "inherit",
+      env: { ...process.env, FORCE_COLOR: "1" },
+    });
+  } catch (e: unknown) {
+    const err = e as { status?: number };
+    if (err.status === 2) {
+      // Already up-to-date — not an error
+      return;
+    }
+    console.error(`Update failed with exit code ${err.status ?? "unknown"}`);
+    process.exitCode = 1;
+  }
 }
 
 async function handleCronCommand(argv: string[]): Promise<void> {

--- a/ui/server/index.js
+++ b/ui/server/index.js
@@ -85,6 +85,7 @@ import configRoutes from './routes/config.js';
 import { startPilotDeckConfigWatcher, stopPilotDeckConfigWatcher } from './services/pilotdeckConfigWatcher.js';
 import { getAlwaysOnDashboardEvents } from './services/always-on-events.js';
 import agentRoutes from './routes/agent.js';
+import updateRoutes from './routes/update.js';
 import projectsRoutes, { WORKSPACES_ROOT, validateWorkspacePath } from './routes/projects.js';
 import userRoutes from './routes/user.js';
 import pluginsRoutes from './routes/plugins.js';
@@ -560,6 +561,9 @@ app.use('/api/sessions', authenticateToken, messagesRoutes);
 
 // Agent API Routes (uses API key authentication)
 app.use('/api/agent', agentRoutes);
+
+// Self-update API Routes (protected)
+app.use('/api/update', authenticateToken, updateRoutes);
 
 // Legacy four-provider config endpoints have been removed. The runtime
 // model is read from PilotDeck config; fall back to a static stub so any

--- a/ui/server/routes/commands.js
+++ b/ui/server/routes/commands.js
@@ -11,6 +11,7 @@ import { getClaudeRuntimeModelConfig, getClaudeRuntimeModelValues } from '../uti
 import { readPilotDeckConfigFile, resolveModel } from '../services/pilotdeckConfig.js';
 import { resolvePilotHome } from '../utils/pilotPaths.js';
 import { executeTurnkeySlashCommand } from '../turnkey-slash.js';
+import { getRegisteredCommands } from '../../../src/adapters/channel/protocol/ChannelCommandRegistry.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -182,15 +183,13 @@ async function scanSkillsDirectory(dir, namespace) {
 }
 
 /**
- * Built-in commands that are always available
+ * Built-in commands that are always available.
+ *
+ * Web-UI-only commands (that don't make sense in IM channels) are defined here.
+ * Commands shared with IM channels (/update, /projects, /switch-project, /status,
+ * /help) are auto-merged from ChannelCommandRegistry — single source of truth.
  */
-const builtInCommands = [
-  {
-    name: '/help',
-    description: 'Show help documentation for PilotDeck',
-    namespace: 'builtin',
-    metadata: { type: 'builtin' }
-  },
+const webOnlyBuiltInCommands = [
   {
     name: '/clear',
     description: 'Clear the conversation history',
@@ -222,12 +221,6 @@ const builtInCommands = [
     metadata: { type: 'builtin' }
   },
   {
-    name: '/status',
-    description: 'Show system status and version information',
-    namespace: 'builtin',
-    metadata: { type: 'builtin' }
-  },
-  {
     name: '/rewind',
     description: 'Rewind the conversation to a previous state',
     namespace: 'builtin',
@@ -246,12 +239,6 @@ const builtInCommands = [
     metadata: { type: 'builtin' }
   },
   {
-    name: '/switch-project',
-    description: 'Switch to another project by name (for example: /switch-project xhs-voxcpm)',
-    namespace: 'builtin',
-    metadata: { type: 'builtin' }
-  },
-  {
     name: '/skill_install',
     description:
       'Install a skill from clawhub.com. Auto-targets ~/.pilotdeck/skills/<slug> in general chat and <project>/.pilotdeck/skills/<slug> when a project is active. Use --global / --project to override.',
@@ -261,6 +248,25 @@ const builtInCommands = [
       argumentHint: '<slug> [--version <v>] [--force] [--global|--project] [--registry <url>]',
     },
   },
+];
+
+// Merge commands from the centralized ChannelCommandRegistry.
+// This ensures /update, /projects, /switch-project, etc. appear in the
+// Web UI menu automatically when added to the registry.
+const registryCommands = getRegisteredCommands()
+  .filter((cmd) => cmd.name !== 'new') // /new is implicit (new session button)
+  .map((cmd) => ({
+    name: '/' + cmd.name,
+    description: cmd.description,
+    namespace: 'builtin',
+    metadata: { type: 'builtin', source: 'registry' },
+  }));
+
+const builtInCommands = [
+  ...webOnlyBuiltInCommands,
+  ...registryCommands.filter(
+    (rc) => !webOnlyBuiltInCommands.some((w) => w.name === rc.name),
+  ),
 ];
 
 /**
@@ -537,6 +543,55 @@ Custom commands can be created in:
   },
 
   '/turnkey': async (args) => executeTurnkeySlashCommand(args),
+
+  '/update': async (args, context) => {
+    const subcommand = (args && args[0]) || 'apply';
+
+    if (subcommand === 'check') {
+      try {
+        const result = await execFileAsync('bash', [
+          '-c',
+          'cd "$(git rev-parse --show-toplevel)" && git fetch origin "$(git branch --show-current)" 2>/dev/null && ' +
+          'LOCAL=$(git rev-parse HEAD) && REMOTE=$(git rev-parse "origin/$(git branch --show-current)") && ' +
+          'if [ "$LOCAL" = "$REMOTE" ]; then echo "up-to-date"; else echo "update-available"; fi'
+        ], { timeout: 30000 });
+        const hasUpdate = result.stdout.trim() === 'update-available';
+        return {
+          type: 'builtin',
+          action: 'update',
+          data: {
+            subcommand: 'check',
+            hasUpdate,
+            message: hasUpdate
+              ? 'New version available! Run `/update` to apply.'
+              : 'Already up-to-date.',
+          },
+        };
+      } catch (e) {
+        return {
+          type: 'builtin',
+          action: 'update',
+          data: {
+            subcommand: 'check',
+            error: true,
+            message: `Failed to check for updates: ${e.message}`,
+          },
+        };
+      }
+    }
+
+    // Default: trigger the update via the API endpoint.
+    // The frontend will call /api/update/apply and stream progress.
+    return {
+      type: 'builtin',
+      action: 'update',
+      data: {
+        subcommand: 'apply',
+        message: 'Starting update... pulling latest code, rebuilding, and restarting.',
+        triggerApi: '/api/update/apply',
+      },
+    };
+  },
 
   '/switch-project': async (args) => {
     // Trim quotes / whitespace; the rest of the project resolution (matching

--- a/ui/server/routes/update.js
+++ b/ui/server/routes/update.js
@@ -1,0 +1,194 @@
+import express from 'express';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { spawn, exec } from 'child_process';
+import { promisify } from 'util';
+
+const execAsync = promisify(exec);
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const PROJECT_ROOT = path.resolve(__dirname, '..', '..');
+
+const router = express.Router();
+
+let updateInProgress = false;
+let lastUpdateResult = null;
+
+function execInProject(cmd) {
+  return execAsync(cmd, { cwd: PROJECT_ROOT, maxBuffer: 10 * 1024 * 1024 });
+}
+
+/**
+ * POST /api/update/check
+ * Check if there are updates available (git fetch + compare HEAD)
+ */
+router.post('/check', async (req, res) => {
+  try {
+    const { stdout: branch } = await execInProject('git branch --show-current');
+    const currentBranch = branch.trim() || 'main';
+
+    await execInProject(`git fetch origin ${currentBranch}`);
+
+    const { stdout: localHead } = await execInProject('git rev-parse HEAD');
+    const { stdout: remoteHead } = await execInProject(`git rev-parse origin/${currentBranch}`);
+
+    const local = localHead.trim();
+    const remote = remoteHead.trim();
+    const hasUpdate = local !== remote;
+
+    let behindCount = 0;
+    let newCommits = [];
+    if (hasUpdate) {
+      const { stdout: countOut } = await execInProject(
+        `git rev-list --count HEAD..origin/${currentBranch}`,
+      );
+      behindCount = parseInt(countOut.trim(), 10) || 0;
+
+      const { stdout: logOut } = await execInProject(
+        `git log --oneline HEAD..origin/${currentBranch} -10`,
+      );
+      newCommits = logOut.trim().split('\n').filter(Boolean);
+    }
+
+    const { stdout: currentCommit } = await execInProject('git log --oneline -1 HEAD');
+
+    res.json({
+      hasUpdate,
+      currentBranch,
+      localHead: local.slice(0, 8),
+      remoteHead: remote.slice(0, 8),
+      behindCount,
+      newCommits,
+      currentCommit: currentCommit.trim(),
+    });
+  } catch (error) {
+    res.status(500).json({
+      error: 'Failed to check for updates',
+      message: error.message,
+    });
+  }
+});
+
+/**
+ * POST /api/update/apply
+ * Pull latest code, rebuild, and prepare for restart.
+ * Streams progress via newline-delimited JSON.
+ */
+router.post('/apply', async (req, res) => {
+  if (updateInProgress) {
+    return res.status(409).json({
+      error: 'Update already in progress',
+      message: 'An update is currently running. Please wait for it to complete.',
+    });
+  }
+
+  updateInProgress = true;
+  lastUpdateResult = null;
+
+  res.setHeader('Content-Type', 'application/x-ndjson');
+  res.setHeader('Cache-Control', 'no-cache');
+  res.setHeader('X-Accel-Buffering', 'no');
+
+  const sendProgress = (stage, message, status = 'running') => {
+    const line = JSON.stringify({ stage, message, status, timestamp: Date.now() });
+    res.write(line + '\n');
+  };
+
+  try {
+    const scriptPath = path.join(PROJECT_ROOT, 'scripts', 'update.sh');
+
+    sendProgress('start', 'Starting update process...');
+
+    const child = spawn('bash', [scriptPath], {
+      cwd: PROJECT_ROOT,
+      env: { ...process.env, FORCE_COLOR: '0' },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    let exitCode = null;
+
+    child.stdout.on('data', (data) => {
+      for (const line of data.toString().split('\n').filter(Boolean)) {
+        sendProgress('progress', line);
+      }
+    });
+
+    child.stderr.on('data', (data) => {
+      for (const line of data.toString().split('\n').filter(Boolean)) {
+        sendProgress('progress', line, 'warning');
+      }
+    });
+
+    exitCode = await new Promise((resolve, reject) => {
+      child.on('close', (code) => resolve(code));
+      child.on('error', reject);
+    });
+
+    if (exitCode === 2) {
+      sendProgress('complete', 'Already up-to-date. No changes needed.', 'up-to-date');
+      lastUpdateResult = { success: true, alreadyUpToDate: true };
+    } else if (exitCode === 0) {
+      sendProgress('complete', 'Update successful! Restart required to apply changes.', 'success');
+      lastUpdateResult = { success: true, alreadyUpToDate: false, needsRestart: true };
+    } else {
+      throw new Error(`Update script exited with code ${exitCode}`);
+    }
+  } catch (error) {
+    sendProgress('error', `Update failed: ${error.message}`, 'error');
+    lastUpdateResult = { success: false, error: error.message };
+  } finally {
+    updateInProgress = false;
+    res.end();
+  }
+});
+
+/**
+ * POST /api/update/restart
+ * Restart PilotDeck by spawning a fresh process, then exiting.
+ * Works in both Docker (process manager respawns) and local dev (self-respawn).
+ */
+router.post('/restart', async (req, res) => {
+  res.json({
+    message: 'Restart initiated.',
+    status: 'restarting',
+  });
+
+  setTimeout(() => {
+    console.log('[update] Spawning replacement process and exiting...');
+
+    // Spawn `npm run dev` (or the same entry point) as a detached process
+    const isDocker = process.env.DOCKER === '1' || process.env.container === 'docker';
+
+    if (isDocker) {
+      // In Docker, just exit — the container restart policy handles respawn
+      process.exit(0);
+    }
+
+    // Local: spawn a new server process detached from this one
+    const projectRoot = path.resolve(PROJECT_ROOT, '..');
+    const child = spawn('bash', ['-c', `sleep 2 && cd "${projectRoot}" && npm run dev`], {
+      cwd: projectRoot,
+      detached: true,
+      stdio: 'ignore',
+      env: { ...process.env },
+    });
+    child.unref();
+
+    // Exit after giving the response time to flush
+    setTimeout(() => process.exit(0), 500);
+  }, 1000);
+});
+
+/**
+ * GET /api/update/status
+ * Return current update state.
+ */
+router.get('/status', (req, res) => {
+  res.json({
+    updateInProgress,
+    lastUpdateResult,
+  });
+});
+
+export default router;

--- a/ui/src/components/app-shell/SidebarV2.tsx
+++ b/ui/src/components/app-shell/SidebarV2.tsx
@@ -960,32 +960,34 @@ export default function SidebarV2({
       )}
     >
       <div className="flex h-16 items-center justify-between pl-2 pr-4">
-        <button
-          type="button"
-          onClick={() => {
-            if (onDeselectProject) {
-              onDeselectProject();
-            } else {
-              navigate('/');
-            }
-          }}
-          aria-label="PilotDeck"
-          title="PilotDeck"
-          className="flex min-w-0 shrink items-center gap-2 rounded-md p-1 transition hover:opacity-80 focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-300 dark:focus-visible:ring-neutral-700"
-        >
-          <img
-            src={pilotdeckLogoLight}
-            alt="PilotDeck"
-            className="h-7 w-auto max-w-[150px] select-none object-contain dark:hidden"
-            draggable={false}
-          />
-          <img
-            src={pilotdeckLogoDark}
-            alt="PilotDeck"
-            className="hidden h-7 w-auto max-w-[150px] select-none object-contain dark:block"
-            draggable={false}
-          />
-        </button>
+        <div className="flex min-w-0 shrink items-center gap-2">
+          <button
+            type="button"
+            onClick={() => {
+              if (onDeselectProject) {
+                onDeselectProject();
+              } else {
+                navigate('/');
+              }
+            }}
+            aria-label="PilotDeck"
+            title="PilotDeck"
+            className="flex min-w-0 shrink items-center gap-2 rounded-md p-1 transition hover:opacity-80 focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-300 dark:focus-visible:ring-neutral-700"
+          >
+            <img
+              src={pilotdeckLogoLight}
+              alt="PilotDeck"
+              className="h-7 w-auto max-w-[150px] select-none object-contain dark:hidden"
+              draggable={false}
+            />
+            <img
+              src={pilotdeckLogoDark}
+              alt="PilotDeck"
+              className="hidden h-7 w-auto max-w-[150px] select-none object-contain dark:block"
+              draggable={false}
+            />
+          </button>
+        </div>
         {onCollapse ? (
           <button
             type="button"

--- a/ui/src/components/app-shell/VersionBadge.tsx
+++ b/ui/src/components/app-shell/VersionBadge.tsx
@@ -1,0 +1,256 @@
+import { useState, useCallback, useRef, useEffect } from 'react';
+import { GitCommit, RefreshCw, X, Check, AlertCircle } from 'lucide-react';
+import { useGitVersion } from '../../hooks/useGitVersion';
+import { cn } from '../../lib/utils.js';
+
+type UpdatePhase = 'idle' | 'updating' | 'success' | 'error';
+
+export function VersionBadge() {
+  const { info, loading, triggerUpdate, triggerRestart, fetchVersion } = useGitVersion();
+  const [showDialog, setShowDialog] = useState(false);
+  const [phase, setPhase] = useState<UpdatePhase>('idle');
+  const [logs, setLogs] = useState<string[]>([]);
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const logsEndRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (logsEndRef.current) {
+      logsEndRef.current.scrollIntoView({ behavior: 'smooth' });
+    }
+  }, [logs]);
+
+  useEffect(() => {
+    if (!showDialog) return;
+    const handleEsc = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && phase !== 'updating') setShowDialog(false);
+    };
+    window.addEventListener('keydown', handleEsc);
+    return () => window.removeEventListener('keydown', handleEsc);
+  }, [showDialog, phase]);
+
+  const handleUpdate = useCallback(async () => {
+    setPhase('updating');
+    setLogs([]);
+    const result = await triggerUpdate();
+    if (result.success) {
+      setLogs(result.lines);
+      setPhase('success');
+    } else {
+      setLogs(result.lines.length > 0 ? result.lines : ['Update failed']);
+      setPhase('error');
+    }
+  }, [triggerUpdate]);
+
+  const handleRestart = useCallback(async () => {
+    // Immediately blank the entire page with a restart splash
+    document.title = 'Restarting PilotDeck...';
+    document.body.innerHTML = '';
+    document.body.style.cssText = 'margin:0;background:#0a0a0a;display:flex;align-items:center;justify-content:center;height:100vh';
+    document.body.innerHTML = `
+      <div style="text-align:center;font-family:system-ui,-apple-system,sans-serif">
+        <svg style="width:40px;height:40px;margin-bottom:16px;animation:spin 1s linear infinite" viewBox="0 0 24 24" fill="none" stroke="#888" stroke-width="2"><path d="M21 12a9 9 0 1 1-6.22-8.56"/></svg>
+        <p style="color:#ccc;font-size:1.1rem;margin:0 0 8px">Restarting PilotDeck...</p>
+        <p style="color:#666;font-size:0.8rem;margin:0">Page will reload automatically when server is ready.</p>
+      </div>
+      <style>@keyframes spin{to{transform:rotate(360deg)}}</style>`;
+
+    // Fire the restart request (don't await — server may die before responding)
+    triggerRestart().catch(() => {});
+
+    // Poll until server is back, then reload
+    const poll = setInterval(async () => {
+      try {
+        const res = await fetch('/health');
+        if (res.ok) { clearInterval(poll); window.location.reload(); }
+      } catch { /* still down */ }
+    }, 2000);
+  }, [triggerRestart]);
+
+  const handleClose = useCallback(() => {
+    if (phase === 'updating') return;
+    setShowDialog(false);
+    setPhase('idle');
+    setLogs([]);
+    fetchVersion();
+  }, [phase, fetchVersion]);
+
+  if (!info) return null;
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setShowDialog(true)}
+        className={cn(
+          'flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-mono transition-colors',
+          info.hasUpdate
+            ? 'bg-blue-100 text-blue-700 hover:bg-blue-200 dark:bg-blue-900/40 dark:text-blue-300 dark:hover:bg-blue-900/60'
+            : 'bg-neutral-100 text-neutral-500 hover:bg-neutral-200 dark:bg-neutral-800 dark:text-neutral-400 dark:hover:bg-neutral-700',
+        )}
+        title={info.hasUpdate ? `Update available (${info.behindCount} commits behind)` : `Version: ${info.commitSha}`}
+      >
+        <GitCommit className="h-3 w-3" strokeWidth={2} />
+        <span>{info.commitSha}</span>
+        {info.hasUpdate && (
+          <span className="ml-0.5 h-1.5 w-1.5 rounded-full bg-blue-500 dark:bg-blue-400" />
+        )}
+      </button>
+
+      {showDialog && (
+        <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/40 backdrop-blur-sm">
+          <div
+            ref={dialogRef}
+            className="relative mx-4 w-full max-w-md rounded-xl border border-neutral-200 bg-white shadow-2xl dark:border-neutral-700 dark:bg-neutral-900"
+          >
+            <div className="flex items-center justify-between border-b border-neutral-200 px-5 py-4 dark:border-neutral-700">
+              <h2 className="text-base font-semibold text-neutral-900 dark:text-neutral-100">
+                {info.hasUpdate ? 'Update Available' : 'Version Info'}
+              </h2>
+              <button
+                type="button"
+                onClick={handleClose}
+                disabled={phase === 'updating'}
+                className="rounded-md p-1 text-neutral-500 hover:bg-neutral-100 hover:text-neutral-900 disabled:opacity-50 dark:text-neutral-400 dark:hover:bg-neutral-800 dark:hover:text-neutral-100"
+              >
+                <X className="h-4 w-4" />
+              </button>
+            </div>
+
+            <div className="px-5 py-4 space-y-3">
+              <div className="flex items-center gap-3">
+                <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-neutral-100 dark:bg-neutral-800">
+                  <GitCommit className="h-5 w-5 text-neutral-600 dark:text-neutral-300" />
+                </div>
+                <div>
+                  <div className="text-sm font-medium text-neutral-900 dark:text-neutral-100">
+                    {info.currentCommit}
+                  </div>
+                  <div className="text-xs text-neutral-500 dark:text-neutral-400">
+                    Branch: {info.branch}
+                  </div>
+                </div>
+              </div>
+
+              {info.hasUpdate && phase === 'idle' && (
+                <div className="rounded-lg border border-blue-200 bg-blue-50 p-3 dark:border-blue-800 dark:bg-blue-950/30">
+                  <p className="text-sm font-medium text-blue-800 dark:text-blue-200">
+                    {info.behindCount} new commit{info.behindCount > 1 ? 's' : ''} available
+                  </p>
+                  {info.newCommits.length > 0 && (
+                    <ul className="mt-2 space-y-1">
+                      {info.newCommits.slice(0, 5).map((commit, i) => (
+                        <li
+                          key={i}
+                          className="truncate text-xs font-mono text-blue-700 dark:text-blue-300"
+                        >
+                          {commit}
+                        </li>
+                      ))}
+                      {info.newCommits.length > 5 && (
+                        <li className="text-xs text-blue-600 dark:text-blue-400">
+                          ... and {info.newCommits.length - 5} more
+                        </li>
+                      )}
+                    </ul>
+                  )}
+                </div>
+              )}
+
+              {phase === 'updating' && (
+                <div className="rounded-lg border border-neutral-200 bg-neutral-50 p-3 dark:border-neutral-700 dark:bg-neutral-800">
+                  <div className="flex items-center gap-2 mb-2">
+                    <RefreshCw className="h-4 w-4 animate-spin text-blue-500" />
+                    <span className="text-sm font-medium text-neutral-700 dark:text-neutral-200">
+                      Updating...
+                    </span>
+                  </div>
+                  <div className="max-h-40 overflow-y-auto rounded bg-neutral-900 p-2">
+                    {logs.map((line, i) => (
+                      <div key={i} className="text-[11px] font-mono text-neutral-300 leading-relaxed">
+                        {line}
+                      </div>
+                    ))}
+                    <div ref={logsEndRef} />
+                  </div>
+                </div>
+              )}
+
+              {phase === 'success' && (
+                <div className="rounded-lg border border-green-200 bg-green-50 p-3 dark:border-green-800 dark:bg-green-950/30">
+                  <div className="flex items-center gap-2 mb-2">
+                    <Check className="h-4 w-4 text-green-600 dark:text-green-400" />
+                    <span className="text-sm font-medium text-green-800 dark:text-green-200">
+                      Update complete!
+                    </span>
+                  </div>
+                  {logs.length > 0 && (
+                    <div className="max-h-32 overflow-y-auto rounded bg-neutral-900 p-2 mt-2">
+                      {logs.slice(-5).map((line, i) => (
+                        <div key={i} className="text-[11px] font-mono text-neutral-300 leading-relaxed">
+                          {line}
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              )}
+
+              {phase === 'error' && (
+                <div className="rounded-lg border border-red-200 bg-red-50 p-3 dark:border-red-800 dark:bg-red-950/30">
+                  <div className="flex items-center gap-2 mb-2">
+                    <AlertCircle className="h-4 w-4 text-red-600 dark:text-red-400" />
+                    <span className="text-sm font-medium text-red-800 dark:text-red-200">
+                      Update failed
+                    </span>
+                  </div>
+                  {logs.length > 0 && (
+                    <div className="max-h-32 overflow-y-auto rounded bg-neutral-900 p-2 mt-2">
+                      {logs.slice(-5).map((line, i) => (
+                        <div key={i} className="text-[11px] font-mono text-red-300 leading-relaxed">
+                          {line}
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+
+            <div className="flex justify-end gap-2 border-t border-neutral-200 px-5 py-3 dark:border-neutral-700">
+              {phase === 'idle' && info.hasUpdate && (
+                <button
+                  type="button"
+                  onClick={handleUpdate}
+                  disabled={loading}
+                  className="inline-flex items-center gap-1.5 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700 disabled:opacity-50 dark:bg-blue-500 dark:hover:bg-blue-600"
+                >
+                  <RefreshCw className="h-3.5 w-3.5" />
+                  Update Now
+                </button>
+              )}
+              {phase === 'success' && (
+                <button
+                  type="button"
+                  onClick={handleRestart}
+                  className="inline-flex items-center gap-1.5 rounded-lg bg-green-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-green-700 dark:bg-green-500 dark:hover:bg-green-600"
+                >
+                  <RefreshCw className="h-3.5 w-3.5" />
+                  Restart to Apply
+                </button>
+              )}
+              {(phase === 'idle' || phase === 'error') && (
+                <button
+                  type="button"
+                  onClick={handleClose}
+                  className="rounded-lg px-4 py-2 text-sm font-medium text-neutral-700 transition-colors hover:bg-neutral-100 dark:text-neutral-300 dark:hover:bg-neutral-800"
+                >
+                  Close
+                </button>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/ui/src/components/auth/context/AuthContext.tsx
+++ b/ui/src/components/auth/context/AuthContext.tsx
@@ -1,5 +1,5 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
-import { DISABLE_LOCAL_AUTH, IS_PLATFORM } from '../../../constants/config';
+import { IS_PLATFORM } from '../../../constants/config';
 import { api } from '../../../utils/api';
 import { AUTH_ERROR_MESSAGES, AUTH_TOKEN_STORAGE_KEY } from '../constants';
 import type {
@@ -82,6 +82,13 @@ export function AuthProvider({ children }: AuthProviderProps) {
       const statusResponse = await api.auth.status();
       const statusPayload = await parseJsonSafely<AuthStatusPayload>(statusResponse);
 
+      if (statusPayload?.authDisabled) {
+        setUser({ username: 'local' });
+        setNeedsSetup(false);
+        await checkOnboardingStatus();
+        return;
+      }
+
       if (statusPayload?.needsSetup) {
         setNeedsSetup(true);
         return;
@@ -116,8 +123,8 @@ export function AuthProvider({ children }: AuthProviderProps) {
   }, [checkOnboardingStatus, clearSession, token]);
 
   useEffect(() => {
-    if (IS_PLATFORM || DISABLE_LOCAL_AUTH) {
-      setUser({ username: DISABLE_LOCAL_AUTH ? 'local' : 'platform-user' });
+    if (IS_PLATFORM) {
+      setUser({ username: 'platform-user' });
       setNeedsSetup(false);
       void checkOnboardingStatus().finally(() => {
         setIsLoading(false);

--- a/ui/src/components/auth/view/ProtectedRoute.tsx
+++ b/ui/src/components/auth/view/ProtectedRoute.tsx
@@ -1,5 +1,4 @@
 import type { ReactNode } from 'react';
-import { DISABLE_LOCAL_AUTH, IS_PLATFORM } from '../../../constants/config';
 import { useAuth } from '../context/AuthContext';
 import Onboarding from '../../onboarding/view/Onboarding';
 import AuthLoadingScreen from './AuthLoadingScreen';
@@ -15,14 +14,6 @@ export default function ProtectedRoute({ children }: ProtectedRouteProps) {
 
   if (isLoading) {
     return <AuthLoadingScreen />;
-  }
-
-  if (IS_PLATFORM || DISABLE_LOCAL_AUTH) {
-    if (!hasCompletedOnboarding) {
-      return <Onboarding onComplete={refreshOnboardingStatus} />;
-    }
-
-    return <>{children}</>;
   }
 
   if (needsSetup) {

--- a/ui/src/components/settings/view/Settings.tsx
+++ b/ui/src/components/settings/view/Settings.tsx
@@ -4,10 +4,13 @@ import {
   ChevronLeft,
   ChevronRight,
   Code2,
+  Download,
   FileCog,
+  GitCommit,
   Globe2,
   MessageSquare,
   Palette,
+  RefreshCw,
   Server,
   Shield,
   X,
@@ -19,6 +22,7 @@ import { useTheme } from '../../../contexts/ThemeContext';
 import { languages } from '../../../i18n/languages';
 import { useUiPreferences } from '../../../hooks/useUiPreferences';
 import { useSettingsController } from '../hooks/useSettingsController';
+import { useGitVersion } from '../../../hooks/useGitVersion';
 import type {
   CodeEditorSettingsState,
   ProjectSortOrder,
@@ -249,6 +253,8 @@ function SettingsHome({ projectSortOrder, onProjectSortOrderChange, onOpenPage }
           />
         </GroupedCard>
       </SettingsGroup>
+
+      <VersionUpdateSection />
     </div>
   );
 }
@@ -490,6 +496,144 @@ function SelectControl({
         </option>
       ))}
     </select>
+  );
+}
+
+function VersionUpdateSection() {
+  const { info, loading, triggerUpdate, triggerRestart, fetchVersion } = useGitVersion();
+  const [phase, setPhase] = useState<'idle' | 'updating' | 'success' | 'error'>('idle');
+  const [logs, setLogs] = useState<string[]>([]);
+
+  const handleUpdate = async () => {
+    setPhase('updating');
+    setLogs([]);
+    const result = await triggerUpdate();
+    if (result.success) {
+      setLogs(result.lines);
+      setPhase('success');
+    } else {
+      setLogs(result.lines.length > 0 ? result.lines : ['Update failed']);
+      setPhase('error');
+    }
+  };
+
+  const handleRestart = async () => {
+    document.title = 'Restarting PilotDeck...';
+    document.body.innerHTML = '';
+    document.body.style.cssText = 'margin:0;background:#0a0a0a;display:flex;align-items:center;justify-content:center;height:100vh';
+    document.body.innerHTML = `
+      <div style="text-align:center;font-family:system-ui,-apple-system,sans-serif">
+        <svg style="width:40px;height:40px;margin-bottom:16px;animation:spin 1s linear infinite" viewBox="0 0 24 24" fill="none" stroke="#888" stroke-width="2"><path d="M21 12a9 9 0 1 1-6.22-8.56"/></svg>
+        <p style="color:#ccc;font-size:1.1rem;margin:0 0 8px">Restarting PilotDeck...</p>
+        <p style="color:#666;font-size:0.8rem;margin:0">Page will reload automatically when server is ready.</p>
+      </div>
+      <style>@keyframes spin{to{transform:rotate(360deg)}}</style>`;
+    triggerRestart().catch(() => {});
+    const poll = setInterval(async () => {
+      try {
+        const res = await fetch('/health');
+        if (res.ok) { clearInterval(poll); window.location.reload(); }
+      } catch { /* still down */ }
+    }, 2000);
+  };
+
+  if (!info) return null;
+
+  return (
+    <SettingsGroup title="About">
+      <GroupedCard divided>
+        <div className="flex min-h-[66px] items-center gap-3.5 px-5 py-3">
+          <GitCommit className="h-4 w-4 flex-shrink-0 text-muted-foreground" />
+          <div className="min-w-0 flex-1">
+            <div className="text-[15px] font-semibold leading-5 text-foreground">Version</div>
+            <div className="mt-0.5 text-xs leading-5 font-mono text-muted-foreground">
+              {info.currentCommit} · {info.branch}
+            </div>
+          </div>
+          {info.hasUpdate && phase === 'idle' && (
+            <span className="rounded-full bg-blue-100 px-2 py-0.5 text-[11px] font-medium text-blue-700 dark:bg-blue-900/40 dark:text-blue-300">
+              {info.behindCount} update{info.behindCount > 1 ? 's' : ''}
+            </span>
+          )}
+        </div>
+
+        {info.hasUpdate && phase === 'idle' && (
+          <div className="px-5 py-3">
+            {info.newCommits.length > 0 && (
+              <ul className="mb-3 space-y-1">
+                {info.newCommits.slice(0, 5).map((commit, i) => (
+                  <li key={i} className="truncate text-xs font-mono text-muted-foreground">
+                    {commit}
+                  </li>
+                ))}
+                {info.newCommits.length > 5 && (
+                  <li className="text-xs text-muted-foreground">
+                    ... and {info.newCommits.length - 5} more
+                  </li>
+                )}
+              </ul>
+            )}
+            <button
+              type="button"
+              onClick={handleUpdate}
+              disabled={loading}
+              className="inline-flex items-center gap-1.5 rounded-lg bg-blue-600 px-3.5 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700 disabled:opacity-50 dark:bg-blue-500 dark:hover:bg-blue-600"
+            >
+              <Download className="h-3.5 w-3.5" />
+              Update Now
+            </button>
+          </div>
+        )}
+
+        {phase === 'updating' && (
+          <div className="px-5 py-3">
+            <div className="flex items-center gap-2 mb-2">
+              <RefreshCw className="h-4 w-4 animate-spin text-blue-500" />
+              <span className="text-sm font-medium text-foreground">Updating...</span>
+            </div>
+            <div className="max-h-32 overflow-y-auto rounded bg-neutral-900 p-2">
+              {logs.map((line, i) => (
+                <div key={i} className="text-[11px] font-mono text-neutral-300 leading-relaxed">{line}</div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {phase === 'success' && (
+          <div className="px-5 py-3 space-y-3">
+            <div className="flex items-center gap-2">
+              <span className="text-sm font-medium text-green-700 dark:text-green-400">Update complete!</span>
+            </div>
+            <button
+              type="button"
+              onClick={handleRestart}
+              className="inline-flex items-center gap-1.5 rounded-lg bg-green-600 px-3.5 py-2 text-sm font-medium text-white transition-colors hover:bg-green-700 dark:bg-green-500 dark:hover:bg-green-600"
+            >
+              <RefreshCw className="h-3.5 w-3.5" />
+              Restart to Apply
+            </button>
+          </div>
+        )}
+
+        {phase === 'error' && (
+          <div className="px-5 py-3">
+            <p className="text-sm font-medium text-red-700 dark:text-red-400 mb-2">Update failed</p>
+            <div className="max-h-24 overflow-y-auto rounded bg-neutral-900 p-2">
+              {logs.slice(-3).map((line, i) => (
+                <div key={i} className="text-[11px] font-mono text-red-300 leading-relaxed">{line}</div>
+              ))}
+            </div>
+            <button
+              type="button"
+              onClick={() => { setPhase('idle'); fetchVersion(); }}
+              className="mt-2 text-xs text-muted-foreground hover:text-foreground"
+            >
+              Dismiss
+            </button>
+          </div>
+        )}
+      </GroupedCard>
+    </SettingsGroup>
   );
 }
 

--- a/ui/src/components/shell/utils/socket.ts
+++ b/ui/src/components/shell/utils/socket.ts
@@ -1,17 +1,12 @@
-import { DISABLE_LOCAL_AUTH, IS_PLATFORM } from '../../../constants/config';
+import { IS_PLATFORM } from '../../../constants/config';
 import type { ShellIncomingMessage, ShellOutgoingMessage } from '../types/types';
 
 export function getShellWebSocketUrl(): string | null {
   const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-
-  if (IS_PLATFORM || DISABLE_LOCAL_AUTH) {
-    return `${protocol}//${window.location.host}/shell`;
-  }
-
   const token = localStorage.getItem('auth-token');
-  if (!token) {
-    console.error('No authentication token found for Shell WebSocket connection');
-    return null;
+
+  if (IS_PLATFORM || !token) {
+    return `${protocol}//${window.location.host}/shell`;
   }
 
   return `${protocol}//${window.location.host}/shell?token=${encodeURIComponent(token)}`;

--- a/ui/src/contexts/WebSocketContext.tsx
+++ b/ui/src/contexts/WebSocketContext.tsx
@@ -1,6 +1,6 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { useAuth } from '../components/auth/context/AuthContext';
-import { DISABLE_LOCAL_AUTH, IS_PLATFORM } from '../constants/config';
+import { IS_PLATFORM } from '../constants/config';
 
 type WSSubscriber = (msg: any) => void;
 
@@ -31,9 +31,8 @@ export const useWebSocket = () => {
 
 const buildWebSocketUrl = (token: string | null) => {
   const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-  if (IS_PLATFORM || DISABLE_LOCAL_AUTH) return `${protocol}//${window.location.host}/ws`; // Platform mode: Use same domain as the page (goes through proxy)
-  if (!token) return null;
-  return `${protocol}//${window.location.host}/ws?token=${encodeURIComponent(token)}`; // OSS mode: Use same host:port that served the page
+  if (IS_PLATFORM || !token) return `${protocol}//${window.location.host}/ws`;
+  return `${protocol}//${window.location.host}/ws?token=${encodeURIComponent(token)}`;
 };
 
 const useWebSocketProviderState = (): WebSocketContextType => {

--- a/ui/src/hooks/useGitVersion.ts
+++ b/ui/src/hooks/useGitVersion.ts
@@ -1,0 +1,105 @@
+import { useCallback, useEffect, useState } from 'react';
+import { authenticatedFetch } from '../utils/api';
+
+export type GitVersionInfo = {
+  commitSha: string;
+  branch: string;
+  hasUpdate: boolean;
+  behindCount: number;
+  newCommits: string[];
+  currentCommit: string;
+  remoteHead: string;
+};
+
+export function useGitVersion() {
+  const [info, setInfo] = useState<GitVersionInfo | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchVersion = useCallback(async () => {
+    try {
+      const res = await authenticatedFetch('/api/update/check', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      });
+      if (!res.ok) throw new Error('Failed to check version');
+      const data = await res.json();
+      setInfo({
+        commitSha: data.localHead,
+        branch: data.currentBranch,
+        hasUpdate: data.hasUpdate,
+        behindCount: data.behindCount ?? 0,
+        newCommits: data.newCommits ?? [],
+        currentCommit: data.currentCommit ?? '',
+        remoteHead: data.remoteHead ?? '',
+      });
+      setError(null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchVersion();
+    const interval = setInterval(fetchVersion, 5 * 60 * 1000);
+    return () => clearInterval(interval);
+  }, [fetchVersion]);
+
+  const triggerUpdate = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await authenticatedFetch('/api/update/apply', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      });
+
+      if (!res.ok && res.status === 409) {
+        setError('Update already in progress');
+        return { success: false, lines: [] as string[] };
+      }
+
+      const reader = res.body?.getReader();
+      const decoder = new TextDecoder();
+      const lines: string[] = [];
+
+      if (reader) {
+        let done = false;
+        while (!done) {
+          const { value, done: streamDone } = await reader.read();
+          done = streamDone;
+          if (value) {
+            const text = decoder.decode(value, { stream: true });
+            for (const line of text.split('\n').filter(Boolean)) {
+              try {
+                const parsed = JSON.parse(line);
+                lines.push(parsed.message || line);
+              } catch {
+                lines.push(line);
+              }
+            }
+          }
+        }
+      }
+
+      return { success: true, lines };
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+      return { success: false, lines: [] as string[] };
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const triggerRestart = useCallback(async () => {
+    try {
+      await authenticatedFetch('/api/update/restart', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      });
+    } catch {
+      // Expected — server will die
+    }
+  }, []);
+
+  return { info, loading, error, fetchVersion, triggerUpdate, triggerRestart };
+}

--- a/ui/src/utils/api.js
+++ b/ui/src/utils/api.js
@@ -1,4 +1,4 @@
-import { DISABLE_LOCAL_AUTH, IS_PLATFORM } from "../constants/config";
+import { IS_PLATFORM } from "../constants/config";
 
 const normalizePathForUrl = (value) => String(value || '').replace(/\\/g, '/');
 
@@ -42,7 +42,7 @@ export const authenticatedFetch = (url, options = {}) => {
     defaultHeaders['Content-Type'] = 'application/json';
   }
 
-  if (!IS_PLATFORM && !DISABLE_LOCAL_AUTH && token) {
+  if (!IS_PLATFORM && token) {
     defaultHeaders['Authorization'] = `Bearer ${token}`;
   }
 


### PR DESCRIPTION
## Summary

- Add `scripts/update.sh` and `pilotdeck update` CLI subcommand for automated git pull, rebuild, and restart
- Introduce `ChannelCommandRegistry` as the single source of truth for system-level slash commands (`/update`, `/projects`, `/status`, `/help`), shared across Feishu, Web UI, and future IM channels
- Add `/api/update` REST endpoints (check, apply with streaming progress, restart) and integrate version check + update UI into the Settings page "About" section
- Fix auth flow to respect server-side `authDisabled` flag instead of relying on client-side env vars

## Test plan

- [ ] Run `pilotdeck update --check` to verify version check works
- [ ] Trigger `/update` from Feishu to verify IM channel command dispatch
- [ ] Open Settings → About section, verify current commit SHA and branch are shown
- [ ] When remote has new commits, verify "Update Now" button appears and streams progress
- [ ] After update completes, click "Restart to Apply" — verify page blanks and auto-reloads when server is back
- [ ] Verify Docker deployment: `process.exit(0)` triggers container restart via restart policy


Made with [Cursor](https://cursor.com)