### PR TITLE
feat: add native skill candidates

### DIFF
--- a/skills/1password/SKILL.md
+++ b/skills/1password/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: 1password
+description: "Set up and use 1Password CLI for sign-in, desktop integration, and reading or injecting secrets."
+homepage: https://developer.1password.com/docs/cli/get-started/
+---
+
+# 1Password CLI
+
+Follow the official CLI get-started steps. Don't guess install commands.
+
+## References
+
+- `references/get-started.md` (install + app integration + sign-in flow)
+- `references/cli-examples.md` (real `op` examples)
+
+## Workflow
+
+1. Check OS + shell.
+2. Verify CLI present: `op --version`.
+3. Confirm desktop app integration is enabled (per get-started) and the app is unlocked.
+4. REQUIRED: create a fresh tmux session for all `op` commands (no direct `op` calls outside tmux).
+5. Sign in / authorize inside tmux: `op signin` (expect app prompt).
+6. Verify access inside tmux: `op whoami` (must succeed before any secret read).
+7. If multiple accounts: use `--account` or `OP_ACCOUNT`.
+
+## REQUIRED tmux session (tmux)
+
+The shell tool uses a fresh TTY per command. To avoid re-prompts and failures, always run `op` inside a dedicated tmux session with a fresh socket/session name.
+
+Example (see `tmux` skill for socket conventions, do not reuse old session names):
+
+```bash
+SOCKET_DIR="${PILOTDECK_TMUX_SOCKET_DIR:-${TMPDIR:-/tmp}/pilotdeck-tmux-sockets}"
+mkdir -p "$SOCKET_DIR"
+SOCKET="$SOCKET_DIR/pilotdeck-op.sock"
+SESSION="op-auth-$(date +%Y%m%d-%H%M%S)"
+
+tmux -S "$SOCKET" new -d -s "$SESSION" -n shell
+tmux -S "$SOCKET" send-keys -t "$SESSION":0.0 -- "op signin --account my.1password.com" Enter
+tmux -S "$SOCKET" send-keys -t "$SESSION":0.0 -- "op whoami" Enter
+tmux -S "$SOCKET" send-keys -t "$SESSION":0.0 -- "op vault list" Enter
+tmux -S "$SOCKET" capture-pane -p -J -t "$SESSION":0.0 -S -200
+tmux -S "$SOCKET" kill-session -t "$SESSION"
+```
+
+## Guardrails
+
+- Never paste secrets into logs, chat, or code.
+- Prefer `op run` / `op inject` over writing secrets to disk.
+- If sign-in without app integration is needed, use `op account add`.
+- If a command returns "account is not signed in", re-run `op signin` inside tmux and authorize in the app.
+- Do not run `op` outside tmux; stop and ask if tmux is unavailable.
+
+## PilotDeck Migration Note
+
+- Source: /var/folders/27/xyyzc_n172l3jjmnxgqmhhzh0000gn/T/tmp.AyWDWGKoS4/openclaw/skills/1password
+- Review status: candidate for PilotDeck native skills pack.
+- Platform-specific OpenClaw/Hermes metadata was removed or should be ignored during review.

--- a/skills/1password/references/cli-examples.md
+++ b/skills/1password/references/cli-examples.md
@@ -1,0 +1,29 @@
+# op CLI examples (from op help)
+
+## Sign in
+
+- `op signin`
+- `op signin --account <shorthand|signin-address|account-id|user-id>`
+
+## Read
+
+- `op read op://app-prod/db/password`
+- `op read "op://app-prod/db/one-time password?attribute=otp"`
+- `op read "op://app-prod/ssh key/private key?ssh-format=openssh"`
+- `op read --out-file ./key.pem op://app-prod/server/ssh/key.pem`
+
+## Run
+
+- `export DB_PASSWORD="op://app-prod/db/password"`
+- `op run --no-masking -- printenv DB_PASSWORD`
+- `op run --env-file="./.env" -- printenv DB_PASSWORD`
+
+## Inject
+
+- `echo "db_password: {{ op://app-prod/db/password }}" | op inject`
+- `op inject -i config.yml.tpl -o config.yml`
+
+## Whoami / accounts
+
+- `op whoami`
+- `op account list`

--- a/skills/1password/references/get-started.md
+++ b/skills/1password/references/get-started.md
@@ -1,0 +1,17 @@
+# 1Password CLI get-started (summary)
+
+- Works on macOS, Windows, and Linux.
+  - macOS/Linux shells: bash, zsh, sh, fish.
+  - Windows shell: PowerShell.
+- Requires a 1Password subscription and the desktop app to use app integration.
+- macOS requirement: Big Sur 11.0.0 or later.
+- Linux app integration requires PolKit + an auth agent.
+- Install the CLI per the official doc for your OS.
+- Enable desktop app integration in the 1Password app:
+  - Open and unlock the app, then select your account/collection.
+  - macOS: Settings > Developer > Integrate with 1Password CLI (Touch ID optional).
+  - Windows: turn on Windows Hello, then Settings > Developer > Integrate.
+  - Linux: Settings > Security > Unlock using system authentication, then Settings > Developer > Integrate.
+- After integration, run any command to sign in (example in docs: `op vault list`).
+- If multiple accounts: use `op signin` to pick one, or `--account` / `OP_ACCOUNT`.
+- For non-integration auth, use `op account add`.

--- a/skills/apple-notes/SKILL.md
+++ b/skills/apple-notes/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: apple-notes
+description: "Create, view, edit, delete, search, move, or export Apple Notes via the memo CLI on macOS."
+homepage: https://github.com/antoniorodr/memo
+---
+
+# Apple Notes CLI
+
+Use `memo notes` to manage Apple Notes directly from the terminal. Create, view, edit, delete, search, move notes between folders, and export to HTML/Markdown.
+
+Setup
+
+- Install (Homebrew): `brew tap antoniorodr/memo && brew install antoniorodr/memo/memo`
+- Manual (pip): `pip install .` (after cloning the repo)
+- macOS-only; if prompted, grant Automation access to Notes.app.
+
+View Notes
+
+- List all notes: `memo notes`
+- Filter by folder: `memo notes -f "Folder Name"`
+- Search notes (fuzzy): `memo notes -s "query"`
+
+Create Notes
+
+- Add a new note: `memo notes -a`
+  - Opens an interactive editor to compose the note.
+- Quick add with title: `memo notes -a "Note Title"`
+
+Edit Notes
+
+- Edit existing note: `memo notes -e`
+  - Interactive selection of note to edit.
+
+Delete Notes
+
+- Delete a note: `memo notes -d`
+  - Interactive selection of note to delete.
+
+Move Notes
+
+- Move note to folder: `memo notes -m`
+  - Interactive selection of note and destination folder.
+
+Export Notes
+
+- Export to HTML/Markdown: `memo notes -ex`
+  - Exports selected note; uses Mistune for markdown processing.
+
+Limitations
+
+- Cannot edit notes containing images or attachments.
+- Interactive prompts may require terminal access.
+
+Notes
+
+- macOS-only.
+- Requires Apple Notes.app to be accessible.
+- For automation, grant permissions in System Settings > Privacy & Security > Automation.
+
+## PilotDeck Migration Note
+
+- Source: /var/folders/27/xyyzc_n172l3jjmnxgqmhhzh0000gn/T/tmp.AyWDWGKoS4/openclaw/skills/apple-notes
+- Review status: candidate for PilotDeck native skills pack.
+- Platform-specific OpenClaw/Hermes metadata was removed or should be ignored during review.

--- a/skills/apple-reminders/SKILL.md
+++ b/skills/apple-reminders/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: apple-reminders
+description: "List, add, edit, complete, or delete Apple Reminders and reminder lists via remindctl."
+homepage: https://github.com/steipete/remindctl
+---
+
+# Apple Reminders CLI (remindctl)
+
+Use `remindctl` to manage Apple Reminders directly from the terminal.
+
+## When to Use
+
+Use when:
+
+- User explicitly mentions "reminder" or "Reminders app"
+- Creating personal to-dos with due dates that sync to iOS
+- Managing Apple Reminders lists
+- User wants tasks to appear in their iPhone/iPad Reminders app
+
+## When NOT to Use
+
+Do not use when:
+
+- Scheduling OpenClaw tasks or alerts -> use `cron` tool with systemEvent instead
+- Calendar events or appointments -> use Apple Calendar
+- Project/work task management -> use Notion, GitHub Issues, or task queue
+- One-time notifications -> use `cron` tool for timed alerts
+- User says "remind me" but means an OpenClaw alert -> clarify first
+
+## Setup
+
+- Install: `brew install steipete/tap/remindctl`
+- macOS-only; grant Reminders permission when prompted
+- Check status: `remindctl status`
+- Request access: `remindctl authorize`
+
+## Common Commands
+
+### View Reminders
+
+```bash
+remindctl                    # Today's reminders
+remindctl today              # Today
+remindctl tomorrow           # Tomorrow
+remindctl week               # This week
+remindctl overdue            # Past due
+remindctl all                # Everything
+remindctl 2026-01-04         # Specific date
+```
+
+### Manage Lists
+
+```bash
+remindctl list               # List all lists
+remindctl list Work          # Show specific list
+remindctl list Projects --create    # Create list
+remindctl list Work --delete        # Delete list
+```
+
+### Create Reminders
+
+```bash
+remindctl add "Buy milk"
+remindctl add --title "Call mom" --list Personal --due tomorrow
+remindctl add --title "Meeting prep" --due "2026-02-15 09:00"
+```
+
+### Complete/Delete
+
+```bash
+remindctl complete 1 2 3     # Complete by ID
+remindctl delete 4A83 --force  # Delete by ID
+```
+
+### Output Formats
+
+```bash
+remindctl today --json       # JSON for scripting
+remindctl today --plain      # TSV format
+remindctl today --quiet      # Counts only
+```
+
+## Date Formats
+
+Accepted by `--due` and date filters:
+
+- `today`, `tomorrow`, `yesterday`
+- `YYYY-MM-DD`
+- `YYYY-MM-DD HH:mm`
+- ISO 8601 (`2026-01-04T12:34:56Z`)
+
+## Example: Clarifying User Intent
+
+User: "Remind me to check on the deploy in 2 hours"
+
+**Ask:** "Do you want this in Apple Reminders (syncs to your phone) or as an OpenClaw alert (I'll message you here)?"
+
+- Apple Reminders -> use this skill
+- OpenClaw alert -> use `cron` tool with systemEvent
+
+## PilotDeck Migration Note
+
+- Source: /var/folders/27/xyyzc_n172l3jjmnxgqmhhzh0000gn/T/tmp.AyWDWGKoS4/openclaw/skills/apple-reminders
+- Review status: candidate for PilotDeck native skills pack.
+- Platform-specific OpenClaw/Hermes metadata was removed or should be ignored during review.

