### PR TITLE
fix(messages): return errors on load failure

### DIFF
--- a/ui/server/routes/messages.js
+++ b/ui/server/routes/messages.js
@@ -52,7 +52,14 @@ router.get('/:sessionId/messages', async (req, res) => {
     });
   } catch (error) {
     console.error('[messages] read_session_messages failed:', error);
-    return res.json({ messages: [], total: 0, hasMore: false, offset: 0, limit: null });
+    return res.status(500).json({
+      error: error instanceof Error ? error.message : String(error),
+      messages: [],
+      total: 0,
+      hasMore: false,
+      offset: 0,
+      limit: null,
+    });
   }
 });
 


### PR DESCRIPTION
## Summary
- return HTTP 500 when the session messages read path fails
- include the error while preserving empty message metadata for response-shape compatibility

## Verification
- npm --workspace ui test
- npm exec -- tsc --noEmit -p tsconfig.json

## Notes
This is a real API semantics bug: the previous route converted read failures into HTTP 200 empty message lists, making failures indistinguishable from an empty session.