### PR TITLE
fix(bash): narrow command deny pattern to actual invocations

### DIFF
--- a/src/tool/builtin/bash/permissions.ts
+++ b/src/tool/builtin/bash/permissions.ts
@@ -3,7 +3,8 @@ import type { PermissionResult } from "../../../permission/index.js";
 const DENY_PATTERNS: RegExp[] = [
   // Unix
   /\brm\s+-[^&|;]*r[^&|;]*f\s+\//,
-  /\bsudo\b/,
+  // sudo as a command (not inside quotes, e.g. `git log -S "sudo"`)
+  /(?:^|[;&|]\s*)sudo\b/,
   /\bchmod\s+-R\s+777\b/,
   /\bchown\s+-R\b/,
   /\bdd\s+if=/,


### PR DESCRIPTION
## Problem

The current regex `/\bsudo\b/` in `DENY_PATTERNS` matches the word "sudo" **anywhere** in the command string — including inside quoted arguments passed to other commands.

This means purely informational commands like these are incorrectly blocked:

```
git log -S "sudo"          # search git history for the word
grep sudo file.txt         # search file contents
echo "sudo is dangerous"   # echo a string
vim sudo.txt              # edit a file with that name
```

## Fix

Change the pattern from:

```ts
/\bsudo\b/
```

to:

```ts
/(?:^|[;&|]\s*)sudo\b/
```

This only matches `sudo` when it appears:
- **At the start of a command** (`sudo ...`)
- **After a command separator** (`; sudo ...`, `&& sudo ...`, `|| sudo ...`, `| sudo ...`)

Commands that merely reference the string as an argument or search term are no longer blocked.

## Test Results

| Command | Expected | Result |
|---------|----------|--------|
| `sudo apt install xxx` | deny | pass |
| `sudo cp /a /b` | deny | pass |
| `echo foo && sudo rm bar` | deny | pass |
| `echo foo; sudo rm bar` | deny | pass |
| `cat foo \| sudo tee bar` | deny | pass |
| `git log -S "sudo"` | allow | pass |
| `grep sudo file.txt` | allow | pass |
| `echo "sudo is blocked"` | allow | pass |
| `cat "file with sudo"` | allow | pass |
| `vim sudo.txt` | allow | pass |
