### PR TITLE
[codex] fix(plan-mode): strengthen guardrails

### DIFF
--- a/src/agent/loop/AgentLoop.ts
+++ b/src/agent/loop/AgentLoop.ts
@@ -1373,10 +1373,12 @@ export class AgentLoop {
 
 function applyPlanModeToolOverrides(tools: CanonicalToolSchema[]): CanonicalToolSchema[] {
   const override = buildPlanModeAgentToolSchema();
-  return tools.map((tool) => {
-    if (tool.name !== "agent") return tool;
-    return { ...tool, description: override.description, inputSchema: override.inputSchema };
-  });
+  return tools
+    .filter((tool) => tool.name !== "enter_plan_mode")
+    .map((tool) => {
+      if (tool.name !== "agent") return tool;
+      return { ...tool, description: override.description, inputSchema: override.inputSchema };
+    });
 }
 
 function mergeUserRules(target: PermissionRule[], userRules: PermissionRule[] | undefined): void {

--- a/src/permission/decision/PermissionRuntime.ts
+++ b/src/permission/decision/PermissionRuntime.ts
@@ -101,7 +101,7 @@ export class PermissionRuntime {
           return deny({
             type: "mode",
             mode: "plan",
-            message: `Plan mode denies side-effecting tool ${tool.name}.`,
+            message: buildPlanModeSideEffectDenyMessage(tool.name),
           });
         }
         return finalizeAsk(toolDecision, permissionContext);
@@ -200,7 +200,7 @@ function decideByMode(
     return deny({
       type: "mode",
       mode: "plan",
-      message: `Plan mode denies side-effecting tool ${tool.name}.`,
+      message: buildPlanModeSideEffectDenyMessage(tool.name),
     });
   }
 
@@ -237,6 +237,13 @@ function allow(reason: PermissionDecisionReason): PermissionDecision {
 
 function deny(reason: PermissionDecisionReason): PermissionDecision {
   return { type: "deny", reason, message: reason.message };
+}
+
+function buildPlanModeSideEffectDenyMessage(toolName: string): string {
+  return [
+    `Plan mode denies side-effecting tool ${toolName}.`,
+    "You are still in plan mode. Continue with read-only exploration and analysis, refine or write the markdown plan under `.pilotdeck/plans/`, then submit it with `exit_plan_mode` when the plan is concrete and actionable.",
+  ].join(" ");
 }
 
 function denyFromRule(rule: PermissionRule): PermissionDecision {

--- a/src/tool/builtin/todoWrite.ts
+++ b/src/tool/builtin/todoWrite.ts
@@ -53,7 +53,12 @@ export function createTodoWriteTool(): PilotDeckToolDefinition<TodoWriteInput, T
     name: "todo_write",
     aliases: ["TodoWrite"],
     description:
-      "Update the execution todo list from a markdown checklist. Use `- [x]` for completed items and `- [ ]` for remaining items.",
+      [
+        "Update the execution todo list from a markdown checklist. Use `- [x]` for completed items and `- [ ]` for remaining items.",
+        "This tool only updates a checklist; it does not write, submit, or replace a final plan.",
+        "In plan mode, do not use todo_write to write the plan itself, and do not treat a todo list as the final plan.",
+        "You may use todo_write in plan mode only to organize planning work such as exploration, analysis, writing a markdown plan under `.pilotdeck/plans/`, and submitting that plan with `exit_plan_mode`.",
+      ].join(" "),
     kind: "session",
     inputSchema: {
       type: "object",

--- a/ui/src/components/chat-v2/MessagesPaneV2.render.test.tsx
+++ b/ui/src/components/chat-v2/MessagesPaneV2.render.test.tsx
@@ -5,6 +5,8 @@ import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import type { ChatMessage, ChatRunMode } from '../chat/types/types';
 import MessagesPaneV2 from './MessagesPaneV2';
 
+const PLAN_MODE_DENY_MESSAGE = 'Plan mode denies side-effecting tool bash. You are still in plan mode. Continue with read-only exploration and analysis, refine or write the markdown plan under `.pilotdeck/plans/`, then submit it with `exit_plan_mode` when the plan is concrete and actionable.';
+
 beforeAll(() => {
   class ResizeObserverMock {
     observe() {}
@@ -261,7 +263,7 @@ describe('MessagesPaneV2 render behavior', () => {
         toolId: 'tool-bash-1',
         toolInput: '{"command":"find . -maxdepth 1 -type f","description":"List files"}',
         toolResult: {
-          content: 'Plan mode denies side-effecting tool bash.',
+          content: PLAN_MODE_DENY_MESSAGE,
           isError: true,
           errorCode: 'permission_denied',
         },

--- a/ui/src/components/chat-v2/processGrouping.test.ts
+++ b/ui/src/components/chat-v2/processGrouping.test.ts
@@ -6,6 +6,8 @@ import {
   type RenderableMessageItem,
 } from './processGrouping';
 
+const PLAN_MODE_DENY_MESSAGE = 'Plan mode denies side-effecting tool bash. You are still in plan mode. Continue with read-only exploration and analysis, refine or write the markdown plan under `.pilotdeck/plans/`, then submit it with `exit_plan_mode` when the plan is concrete and actionable.';
+
 const baseTime = Date.parse('2026-05-18T08:00:00.000Z');
 
 function timestamp(offsetMs: number): string {
@@ -290,7 +292,7 @@ describe('processGrouping', () => {
 
   it('folds plan-mode side-effect denials into the process row', () => {
     const planModeDeny = {
-      content: 'Plan mode denies side-effecting tool bash.',
+      content: PLAN_MODE_DENY_MESSAGE,
       isError: true,
       errorCode: 'permission_denied',
     };

--- a/ui/src/components/chat/view/subcomponents/MessageComponent.tool-error.test.tsx
+++ b/ui/src/components/chat/view/subcomponents/MessageComponent.tool-error.test.tsx
@@ -4,6 +4,8 @@ import { afterEach, describe, expect, it } from 'vitest';
 import type { ChatMessage } from '../../types/types';
 import MessageComponent from './MessageComponent';
 
+const PLAN_MODE_DENY_MESSAGE = 'Plan mode denies side-effecting tool bash. You are still in plan mode. Continue with read-only exploration and analysis, refine or write the markdown plan under `.pilotdeck/plans/`, then submit it with `exit_plan_mode` when the plan is concrete and actionable.';
+
 afterEach(() => {
   cleanup();
 });
@@ -95,7 +97,7 @@ describe('MessageComponent tool errors', () => {
       toolInput: '{"command":"cd .","description":"List files"}',
       toolResult: {
         isError: true,
-        content: 'Plan mode denies side-effecting tool bash.',
+        content: PLAN_MODE_DENY_MESSAGE,
         errorCode: 'permission_denied',
       },
     });
@@ -112,5 +114,6 @@ describe('MessageComponent tool errors', () => {
 
     fireEvent.click(summary as HTMLElement);
     expect(screen.getByText(/Plan mode denies side-effecting tool bash/)).toBeTruthy();
+    expect(screen.getByText(/Continue with read-only exploration and analysis/)).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary

- Enhance plan-mode side-effect denial messages with guidance to continue read-only exploration and write/submit a markdown plan.
- Hide `enter_plan_mode` from the main agent's visible tool list while already in plan mode.
- Clarify `todo_write` usage so todo lists cannot replace final markdown plans in plan mode.

## Validation

- `npm run build`
- `npm --prefix ui test -- MessageComponent.tool-error.test.tsx MessagesPaneV2.render.test.tsx processGrouping.test.ts`
- `npm test`

## Notes

- The local untracked `tests/` directory was intentionally not included in this PR.