### PR TITLE
fix: resolve Docker startup race causing "Gateway hello timed out"

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -150,9 +150,45 @@ echo "[pilotdeck-docker] Starting PilotDeck (gateway + UI server)..."
 echo "[pilotdeck-docker] Config: $CONFIG_FILE"
 echo "[pilotdeck-docker] UI will be available at http://0.0.0.0:${SERVER_PORT:-3001}"
 
+# ── Remove stale auth token so the bridge never uses a leftover value ──
+rm -f "$PILOT_HOME/server-token"
+
 # ── Start gateway + UI server via concurrently ────────────────────────
+# The bridge retries for PILOTDECK_BRIDGE_TIMEOUT ms (default 30s) which
+# may be too short on cold Docker starts. We first wait for the gateway
+# health endpoint before launching the bridge, eliminating the race.
 cd /app
 
-exec npx concurrently --kill-others --names gateway,server \
-  "node dist/src/cli/pilotdeck.js server" \
-  "node --import tsx ui/server/index.js"
+GATEWAY_PORT="${PILOTDECK_GATEWAY_PORT:-18789}"
+GATEWAY_HEALTH_URL="http://127.0.0.1:${GATEWAY_PORT}/health"
+GATEWAY_READY_TIMEOUT="${PILOTDECK_GATEWAY_READY_TIMEOUT:-120}"
+
+wait_for_gateway() {
+  echo "[pilotdeck-docker] Waiting for gateway to become ready (timeout=${GATEWAY_READY_TIMEOUT}s)..."
+  local elapsed=0
+  while [ "$elapsed" -lt "$GATEWAY_READY_TIMEOUT" ]; do
+    if curl -sf "$GATEWAY_HEALTH_URL" > /dev/null 2>&1; then
+      echo "[pilotdeck-docker] Gateway is ready (took ${elapsed}s)."
+      return 0
+    fi
+    sleep 1
+    elapsed=$((elapsed + 1))
+  done
+  echo "[pilotdeck-docker] WARNING: Gateway did not become ready within ${GATEWAY_READY_TIMEOUT}s, starting bridge anyway." >&2
+  return 0
+}
+
+node dist/src/cli/pilotdeck.js server &
+GATEWAY_PID=$!
+
+wait_for_gateway
+
+node --import tsx ui/server/index.js &
+BRIDGE_PID=$!
+
+# If either process exits, kill the other and propagate the exit code.
+wait -n $GATEWAY_PID $BRIDGE_PID 2>/dev/null
+EXIT_CODE=$?
+kill $GATEWAY_PID $BRIDGE_PID 2>/dev/null
+wait $GATEWAY_PID $BRIDGE_PID 2>/dev/null
+exit $EXIT_CODE

--- a/src/gateway/client/GatewayWsClient.ts
+++ b/src/gateway/client/GatewayWsClient.ts
@@ -70,13 +70,33 @@ export class GatewayWsClient {
     );
 
     return new Promise((resolve, reject) => {
-      const timeout = setTimeout(() => reject(new Error("Gateway hello timed out.")), 5000);
-      const onHello = () => {
-        if (this.hello) {
+      let settled = false;
+      const timeout = setTimeout(() => {
+        if (!settled) {
+          settled = true;
+          reject(new Error("Gateway hello timed out."));
+        }
+      }, 10_000);
+
+      const onClose = (event: CloseEvent) => {
+        if (!settled) {
+          settled = true;
           clearTimeout(timeout);
+          const reason = event.reason || `code ${event.code}`;
+          reject(new Error(`Gateway closed during hello: ${reason}`));
+        }
+      };
+      ws.addEventListener("close", onClose, { once: true });
+
+      const onHello = () => {
+        if (settled) return;
+        if (this.hello) {
+          settled = true;
+          clearTimeout(timeout);
+          ws.removeEventListener("close", onClose);
           resolve(this.hello);
         } else {
-          setTimeout(onHello, 0);
+          setTimeout(onHello, 50);
         }
       };
       onHello();

--- a/ui/server/pilotdeck-bridge.js
+++ b/ui/server/pilotdeck-bridge.js
@@ -71,8 +71,9 @@ const GATEWAY_TOKEN_PATH =
 // parallel by `concurrently`. We allow up to 30 s for the gateway to
 // come up before failing the first call — covers cold MCP startup on
 // slower machines.
-const GATEWAY_CONNECT_TIMEOUT_MS = 30_000;
-const GATEWAY_CONNECT_RETRY_INTERVAL_MS = 250;
+const GATEWAY_CONNECT_TIMEOUT_MS =
+    Number.parseInt(process.env.PILOTDECK_BRIDGE_TIMEOUT ?? '', 10) || 60_000;
+const GATEWAY_CONNECT_RETRY_INTERVAL_MS = 500;
 const subagentActivityStarts = new Map();
 
 function normalizeToolDisplayName(name) {


### PR DESCRIPTION
The bridge and gateway were started concurrently via `concurrently`, but on cold Docker starts the gateway often took >30s to initialize (MCP, cron, channels), causing the bridge to timeout with "Gateway hello timed out" (issue #104).

Changes:
- docker-entrypoint.sh: start gateway first, poll /health before launching bridge; delete stale server-token on startup
- pilotdeck-bridge.js: make connect timeout configurable via PILOTDECK_BRIDGE_TIMEOUT env var (default 60s, was hardcoded 30s)
- GatewayWsClient.ts: properly reject hello promise on WS close (e.g. auth_failed) instead of waiting for the full timeout; increase hello timeout from 5s to 10s

Closes #104