### PR TITLE
fix(tool): ignore empty read_file pages

### DIFF
--- a/src/tool/builtin/readFile.ts
+++ b/src/tool/builtin/readFile.ts
@@ -82,6 +82,12 @@ export function createReadFileTool(): PilotDeckToolDefinition<ReadFileInput> {
     isReadOnly: () => true,
     isConcurrencySafe: () => true,
     validateInput: async (input, context) => {
+      let normalizedInput: ReadFileInput = input;
+      if (typeof input.pages === "string" && input.pages.trim().length === 0) {
+        const { pages: _pages, ...rest } = input;
+        normalizedInput = rest;
+      }
+
       if (input.offset !== undefined && input.offset < 1) {
         return {
           ok: false,
@@ -94,8 +100,8 @@ export function createReadFileTool(): PilotDeckToolDefinition<ReadFileInput> {
           issues: [{ path: "limit", code: "invalid_schema", message: "limit must be greater than or equal to 0." }],
         };
       }
-      if (input.pages !== undefined) {
-        const parsed = parsePdfPageRange(input.pages);
+      if (normalizedInput.pages !== undefined) {
+        const parsed = parsePdfPageRange(normalizedInput.pages);
         if (!parsed) {
           return {
             ok: false,
@@ -115,7 +121,7 @@ export function createReadFileTool(): PilotDeckToolDefinition<ReadFileInput> {
       }
 
       const absolutePath = path.resolve(
-        path.isAbsolute(input.file_path) ? input.file_path : path.join(context.cwd, input.file_path),
+        path.isAbsolute(normalizedInput.file_path) ? normalizedInput.file_path : path.join(context.cwd, normalizedInput.file_path),
       );
       if (isBlockedDevicePath(absolutePath)) {
         return {
@@ -129,7 +135,7 @@ export function createReadFileTool(): PilotDeckToolDefinition<ReadFileInput> {
           issues: [{ path: "file_path", code: "invalid_schema", message: "binary files are not supported by read_file." }],
         };
       }
-      return { ok: true, input };
+      return { ok: true, input: normalizedInput };
     },
     execute: async (input, context) => {
       const resolved = resolvePilotDeckWorkspacePath(input.file_path, context, { mustExist: true });

--- a/tests/tool/builtin/readFile.test.ts
+++ b/tests/tool/builtin/readFile.test.ts
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createReadFileTool } from "../../../src/tool/builtin/readFile.js";
+import type { PilotDeckToolRuntimeContext } from "../../../src/tool/protocol/types.js";
+
+const context = {
+  sessionId: "test-session",
+  turnId: "test-turn",
+  cwd: "/tmp",
+  permissionMode: "default",
+  permissionContext: {},
+} as unknown as PilotDeckToolRuntimeContext;
+
+test("read_file treats an empty pages string as omitted", async () => {
+  const tool = createReadFileTool();
+
+  const result = await tool.validateInput?.({
+    file_path: "notes.txt",
+    pages: "",
+  }, context);
+
+  assert.deepEqual(result, {
+    ok: true,
+    input: {
+      file_path: "notes.txt",
+    },
+  });
+});


### PR DESCRIPTION
## Summary
- Normalize empty `read_file.pages` strings to omitted input before validation
- Keep non-empty PDF page range validation unchanged
- Add a node:test regression test for optional empty `pages` input

Fixes #108

## Test Plan
- npm test