### PR TITLE
fix(config): reject non-object raw yaml

### DIFF
--- a/ui/server/services/pilotdeckConfig.js
+++ b/ui/server/services/pilotdeckConfig.js
@@ -601,5 +601,9 @@ export function rawYamlToMaskedString(rawYaml) {
 }
 
 export function parseConfigYaml(raw) {
-  return normalizePilotDeckConfig(parseYaml(raw) || {});
+  const parsed = parseYaml(raw);
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error('raw YAML must parse to an object');
+  }
+  return normalizePilotDeckConfig(parsed);
 }

--- a/ui/server/services/pilotdeckConfig.raw-yaml.test.js
+++ b/ui/server/services/pilotdeckConfig.raw-yaml.test.js
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+import { parseConfigYaml } from './pilotdeckConfig.js';
+
+describe('parseConfigYaml', () => {
+  it('rejects raw YAML whose root is not an object', () => {
+    expect(() => parseConfigYaml('[]')).toThrow('raw YAML must parse to an object');
+    expect(() => parseConfigYaml('null')).toThrow('raw YAML must parse to an object');
+    expect(() => parseConfigYaml('plain')).toThrow('raw YAML must parse to an object');
+  });
+});


### PR DESCRIPTION
## Summary
- make parseConfigYaml reject null, array, and primitive YAML roots
- align raw YAML validation with the save path root-type contract
- add focused coverage for non-object raw YAML inputs

## Verification
- npm --workspace ui exec vitest run server/services/pilotdeckConfig.raw-yaml.test.js
- npm exec -- tsc --noEmit -p tsconfig.json

## Notes
This is a real validate/save mismatch: /api/config/validate could normalize non-object YAML into defaults while the PUT path rejected the same input.