### PR TITLE
fix(always-on): clear activeWorkCycleId from state after archive/apply

### DIFF
--- a/src/always-on/index.ts
+++ b/src/always-on/index.ts
@@ -157,7 +157,7 @@ export {
   type WebPlanContextRefs,
   type WebPlanStatus,
 } from "./web/DiscoveryPlanStatus.js";
-export { DiscoveryPlanService, normalizeDiscoveryPlanRecord, type DiscoveryPlanServiceDeps } from "./web/DiscoveryPlanService.js";
+export { DiscoveryPlanService, normalizeDiscoveryPlanRecord, type DiscoveryPlanServiceDeps, type StateManager } from "./web/DiscoveryPlanService.js";
 export { buildDiscoveryContext, type DiscoveryContextDeps } from "./web/DiscoveryPlanContext.js";
 export { AlwaysOnRunHistoryService, type AlwaysOnRunHistoryServiceDeps, type RunHistoryEntry, type RunHistoryDetailEntry } from "./web/AlwaysOnRunHistoryService.js";
 export { GitWorktreeProvider, type GitWorktreeProviderOptions } from "./workspace/GitWorktreeProvider.js";

--- a/src/always-on/web/DiscoveryPlanService.ts
+++ b/src/always-on/web/DiscoveryPlanService.ts
@@ -103,6 +103,10 @@ export type WorkspaceManager = {
   ): Promise<void>;
 };
 
+export type StateManager = {
+  clearActiveWorkCycleId(projectRoot: string): Promise<void>;
+};
+
 export type DiscoveryPlanServiceDeps = {
   pilotHome: string;
   createProjectId: (projectRoot: string) => string;
@@ -111,6 +115,7 @@ export type DiscoveryPlanServiceDeps = {
   activity: SessionActivityChecker;
   events: RunEventSink;
   workspace?: WorkspaceManager;
+  state?: StateManager;
 };
 
 // ---------------------------------------------------------------------------
@@ -395,6 +400,14 @@ export class DiscoveryPlanService {
     }
     await writePlanStore(projectDir, store);
 
+    if (this.deps.state) {
+      try {
+        await this.deps.state.clearActiveWorkCycleId(projectRoot);
+      } catch {
+        // Best effort — state cleanup should not block archive.
+      }
+    }
+
     return { archived: true };
   }
 
@@ -500,6 +513,14 @@ export class DiscoveryPlanService {
           }
         }
         await writePlanStore(projectDir, store);
+
+        if (this.deps.state) {
+          try {
+            await this.deps.state.clearActiveWorkCycleId(projectRoot);
+          } catch {
+            // Best effort — state cleanup should not block apply finalization.
+          }
+        }
       }
     }
 

--- a/ui/server/discovery-plans.js
+++ b/ui/server/discovery-plans.js
@@ -27,6 +27,8 @@ import {
   applyWorktreeToProject,
   disposeWorkspace as disposeWorkspaceImpl,
 } from '../../src/always-on/workspace/WorkspaceApply.js';
+import { resolveAlwaysOnPaths } from '../../src/always-on/storage/AlwaysOnPaths.js';
+import { DiscoveryStateStore } from '../../src/always-on/storage/DiscoveryStateStore.js';
 
 // ---------------------------------------------------------------------------
 // Wire dependencies for the service
@@ -48,6 +50,16 @@ function getService() {
     workspace: {
       applyWorktreeChanges: applyWorktreeToProject,
       disposeWorkspace: disposeWorkspaceImpl,
+    },
+    state: {
+      clearActiveWorkCycleId: async (projectRoot) => {
+        const paths = resolveAlwaysOnPaths({
+          pilotHome: resolvePilotHome(),
+          projectKey: projectRoot,
+        });
+        const store = new DiscoveryStateStore(paths);
+        await store.clearActiveWorkCycleId(new Date());
+      },
     },
   });
 }


### PR DESCRIPTION
## Summary

- `DiscoveryStateStore.clearActiveWorkCycleId()` was defined but never called anywhere in the codebase. After a work cycle is archived or applied, `state.json` retains a stale `activeWorkCycleId` pointing to the now-terminated cycle.
- This fix calls `clearActiveWorkCycleId` in `DiscoveryPlanService.archiveCycle()` and `updateCycleExecution()` (applied branch) via a new optional `StateManager` dependency, keeping full backward compatibility.
- Both call sites are wrapped in try/catch (best-effort) so state cleanup never blocks the main archive/apply flow.

## Test plan

- [x] `npm run build` passes
- [x] `npm test` passes
- [ ] Manual: archive a cycle, verify `state.json` no longer contains `activeWorkCycleId`
- [ ] Manual: apply a cycle successfully, verify `state.json` no longer contains `activeWorkCycleId`
- [ ] Manual: apply a cycle that fails, verify `activeWorkCycleId` is preserved (cycle remains active)

Made with [Cursor](https://cursor.com)