### PR TITLE
fix: address issues #135, #133, #131, #129

### DIFF
--- a/src/model/streaming/normalizeStreamEvent.ts
+++ b/src/model/streaming/normalizeStreamEvent.ts
@@ -8,25 +8,26 @@ import {
 import type { CanonicalModelEvent, ModelProtocol } from "../protocol/canonical.js";
 
 export type StreamNormalizerState = {
-  anthropic: AnthropicStreamState;
-  openai: OpenAIStreamState;
+  anthropic?: AnthropicStreamState;
+  openai?: OpenAIStreamState;
 };
 
-export function createStreamNormalizerState(): StreamNormalizerState {
-  return {
-    anthropic: createAnthropicStreamState(),
-    openai: createOpenAIStreamState(),
-  };
+export function createStreamNormalizerState(protocol: ModelProtocol): StreamNormalizerState {
+  return protocol === "anthropic"
+    ? { anthropic: createAnthropicStreamState() }
+    : { openai: createOpenAIStreamState() };
 }
 
 export function normalizeStreamEvent(
   protocol: ModelProtocol,
   raw: unknown,
-  state: StreamNormalizerState = createStreamNormalizerState(),
+  state: StreamNormalizerState,
 ): CanonicalModelEvent[] {
   if (protocol === "anthropic") {
+    state.anthropic ??= createAnthropicStreamState();
     return normalizeAnthropicStreamEvent(raw, state.anthropic);
   }
 
+  state.openai ??= createOpenAIStreamState();
   return normalizeOpenAIStreamEvent(raw, state.openai);
 }

--- a/src/model/streaming/streamModel.ts
+++ b/src/model/streaming/streamModel.ts
@@ -100,7 +100,7 @@ export async function* streamModel(
       return;
     }
 
-    const state = createStreamNormalizerState();
+    const state = createStreamNormalizerState(provider.protocol);
     let streamCompleted = false;
 
     try {

--- a/src/task/runtime/BackgroundTaskRuntime.ts
+++ b/src/task/runtime/BackgroundTaskRuntime.ts
@@ -151,6 +151,7 @@ export class BackgroundTaskRuntime {
       child.unref();
     } catch (err) {
       task.status = "failed";
+      task.completionStatusSentInAttachment = true;
       task.endedAt = this.options.now();
       const message = err instanceof Error ? err.message : String(err);
       output.append(Buffer.from(`spawn error: ${message}\n`));
@@ -186,6 +187,7 @@ export class BackgroundTaskRuntime {
       } else {
         task.status = "failed";
       }
+      task.completionStatusSentInAttachment = true;
       resolveDone();
     });
 

--- a/src/web/client/GatewayBrowserClient.ts
+++ b/src/web/client/GatewayBrowserClient.ts
@@ -61,6 +61,8 @@ export class GatewayBrowserClient {
   private readonly streams = new Map<string, AsyncEventQueue<WebGatewayEvent>>();
   private connectError?: Error;
   private closed = false;
+  private helloResolve?: (hello: WebHelloOk) => void;
+  private helloReject?: (error: Error) => void;
 
   constructor(private readonly options: GatewayBrowserClientOptions) {}
 
@@ -251,18 +253,32 @@ export class GatewayBrowserClient {
     this.ws.send(JSON.stringify(frame));
   }
 
-  private async waitForHello(timeoutMs: number): Promise<WebHelloOk> {
-    const start = Date.now();
-    while (Date.now() - start < timeoutMs) {
-      if (this.hello) {
-        return this.hello;
-      }
-      if (this.connectError || this.closed) {
-        throw this.connectError ?? new Error("Gateway WebSocket closed before hello.");
-      }
-      await sleep(10);
+  private waitForHello(timeoutMs: number): Promise<WebHelloOk> {
+    if (this.hello) return Promise.resolve(this.hello);
+    if (this.connectError || this.closed) {
+      return Promise.reject(
+        this.connectError ?? new Error("Gateway WebSocket closed before hello."),
+      );
     }
-    throw new Error("Gateway hello timed out.");
+    return new Promise<WebHelloOk>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.helloResolve = undefined;
+        this.helloReject = undefined;
+        reject(new Error("Gateway hello timed out."));
+      }, timeoutMs);
+      this.helloResolve = (hello) => {
+        clearTimeout(timer);
+        this.helloResolve = undefined;
+        this.helloReject = undefined;
+        resolve(hello);
+      };
+      this.helloReject = (err) => {
+        clearTimeout(timer);
+        this.helloResolve = undefined;
+        this.helloReject = undefined;
+        reject(err);
+      };
+    });
   }
 
   private ensureConnected(): void {
@@ -283,6 +299,7 @@ export class GatewayBrowserClient {
     }
     if ((frame as WebHelloOk).type === "hello_ok") {
       this.hello = frame as WebHelloOk;
+      this.helloResolve?.(this.hello);
       return;
     }
     if (frame.type === "response") {
@@ -326,6 +343,7 @@ export class GatewayBrowserClient {
     );
     if (!this.hello) {
       this.connectError ??= error;
+      this.helloReject?.(error);
     }
     this.failPendingAndStreams(error);
   }
@@ -441,8 +459,4 @@ function waitForOpen(ws: WebSocketLike): Promise<void> {
     ws.addEventListener("open", onOpen, { once: true });
     ws.addEventListener("error", onError, { once: true });
   });
-}
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/ui/src/contexts/WebSocketContext.tsx
+++ b/ui/src/contexts/WebSocketContext.tsx
@@ -37,8 +37,9 @@ const buildWebSocketUrl = (token: string | null) => {
 
 const useWebSocketProviderState = (): WebSocketContextType => {
   const wsRef = useRef<WebSocket | null>(null);
-  const unmountedRef = useRef(false); // Track if component is unmounted
-  const hasConnectedRef = useRef(false); // Track if we've ever connected (to detect reconnects)
+  const unmountedRef = useRef(false);
+  const hasConnectedRef = useRef(false);
+  const connectIdRef = useRef(0);
   const [latestMessage, setLatestMessage] = useState<any>(null);
   const [isConnected, setIsConnected] = useState(false);
   const reconnectTimeoutRef = useRef<NodeJS.Timeout | null>(null);
@@ -46,89 +47,95 @@ const useWebSocketProviderState = (): WebSocketContextType => {
   const { token } = useAuth();
 
   useEffect(() => {
-    connect();
-    
-    return () => {
-      unmountedRef.current = true;
-      if (reconnectTimeoutRef.current) {
-        clearTimeout(reconnectTimeoutRef.current);
-      }
-      if (wsRef.current) {
-        wsRef.current.close();
+    return () => { unmountedRef.current = true; };
+  }, []);
+
+  useEffect(() => {
+    const id = ++connectIdRef.current;
+
+    const connect = () => {
+      if (unmountedRef.current || connectIdRef.current !== id) return;
+      try {
+        const wsUrl = buildWebSocketUrl(token);
+        if (!wsUrl) return console.warn('No authentication token found for WebSocket connection');
+
+        const websocket = new WebSocket(wsUrl);
+
+        websocket.onopen = () => {
+          if (connectIdRef.current !== id) { websocket.close(); return; }
+          setIsConnected(true);
+          wsRef.current = websocket;
+          if (hasConnectedRef.current) {
+            const reconnectMsg = { type: 'websocket-reconnected', timestamp: Date.now() };
+            const subs = subscribersRef.current;
+            if (subs.size > 0) {
+              subs.forEach((sub) => {
+                try { sub(reconnectMsg); } catch {}
+              });
+            }
+            setLatestMessage(reconnectMsg);
+          }
+          hasConnectedRef.current = true;
+        };
+
+        websocket.onmessage = (event) => {
+          if (connectIdRef.current !== id) return;
+          try {
+            const data = JSON.parse(event.data);
+            const subs = subscribersRef.current;
+            if (subs.size > 0) {
+              subs.forEach((sub) => {
+                try {
+                  sub(data);
+                } catch (err) {
+                  console.error('WebSocket subscriber error:', err);
+                }
+              });
+            }
+            setLatestMessage(data);
+          } catch (error) {
+            console.error('Error parsing WebSocket message:', error);
+          }
+        };
+
+        websocket.onclose = () => {
+          if (connectIdRef.current !== id) return;
+          setIsConnected(false);
+          wsRef.current = null;
+          reconnectTimeoutRef.current = setTimeout(() => {
+            if (unmountedRef.current || connectIdRef.current !== id) return;
+            connect();
+          }, 3000);
+        };
+
+        websocket.onerror = (error) => {
+          console.error('WebSocket error:', error);
+        };
+      } catch (error) {
+        console.error('Error creating WebSocket connection:', error);
       }
     };
-  }, [token]); // everytime token changes, we reconnect
 
-  const connect = useCallback(() => {
-    if (unmountedRef.current) return; // Prevent connection if unmounted
-    try {
-      // Construct WebSocket URL
-      const wsUrl = buildWebSocketUrl(token);
+    connect();
 
-      if (!wsUrl) return console.warn('No authentication token found for WebSocket connection');
-      
-      const websocket = new WebSocket(wsUrl);
-
-      websocket.onopen = () => {
-        setIsConnected(true);
-        wsRef.current = websocket;
-        if (hasConnectedRef.current) {
-          // This is a reconnect — signal so components can catch up on missed messages
-          const reconnectMsg = { type: 'websocket-reconnected', timestamp: Date.now() };
-          const subs = subscribersRef.current;
-          if (subs.size > 0) {
-            subs.forEach((sub) => {
-              try { sub(reconnectMsg); } catch {}
-            });
-          }
-          setLatestMessage(reconnectMsg);
-        }
-        hasConnectedRef.current = true;
-      };
-
-      websocket.onmessage = (event) => {
-        try {
-          const data = JSON.parse(event.data);
-          // Synchronously fan out to subscribers BEFORE the React state
-          // update. React 18 auto-batches setLatestMessage across multiple
-          // onmessage calls in the same task, so consumers that need every
-          // single message (e.g. stream_delta accumulators) must subscribe
-          // here instead of reading `latestMessage`.
-          const subs = subscribersRef.current;
-          if (subs.size > 0) {
-            subs.forEach((sub) => {
-              try {
-                sub(data);
-              } catch (err) {
-                console.error('WebSocket subscriber error:', err);
-              }
-            });
-          }
-          setLatestMessage(data);
-        } catch (error) {
-          console.error('Error parsing WebSocket message:', error);
-        }
-      };
-
-      websocket.onclose = () => {
-        setIsConnected(false);
+    return () => {
+      connectIdRef.current++;
+      if (reconnectTimeoutRef.current) {
+        clearTimeout(reconnectTimeoutRef.current);
+        reconnectTimeoutRef.current = null;
+      }
+      const ws = wsRef.current;
+      if (ws) {
+        ws.onopen = null;
+        ws.onmessage = null;
+        ws.onclose = null;
+        ws.onerror = null;
+        ws.close();
         wsRef.current = null;
-        
-        // Attempt to reconnect after 3 seconds
-        reconnectTimeoutRef.current = setTimeout(() => {
-          if (unmountedRef.current) return; // Prevent reconnection if unmounted
-          connect();
-        }, 3000);
-      };
-
-      websocket.onerror = (error) => {
-        console.error('WebSocket error:', error);
-      };
-
-    } catch (error) {
-      console.error('Error creating WebSocket connection:', error);
-    }
-  }, [token]); // everytime token changes, we reconnect
+      }
+      setIsConnected(false);
+    };
+  }, [token]);
 
   const sendMessage = useCallback((message: any) => {
     const socket = wsRef.current;


### PR DESCRIPTION
## Summary

Batch fix for four open issues reported by @Livezt:

- **#135** — `completionStatusSentInAttachment` flag was initialized to `false` but never flipped to `true` when a task reached a terminal state. Set it in both the `exit` handler and the `spawn`-error path.
- **#133** — `waitForHello` used a 10ms polling loop (~100 wakeups/sec). Replaced with a deferred Promise resolved by `handleMessage` on `hello_ok` or rejected on close/timeout.
- **#131** — `createStreamNormalizerState()` always allocated both Anthropic and OpenAI stream state objects. Now accepts a `protocol` parameter and only creates the one in use; `normalizeStreamEvent` lazily initializes on fallback.
- **#129** — WebSocket reconnect race condition: `unmountedRef` was incorrectly set to `true` on token-change cleanup (not just unmount), permanently blocking reconnection. Old WS `onclose` also spawned phantom reconnect timers with stale tokens. Fixed with a generation counter (`connectIdRef`) and proper handler cleanup.

## Test plan

- [ ] Verify background tasks correctly report `completionStatusSentInAttachment = true` after completion/failure/cancellation
- [ ] Verify `GatewayBrowserClient.connect()` resolves on `hello_ok` without CPU-intensive polling
- [ ] Verify stream normalization works correctly for both Anthropic and OpenAI providers
- [ ] Verify WebSocket reconnects cleanly when auth token changes (no stale connections or phantom timers)

Closes #135, closes #133, closes #131, closes #129

Made with [Cursor](https://cursor.com)