--- a/skills/bear-notes/SKILL.md
+++ b/skills/bear-notes/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: bear-notes
+description: "Create, search, and manage Bear notes via grizzly CLI."
+homepage: https://bear.app
+---
+
+# Bear Notes
+
+Use `grizzly` to create, read, and manage notes in Bear on macOS.
+
+Requirements
+
+- Bear app installed and running
+- For some operations (add-text, tags, open-note --selected), a Bear app token (stored in `~/.config/grizzly/token`)
+
+## Getting a Bear Token
+
+For operations that require a token (add-text, tags, open-note --selected), you need an authentication token:
+
+1. Open Bear -> Help -> API Token -> Copy Token
+2. Save it: `echo "YOUR_TOKEN" > ~/.config/grizzly/token`
+
+## Common Commands
+
+Create a note
+
+```bash
+echo "Note content here" | grizzly create --title "My Note" --tag work
+grizzly create --title "Quick Note" --tag inbox < /dev/null
+```
+
+Open/read a note by ID
+
+```bash
+grizzly open-note --id "NOTE_ID" --enable-callback --json
+```
+
+Append text to a note
+
+```bash
+echo "Additional content" | grizzly add-text --id "NOTE_ID" --mode append --token-file ~/.config/grizzly/token
+```
+
+List all tags
+
+```bash
+grizzly tags --enable-callback --json --token-file ~/.config/grizzly/token
+```
+
+Search notes (via open-tag)
+
+```bash
+grizzly open-tag --name "work" --enable-callback --json
+```
+
+## Options
+
+Common flags:
+
+- `--dry-run` - Preview the URL without executing
+- `--print-url` - Show the x-callback-url
+- `--enable-callback` - Wait for Bear's response (needed for reading data)
+- `--json` - Output as JSON (when using callbacks)
+- `--token-file PATH` - Path to Bear API token file
+
+## Configuration
+
+Grizzly reads config from (in priority order):
+
+1. CLI flags
+2. Environment variables (`GRIZZLY_TOKEN_FILE`, `GRIZZLY_CALLBACK_URL`, `GRIZZLY_TIMEOUT`)
+3. `.grizzly.toml` in current directory
+4. `~/.config/grizzly/config.toml`
+
+Example `~/.config/grizzly/config.toml`:
+
+```toml
+token_file = "~/.config/grizzly/token"
+callback_url = "http://127.0.0.1:42123/success"
+timeout = "5s"
+```
+
+## Notes
+
+- Bear must be running for commands to work
+- Note IDs are Bear's internal identifiers (visible in note info or via callbacks)
+- Use `--enable-callback` when you need to read data back from Bear
+- Some operations require a valid token (add-text, tags, open-note --selected)
+
+## PilotDeck Migration Note
+
+- Source: /var/folders/27/xyyzc_n172l3jjmnxgqmhhzh0000gn/T/tmp.AyWDWGKoS4/openclaw/skills/bear-notes
+- Review status: candidate for PilotDeck native skills pack.
+- Platform-specific OpenClaw/Hermes metadata was removed or should be ignored during review.

--- a/skills/blogwatcher/SKILL.md
+++ b/skills/blogwatcher/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: blogwatcher
+description: "Monitor blogs and RSS/Atom feeds for updates using the blogwatcher CLI."
+homepage: https://github.com/Hyaxia/blogwatcher
+---
+
+# blogwatcher
+
+Track blog and RSS/Atom feed updates with the `blogwatcher` CLI.
+
+Install
+
+- Go: `go install github.com/Hyaxia/blogwatcher/cmd/blogwatcher@latest`
+
+Quick start
+
+- `blogwatcher --help`
+
+Common commands
+
+- Add a blog: `blogwatcher add "My Blog" https://example.com`
+- List blogs: `blogwatcher blogs`
+- Scan for updates: `blogwatcher scan`
+- List articles: `blogwatcher articles`
+- Mark an article read: `blogwatcher read 1`
+- Mark all articles read: `blogwatcher read-all`
+- Remove a blog: `blogwatcher remove "My Blog"`
+
+Example output
+
+```
+$ blogwatcher blogs
+Tracked blogs (1):
+
+  xkcd
+    URL: https://xkcd.com
+```
+
+```
+$ blogwatcher scan
+Scanning 1 blog(s)...
+
+  xkcd
+    Source: RSS | Found: 4 | New: 4
+
+Found 4 new article(s) total!
+```
+
+Notes
+
+- Use `blogwatcher <command> --help` to discover flags and options.
+
+## PilotDeck Migration Note
+
+- Source: /var/folders/27/xyyzc_n172l3jjmnxgqmhhzh0000gn/T/tmp.AyWDWGKoS4/openclaw/skills/blogwatcher
+- Review status: candidate for PilotDeck native skills pack.
+- Platform-specific OpenClaw/Hermes metadata was removed or should be ignored during review.

--- a/skills/diagram-maker/SKILL.md
+++ b/skills/diagram-maker/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: diagram-maker
+description: Create SVG/HTML or Excalidraw diagrams for concepts, architecture, flows, and whiteboards.
+---
+
+# Diagram Maker
+
+Create diagrams as artifacts, not prose. Choose one output mode:
+
+- `clean-svg`: educational concepts, physical systems, processes, lifecycle, simple data flow.
+- `architecture-svg`: software/cloud/infra topology, services, databases, queues, trust zones.
+- `excalidraw`: editable hand-drawn whiteboard, flowchart, sequence, architecture sketch.
+
+Routing
+
+- User wants editable/collaborative: choose Excalidraw.
+- User wants polished standalone browser output: choose SVG/HTML.
+- Software architecture with infra components: choose architecture SVG.
+- Science, product, process, concept map, physical object: choose clean SVG.
+- Unsure: ask one short question only if output format matters; otherwise choose clean SVG.
+
+Workflow
+
+1. Extract nodes, groups, labels, and directed relationships.
+2. Pick layout first: left-to-right, top-down, hub-spoke, swimlanes, layered stack, sequence.
+3. Keep labels short. Prefer 5-9 main elements over dense diagrams.
+4. Generate the file at the requested path, or `./diagram.html` / `./diagram.excalidraw`.
+5. Verify syntax by opening/parsing when feasible.
+
+SVG/HTML rules
+
+- Single standalone `.html` file with inline CSS and inline SVG.
+- No external fonts, JS, images, gradients, glows, decorative blobs, or remote assets.
+- Use semantic colors, not rainbow sequences: neutral, input, process, storage, external, risk.
+- Draw connectors before nodes so arrows sit behind boxes.
+- Every connector path has `fill="none"` and a marker arrow when directed.
+- Leave 24px text padding inside boxes; do not let text touch borders.
+- Legend only when symbols/colors are not obvious.
+
+SVG template
+
+Use `references/svg-template.md` as the wrapper and replace `<!-- SVG -->`.
+
+Excalidraw rules
+
+- Save `.excalidraw` JSON with `type`, `version`, `source`, `elements`, and `appState`.
+- Use bound text for shape labels. Do not use a nonstandard `label` property.
+- Keep bound text immediately after its container in the elements array.
+- Minimum labeled shape: 120x60. Minimum body text: 16px.
+- Use roughness `1`, `fontFamily: 1`, and simple fills.
+
+For exact Excalidraw element snippets, read `references/excalidraw-patterns.md`.
+
+## PilotDeck Migration Note
+
+- Source: /var/folders/27/xyyzc_n172l3jjmnxgqmhhzh0000gn/T/tmp.AyWDWGKoS4/openclaw/skills/diagram-maker
+- Review status: candidate for PilotDeck native skills pack.
+- Platform-specific OpenClaw/Hermes metadata was removed or should be ignored during review.

