### PR TITLE
fix: restore correct permission mode when exiting plan mode

### DIFF
--- a/src/agent/loop/AgentLoop.ts
+++ b/src/agent/loop/AgentLoop.ts
@@ -60,6 +60,8 @@ export type AgentLoopInput = {
   messages: CanonicalMessage[];
   maxTurns?: number;
   permissionMode?: PermissionMode;
+  /** The user's actual permission preference before plan-mode override. */
+  basePermissionMode?: PermissionMode;
   permissionRules?: Partial<PermissionRuleSet>;
   abortSignal?: AbortSignal;
   onDurableMessage?: (message: CanonicalMessage) => void | Promise<void>;
@@ -96,7 +98,7 @@ export class AgentLoop {
   }
 
   async *run(input: AgentLoopInput): AsyncGenerator<AgentEvent, AgentLoopRunResult, unknown> {
-    this.applyPermissionOverrides(input.permissionMode, input.permissionRules);
+    this.applyPermissionOverrides(input.permissionMode, input.permissionRules, input.basePermissionMode);
     const startedAt = this.now().toISOString();
     let messages = [...input.messages];
     let turnCount = 1;
@@ -1351,10 +1353,11 @@ export class AgentLoop {
   private applyPermissionOverrides(
     permissionMode?: PermissionMode,
     permissionRules?: Partial<PermissionRuleSet>,
+    basePermissionMode?: PermissionMode,
   ): void {
     if (permissionMode) {
       if (permissionMode === "plan" && this.config.permissionMode !== "plan") {
-        this.config.permissionModeBeforePlan = this.config.permissionMode;
+        this.config.permissionModeBeforePlan = basePermissionMode ?? this.config.permissionMode;
       }
       this.config.permissionMode = permissionMode;
       this.config.permissionContext.mode = permissionMode;

--- a/src/agent/protocol/input.ts
+++ b/src/agent/protocol/input.ts
@@ -10,5 +10,7 @@ export type AgentSubmitOptions = {
   maxTurns?: number;
   metadata?: Record<string, unknown>;
   permissionMode?: PermissionMode;
+  /** The user's actual permission preference before plan-mode override. */
+  basePermissionMode?: PermissionMode;
   permissionRules?: Partial<PermissionRuleSet>;
 };

--- a/src/agent/session/AgentSession.ts
+++ b/src/agent/session/AgentSession.ts
@@ -78,6 +78,7 @@ export class AgentSession {
       input,
       maxTurns: submitOptions.maxTurns,
       permissionMode: submitOptions.permissionMode,
+      basePermissionMode: submitOptions.basePermissionMode,
       permissionRules: submitOptions.permissionRules,
       abortSignal: this.state.abortController.signal,
     });

--- a/src/agent/turn/TurnRunner.ts
+++ b/src/agent/turn/TurnRunner.ts
@@ -17,6 +17,8 @@ export type TurnRunnerOptions = {
   input: AgentInput;
   maxTurns?: number;
   permissionMode?: PermissionMode;
+  /** The user's actual permission preference before plan-mode override. */
+  basePermissionMode?: PermissionMode;
   permissionRules?: Partial<PermissionRuleSet>;
   abortSignal?: AbortSignal;
 };
@@ -105,6 +107,7 @@ export class TurnRunner {
         messages,
         maxTurns: options.maxTurns,
         permissionMode: options.permissionMode,
+        basePermissionMode: options.basePermissionMode,
         permissionRules: options.permissionRules,
         abortSignal: options.abortSignal,
         onDurableMessage: (msg) => this.transcript.recordDurableMessage(options.sessionId, options.turnId, msg),

--- a/src/gateway/client/InProcessGateway.ts
+++ b/src/gateway/client/InProcessGateway.ts
@@ -315,6 +315,7 @@ export class InProcessGateway implements Gateway {
             turnId: runId,
             maxTurns: input.maxTurns,
             permissionMode,
+            basePermissionMode: input.basePermissionMode,
             permissionRules: {
               ...persistedRules,
               allow: [...sessionAllowRules, ...persistedRules.allow],

--- a/src/gateway/protocol/types.ts
+++ b/src/gateway/protocol/types.ts
@@ -75,6 +75,8 @@ export type GatewaySubmitTurnInput = {
   workspaceCwd?: string;
   attachments?: ChannelAttachment[];
   mode?: GatewayMode;
+  /** The user's actual permission preference before plan-mode override. */
+  basePermissionMode?: GatewayMode;
   runId?: string;
   maxTurns?: number;
   telemetry?: {

--- a/ui/server/pilotdeck-bridge.js
+++ b/ui/server/pilotdeck-bridge.js
@@ -736,6 +736,7 @@ export async function runChatViaGateway(
         ...(uiFilesToAttachments(options?.attachments) || []),
     ];
     const resolvedMode = resolvePermissionMode(options);
+    const basePermissionMode = options?.basePermissionMode || undefined;
     console.log(`[pilotdeck-bridge] submitTurn mode=${resolvedMode} (options.permissionMode=${options?.permissionMode}, options.mode=${options?.mode})`);
 
     try {
@@ -746,6 +747,7 @@ export async function runChatViaGateway(
             message: command ?? '',
             mode: resolvedMode,
             runId,
+            ...(basePermissionMode ? { basePermissionMode } : {}),
             ...(attachments.length > 0 ? { attachments } : {}),
             ...(options.workspaceCwd ? { workspaceCwd: options.workspaceCwd } : {}),
         });

--- a/ui/src/components/chat-v2/ChatInterfaceV2.tsx
+++ b/ui/src/components/chat-v2/ChatInterfaceV2.tsx
@@ -202,6 +202,7 @@ function ChatInterfaceV2({
     currentSessionId,
     model,
     permissionMode: effectivePermissionMode,
+    basePermissionMode: permissionMode,
     cycleRunMode,
     isLoading,
     canAbortSession,

--- a/ui/src/components/chat/hooks/useChatComposerState.ts
+++ b/ui/src/components/chat/hooks/useChatComposerState.ts
@@ -45,6 +45,7 @@ interface UseChatComposerStateArgs {
   currentSessionId: string | null;
   model: string;
   permissionMode: PermissionMode | string;
+  basePermissionMode?: PermissionMode | string;
   cycleRunMode: () => void;
   isLoading: boolean;
   canAbortSession: boolean;
@@ -141,6 +142,7 @@ export function useChatComposerState({
   currentSessionId,
   model,
   permissionMode,
+  basePermissionMode,
   cycleRunMode,
   isLoading,
   canAbortSession,
@@ -788,6 +790,7 @@ export function useChatComposerState({
         temporarySessionId: sessionToActivate,
         toolsSettings,
         permissionMode,
+        basePermissionMode,
         model,
         sessionSummary,
         images: uploadedImages,
@@ -820,6 +823,7 @@ export function useChatComposerState({
       onSessionProcessing,
       pendingViewSessionRef,
       permissionMode,
+      basePermissionMode,
       resetCommandMenuState,
       scrollToBottom,
       selectedProject,

--- a/ui/src/components/chat/utils/sessionLauncher.ts
+++ b/ui/src/components/chat/utils/sessionLauncher.ts
@@ -9,6 +9,7 @@ type StartSessionOptions = {
   sessionId?: string | null;
   temporarySessionId?: string;
   permissionMode?: PermissionMode | string;
+  basePermissionMode?: PermissionMode | string;
   model?: string;
   sessionSummary?: string | null;
   toolsSettings?: PilotDeckSettings;
@@ -82,6 +83,7 @@ export function startSessionCommand({
   sessionId,
   temporarySessionId,
   permissionMode = 'default',
+  basePermissionMode,
   model,
   sessionSummary,
   toolsSettings = getPilotDeckSettings(),
@@ -104,6 +106,7 @@ export function startSessionCommand({
       cwd: resolvedProjectPath,
       toolsSettings,
       permissionMode,
+      ...(basePermissionMode ? { basePermissionMode } : {}),
       ...(model ? { model } : {}),
       sessionSummary,
       ...(alwaysOnPlanId ? { alwaysOnPlanId } : {}),


### PR DESCRIPTION
## Summary

- Adds `basePermissionMode` field throughout the protocol (frontend → bridge → gateway → agent loop) to carry the user's actual permission preference independently of the plan-mode override.
- `applyPermissionOverrides` now uses `basePermissionMode` (when present) instead of the stale `this.config.permissionMode` to populate `permissionModeBeforePlan`, ensuring Full Access is correctly restored after `exit_plan_mode`.
- Fixes the bug where a fresh session entering UI Plan mode with "Full Access" selected would restore to "Default Permissions" on exit, causing unexpected permission prompts.

## Context

The previous fix (`eccec3e`) tried to save the pre-plan permission mode in `applyPermissionOverrides`, but it saved whatever `this.config.permissionMode` happened to be (often `'default'` on a fresh session). The root cause is that the frontend computes `effectivePermissionMode = runMode === 'plan' ? 'plan' : permissionMode`, erasing the user's real preference before sending it to the backend.

## Test plan

- [ ] Start a new session with "Full Access" + "Plan" mode selected
- [ ] Send a message, let the agent plan and call `exit_plan_mode`
- [ ] Click "Execute" — verify no unexpected permission prompts appear for subsequent tool calls
- [ ] Verify existing Agent mode + tool-initiated `enter_plan_mode`/`exit_plan_mode` still restores correctly
- [ ] Verify "Default Permissions" + Plan mode correctly restores to default on exit

Made with [Cursor](https://cursor.com)