### PR TITLE
fix(large-file-repair): preserve pendingRepair state when non-file tools fail

### DIFF
--- a/src/agent/loop/LargeFileRepair.ts
+++ b/src/agent/loop/LargeFileRepair.ts
@@ -62,7 +62,9 @@ export class LargeFileRepair {
     if (this.wroteFile) {
       const risk = hasPostDraftRisk(results);
       if (!risk) {
-        this.pendingLargeFileRepair = false;
+        if (results.every((r) => r.type === "success")) {
+          this.pendingLargeFileRepair = false;
+        }
         return undefined;
       }
       return this.tryPostDraft("large_file_post_draft_repair");


### PR DESCRIPTION
## Summary

- Only clear `pendingLargeFileRepair` when **all** tool results are successful, not merely when `hasPostDraftRisk` returns false
- Previously, if the model switched from `write_file`/`edit_file` to `bash` (with invalid params) during repair, `pendingLargeFileRepair` was cleared, disabling the circuit breaker deferral and causing premature "Terminated: 3 consecutive turns with all tool calls failing input validation" errors

## Root Cause

During post-draft repair, `analyzeToolResults` checks `hasPostDraftRisk()`. If the model calls non-file tools (e.g. `bash`) that fail, `hasPostDraftRisk` returns false → `pendingLargeFileRepair` is set to false → the circuit breaker no longer defers to `LargeFileRepair` → 3 consecutive invalid turns → session terminated.

## Test plan

- [ ] Trigger large file repair with a weak model (e.g. qwen3.6-flash) writing 800+ line HTML
- [ ] Verify model switching to `bash` during repair does not cause premature termination
- [ ] Verify `pendingLargeFileRepair` is still cleared after a fully successful turn

Made with [Cursor](https://cursor.com)