--- a/skills/diagram-maker/references/excalidraw-patterns.md
+++ b/skills/diagram-maker/references/excalidraw-patterns.md
@@ -1,0 +1,85 @@
+# Excalidraw Patterns
+
+Envelope:
+
+```json
+{
+  "type": "excalidraw",
+  "version": 2,
+  "source": "openclaw/diagram-maker",
+  "elements": [],
+  "appState": { "viewBackgroundColor": "#ffffff" }
+}
+```
+
+Labeled rounded rectangle:
+
+```json
+{
+  "type": "rectangle",
+  "id": "svc",
+  "x": 100,
+  "y": 100,
+  "width": 180,
+  "height": 72,
+  "roundness": { "type": 3 },
+  "backgroundColor": "#a5d8ff",
+  "fillStyle": "solid",
+  "strokeWidth": 2,
+  "roughness": 1,
+  "opacity": 100,
+  "boundElements": [{ "id": "svc_text", "type": "text" }]
+}
+```
+
+Bound text:
+
+```json
+{
+  "type": "text",
+  "id": "svc_text",
+  "x": 112,
+  "y": 124,
+  "width": 156,
+  "height": 24,
+  "text": "API service",
+  "originalText": "API service",
+  "fontSize": 20,
+  "fontFamily": 1,
+  "strokeColor": "#1e1e1e",
+  "textAlign": "center",
+  "verticalAlign": "middle",
+  "containerId": "svc",
+  "autoResize": true
+}
+```
+
+Bound arrow:
+
+```json
+{
+  "type": "arrow",
+  "id": "a1",
+  "x": 280,
+  "y": 136,
+  "width": 140,
+  "height": 0,
+  "points": [
+    [0, 0],
+    [140, 0]
+  ],
+  "endArrowhead": "arrow",
+  "startBinding": { "elementId": "svc", "fixedPoint": [1, 0.5] },
+  "endBinding": { "elementId": "db", "fixedPoint": [0, 0.5] }
+}
+```
+
+Palette:
+
+- Primary/input: `#a5d8ff`
+- Process: `#d0bfff`
+- Success/output: `#b2f2bb`
+- Storage/data: `#c3fae8`
+- External/warning: `#ffd8a8`
+- Error/risk: `#ffc9c9`
+- Note/decision: `#fff3bf`

--- a/skills/diagram-maker/references/svg-template.md
+++ b/skills/diagram-maker/references/svg-template.md
@@ -1,0 +1,112 @@
+# SVG HTML Template
+
+Copy this to a `.html` file and replace `<!-- SVG -->`.
+
+```html
+<!doctype html>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Diagram</title>
+<style>
+  :root {
+    color-scheme: light dark;
+    --bg: #f8fafc;
+    --fg: #172033;
+    --muted: #5b6475;
+    --line: #64748b;
+    --neutral: #e2e8f0;
+    --input: #bfdbfe;
+    --process: #c7d2fe;
+    --storage: #99f6e4;
+    --external: #fde68a;
+    --risk: #fecaca;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #0f172a;
+      --fg: #e5e7eb;
+      --muted: #a3adbd;
+      --line: #94a3b8;
+      --neutral: #334155;
+      --input: #1d4ed8;
+      --process: #4338ca;
+      --storage: #0f766e;
+      --external: #92400e;
+      --risk: #991b1b;
+    }
+  }
+  body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--fg);
+    font:
+      14px/1.4 ui-sans-serif,
+      system-ui,
+      -apple-system,
+      BlinkMacSystemFont,
+      "Segoe UI",
+      sans-serif;
+  }
+  main {
+    max-width: 980px;
+    margin: 32px auto;
+    padding: 0 20px;
+  }
+  svg {
+    width: 100%;
+    height: auto;
+    display: block;
+  }
+  .title {
+    font-size: 20px;
+    font-weight: 650;
+    fill: var(--fg);
+  }
+  .label {
+    font-size: 14px;
+    font-weight: 600;
+    fill: var(--fg);
+  }
+  .small {
+    font-size: 12px;
+    fill: var(--muted);
+  }
+  .node {
+    stroke: var(--line);
+    stroke-width: 1;
+  }
+  .neutral {
+    fill: var(--neutral);
+  }
+  .input {
+    fill: var(--input);
+  }
+  .process {
+    fill: var(--process);
+  }
+  .storage {
+    fill: var(--storage);
+  }
+  .external {
+    fill: var(--external);
+  }
+  .risk {
+    fill: var(--risk);
+  }
+  .edge {
+    stroke: var(--line);
+    stroke-width: 1.5;
+    fill: none;
+  }
+  .zone {
+    fill: none;
+    stroke: var(--line);
+    stroke-width: 1;
+    stroke-dasharray: 6 5;
+    opacity: 0.8;
+  }
+</style>
+<main>
+  <!-- SVG -->
+</main>
+```

--- a/skills/frontend-design/SKILL.md
+++ b/skills/frontend-design/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: frontend-design
+description: 前端界面设计原则：视觉层次、布局、色彩、间距、响应式和避免“AI 味”页面。
+---
+
+# Frontend Design
+
+Use this skill when creating or reviewing frontend UI where visual quality matters.
+
+## Workflow
+
+1. Clarify the product context, target user, and page goal.
+2. Establish visual hierarchy before writing code: primary action, secondary action, supporting content.
+3. Choose a deliberate visual direction instead of generic gradients and cards.
+4. Use consistent spacing, type scale, color tokens, border radius, shadows, and component rhythm.
+5. Design responsive states, loading states, empty states, error states, and disabled states.
+6. Verify the result in a browser or preview surface when available.
+
+## Review Checklist
+
+- The page has a clear focal point and primary action.
+- Components align to a consistent grid.
+- Typography has enough contrast and hierarchy.
+- Color is meaningful, not decorative noise.
+- The UI works at common mobile/tablet/desktop widths.
+- Empty/loading/error states are intentional.
+
+## PilotDeck Migration Note
+
+- Source inspiration: Anthropic frontend-design skill and general frontend design best practices.
+- This is a PilotDeck-native draft, not a verbatim copy.
+

--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: github
+description: "GitHub CLI for issues, PRs, CI/check logs, comments, reviews, releases, repos, and gh api queries."
+---
+
+# GitHub
+
+Use `gh` for GitHub. Use `git` for local commits/branches/push/pull. Use code-reading tools for deep reviews.
+
+## Auth
+
+```bash
+gh auth status
+gh auth login
+```
+
+Gateway HOME can differ from operator HOME. If `gh` auth exists elsewhere, set `GH_CONFIG_DIR` in the gateway service env and restart.
+
+## PRs
+
+```bash
+gh pr list --repo owner/repo --json number,title,state,author,url
+gh pr view 55 --repo owner/repo --json title,body,author,files,commits,reviews,reviewDecision
+gh pr checks 55 --repo owner/repo
+gh pr diff 55 --repo owner/repo
+gh pr create --repo owner/repo --title "feat: title" --body-file /tmp/pr.md
+gh pr merge 55 --repo owner/repo --squash
+```
+
+URLs work directly: `gh pr view https://github.com/owner/repo/pull/55`.
+
+## Issues
+
+```bash
+gh issue list --repo owner/repo --state open --json number,title,labels,url
+gh issue view 42 --repo owner/repo --json title,body,comments,labels,state
+gh issue create --repo owner/repo --title "Bug: ..." --body-file /tmp/issue.md
+gh issue comment 42 --repo owner/repo --body-file /tmp/comment.md
+gh issue close 42 --repo owner/repo --comment "Fixed in ..."
+```
+
+## CI/runs
+
+```bash
+gh run list --repo owner/repo --limit 10
+gh run view <run-id> --repo owner/repo --json status,conclusion,headSha,url
+gh run view <run-id> --repo owner/repo --log-failed
+gh run rerun <run-id> --repo owner/repo --failed
+```
+
+## API
+
+```bash
+gh api repos/owner/repo/pulls/55 --jq '.title, .state, .user.login'
+gh api repos/owner/repo/labels --jq '.[].name'
+gh api --cache 1h repos/owner/repo --jq '{stars: .stargazers_count, forks: .forks_count}'
+```
+
+Use `--json` + `--jq` for structured output. Use `--body-file` for comments/bodies containing backticks, shell snippets, env names, or user text.
+
+## PilotDeck Migration Note
+
+- Source: /var/folders/27/xyyzc_n172l3jjmnxgqmhhzh0000gn/T/tmp.AyWDWGKoS4/openclaw/skills/github
+- Review status: candidate for PilotDeck native skills pack.
+- Platform-specific OpenClaw/Hermes metadata was removed or should be ignored during review.

