### PR TITLE
fix(ws): resolve dev-mode WebSocket disconnect caused by React Strict…

### DIFF
--- a/ui/server/index.js
+++ b/ui/server/index.js
@@ -1825,6 +1825,8 @@ function handleChatConnection(ws, request) {
         try {
             const data = JSON.parse(message);
 
+            if (data.type === 'ping') return;
+
             if (data.type === 'always-on-presence') {
                 await alwaysOnHeartbeat.handlePresence(ws, data);
             } else if (data.type === 'always-on-presence-clear') {

--- a/ui/src/contexts/WebSocketContext.tsx
+++ b/ui/src/contexts/WebSocketContext.tsx
@@ -47,6 +47,7 @@ const useWebSocketProviderState = (): WebSocketContextType => {
   const { token } = useAuth();
 
   useEffect(() => {
+    unmountedRef.current = false;
     return () => { unmountedRef.current = true; };
   }, []);
 
@@ -65,6 +66,14 @@ const useWebSocketProviderState = (): WebSocketContextType => {
           if (connectIdRef.current !== id) { websocket.close(); return; }
           setIsConnected(true);
           wsRef.current = websocket;
+
+          const pingInterval = setInterval(() => {
+            if (websocket.readyState === WebSocket.OPEN) {
+              websocket.send(JSON.stringify({ type: 'ping' }));
+            }
+          }, 30_000);
+          websocket.addEventListener('close', () => clearInterval(pingInterval));
+
           if (hasConnectedRef.current) {
             const reconnectMsg = { type: 'websocket-reconnected', timestamp: Date.now() };
             const subs = subscribersRef.current;

--- a/ui/vite.config.js
+++ b/ui/vite.config.js
@@ -53,11 +53,15 @@ export default defineConfig(({ mode }) => {
         '/memory-dashboard': `http://${proxyHost}:${serverPort}`,
         '/ws': {
           target: `ws://${proxyHost}:${serverPort}`,
-          ws: true
+          ws: true,
+          timeout: 0,
+          proxyTimeout: 0,
         },
         '/shell': {
           target: `ws://${proxyHost}:${serverPort}`,
-          ws: true
+          ws: true,
+          timeout: 0,
+          proxyTimeout: 0,
         }
       }
     },


### PR DESCRIPTION
…Mode double-mount

Reset unmountedRef on re-mount so connect() is not short-circuited after StrictMode's unmount-remount cycle. Add 30s client ping heartbeat to prevent idle timeout through Vite dev proxy, and set proxy timeout to 0 for both /ws and /shell endpoints.