### PR TITLE
fix: align permission-response message type between frontend and server

### DIFF
--- a/ui/server/index.js
+++ b/ui/server/index.js
@@ -1847,10 +1847,7 @@ function handleChatConnection(ws, request) {
                 const provider = data.provider || 'pilotdeck';
                 const success = await abortViaGateway(data.sessionId, provider);
                 writer.send(createNormalizedMessage({ kind: 'complete', exitCode: success ? 0 : 1, aborted: true, success, sessionId: data.sessionId, provider }));
-            } else if (
-                data.type === 'claude-permission-response' ||
-                data.type === 'permission-response'
-            ) {
+            } else if (data.type === 'permission-response') {
                 if (data.requestId) {
                     await decidePermissionViaGateway(
                         data.requestId,

--- a/ui/src/components/chat/hooks/useChatComposerState.ts
+++ b/ui/src/components/chat/hooks/useChatComposerState.ts
@@ -1136,7 +1136,7 @@ export function useChatComposerState({
         }
 
         sendMessage({
-          type: 'pilotdeck-permission-response',
+          type: 'permission-response',
           requestId,
           allow: Boolean(decision?.allow),
           updatedInput: decision?.updatedInput,


### PR DESCRIPTION
## Summary

- 前端 `useChatComposerState.ts` 发送的授权响应消息类型从 `pilotdeck-permission-response` 改为 `permission-response`，与服务端路由匹配
- 移除服务端 `ui/server/index.js` 中已过时的 `claude-permission-response` 兼容分支，统一为 `permission-response`

## Problem

前端发送 `pilotdeck-permission-response`，但服务端 WebSocket 消息路由只匹配 `claude-permission-response` 或 `permission-response`，三者没有交集，导致用户的授权决策被静默丢弃，Agent 权限请求永远得不到回复。

## Test plan

- [ ] 启动 Agent 会话，触发需要授权的操作（如文件写入）
- [ ] 在前端点击"允许"或"拒绝"
- [ ] 验证 Agent 能正确收到授权决策并继续执行

Made with [Cursor](https://cursor.com)