--- a/skills/gog/SKILL.md
+++ b/skills/gog/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: gog
+description: "Google Workspace CLI for Gmail, Calendar, Drive, Contacts, Sheets, and Docs."
+homepage: https://gogcli.sh
+---
+
+# gog
+
+Use `gog` for Gmail/Calendar/Drive/Contacts/Sheets/Docs. Requires OAuth setup.
+
+Setup (once)
+
+- `gog auth credentials /path/to/client_secret.json`
+- `gog auth add you@gmail.com --services gmail,calendar,drive,contacts,docs,sheets`
+- `gog auth list`
+
+Common commands
+
+- Gmail search: `gog gmail search 'newer_than:7d' --max 10`
+- Gmail messages search (per email, ignores threading): `gog gmail messages search "in:inbox from:ryanair.com" --max 20 --account you@example.com`
+- Gmail send (plain): `gog gmail send --to a@b.com --subject "Hi" --body "Hello"`
+- Gmail send (multi-line): `gog gmail send --to a@b.com --subject "Hi" --body-file ./message.txt`
+- Gmail send (stdin): `gog gmail send --to a@b.com --subject "Hi" --body-file -`
+- Gmail send (HTML): `gog gmail send --to a@b.com --subject "Hi" --body-html "<p>Hello</p>"`
+- Gmail draft: `gog gmail drafts create --to a@b.com --subject "Hi" --body-file ./message.txt`
+- Gmail send draft: `gog gmail drafts send <draftId>`
+- Gmail reply: `gog gmail send --to a@b.com --subject "Re: Hi" --body "Reply" --reply-to-message-id <msgId>`
+- Calendar list events: `gog calendar events <calendarId> --from <iso> --to <iso>`
+- Calendar create event: `gog calendar create <calendarId> --summary "Title" --from <iso> --to <iso>`
+- Calendar create with color: `gog calendar create <calendarId> --summary "Title" --from <iso> --to <iso> --event-color 7`
+- Calendar update event: `gog calendar update <calendarId> <eventId> --summary "New Title" --event-color 4`
+- Calendar show colors: `gog calendar colors`
+- Drive search: `gog drive search "query" --max 10`
+- Contacts: `gog contacts list --max 20`
+- Sheets get: `gog sheets get <sheetId> "Tab!A1:D10" --json`
+- Sheets update: `gog sheets update <sheetId> "Tab!A1:B2" --values-json '[["A","B"],["1","2"]]' --input USER_ENTERED`
+- Sheets append: `gog sheets append <sheetId> "Tab!A:C" --values-json '[["x","y","z"]]' --insert INSERT_ROWS`
+- Sheets clear: `gog sheets clear <sheetId> "Tab!A2:Z"`
+- Sheets metadata: `gog sheets metadata <sheetId> --json`
+- Docs export: `gog docs export <docId> --format txt --out /tmp/doc.txt`
+- Docs cat: `gog docs cat <docId>`
+
+Calendar Colors
+
+- Use `gog calendar colors` to see all available event colors (IDs 1-11)
+- Add colors to events with `--event-color <id>` flag
+- Event color IDs (from `gog calendar colors` output):
+  - 1: #a4bdfc
+  - 2: #7ae7bf
+  - 3: #dbadff
+  - 4: #ff887c
+  - 5: #fbd75b
+  - 6: #ffb878
+  - 7: #46d6db
+  - 8: #e1e1e1
+  - 9: #5484ed
+  - 10: #51b749
+  - 11: #dc2127
+
+Email Formatting
+
+- Prefer plain text. Use `--body-file` for multi-paragraph messages (or `--body-file -` for stdin).
+- Same `--body-file` pattern works for drafts and replies.
+- `--body` does not unescape `\n`. If you need inline newlines, use a heredoc or `$'Line 1\n\nLine 2'`.
+- Use `--body-html` only when you need rich formatting.
+- HTML tags: `<p>` for paragraphs, `<br>` for line breaks, `<strong>` for bold, `<em>` for italic, `<a href="url">` for links, `<ul>`/`<li>` for lists.
+- Example (plain text via stdin):
+
+  ```bash
+  gog gmail send --to recipient@example.com \
+    --subject "Meeting Follow-up" \
+    --body-file - <<'EOF'
+  Hi Name,
+
+  Thanks for meeting today. Next steps:
+  - Item one
+  - Item two
+
+  Best regards,
+  Your Name
+  EOF
+  ```
+
+- Example (HTML list):
+  ```bash
+  gog gmail send --to recipient@example.com \
+    --subject "Meeting Follow-up" \
+    --body-html "<p>Hi Name,</p><p>Thanks for meeting today. Here are the next steps:</p><ul><li>Item one</li><li>Item two</li></ul><p>Best regards,<br>Your Name</p>"
+  ```
+
+Notes
+
+- Set `GOG_ACCOUNT=you@gmail.com` to avoid repeating `--account`.
+- For scripting, prefer `--json` plus `--no-input`.
+- Sheets values can be passed via `--values-json` (recommended) or as inline rows.
+- Docs supports export/cat/copy. In-place edits require a Docs API client (not in gog).
+- Confirm before sending mail or creating events.
+- `gog gmail search` returns one row per thread; use `gog gmail messages search` when you need every individual email returned separately.
+
+## PilotDeck Migration Note
+
+- Source: /var/folders/27/xyyzc_n172l3jjmnxgqmhhzh0000gn/T/tmp.AyWDWGKoS4/openclaw/skills/gog
+- Review status: candidate for PilotDeck native skills pack.
+- Platform-specific OpenClaw/Hermes metadata was removed or should be ignored during review.

--- a/skills/himalaya/SKILL.md
+++ b/skills/himalaya/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: himalaya
+description: "Himalaya CLI for IMAP/SMTP mail: list, read, search, compose, reply, forward, copy, move, delete."
+homepage: https://github.com/pimalaya/himalaya
+---
+
+# Himalaya
+
+Use `himalaya` for IMAP/SMTP email from shell.
+
+## References
+
+- `references/configuration.md`: account config, auth, backend setup.
+- `references/message-composition.md`: MML compose syntax.
+
+## Setup
+
+```bash
+himalaya --version
+himalaya account configure
+```
+
+Config path: `~/.config/himalaya/config.toml`.
+
+Prefer password managers/keyrings for credentials; do not paste secrets into chat/logs.
+
+## Read/search
+
+```bash
+himalaya folder list
+himalaya envelope list
+himalaya message read <id>
+himalaya envelope list from alice@example.com subject invoice
+```
+
+## Write
+
+```bash
+himalaya message write
+himalaya template write
+himalaya template send < /tmp/message.txt
+himalaya message reply <id>
+himalaya message forward <id>
+```
+
+Use MML for attachments and rich messages; read `references/message-composition.md` first.
+
+## Organize
+
+```bash
+himalaya message copy <id> <folder>
+himalaya message move <id> <folder>
+himalaya message delete <id>
+himalaya flag add <id> --flag seen
+himalaya flag remove <id> --flag seen
+```
+
+## Safety
+
+- Confirm before sending, deleting, or moving many messages.
+- Use `--account` when multiple accounts exist.
+- Quote exact message IDs in summaries.
+
+## PilotDeck Migration Note
+
+- Source: /var/folders/27/xyyzc_n172l3jjmnxgqmhhzh0000gn/T/tmp.AyWDWGKoS4/openclaw/skills/himalaya
+- Review status: candidate for PilotDeck native skills pack.
+- Platform-specific OpenClaw/Hermes metadata was removed or should be ignored during review.

--- a/skills/himalaya/references/configuration.md
+++ b/skills/himalaya/references/configuration.md
@@ -1,0 +1,184 @@
+# Himalaya Configuration Reference
+
+Configuration file location: `~/.config/himalaya/config.toml`
+
+## Minimal IMAP + SMTP Setup
+
+```toml
+[accounts.default]
+email = "user@example.com"
+display-name = "Your Name"
+default = true
+
+# IMAP backend for reading emails
+backend.type = "imap"
+backend.host = "imap.example.com"
+backend.port = 993
+backend.encryption.type = "tls"
+backend.login = "user@example.com"
+backend.auth.type = "password"
+backend.auth.raw = "your-password"
+
+# SMTP backend for sending emails
+message.send.backend.type = "smtp"
+message.send.backend.host = "smtp.example.com"
+message.send.backend.port = 587
+message.send.backend.encryption.type = "start-tls"
+message.send.backend.login = "user@example.com"
+message.send.backend.auth.type = "password"
+message.send.backend.auth.raw = "your-password"
+```
+
+## Password Options
+
+### Raw password (testing only, not recommended)
+
+```toml
+backend.auth.raw = "your-password"
+```
+
+### Password from command (recommended)
+
+```toml
+backend.auth.cmd = "pass show email/imap"
+# backend.auth.cmd = "security find-generic-password -a user@example.com -s imap -w"
+```
+
+### System keyring (requires keyring feature)
+
+```toml
+backend.auth.keyring = "imap-example"
+```
+
+Then run `himalaya account configure <account>` to store the password.
+
+## Gmail Configuration
+
+```toml
+[accounts.gmail]
+email = "you@gmail.com"
+display-name = "Your Name"
+default = true
+
+backend.type = "imap"
+backend.host = "imap.gmail.com"
+backend.port = 993
+backend.encryption.type = "tls"
+backend.login = "you@gmail.com"
+backend.auth.type = "password"
+backend.auth.cmd = "pass show google/app-password"
+
+message.send.backend.type = "smtp"
+message.send.backend.host = "smtp.gmail.com"
+message.send.backend.port = 587
+message.send.backend.encryption.type = "start-tls"
+message.send.backend.login = "you@gmail.com"
+message.send.backend.auth.type = "password"
+message.send.backend.auth.cmd = "pass show google/app-password"
+```
+
+**Note:** Gmail requires an App Password if 2FA is enabled.
+
+## iCloud Configuration
+
+```toml
+[accounts.icloud]
+email = "you@icloud.com"
+display-name = "Your Name"
+
+backend.type = "imap"
+backend.host = "imap.mail.me.com"
+backend.port = 993
+backend.encryption.type = "tls"
+backend.login = "you@icloud.com"
+backend.auth.type = "password"
+backend.auth.cmd = "pass show icloud/app-password"
+
+message.send.backend.type = "smtp"
+message.send.backend.host = "smtp.mail.me.com"
+message.send.backend.port = 587
+message.send.backend.encryption.type = "start-tls"
+message.send.backend.login = "you@icloud.com"
+message.send.backend.auth.type = "password"
+message.send.backend.auth.cmd = "pass show icloud/app-password"
+```
+
+**Note:** Generate an app-specific password at appleid.apple.com
+
+## Folder Aliases
+
+Map custom folder names:
+
+```toml
+[accounts.default.folder.alias]
+inbox = "INBOX"
+sent = "Sent"
+drafts = "Drafts"
+trash = "Trash"
+```
+
+## Multiple Accounts
+
+```toml
+[accounts.personal]
+email = "personal@example.com"
+default = true
+# ... backend config ...
+
+[accounts.work]
+email = "work@company.com"
+# ... backend config ...
+```
+
+Switch accounts with `--account`:
+
+```bash
+himalaya --account work envelope list
+```
+
+## Notmuch Backend (local mail)
+
+```toml
+[accounts.local]
+email = "user@example.com"
+
+backend.type = "notmuch"
+backend.db-path = "~/.mail/.notmuch"
+```
+
+## OAuth2 Authentication (for providers that support it)
+
+```toml
+backend.auth.type = "oauth2"
+backend.auth.client-id = "your-client-id"
+backend.auth.client-secret.cmd = "pass show oauth/client-secret"
+backend.auth.access-token.cmd = "pass show oauth/access-token"
+backend.auth.refresh-token.cmd = "pass show oauth/refresh-token"
+backend.auth.auth-url = "https://provider.com/oauth/authorize"
+backend.auth.token-url = "https://provider.com/oauth/token"
+```
+
+## Additional Options
+
+### Signature
+
+```toml
+[accounts.default]
+signature = "Best regards,\nYour Name"
+signature-delim = "-- \n"
+```
+
+### Downloads directory
+
+```toml
+[accounts.default]
+downloads-dir = "~/Downloads/himalaya"
+```
+
+### Editor for composing
+
+Set via environment variable:
+
+```bash
+export EDITOR="vim"
+```

