### PR TITLE
fix(chat-v2): restore ordered/unordered list markers in user message bubble

### DIFF
--- a/ui/src/components/chat-v2/MessageRowV2.tsx
+++ b/ui/src/components/chat-v2/MessageRowV2.tsx
@@ -272,7 +272,7 @@ function MessageRowV2({
                 </div>
               ) : null}
               {formattedContent ? (
-                <Markdown className="min-w-0 break-words [overflow-wrap:anywhere]" projectName={selectedProject?.name}>{formattedContent}</Markdown>
+                <Markdown className="prose prose-sm prose-neutral max-w-none dark:prose-invert prose-p:my-1 prose-ol:my-1 prose-ul:my-1 prose-li:my-0 min-w-0 break-words [overflow-wrap:anywhere]" projectName={selectedProject?.name}>{formattedContent}</Markdown>
               ) : null}
             </>
           )}


### PR DESCRIPTION
## Summary

- V2 聊天界面中用户消息的 `Markdown` 组件缺少 Tailwind Typography `prose` 类，导致 Tailwind Preflight 重置的 `ol { list-style: none }` 未被覆盖，有序/无序列表的序号不可见
- 给用户消息的 `Markdown` 组件加上 `prose prose-sm prose-neutral max-w-none dark:prose-invert` 及紧凑间距修饰类，恢复列表标记显示

## Root Cause

Tailwind CSS Preflight 全局重置 `ol/ul { list-style: none }`，助手消息通过 `prose` 类（`@tailwindcss/typography`）恢复了 `list-style-type: decimal`，但用户消息气泡的 `Markdown` 组件未添加 `prose` 类，因此序号丢失。

## Test plan

- [ ] 在 V2 聊天界面输入 `1. 第一项\n2. 第二项\n3. 第三项` 发送，确认渲染后显示数字序号
- [ ] 确认无序列表 `- item` 也正常显示圆点标记
- [ ] 确认用户气泡中的代码块、链接、粗体等 Markdown 功能不受影响
- [ ] 确认暗色模式下文字颜色正常


Made with [Cursor](https://cursor.com)