### PR TITLE
fix(ui): persist Always-On badge read marker to prevent false unread dot

### DIFF
--- a/ui/src/components/app-shell/MainAreaV2.tsx
+++ b/ui/src/components/app-shell/MainAreaV2.tsx
@@ -104,9 +104,13 @@ export default function MainAreaV2(props: MainAreaV2Props) {
         const payload = (await response.json()) as AlwaysOnDashboardEventsResponse;
 
         if (!cancelled) {
-          setLatestAlwaysOnEventMarker(
-            Array.isArray(payload.events) ? getBadgeEventMarker(payload.events) : null,
-          );
+          const marker = Array.isArray(payload.events) ? getBadgeEventMarker(payload.events) : null;
+          setLatestAlwaysOnEventMarker(marker);
+
+          if (marker && !localStorage.getItem(ALWAYS_ON_LAST_VIEWED_MARKER_KEY)) {
+            setLastViewedAlwaysOnEventMarker(marker);
+            localStorage.setItem(ALWAYS_ON_LAST_VIEWED_MARKER_KEY, marker);
+          }
         }
       } catch {
         // Keep the previous marker when the lightweight notification poll fails.

--- a/ui/src/components/app-shell/MainAreaV2.tsx
+++ b/ui/src/components/app-shell/MainAreaV2.tsx
@@ -43,6 +43,7 @@ const TABS: Tab[] = [
 ];
 
 const ALWAYS_ON_EVENT_BADGE_POLL_INTERVAL_MS = 15_000;
+const ALWAYS_ON_LAST_VIEWED_MARKER_KEY = 'pilotdeck:always-on-last-viewed-marker';
 const ALWAYS_ON_EVENT_BADGE_LIMIT = 200;
 
 const BADGE_EVENT_PHASES = new Set<AlwaysOnDashboardEvent['phase']>([
@@ -80,7 +81,9 @@ export default function MainAreaV2(props: MainAreaV2Props) {
   } = props;
   const [alwaysOnSubTab, setAlwaysOnSubTab] = useState<AlwaysOnSubTab>('dashboard');
   const [latestAlwaysOnEventMarker, setLatestAlwaysOnEventMarker] = useState<string | null>(null);
-  const [lastViewedAlwaysOnEventMarker, setLastViewedAlwaysOnEventMarker] = useState<string | null>(null);
+  const [lastViewedAlwaysOnEventMarker, setLastViewedAlwaysOnEventMarker] = useState<string | null>(
+    () => localStorage.getItem(ALWAYS_ON_LAST_VIEWED_MARKER_KEY),
+  );
 
   useEffect(() => {
     if (activeTab === 'home') {
@@ -124,6 +127,7 @@ export default function MainAreaV2(props: MainAreaV2Props) {
   useEffect(() => {
     if (activeTab === 'always-on' && latestAlwaysOnEventMarker) {
       setLastViewedAlwaysOnEventMarker(latestAlwaysOnEventMarker);
+      localStorage.setItem(ALWAYS_ON_LAST_VIEWED_MARKER_KEY, latestAlwaysOnEventMarker);
     }
   }, [activeTab, latestAlwaysOnEventMarker]);
 


### PR DESCRIPTION
## Summary

- Always-On 按钮的蓝色未读气泡在页面刷新或新开页面时总是出现，即使没有任何新的 Always-On 事件。
- 根因：`lastViewedAlwaysOnEventMarker`（已读标记）仅存于 React 内存状态，初始值为 `null`，页面加载后任何历史事件都会被误判为未读。
- 修复：将已读标记持久化到 `localStorage`，并在首次加载且无已存储标记时自动以当前最新事件建立基线。

### Changes

1. **持久化已读标记**：`useState` 初始值从 `localStorage` 读取；用户查看 Always-On 标签页时同步写入 `localStorage`。
2. **基线初始化**：首次 API 轮询返回事件时，若 `localStorage` 无标记，静默将当前事件设为已读基线，避免历史事件触发气泡。

### Behavior

| 场景 | 修复前 | 修复后 |
|------|--------|--------|
| 刷新页面 | 蓝色气泡出现 | 不出现 |
| 新开页面（从未访问过 Always-On） | 蓝色气泡出现 | 不出现 |
| 后端产生新的 plan/report 事件 | 蓝色气泡出现 | 蓝色气泡出现 |
| 用户点击 Always-On 标签页后 | 气泡消失 | 气泡消失 |

## Test plan

- [ ] 刷新页面，确认 Always-On 按钮无蓝色气泡（后端无新事件时）
- [ ] 关闭所有标签页后重新打开 URL，确认无蓝色气泡
- [ ] 清除 localStorage 后打开页面，确认无蓝色气泡（基线自动建立）
- [ ] 触发一次 Always-On discovery run，确认产生新事件后蓝色气泡出现
- [ ] 点击 Always-On 标签页，确认气泡消失；再切回其他标签页，确认气泡不再出现


Made with [Cursor](https://cursor.com)