--- a/skills/himalaya/references/message-composition.md
+++ b/skills/himalaya/references/message-composition.md
@@ -1,0 +1,199 @@
+# Message Composition with MML (MIME Meta Language)
+
+Himalaya uses MML for composing emails. MML is a simple XML-based syntax that compiles to MIME messages.
+
+## Basic Message Structure
+
+An email message is a list of **headers** followed by a **body**, separated by a blank line:
+
+```
+From: sender@example.com
+To: recipient@example.com
+Subject: Hello World
+
+This is the message body.
+```
+
+## Headers
+
+Common headers:
+
+- `From`: Sender address
+- `To`: Primary recipient(s)
+- `Cc`: Carbon copy recipients
+- `Bcc`: Blind carbon copy recipients
+- `Subject`: Message subject
+- `Reply-To`: Address for replies (if different from From)
+- `In-Reply-To`: Message ID being replied to
+
+### Address Formats
+
+```
+To: user@example.com
+To: John Doe <john@example.com>
+To: "John Doe" <john@example.com>
+To: user1@example.com, user2@example.com, "Jane" <jane@example.com>
+```
+
+## Plain Text Body
+
+Simple plain text email:
+
+```
+From: alice@localhost
+To: bob@localhost
+Subject: Plain Text Example
+
+Hello, this is a plain text email.
+No special formatting needed.
+
+Best,
+Alice
+```
+
+## MML for Rich Emails
+
+### Multipart Messages
+
+Alternative text/html parts:
+
+```
+From: alice@localhost
+To: bob@localhost
+Subject: Multipart Example
+
+<#multipart type=alternative>
+This is the plain text version.
+<#part type=text/html>
+<html><body><h1>This is the HTML version</h1></body></html>
+<#/multipart>
+```
+
+### Attachments
+
+Attach a file:
+
+```
+From: alice@localhost
+To: bob@localhost
+Subject: With Attachment
+
+Here is the document you requested.
+
+<#part filename=/path/to/document.pdf><#/part>
+```
+
+Attachment with custom name:
+
+```
+<#part filename=/path/to/file.pdf name=report.pdf><#/part>
+```
+
+Multiple attachments:
+
+```
+<#part filename=/path/to/doc1.pdf><#/part>
+<#part filename=/path/to/doc2.pdf><#/part>
+```
+
+### Inline Images
+
+Embed an image inline:
+
+```
+From: alice@localhost
+To: bob@localhost
+Subject: Inline Image
+
+<#multipart type=related>
+<#part type=text/html>
+<html><body>
+<p>Check out this image:</p>
+<img src="cid:image1">
+</body></html>
+<#part disposition=inline id=image1 filename=/path/to/image.png><#/part>
+<#/multipart>
+```
+
+### Mixed Content (Text + Attachments)
+
+```
+From: alice@localhost
+To: bob@localhost
+Subject: Mixed Content
+
+<#multipart type=mixed>
+<#part type=text/plain>
+Please find the attached files.
+
+Best,
+Alice
+<#part filename=/path/to/file1.pdf><#/part>
+<#part filename=/path/to/file2.zip><#/part>
+<#/multipart>
+```
+
+## MML Tag Reference
+
+### `<#multipart>`
+
+Groups multiple parts together.
+
+- `type=alternative`: Different representations of same content
+- `type=mixed`: Independent parts (text + attachments)
+- `type=related`: Parts that reference each other (HTML + images)
+
+### `<#part>`
+
+Defines a message part.
+
+- `type=<mime-type>`: Content type (e.g., `text/html`, `application/pdf`)
+- `filename=<path>`: File to attach
+- `name=<name>`: Display name for attachment
+- `disposition=inline`: Display inline instead of as attachment
+- `id=<cid>`: Content ID for referencing in HTML
+
+## Composing from CLI
+
+### Interactive compose
+
+Opens your `$EDITOR`:
+
+```bash
+himalaya message write
+```
+
+### Reply (opens editor with quoted message)
+
+```bash
+himalaya message reply 42
+himalaya message reply 42 --all  # reply-all
+```
+
+### Forward
+
+```bash
+himalaya message forward 42
+```
+
+### Send from stdin
+
+```bash
+cat message.txt | himalaya template send
+```
+
+### Prefill headers from CLI
+
+```bash
+himalaya message write \
+  -H "To:recipient@example.com" \
+  -H "Subject:Quick Message" \
+  "Message body here"
+```
+
+## Tips
+
+- The editor opens with a template; fill in headers and body.
+- Save and exit the editor to send; exit without saving to cancel.
+- MML parts are compiled to proper MIME when sending.
+- Use `himalaya message export --full` to inspect the raw MIME structure of received emails.

--- a/skills/notion/SKILL.md
+++ b/skills/notion/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: notion
+description: "Notion CLI/API for pages, Markdown content, data sources, files, comments, search, Workers, and raw API calls."
+homepage: https://developers.notion.com/cli/get-started/overview
+---
+
+# Notion
+
+Prefer official `ntn` CLI. Use curl only when `ntn` is unavailable or a raw request is clearer.
+
+## Setup
+
+```bash
+npm install -g ntn
+ntn --version
+ntn login
+```
+
+Script/headless auth:
+
+```bash
+export NOTION_API_TOKEN=secret_or_ntn_token
+export NOTION_API_VERSION=2026-03-11
+```
+
+`ntn api` sets `Authorization` and `Notion-Version` automatically. It uses CLI login by default, or `NOTION_API_TOKEN` when set.
+
+## Inspect
+
+```bash
+ntn doctor
+ntn api ls
+ntn api ls --json
+ntn api v1/comments --help
+ntn api v1/comments --spec -X POST
+ntn api v1/comments --docs -X POST
+```
+
+## Pages
+
+Markdown-first helpers:
+
+```bash
+ntn pages get <page-id>
+ntn pages get <page-id> --json
+ntn pages create --parent page:<page-id> --content '# Title\n\nBody'
+ntn pages create --parent data-source:<data-source-id> < page.md
+ntn pages update <page-id> --content '# Updated'
+ntn pages update <page-id> < page.md
+ntn pages trash <page-id> --yes
+```
+
+Notes:
+
+- `pages get` prints Markdown with page properties as frontmatter.
+- Content input: `--content`, stdin, or editor in a TTY.
+- Parent refs: `page:<id>`, `database:<id>`, `data-source:<id>`.
+- For properties/templates/full Pages API, use `ntn api v1/pages`.
+
+## Data sources
+
+```bash
+ntn datasources resolve <database-id>
+ntn datasources resolve <database-id> --json
+ntn datasources query <data-source-id>
+ntn datasources query <data-source-id> --limit 50 --json
+ntn datasources query <data-source-id> --sort 'Date desc'
+ntn datasources query <data-source-id> --filter '{"property":"Done","checkbox":{"equals":true}}'
+```
+
+Use `resolve` when you have a database ID. Query needs a data source ID.
+
+## Raw API
+
+```bash
+ntn api v1/users/me
+ntn api v1/search query=roadmap page_size:=10
+ntn api v1/pages 'parent[data_source_id]='"$DS_ID" 'properties[Name][title][0][text][content]=New item'
+ntn api "v1/pages/$PAGE_ID" -X PATCH in_trash:=true
+ntn api "v1/blocks/$PAGE_ID/children" -X PATCH \
+  'children[0][type]=paragraph' \
+  'children[0][paragraph][rich_text][0][text][content]=Hello'
+```
+
+Input syntax:
+
+- `path=value`: string body field.
+- `path:=json`: typed JSON body field.
+- `name==value`: query parameter.
+- `Header:Value`: request header.
+- `--data '<json>'` or stdin JSON for larger bodies.
+- Only one body source per request.
+
+## Files
+
+```bash
+ntn files create < image.png
+ntn files create --filename photo.png --content-type image/png < /tmp/photo
+ntn files create --external-url https://example.com/photo.png
+ntn files get <upload-id>
+ntn files list
+```
+
+## Workers
+
+```bash
+ntn workers new
+ntn workers deploy
+ntn workers list --json
+ntn workers runs list --json
+ntn workers runs logs <run-id>
+```
+
+Workers may require Business/Enterprise plan and workspace enablement.
+
+## Curl fallback
+
+```bash
+curl -sS "https://api.notion.com/v1/users/me" \
+  -H "Authorization: Bearer $NOTION_API_TOKEN" \
+  -H "Notion-Version: 2026-03-11" \
+  -H "Content-Type: application/json"
+```
+
+## Version notes
+
+- Current latest API version: `2026-03-11`.
+- Use `in_trash`, not `archived`.
+- Append block positioning uses `position`, not flat `after`.
+- `transcription` block renamed to `meeting_notes`.
+- Databases can contain multiple data sources; page parents generally use `data_source_id`.
+
+## PilotDeck Migration Note
+
+- Source: /var/folders/27/xyyzc_n172l3jjmnxgqmhhzh0000gn/T/tmp.AyWDWGKoS4/openclaw/skills/notion
+- Review status: candidate for PilotDeck native skills pack.
+- Platform-specific OpenClaw/Hermes metadata was removed or should be ignored during review.

