### PR TITLE
fix(plan-todo): replace hard gate with soft reminder after 10 tool calls

### DIFF
--- a/src/agent/runtime/PlanTodoState.ts
+++ b/src/agent/runtime/PlanTodoState.ts
@@ -7,7 +7,7 @@ import type {
 type SessionPlanTodoState = {
   approvedPlan?: string;
   requiresInitialization: boolean;
-  requiresRefresh: boolean;
+  toolCallsSinceLastTodoWrite: number;
   lastMarkdown?: string;
   todos: PilotDeckTodoItem[];
 };
@@ -26,7 +26,7 @@ export function createPlanTodoStateManager(): PlanTodoStateManager {
     if (!state) {
       state = {
         requiresInitialization: false,
-        requiresRefresh: false,
+        toolCallsSinceLastTodoWrite: 0,
         todos: [],
       };
       states.set(sessionId, state);
@@ -38,7 +38,7 @@ export function createPlanTodoStateManager(): PlanTodoStateManager {
     return {
       approvedPlan: state.approvedPlan,
       requiresInitialization: state.requiresInitialization,
-      requiresRefresh: state.requiresRefresh,
+      toolCallsSinceLastTodoWrite: state.toolCallsSinceLastTodoWrite,
       lastMarkdown: state.lastMarkdown,
       todos: state.todos,
     };
@@ -53,11 +53,12 @@ export function createPlanTodoStateManager(): PlanTodoStateManager {
         "Represent completed items as `- [x]` and remaining items as `- [ ]`.",
       ].join("\n");
     }
-    if (state.requiresRefresh) {
+    if (state.toolCallsSinceLastTodoWrite >= 10) {
       return [
-        "Your todo checklist is stale.",
-        `Before the next non-read-only tool call, you MUST call \`${TODO_WRITE_TOOL_NAME}\` again and update the markdown checklist to reflect the latest completed steps.`,
-      ].join("\n");
+        `You haven't updated the todo list in a while (${state.toolCallsSinceLastTodoWrite} tool calls since last update).`,
+        `Consider calling \`${TODO_WRITE_TOOL_NAME}\` to reflect your current progress.`,
+        "This is a gentle reminder — ignore if not applicable.",
+      ].join(" ");
     }
     return undefined;
   }
@@ -76,12 +77,6 @@ export function createPlanTodoStateManager(): PlanTodoStateManager {
         `Call \`${TODO_WRITE_TOOL_NAME}\` first with a markdown checklist based on the approved plan, then retry this tool.`,
       ].join(" ");
     }
-    if (state.requiresRefresh) {
-      return [
-        "The todo list is stale after progress was made on the approved plan.",
-        `Call \`${TODO_WRITE_TOOL_NAME}\` first to update the markdown checklist and mark completed items, then retry this tool.`,
-      ].join(" ");
-    }
     return undefined;
   }
 
@@ -93,7 +88,7 @@ export function createPlanTodoStateManager(): PlanTodoStateManager {
         markPlanApproved(plan: string) {
           state.approvedPlan = plan.trim() || undefined;
           state.requiresInitialization = Boolean(state.approvedPlan);
-          state.requiresRefresh = false;
+          state.toolCallsSinceLastTodoWrite = 0;
           state.lastMarkdown = undefined;
           state.todos = [];
         },
@@ -101,7 +96,7 @@ export function createPlanTodoStateManager(): PlanTodoStateManager {
           state.lastMarkdown = markdown;
           state.todos = todos;
           state.requiresInitialization = false;
-          state.requiresRefresh = false;
+          state.toolCallsSinceLastTodoWrite = 0;
         },
         markToolProgressChanged(toolName: string) {
           if (!state.approvedPlan || toolName === TODO_WRITE_TOOL_NAME) {
@@ -110,7 +105,7 @@ export function createPlanTodoStateManager(): PlanTodoStateManager {
           if (state.requiresInitialization) {
             return;
           }
-          state.requiresRefresh = true;
+          state.toolCallsSinceLastTodoWrite += 1;
         },
         buildPromptAddendum: () => buildPromptAddendum(state),
         blockingMessageFor: (toolName, isReadOnly) =>

--- a/src/tool/protocol/types.ts
+++ b/src/tool/protocol/types.ts
@@ -161,7 +161,7 @@ export type PilotDeckTodoItem = {
 export type PilotDeckPlanTodoStateSnapshot = {
   approvedPlan?: string;
   requiresInitialization: boolean;
-  requiresRefresh: boolean;
+  toolCallsSinceLastTodoWrite: number;
   lastMarkdown?: string;
   todos: PilotDeckTodoItem[];
 };


### PR DESCRIPTION
## Summary

- Replace the `requiresRefresh` boolean hard gate in `PlanTodoState` with a `toolCallsSinceLastTodoWrite` counter
- After 10+ successful non-read-only tool calls without a `todo_write`, inject a non-blocking soft reminder via `appendSystemPrompt` instead of blocking execution
- Retain the `requiresInitialization` hard gate for plan-just-approved state (agent must initialize todo list before any work)

This fixes the issue where batched sequential tool calls would repeatedly fail because the first successful call set `requiresRefresh = true`, blocking all subsequent calls in the same batch until `todo_write` was called — causing ~3x round-trip overhead and poor user experience.

## Test plan

- [ ] Verify TypeScript compiles cleanly (`npx tsc --noEmit`)
- [ ] Confirm plan approval still forces initial `todo_write` before any non-read-only tool
- [ ] Confirm batched tool calls (e.g. 2 parallel bash commands) no longer get blocked by stale-todo gate
- [ ] Confirm soft reminder appears in system prompt after 10+ tool calls without `todo_write`
- [ ] Confirm `todo_write` resets the counter and clears the reminder


Made with [Cursor](https://cursor.com)