### PR TITLE
fix(cli): honor configured gateway port

### DIFF
--- a/src/cli/pilotdeck.ts
+++ b/src/cli/pilotdeck.ts
@@ -215,6 +215,7 @@ async function main(argv = process.argv.slice(2)): Promise<void> {
     // --- Server startup ---
 
     const envPort = Number.parseInt(env.PILOTDECK_GATEWAY_PORT ?? "", 10);
+    const configPort = snapshot.config.gateway?.port;
     const extraChannels = await loadEnabledChannels(snapshot.config.adapters);
     const feishuCfg = snapshot.config.adapters?.feishu;
     const feishuChannel = feishuCfg?.enabled === true
@@ -231,7 +232,7 @@ async function main(argv = process.argv.slice(2)): Promise<void> {
     const weixinChannel = weixinCfg?.enabled === true ? new WeixinChannel() : undefined;
     const server = await startPilotDeckServer({
       gateway,
-      port: readPort(argv) ?? (Number.isFinite(envPort) ? envPort : 18789),
+      port: readPort(argv) ?? (Number.isFinite(envPort) ? envPort : configPort ?? 18789),
       staticAssetsPath: resolve(projectRoot, "ui/dist"),
       feishu: feishuChannel,
       weixin: weixinChannel,


### PR DESCRIPTION
## Summary
- use gateway.port from the loaded config snapshot when no CLI --port or PILOTDECK_GATEWAY_PORT is provided
- preserve existing precedence: CLI flag, environment variable, config, default 18789

## Verification
- npm exec -- tsc --noEmit -p tsconfig.json

## Notes
This is a real config/runtime mismatch: gateway.port was parsed into the config snapshot but the server startup path ignored it.