### PR TITLE
feat(ui): expose maxPlansPerCycle in Always-On settings

### DIFF
--- a/ui/src/components/settings/view/tabs/PilotDeckConfigTab.tsx
+++ b/ui/src/components/settings/view/tabs/PilotDeckConfigTab.tsx
@@ -123,6 +123,7 @@ type PilotDeckConfig = {
       snapshotBaseDir?: string;
       snapshotMaxBytes?: number;
       gitLfs?: boolean;
+      maxPlansPerCycle?: number;
     };
     execution?: {
       maxTurns?: number;
@@ -1675,6 +1676,13 @@ function AlwaysOnSection({
                     value={workspace.snapshotMaxBytes}
                     placeholder="1073741824"
                     onChange={(value) => onChange(patch(config, ['alwaysOn', 'workspace', 'snapshotMaxBytes'], value))}
+                  />
+                </FormRow>
+                <FormRow label={t('pilotDeckConfig.panels.alwaysOn.workspace.maxPlansPerCycle.label')} description={t('pilotDeckConfig.panels.alwaysOn.workspace.maxPlansPerCycle.description')}>
+                  <NumberInput
+                    value={workspace.maxPlansPerCycle}
+                    placeholder="3"
+                    onChange={(value) => onChange(patch(config, ['alwaysOn', 'workspace', 'maxPlansPerCycle'], value))}
                   />
                 </FormRow>
                 <SettingsRow

--- a/ui/src/i18n/locales/en/settings.json
+++ b/ui/src/i18n/locales/en/settings.json
@@ -772,6 +772,7 @@
           "gitWorktree": { "label": "Git worktree base dir", "description": "Root directory for git worktree-based isolation." },
           "snapshotDir": { "label": "Snapshot base dir", "description": "Root directory for snapshot-based isolation." },
           "snapshotMaxBytes": { "label": "Snapshot max bytes", "description": "Maximum size of a workspace snapshot." },
+          "maxPlansPerCycle": { "label": "Max plans per cycle", "description": "Maximum number of plans that can be accumulated in a single isolation environment cycle." },
           "gitLfs": { "label": "Git LFS", "description": "Include Git LFS objects in workspace snapshots." }
         },
         "execution": {

--- a/ui/src/i18n/locales/zh-CN/settings.json
+++ b/ui/src/i18n/locales/zh-CN/settings.json
@@ -772,6 +772,7 @@
           "gitWorktree": { "label": "Git 工作树根目录", "description": "基于 Git 工作树隔离的根目录。" },
           "snapshotDir": { "label": "快照根目录", "description": "基于快照隔离的根目录。" },
           "snapshotMaxBytes": { "label": "快照最大字节数", "description": "工作区快照的最大大小。" },
+          "maxPlansPerCycle": { "label": "每周期最大计划数", "description": "单个隔离环境周期内最多可累计执行的计划数量。" },
           "gitLfs": { "label": "Git LFS", "description": "在工作区快照中包含 Git LFS 对象。" }
         },
         "execution": {


### PR DESCRIPTION
## Summary

- Add `maxPlansPerCycle` NumberInput control to the Always-On > Workspace section in the Web UI config panel, allowing users to adjust the per-cycle plan limit without editing `config.yaml` manually.
- Add corresponding i18n translations for both English and Chinese.

## Test plan

- [ ] Open Web UI Settings > PilotDeck Config > Always-On > Workspace section
- [ ] Verify the "Max plans per cycle" / "每周期最大计划数" input appears between "Snapshot max bytes" and "Git LFS"
- [ ] Enter a value, save, and confirm it persists in `config.yaml` under `alwaysOn.workspace.maxPlansPerCycle`
- [ ] Verify the backend correctly reads the updated value (check DiscoveryScheduler cycle_full gate)

Made with [Cursor](https://cursor.com)