--- a/skills/obsidian/SKILL.md
+++ b/skills/obsidian/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: obsidian
+description: "Work with Obsidian vaults using the official obsidian CLI: read/search/create/edit notes, tasks, links, properties, plugins."
+homepage: https://obsidian.md/cli
+---
+
+# Obsidian
+
+Use the official `obsidian` CLI for Obsidian vault work. Vault files are plain Markdown, so direct file edits are still fine when safer/faster.
+
+## Requirements
+
+- Obsidian 1.12.7+ installed.
+- Settings -> General -> Command line interface enabled.
+- `obsidian` registered on PATH.
+- Obsidian app running; the CLI connects to the running app.
+
+Check:
+
+```bash
+obsidian version
+obsidian help
+```
+
+macOS registration creates `/usr/local/bin/obsidian` pointing at the app-bundled CLI. Linux registration copies the binary to `~/.local/bin/obsidian`.
+
+## Vault model
+
+- Notes: `*.md`.
+- Config: `.obsidian/`; avoid editing unless asked.
+- Canvases: `*.canvas` JSON.
+- Attachments: vault-configured folder.
+- Multiple vaults are common; pass `vault="<name>"` when ambiguous.
+
+Obsidian desktop tracks vaults here:
+
+- `~/Library/Application Support/obsidian/obsidian.json`
+
+## Command pattern
+
+```bash
+obsidian <command> [name=value] [flag]
+obsidian vault="Notes" search query="meeting notes" format=json
+```
+
+Parameter values with spaces need quotes. Add `--copy` to copy output where useful.
+
+## Common commands
+
+Open/read:
+
+```bash
+obsidian open file=Recipe
+obsidian open path="Inbox/Idea.md" newtab
+obsidian read
+obsidian read file=Recipe
+```
+
+Search:
+
+```bash
+obsidian search query="TODO" matches
+obsidian search query="status::active" format=json
+obsidian search:open query="project notes"
+```
+
+Create/modify:
+
+```bash
+obsidian create name="New Note"
+obsidian create path="Inbox/Idea.md" content="# Idea"
+obsidian append file=Note content="New line"
+obsidian prepend file=Note content="After frontmatter"
+```
+
+Move/delete:
+
+```bash
+obsidian move file=Note to=Archive/
+obsidian move path="Inbox/Old.md" to="Projects/New.md"
+obsidian delete file=Note
+```
+
+Daily/tasks:
+
+```bash
+obsidian daily
+obsidian daily:read
+obsidian daily:append content="- [ ] Review inbox"
+obsidian tasks all todo
+obsidian task file=Note line=8 done
+```
+
+Properties/links:
+
+```bash
+obsidian tags all counts
+obsidian property:read file=Note name=status
+obsidian property:set file=Note name=status value=done
+obsidian backlinks file=Note
+obsidian unresolved verbose counts
+```
+
+Developer/debug:
+
+```bash
+obsidian plugin:reload my-plugin
+obsidian dev:errors
+obsidian dev:screenshot file=shot.png
+obsidian eval "app.vault.getFiles().length"
+```
+
+## Notes
+
+- `file=<name>` uses Obsidian-style file resolution; `path=<vault-relative.md>` is exact.
+- Prefer CLI move/delete/property commands for Obsidian-aware updates.
+- Prefer direct Markdown edits for bulk text changes after locating the vault path.
+- Do not rely on third-party `obsidian-cli` unless user explicitly asks for it.
+
+## PilotDeck Migration Note
+
+- Source: /var/folders/27/xyyzc_n172l3jjmnxgqmhhzh0000gn/T/tmp.AyWDWGKoS4/openclaw/skills/obsidian
+- Review status: candidate for PilotDeck native skills pack.
+- Platform-specific OpenClaw/Hermes metadata was removed or should be ignored during review.

--- a/skills/react-next-best-practices/SKILL.md
+++ b/skills/react-next-best-practices/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: react-next-best-practices
+description: React/Next.js 项目最佳实践：组件拆分、数据获取、性能、bundle、RSC、hydration 和路由。
+---
+
+# React / Next.js Best Practices
+
+Use this skill when creating, reviewing, or refactoring React or Next.js applications.
+
+## Focus Areas
+
+- Component boundaries: keep components cohesive and avoid unnecessary abstraction.
+- Data fetching: avoid waterfalls; keep server/client responsibilities explicit.
+- Rendering model: distinguish Server Components, Client Components, SSR, SSG, and dynamic routes.
+- State: keep local state local; avoid global state unless shared behavior requires it.
+- Performance: watch bundle size, memoization misuse, expensive renders, image loading, and caching.
+- Hydration: avoid browser-only values during server render unless guarded.
+- Accessibility: use semantic HTML before custom ARIA.
+- Testing: prefer targeted tests for changed behavior.
+
+## Review Output
+
+Return concrete findings with file paths, severity, and suggested fixes. Avoid generic advice unless tied to the current code.
+
+## PilotDeck Migration Note
+
+- Source inspiration: Vercel Agent Skills for React/Next.js workflows.
+- This is a PilotDeck-native draft, not a verbatim copy and is not Vercel-platform-specific.
+

--- a/skills/spike/SKILL.md
+++ b/skills/spike/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: spike
+description: Run throwaway prototypes to validate feasibility, compare approaches, and report a verdict.
+---
+
+# Spike
+
+Use when the user wants to test an idea before committing to a real build: "spike this", "quick prototype", "is this possible", "compare A/B", "before we build".
+
+Do not use when reading docs/code can answer the question, or when the user clearly asked for production implementation.
+
+Loop
+
+1. Question: state the concrete feasibility question.
+2. Research: read enough docs/source to choose credible approach.
+3. Build: create the smallest runnable artifact that validates or invalidates the idea.
+4. Stress: try one edge case or failure mode.
+5. Verdict: `VALIDATED`, `PARTIAL`, or `INVALIDATED`.
+
+Output shape
+
+- Default workspace: `.tmp/openclaw-spikes/<slug>` unless user asks for a tracked repo-local path.
+- Repo-local option: `spikes/<NNN-slug>/` with `README.md` and minimal code.
+- Prefer runnable CLI, tiny HTML, one endpoint, or focused test.
+- Avoid package sprawl, Docker, env files, app frameworks, and production cleanup.
+
+Multi-spike ideas
+
+- Split into 2-5 independent questions.
+- Run the riskiest question first.
+- For A/B comparisons, keep inputs equal and measure the same dimensions.
+- Ask before building all variants if the work is more than a small prototype.
+
+Verdict format
+
+```markdown
+## Verdict: VALIDATED | PARTIAL | INVALIDATED
+
+Question: ...
+Evidence: exact command/output/measurement.
+What worked: ...
+What failed or surprised us: ...
+Recommendation: ship / adjust / avoid, with the next production step.
+```
+
+Rules
+
+- An invalidated spike is useful when it rules out a path with evidence.
+- Do not merge spike code into production without rewriting it normally.
+- If external dependencies are evaluated, check health: recent release/commit, docs, license, install friction.
+
+## PilotDeck Migration Note
+
+- Source: /var/folders/27/xyyzc_n172l3jjmnxgqmhhzh0000gn/T/tmp.AyWDWGKoS4/openclaw/skills/spike
+- Review status: candidate for PilotDeck native skills pack.
+- Platform-specific OpenClaw/Hermes metadata was removed or should be ignored during review.

