### PR TITLE
fix: restore pre-plan permission mode when exiting plan via UI

### DIFF
--- a/src/agent/loop/AgentLoop.ts
+++ b/src/agent/loop/AgentLoop.ts
@@ -1353,6 +1353,9 @@ export class AgentLoop {
     permissionRules?: Partial<PermissionRuleSet>,
   ): void {
     if (permissionMode) {
+      if (permissionMode === "plan" && this.config.permissionMode !== "plan") {
+        this.config.permissionModeBeforePlan = this.config.permissionMode;
+      }
       this.config.permissionMode = permissionMode;
       this.config.permissionContext.mode = permissionMode;
     }


### PR DESCRIPTION
## Summary

- When users enter Plan mode via the UI (not via the `enter_plan_mode` tool), the `applyPermissionOverrides` method now saves the current permission mode to `permissionModeBeforePlan` before overwriting it with `"plan"`.
- This ensures that when the agent exits Plan mode (via `exit_plan_mode`), the permission correctly restores to the user's previous setting (e.g. `bypassPermissions` / Full Access) instead of falling back to `"default"`.

## Root Cause

There are two paths to enter Plan mode:

1. **Tool-initiated**: model calls `enter_plan_mode` → `AgentLoop` saves `permissionModeBeforePlan` via `readRequestedMode` (line 712-713) → exit restores correctly.
2. **UI-initiated**: user clicks Plan button → `effectivePermissionMode = 'plan'` sent as `AgentLoopInput.permissionMode` → `applyPermissionOverrides` sets `permissionMode = "plan"` but did **NOT** save `permissionModeBeforePlan` → exit falls back to `"default"`.

This fix aligns path 2 with path 1 by adding the same save logic to `applyPermissionOverrides`.

## Test plan

- [ ] Start a session with **Full Access** (`bypassPermissions`) selected
- [ ] Switch to **Plan** mode via the UI button and send a message
- [ ] Let the agent generate a plan and approve it via "Execute"
- [ ] Verify the agent continues executing with Full Access permissions (no permission prompts for write operations)
- [ ] Verify tool-initiated plan mode (`enter_plan_mode`) still works correctly
- [ ] Verify multi-turn plan sessions do not overwrite the saved permission

Made with [Cursor](https://cursor.com)