### PR TITLE
fix(ui): avoid Vite HMR websocket collision

### DIFF
--- a/ui/vite.config.js
+++ b/ui/vite.config.js
@@ -48,6 +48,9 @@ export default defineConfig(({ mode }) => {
     server: {
       host,
       port: parseInt(env.VITE_PORT) || 5173,
+      hmr: {
+        path: '/__vite_hmr'
+      },
       proxy: {
         '/api': `http://${proxyHost}:${serverPort}`,
         '/memory-dashboard': `http://${proxyHost}:${serverPort}`,


### PR DESCRIPTION
## Summary

- Configure Vite HMR to use a dedicated `/__vite_hmr` path.
- Avoid collisions with PilotDeck's chat WebSocket proxy on `/ws` during local dev.

## Problem

In local dev mode, the app chat socket also uses `/ws`. When Vite HMR traffic reaches the PilotDeck chat WebSocket handler, the server can receive a plain `ping` frame and try to parse it as JSON, producing an error like:

```text
[ERROR] Chat WebSocket error: Unexpected token 'p', "ping" is not valid JSON
```

After that, the browser UI can remain stuck in `Sending...` / `Thinking` even though the prompt never reaches the model provider.

## Verification

- `pnpm --filter pilotdeck-ui build`
- Manually reproduced the local chat flow after isolating HMR from `/ws`.