--- a/skills/summarize/SKILL.md
+++ b/skills/summarize/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: summarize
+description: "Summarize or transcribe URLs, YouTube/videos, podcasts, articles, transcripts, PDFs, and local files."
+homepage: https://summarize.sh
+---
+
+# Summarize
+
+Fast CLI to summarize URLs, local files, and YouTube links.
+
+## When to use (trigger phrases)
+
+Use this skill immediately when the user asks any of:
+
+- "use summarize.sh"
+- "what's this link/video about?"
+- "summarize this URL/article"
+- "transcribe this YouTube/video" (best-effort transcript extraction; no `yt-dlp` needed)
+
+## Quick start
+
+```bash
+summarize "https://example.com"
+summarize "/path/to/file.pdf"
+summarize "https://youtu.be/dQw4w9WgXcQ" --youtube auto
+```
+
+## YouTube: summary vs transcript
+
+Best-effort transcript (URLs only):
+
+```bash
+summarize "https://youtu.be/dQw4w9WgXcQ" --youtube auto --extract
+```
+
+If the user asked for a transcript but it's huge, return a tight summary first, then ask which section/time range to expand.
+
+## Model + keys
+
+Set the API key for your chosen provider:
+
+- OpenAI: `OPENAI_API_KEY`
+- Anthropic: `ANTHROPIC_API_KEY`
+- xAI: `XAI_API_KEY`
+- Google: `GEMINI_API_KEY` (aliases: `GOOGLE_GENERATIVE_AI_API_KEY`, `GOOGLE_API_KEY`)
+
+Default model is `auto`; config may choose the provider/model.
+
+## Useful flags
+
+- `--length short|medium|long|xl|xxl|<chars>`
+- `--max-output-tokens <count>`
+- `--extract` (print extracted content, no LLM summary)
+- `--json` (machine readable)
+- `--firecrawl auto|off|always` (fallback extraction)
+- `--youtube auto` (Apify fallback if `APIFY_API_TOKEN` set)
+
+## Config
+
+Optional config file: `~/.summarize/config.json`
+
+```json
+{ "model": "openai/gpt-5.2" }
+```
+
+Optional services:
+
+- `FIRECRAWL_API_KEY` for blocked sites
+- `APIFY_API_TOKEN` for YouTube fallback
+
+## PilotDeck Migration Note
+
+- Source: /var/folders/27/xyyzc_n172l3jjmnxgqmhhzh0000gn/T/tmp.AyWDWGKoS4/openclaw/skills/summarize
+- Review status: candidate for PilotDeck native skills pack.
+- Platform-specific OpenClaw/Hermes metadata was removed or should be ignored during review.

--- a/skills/tmux/SKILL.md
+++ b/skills/tmux/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: tmux
+description: "Control tmux sessions/panes for interactive CLIs: list, capture output, send keys, paste text, monitor prompts."
+---
+
+# tmux
+
+Use for existing interactive tmux sessions. For one-shot commands, use normal shell. For new non-interactive background jobs, use background execution.
+
+## Basics
+
+```bash
+tmux ls
+tmux list-windows -t shared
+tmux list-panes -t shared:0
+tmux capture-pane -t shared:0.0 -p
+tmux capture-pane -t shared:0.0 -p -S -
+```
+
+Target format: `session:window.pane`, e.g. `shared:0.0`.
+
+## Send input
+
+Literal text, then Enter:
+
+```bash
+tmux send-keys -t shared:0.0 -l -- "Please continue"
+tmux send-keys -t shared:0.0 Enter
+```
+
+Special keys:
+
+```bash
+tmux send-keys -t shared:0.0 C-c
+tmux send-keys -t shared:0.0 C-d
+tmux send-keys -t shared:0.0 Escape
+```
+
+Use `-l --` for arbitrary text. Split text and Enter to avoid paste/newline surprises.
+
+## Sessions
+
+```bash
+tmux new-session -d -s worker
+tmux rename-session -t old new
+tmux kill-session -t worker
+```
+
+## Prompt checks
+
+```bash
+tmux capture-pane -t worker-3 -p | tail -20
+tmux capture-pane -t worker-3 -p | rg "proceed|permission|Yes|No|❯"
+```
+
+Approve/select only when the prompt is understood:
+
+```bash
+tmux send-keys -t worker-3 -l -- "y"
+tmux send-keys -t worker-3 Enter
+```
+
+## Helpers
+
+- `scripts/find-sessions.sh`: discover sessions.
+- `scripts/wait-for-text.sh`: wait until pane output contains text.
+
+## Notes
+
+- `capture-pane -p` prints to stdout for scripts.
+- `-S -` captures full scrollback.
+- tmux sessions persist across SSH disconnects.
+
+## PilotDeck Migration Note
+
+- Source: /var/folders/27/xyyzc_n172l3jjmnxgqmhhzh0000gn/T/tmp.AyWDWGKoS4/openclaw/skills/tmux
+- Review status: candidate for PilotDeck native skills pack.
+- Platform-specific OpenClaw/Hermes metadata was removed or should be ignored during review.

