### PR TITLE
fix(mcp): browser-use screenshot saving path and inline rendering

### DIFF
--- a/src/cli/createLocalGateway.ts
+++ b/src/cli/createLocalGateway.ts
@@ -760,7 +760,7 @@ class ProjectRuntimeRegistry {
             sanitizeSessionIdForPath(context.sessionKey),
           );
           mkdirSyncFs(outDir, { recursive: true });
-          return { ...spec, args: [...(spec.args ?? []), `--output-dir=${outDir}`] };
+          return { ...spec, cwd: outDir, args: [...(spec.args ?? []), `--output-dir=${outDir}`] };
         }
         return spec;
       });

--- a/src/mcp/runtime/PluginToToolBridge.ts
+++ b/src/mcp/runtime/PluginToToolBridge.ts
@@ -17,6 +17,9 @@
  * block until the downstream pipeline supports them.
  */
 
+import { readFileSync } from "node:fs";
+import { resolve as resolvePath } from "node:path";
+
 import { PilotDeckToolRuntimeError } from "../../tool/protocol/errors.js";
 import type {
   PilotDeckToolDefinition,
@@ -87,7 +90,7 @@ function buildToolDefinition(
           );
         }
         return {
-          content: marshalMcpContent(content),
+          content: marshalMcpContent(content, client.spec.transport === "stdio" ? client.spec.cwd : undefined),
           data: content,
           metadata: {
             mcp: { serverId: spec.serverId, toolName: spec.toolName, wireName: spec.wireName },
@@ -128,12 +131,19 @@ type McpContentBlock = { type: string; [key: string]: unknown };
  * `TextContent`  → `{ type: "text" }`
  * `ImageContent` → `{ type: "image" }` (renders inline in chat)
  * Everything else falls through as a single `json` block.
+ *
+ * When `cwd` is provided and no inline image block is present, the function
+ * scans text blocks for Markdown image links (`[…](./file.png)`) and reads
+ * the referenced files from disk so that screenshots taken with a
+ * user-specified `filename` (which `@playwright/mcp` saves without returning
+ * base64 data) still render inline in the chat UI.
  */
-function marshalMcpContent(raw: unknown): PilotDeckToolResultContent[] {
+function marshalMcpContent(raw: unknown, cwd?: string): PilotDeckToolResultContent[] {
   if (!Array.isArray(raw)) return [{ type: "json", value: raw }];
 
   const result: PilotDeckToolResultContent[] = [];
   const remainder: unknown[] = [];
+  let hasImageBlock = false;
 
   for (const block of raw as McpContentBlock[]) {
     if (!block || typeof block !== "object" || typeof block.type !== "string") {
@@ -148,8 +158,18 @@ function marshalMcpContent(raw: unknown): PilotDeckToolResultContent[] {
       typeof block.mimeType === "string"
     ) {
       result.push({ type: "image", mimeType: block.mimeType as string, data: block.data as string });
+      hasImageBlock = true;
     } else {
       remainder.push(block);
+    }
+  }
+
+  if (!hasImageBlock && cwd) {
+    for (const block of raw as McpContentBlock[]) {
+      if (block?.type === "text" && typeof block.text === "string") {
+        const images = extractFileImages(block.text as string, cwd);
+        for (const img of images) result.push(img);
+      }
     }
   }
 
@@ -160,6 +180,32 @@ function marshalMcpContent(raw: unknown): PilotDeckToolResultContent[] {
     result.push({ type: "json", value: raw });
   }
   return result;
+}
+
+const IMAGE_LINK_RE = /\[.*?\]\((\.[^)]*\.(?:png|jpe?g|gif|webp))\)/gi;
+
+/**
+ * Extract image file references from Markdown text, read the files from disk,
+ * and return them as base64 image blocks.
+ */
+function extractFileImages(text: string, cwd: string): PilotDeckToolResultContent[] {
+  const results: PilotDeckToolResultContent[] = [];
+  for (const match of text.matchAll(IMAGE_LINK_RE)) {
+    const relPath = match[1];
+    try {
+      const absPath = resolvePath(cwd, relPath);
+      const data = readFileSync(absPath);
+      const ext = relPath.split(".").pop()?.toLowerCase() ?? "png";
+      const mimeType = ext === "jpg" || ext === "jpeg" ? "image/jpeg"
+        : ext === "gif" ? "image/gif"
+        : ext === "webp" ? "image/webp"
+        : "image/png";
+      results.push({ type: "image", mimeType, data: data.toString("base64") });
+    } catch {
+      // File not readable — skip silently; the text link remains as-is.
+    }
+  }
+  return results;
 }
 
 function extractMcpErrorText(


### PR DESCRIPTION
## Summary

- Set `cwd: outDir` on the browser-use MCP spec so that screenshots (both auto-named and user-specified `filename`) are saved to `projectRoot/.pilotdeck/browser_screenshots/<sessionId>/` instead of an unpredictable inherited CWD.
- Add a file-reading fallback in `marshalMcpContent()`: when `@playwright/mcp` returns only a text block with a Markdown image link (no base64 — happens when the LLM passes `filename`), read the referenced file from disk and inject it as an inline image block, so the existing `toolResultImages` rendering pipeline can display it.

## Root cause

`@playwright/mcp` has two path-resolution strategies for `browser_take_screenshot`:

| LLM passes `filename`? | File saved to | Response contains |
|---|---|---|
| No | `--output-dir` (absolute) | `text` + `image` (base64) blocks |
| Yes | `workspaceFile(filename)` → relative to **process CWD** | `text` block only (Markdown link) |

PilotDeck spawned the browser-use MCP process without setting `cwd`, so `process.cwd()` was inherited from the PilotDeck parent — an unpredictable location. Screenshots with `filename` were written to the wrong directory (or silently failed), and even when the file existed, the response lacked base64 data for the UI to render.

## Test plan

- [ ] Start a session, ask the agent to take a screenshot (triggers `browser_take_screenshot`)
- [ ] Verify the screenshot file appears in `projectRoot/.pilotdeck/browser_screenshots/<sessionId>/`
- [ ] Verify the screenshot renders inline in the tool result area of the Web UI
- [ ] Refresh the page and verify the screenshot is still visible (session history path)
- [ ] Test with a model that does NOT pass `filename` — verify base64 inline rendering still works
- [ ] Test with a model that passes `filename` — verify the file-reading fallback kicks in


Made with [Cursor](https://cursor.com)