### PR TITLE
fix: correct update API path and show friendly prompt for unconfigured web_search

### DIFF
--- a/src/tool/builtin/webSearch.ts
+++ b/src/tool/builtin/webSearch.ts
@@ -141,15 +141,17 @@ Usage notes:
       const custom = normalizeCustomProviderConfig(options.customProvider);
       if (!apiKey && !(provider === "custom" && custom.auth === "none")) {
         throw new PilotDeckToolRuntimeError(
-          "unsupported_tool",
-          "web_search is not configured. Set tools.webSearch.provider to glm, tavily, or custom and provide tools.webSearch.apiKey, or set GLM_WEB_SEARCH_API_KEY/ZAI_API_KEY/TAVILY_API_KEY/CUSTOM_WEB_SEARCH_API_KEY.",
+          "setup_required",
+          "web_search requires an API key. Please configure it in Settings → Search.",
+          { tool: "web_search" },
         );
       }
       if (provider === "custom") {
         if (!options.endpoint?.trim()) {
           throw new PilotDeckToolRuntimeError(
-            "unsupported_tool",
-            "web_search custom provider requires tools.webSearch.endpoint.",
+            "setup_required",
+            "web_search custom provider requires an endpoint URL. Please configure it in Settings → Search.",
+            { tool: "web_search" },
           );
         }
         return performCustomSearch({

--- a/src/tool/protocol/errors.ts
+++ b/src/tool/protocol/errors.ts
@@ -11,7 +11,8 @@ export type PilotDeckToolErrorCode =
   | "path_not_allowed"
   | "file_not_found"
   | "file_conflict"
-  | "unsupported_tool";
+  | "unsupported_tool"
+  | "setup_required";
 
 export type PilotDeckToolError = {
   code: PilotDeckToolErrorCode;

--- a/ui/server/index.js
+++ b/ui/server/index.js
@@ -14,7 +14,7 @@ import { dirname } from 'path';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-const installMode = fs.existsSync(path.join(__dirname, '..', '.git')) ? 'git' : 'npm';
+const installMode = fs.existsSync(path.join(__dirname, '..', '..', '.git')) ? 'git' : 'npm';
 
 // ANSI color codes for terminal output
 const colors = {

--- a/ui/server/routes/update.js
+++ b/ui/server/routes/update.js
@@ -8,7 +8,7 @@ const execAsync = promisify(exec);
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-const PROJECT_ROOT = path.resolve(__dirname, '..', '..');
+const PROJECT_ROOT = path.resolve(__dirname, '..', '..', '..');
 
 const router = express.Router();
 

--- a/ui/src/components/chat/view/subcomponents/MessageComponent.tsx
+++ b/ui/src/components/chat/view/subcomponents/MessageComponent.tsx
@@ -382,6 +382,43 @@ const MessageComponent = memo(({ message, prevMessage, createDiff, onFileOpen, o
                           ? cleanToolUseErrorContent(message.toolResult?.content)
                           : stringifyMessageContent(message.toolResult?.content);
 
+                        if (message.toolResult?.errorCode === 'setup_required') {
+                          return (
+                            <div className="my-1 flex items-start gap-3 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 dark:border-amber-800/50 dark:bg-amber-950/30">
+                              <svg className="mt-0.5 h-4 w-4 flex-shrink-0 text-amber-500 dark:text-amber-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L4.082 16.5c-.77.833.192 2.5 1.732 2.5z" />
+                              </svg>
+                              <div className="min-w-0 flex-1">
+                                <div className="text-sm font-medium text-amber-800 dark:text-amber-200">
+                                  {t('setupRequired.title', { defaultValue: 'Configuration needed' })}
+                                </div>
+                                <div className="mt-0.5 text-xs text-amber-700 dark:text-amber-300/80">
+                                  {renderedErrorContent}
+                                </div>
+                                {onShowSettings && (
+                                  <button
+                                    type="button"
+                                    onClick={() => {
+                                      if (typeof window !== 'undefined' && window.openSettings) {
+                                        window.openSettings('config');
+                                      } else {
+                                        onShowSettings();
+                                      }
+                                    }}
+                                    className="mt-2 inline-flex items-center gap-1.5 rounded-md border border-amber-300 bg-white/80 px-3 py-1.5 text-xs font-medium text-amber-800 transition-colors hover:bg-white dark:border-amber-700 dark:bg-amber-900/40 dark:text-amber-200 dark:hover:bg-amber-900/60"
+                                  >
+                                    <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+                                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                                    </svg>
+                                    {t('setupRequired.openSettings', { defaultValue: 'Open Settings' })}
+                                  </button>
+                                )}
+                              </div>
+                            </div>
+                          );
+                        }
+
                         if (!permissionSuggestion) {
                           return (
                             <CollapsibleDisplay

--- a/ui/src/i18n/locales/en/chat.json
+++ b/ui/src/i18n/locales/en/chat.json
@@ -25,6 +25,10 @@
     "title": "Tool error",
     "description": ""
   },
+  "setupRequired": {
+    "title": "Configuration needed",
+    "openSettings": "Open Settings"
+  },
   "interrupted": {
     "label": "Interrupted by user"
   },

--- a/ui/src/i18n/locales/zh-CN/chat.json
+++ b/ui/src/i18n/locales/zh-CN/chat.json
@@ -25,6 +25,10 @@
     "title": "工具错误",
     "description": ""
   },
+  "setupRequired": {
+    "title": "需要配置",
+    "openSettings": "前往设置"
+  },
   "interrupted": {
     "label": "已被用户暂停"
   },


### PR DESCRIPTION
## Summary

- **Fix self-update API path**: `PROJECT_ROOT` in `update.js` and `installMode` detection in `index.js` were off by one directory level — they resolved to `ui/` instead of the repo root where `.git` lives, causing `/api/update/check` to always return 500 (`fatal: not a git repository`). The Settings "About > Version" section was stuck on "Checking for updates..." indefinitely.

- **Friendly setup prompt for `web_search`**: When the search API key is not configured, the tool now throws a new `setup_required` error code instead of `unsupported_tool`. The chat UI renders an amber "Configuration needed" prompt with a one-click "Open Settings" button that navigates directly to the config page, replacing the generic red "Tool error" box.

## Changes

| File | What |
|------|------|
| `ui/server/routes/update.js` | Fix `PROJECT_ROOT` (add missing `..` level) |
| `ui/server/index.js` | Fix `installMode` `.git` detection path |
| `src/tool/protocol/errors.ts` | Add `setup_required` error code |
| `src/tool/builtin/webSearch.ts` | Use `setup_required` with clearer message |
| `ui/src/components/chat/.../MessageComponent.tsx` | Render amber config prompt for `setup_required` |
| `ui/src/i18n/locales/{en,zh-CN}/chat.json` | Add i18n strings (EN + ZH) |

## Test plan

- [ ] Run `npm run dev`, open Settings → About: version info should load immediately (no stuck "Checking for updates...")
- [ ] Verify `/health` returns `installMode: "git"` (not `"npm"`)
- [ ] Trigger `web_search` without API key configured → should show amber prompt with "Open Settings" button
- [ ] Click "Open Settings" → should navigate to Settings config page
- [ ] Verify prompt shows Chinese text ("需要配置" / "前往设置") when locale is zh-CN


Made with [Cursor](https://cursor.com)