--- a/skills/tmux/scripts/find-sessions.sh
+++ b/skills/tmux/scripts/find-sessions.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: find-sessions.sh [-L socket-name|-S socket-path|-A] [-q pattern]
+
+List tmux sessions on a socket (default tmux socket if none provided).
+
+Options:
+  -L, --socket       tmux socket name (passed to tmux -L)
+  -S, --socket-path  tmux socket path (passed to tmux -S)
+  -A, --all          scan all sockets under PILOTDECK_TMUX_SOCKET_DIR
+  -q, --query        case-insensitive substring to filter session names
+  -h, --help         show this help
+USAGE
+}
+
+socket_name=""
+socket_path=""
+query=""
+scan_all=false
+socket_dir="${PILOTDECK_TMUX_SOCKET_DIR:-${TMPDIR:-/tmp}/pilotdeck-tmux-sockets}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -L|--socket)      socket_name="${2-}"; shift 2 ;;
+    -S|--socket-path) socket_path="${2-}"; shift 2 ;;
+    -A|--all)         scan_all=true; shift ;;
+    -q|--query)       query="${2-}"; shift 2 ;;
+    -h|--help)        usage; exit 0 ;;
+    *) echo "Unknown option: $1" >&2; usage; exit 1 ;;
+  esac
+done
+
+if [[ "$scan_all" == true && ( -n "$socket_name" || -n "$socket_path" ) ]]; then
+  echo "Cannot combine --all with -L or -S" >&2
+  exit 1
+fi
+
+if [[ -n "$socket_name" && -n "$socket_path" ]]; then
+  echo "Use either -L or -S, not both" >&2
+  exit 1
+fi
+
+if ! command -v tmux >/dev/null 2>&1; then
+  echo "tmux not found in PATH" >&2
+  exit 1
+fi
+
+list_sessions() {
+  local label="$1"; shift
+  local tmux_cmd=(tmux "$@")
+
+  if ! sessions="$("${tmux_cmd[@]}" list-sessions -F '#{session_name}\t#{session_attached}\t#{session_created_string}' 2>/dev/null)"; then
+    echo "No tmux server found on $label" >&2
+    return 1
+  fi
+
+  if [[ -n "$query" ]]; then
+    sessions="$(printf '%s\n' "$sessions" | grep -i -- "$query" || true)"
+  fi
+
+  if [[ -z "$sessions" ]]; then
+    echo "No sessions found on $label"
+    return 0
+  fi
+
+  echo "Sessions on $label:"
+  printf '%s\n' "$sessions" | while IFS=$'\t' read -r name attached created; do
+    attached_label=$([[ "$attached" == "1" ]] && echo "attached" || echo "detached")
+    printf '  - %s (%s, started %s)\n' "$name" "$attached_label" "$created"
+  done
+}
+
+if [[ "$scan_all" == true ]]; then
+  if [[ ! -d "$socket_dir" ]]; then
+    echo "Socket directory not found: $socket_dir" >&2
+    exit 1
+  fi
+
+  shopt -s nullglob
+  sockets=("$socket_dir"/*)
+  shopt -u nullglob
+
+  if [[ "${#sockets[@]}" -eq 0 ]]; then
+    echo "No sockets found under $socket_dir" >&2
+    exit 1
+  fi
+
+  exit_code=0
+  for sock in "${sockets[@]}"; do
+    if [[ ! -S "$sock" ]]; then
+      continue
+    fi
+    list_sessions "socket path '$sock'" -S "$sock" || exit_code=$?
+  done
+  exit "$exit_code"
+fi
+
+tmux_cmd=(tmux)
+socket_label="default socket"
+
+if [[ -n "$socket_name" ]]; then
+  tmux_cmd+=(-L "$socket_name")
+  socket_label="socket name '$socket_name'"
+elif [[ -n "$socket_path" ]]; then
+  tmux_cmd+=(-S "$socket_path")
+  socket_label="socket path '$socket_path'"
+fi
+
+list_sessions "$socket_label" "${tmux_cmd[@]:1}"

--- a/skills/tmux/scripts/wait-for-text.sh
+++ b/skills/tmux/scripts/wait-for-text.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: wait-for-text.sh -t target -p pattern [options]
+
+Poll a tmux pane for text and exit when found.
+
+Options:
+  -t, --target    tmux target (session:window.pane), required
+  -p, --pattern   regex pattern to look for, required
+  -F, --fixed     treat pattern as a fixed string (grep -F)
+  -T, --timeout   seconds to wait (integer, default: 15)
+  -i, --interval  poll interval in seconds (default: 0.5)
+  -l, --lines     number of history lines to inspect (integer, default: 1000)
+  -h, --help      show this help
+USAGE
+}
+
+target=""
+pattern=""
+grep_flag="-E"
+timeout=15
+interval=0.5
+lines=1000
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -t|--target)   target="${2-}"; shift 2 ;;
+    -p|--pattern)  pattern="${2-}"; shift 2 ;;
+    -F|--fixed)    grep_flag="-F"; shift ;;
+    -T|--timeout)  timeout="${2-}"; shift 2 ;;
+    -i|--interval) interval="${2-}"; shift 2 ;;
+    -l|--lines)    lines="${2-}"; shift 2 ;;
+    -h|--help)     usage; exit 0 ;;
+    *) echo "Unknown option: $1" >&2; usage; exit 1 ;;
+  esac
+done
+
+if [[ -z "$target" || -z "$pattern" ]]; then
+  echo "target and pattern are required" >&2
+  usage
+  exit 1
+fi
+
+if ! [[ "$timeout" =~ ^[0-9]+$ ]]; then
+  echo "timeout must be an integer number of seconds" >&2
+  exit 1
+fi
+
+if ! [[ "$lines" =~ ^[0-9]+$ ]]; then
+  echo "lines must be an integer" >&2
+  exit 1
+fi
+
+if ! command -v tmux >/dev/null 2>&1; then
+  echo "tmux not found in PATH" >&2
+  exit 1
+fi
+
+# End time in epoch seconds (integer, good enough for polling)
+start_epoch=$(date +%s)
+deadline=$((start_epoch + timeout))
+
+while true; do
+  # -J joins wrapped lines, -S uses negative index to read last N lines
+  pane_text="$(tmux capture-pane -p -J -t "$target" -S "-${lines}" 2>/dev/null || true)"
+
+  if printf '%s\n' "$pane_text" | grep $grep_flag -- "$pattern" >/dev/null 2>&1; then
+    exit 0
+  fi
+
+  now=$(date +%s)
+  if (( now >= deadline )); then
+    echo "Timed out after ${timeout}s waiting for pattern: $pattern" >&2
+    echo "Last ${lines} lines from $target:" >&2
+    printf '%s\n' "$pane_text" >&2
+    exit 1
+  fi
+
+  sleep "$interval"
+done

--- a/skills/trello/SKILL.md
+++ b/skills/trello/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: trello
+description: "Manage Trello boards, lists, and cards via the Trello REST API."
+homepage: https://developer.atlassian.com/cloud/trello/rest/
+---
+
+# Trello Skill
+
+Manage Trello boards, lists, and cards directly from OpenClaw.
+
+## Setup
+
+1. Get your API key: https://trello.com/app-key
+2. Generate a token (click "Token" link on that page)
+3. Set environment variables:
+   ```bash
+   export TRELLO_API_KEY="your-api-key"
+   export TRELLO_TOKEN="your-token"
+   ```
+
+## Usage
+
+All commands use curl to hit the Trello REST API.
+
+### List boards
+
+```bash
+curl -s "https://api.trello.com/1/members/me/boards?key=$TRELLO_API_KEY&token=$TRELLO_TOKEN" | jq '.[] | {name, id}'
+```
+
+### List lists in a board
+
+```bash
+curl -s "https://api.trello.com/1/boards/{boardId}/lists?key=$TRELLO_API_KEY&token=$TRELLO_TOKEN" | jq '.[] | {name, id}'
+```
+
+### List cards in a list
+
+```bash
+curl -s "https://api.trello.com/1/lists/{listId}/cards?key=$TRELLO_API_KEY&token=$TRELLO_TOKEN" | jq '.[] | {name, id, desc}'
+```
+
+### Create a card
+
+```bash
+curl -s -X POST "https://api.trello.com/1/cards?key=$TRELLO_API_KEY&token=$TRELLO_TOKEN" \
+  -d "idList={listId}" \
+  -d "name=Card Title" \
+  -d "desc=Card description"
+```
+
+### Move a card to another list
+
+```bash
+curl -s -X PUT "https://api.trello.com/1/cards/{cardId}?key=$TRELLO_API_KEY&token=$TRELLO_TOKEN" \
+  -d "idList={newListId}"
+```
+
+### Add a comment to a card
+
+```bash
+curl -s -X POST "https://api.trello.com/1/cards/{cardId}/actions/comments?key=$TRELLO_API_KEY&token=$TRELLO_TOKEN" \
+  -d "text=Your comment here"
+```
+
+### Archive a card
+
+```bash
+curl -s -X PUT "https://api.trello.com/1/cards/{cardId}?key=$TRELLO_API_KEY&token=$TRELLO_TOKEN" \
+  -d "closed=true"
+```
+
+## Notes
+
+- Board/List/Card IDs can be found in the Trello URL or via the list commands
+- The API key and token provide full access to your Trello account - keep them secret!
+- Rate limits: 300 requests per 10 seconds per API key; 100 requests per 10 seconds per token; `/1/members` endpoints are limited to 100 requests per 900 seconds
+
+## Examples
+
+```bash
+# Get all boards
+curl -s "https://api.trello.com/1/members/me/boards?key=$TRELLO_API_KEY&token=$TRELLO_TOKEN&fields=name,id" | jq
+
+# Find a specific board by name
+curl -s "https://api.trello.com/1/members/me/boards?key=$TRELLO_API_KEY&token=$TRELLO_TOKEN" | jq '.[] | select(.name | contains("Work"))'
+
+# Get all cards on a board
+curl -s "https://api.trello.com/1/boards/{boardId}/cards?key=$TRELLO_API_KEY&token=$TRELLO_TOKEN" | jq '.[] | {name, list: .idList}'
+```
+
+## PilotDeck Migration Note
+
+- Source: /var/folders/27/xyyzc_n172l3jjmnxgqmhhzh0000gn/T/tmp.AyWDWGKoS4/openclaw/skills/trello
+- Review status: candidate for PilotDeck native skills pack.
+- Platform-specific OpenClaw/Hermes metadata was removed or should be ignored during review.

--- a/skills/weather/SKILL.md
+++ b/skills/weather/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: weather
+description: "Current weather and forecasts with wttr.in via curl for locations, rain, temperature, travel planning."
+homepage: https://wttr.in/:help
+---
+
+# Weather
+
+Use for current weather, rain/temperature checks, forecasts, and travel planning. Need a city, region, airport code, or coordinates.
+
+## Commands
+
+```bash
+curl "wttr.in/London?format=3"
+curl "wttr.in/London?0"
+curl "wttr.in/London"
+curl "wttr.in/London?format=v2"
+curl "wttr.in/London?1"
+curl "wttr.in/New+York?format=3"
+```
+
+Useful formats:
+
+- `%l`: location
+- `%c`: condition icon
+- `%t`: temperature
+- `%f`: feels like
+- `%w`: wind
+- `%h`: humidity
+- `%p`: precipitation
+
+```bash
+curl "wttr.in/London?format=%l:+%c+%t,+feels+%f,+rain+%p,+wind+%w"
+```
+
+JSON:
+
+```bash
+curl "wttr.in/London?format=j1"
+```
+
+## Notes
+
+- For severe alerts, aviation, marine, or official decisions, use official local weather services.
+- For historical climate/weather, use an archive/API, not wttr.in.
+- For hyper-local microclimates, prefer local sensors.
+
+## PilotDeck Migration Note
+
+- Source: /var/folders/27/xyyzc_n172l3jjmnxgqmhhzh0000gn/T/tmp.AyWDWGKoS4/openclaw/skills/weather
+- Review status: candidate for PilotDeck native skills pack.
+- Platform-specific OpenClaw/Hermes metadata was removed or should be ignored during review.

--- a/skills/web-design-guidelines/SKILL.md
+++ b/skills/web-design-guidelines/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: web-design-guidelines
+description: 前端 UI 审查清单：可读性、视觉密度、间距、响应式、空状态、加载态和可访问性。
+---
+
+# Web Design Guidelines
+
+Use this skill after building or modifying web UI. It helps the agent review whether the interface is usable, readable, responsive, and polished.
+
+## Checklist
+
+1. Layout: consistent alignment, predictable grid, no accidental crowding.
+2. Typography: readable sizes, clear hierarchy, line length under control.
+3. Color: sufficient contrast, semantic states, no random palette mixing.
+4. Interaction: clear hover/focus/active/disabled states.
+5. Responsiveness: mobile, tablet, and desktop layouts remain usable.
+6. Accessibility: keyboard focus, labels, alt text, contrast, reduced motion where relevant.
+7. Product states: loading, empty, error, offline, and success states exist when needed.
+8. Polish: spacing, borders, shadows, icon sizes, and copy tone feel consistent.
+
+## Output
+
+When reviewing, return: pass/fail summary, top issues, concrete fixes, and files/components likely affected.
+
+## PilotDeck Migration Note
+
+- Source inspiration: Vercel Agent Skills web design guidance and common UI QA practice.
+- This is a PilotDeck-native draft, not a verbatim copy.
+


### PR DESCRIPTION
## Summary

Adds a curated PilotDeck native skill pack focused on common, low-coupling workflows:

- Core developer workflow: `github`, `tmux`, `spike`, `diagram-maker`
- Frontend/UI: `frontend-design`, `web-design-guidelines`, `react-next-best-practices` (keeps existing `frontend-slides` unchanged)
- Research-lite: `summarize`, `blogwatcher`, `weather`
- Knowledge/notes: `obsidian`, `notion`, `apple-notes`, `bear-notes`
- Office/productivity: `himalaya`, `gog`, `trello`, `1password`, `apple-reminders`

## Notes

- Adds 19 new skill directories; `frontend-slides` already existed and was not overwritten.
- Removed obvious OpenClaw-specific runtime bindings from migrated candidates.
- Login-required skills remain explicit in their docs, e.g. GitHub, Google Workspace, Notion, email, Trello, and 1Password.

## Validation

- `npm run build`
- Checked all added skill directories contain `SKILL.md`.
- Grepped for strong OpenClaw runtime bindings such as `OPENCLAW`, `~/.openclaw`, `TaskFlow`, `plugins.entries`, and `__openclaw__`.
