### PR TITLE
[codex] fix(plan-mode): follow up hard enforcement

### DIFF
--- a/src/tool/builtin/todoWrite.ts
+++ b/src/tool/builtin/todoWrite.ts
@@ -53,7 +53,12 @@ export function createTodoWriteTool(): PilotDeckToolDefinition<TodoWriteInput, T
     name: "todo_write",
     aliases: ["TodoWrite"],
     description:
-      "Update the execution todo list from a markdown checklist. Use `- [x]` for completed items and `- [ ]` for remaining items.",
+      [
+        "Update the execution todo list from a markdown checklist. Use `- [x]` for completed items and `- [ ]` for remaining items.",
+        "This tool only updates a checklist; it does not write, submit, or replace a final plan.",
+        "In plan mode, do not use todo_write to write the plan itself, and do not treat a todo list as the final plan.",
+        "You may use todo_write in plan mode only to organize planning work such as exploration, analysis, writing a markdown plan under `.pilotdeck/plans/`, and submitting that plan with `exit_plan_mode`.",
+      ].join(" "),
     kind: "session",
     inputSchema: {
       type: "object",

--- a/ui/server/pilotdeck-bridge.js
+++ b/ui/server/pilotdeck-bridge.js
@@ -94,10 +94,12 @@ function normalizeToolDisplayName(name) {
 }
 
 function isPlanModeToolDenyText(text) {
-    return typeof text === 'string' && /plan mode denies side-effecting tool\b/i.test(text);
+    if (typeof text !== 'string') return false;
+    return /\[PLAN_MODE_VIOLATION\]/i.test(text) || /plan mode denies side-effecting tool\b/i.test(text);
 }
 
 function normalizeToolErrorCode(errorCode, resultPreview) {
+    if (errorCode === 'plan_mode_violation') return 'plan_mode_denied';
     if (isPlanModeToolDenyText(resultPreview)) return 'plan_mode_denied';
     return errorCode;
 }

--- a/ui/src/components/chat-v2/processGrouping.test.ts
+++ b/ui/src/components/chat-v2/processGrouping.test.ts
@@ -309,4 +309,26 @@ describe('processGrouping', () => {
     expect(attachments[0].processDetailMessages.map((message) => message.id)).toEqual(['plan-deny-1']);
     expect(attachments[0].processSummary.toolErrorCount).toBe(1);
   });
+
+  it('folds structured plan-mode violations into the process row', () => {
+    const planModeDeny = {
+      content: '[PLAN_MODE_VIOLATION] Tool "edit_notebook" is BLOCKED in plan mode.',
+      isError: true,
+      errorCode: 'plan_mode_violation',
+    };
+    const messages = [
+      user('u1'),
+      tool('plan-deny-1', 'edit_notebook', { file_path: 'notebook.ipynb' }, 100, planModeDeny),
+      assistant('a1', 'I will continue with a plan.', 200),
+    ];
+
+    const items = buildRenderableMessageItems(messages);
+    const assistantItem = items.find((item) => item.message.id === 'a1');
+    const attachments = processAttachments(assistantItem);
+
+    expect(items.map((item) => item.message.id)).toEqual(['u1', 'a1']);
+    expect(attachments).toHaveLength(1);
+    expect(attachments[0].processDetailMessages.map((message) => message.id)).toEqual(['plan-deny-1']);
+    expect(attachments[0].processSummary.toolErrorCount).toBe(1);
+  });
 });

--- a/ui/src/components/chat/utils/chatPermissions.ts
+++ b/ui/src/components/chat/utils/chatPermissions.ts
@@ -48,10 +48,16 @@ const PERMISSION_ERROR_CODES = new Set<string>([
 
 export function isPlanModeToolDeny(message: ChatMessage | null | undefined): boolean {
   if (!message?.toolResult?.isError) return false;
+  const errorCode = typeof message.toolResult.errorCode === 'string'
+    ? message.toolResult.errorCode
+    : '';
+  if (errorCode === 'plan_mode_violation' || errorCode === 'plan_mode_denied') {
+    return true;
+  }
   const content = typeof message.toolResult.content === 'string'
     ? message.toolResult.content
     : '';
-  return /plan mode denies side-effecting tool\b/i.test(content);
+  return /\[PLAN_MODE_VIOLATION\]/i.test(content) || /plan mode denies side-effecting tool\b/i.test(content);
 }
 
 export function getPilotDeckPermissionSuggestion(

--- a/ui/src/components/chat/view/subcomponents/MessageComponent.tool-error.test.tsx
+++ b/ui/src/components/chat/view/subcomponents/MessageComponent.tool-error.test.tsx
@@ -4,6 +4,8 @@ import { afterEach, describe, expect, it } from 'vitest';
 import type { ChatMessage } from '../../types/types';
 import MessageComponent from './MessageComponent';
 
+const PLAN_MODE_VIOLATION_MESSAGE = '[PLAN_MODE_VIOLATION] Tool "edit_notebook" is BLOCKED in plan mode.\n\nYou are in READ-ONLY plan mode. This tool cannot be executed.';
+
 afterEach(() => {
   cleanup();
 });
@@ -112,5 +114,35 @@ describe('MessageComponent tool errors', () => {
 
     fireEvent.click(summary as HTMLElement);
     expect(screen.getByText(/Plan mode denies side-effecting tool bash/)).toBeTruthy();
+  });
+
+  it('renders structured plan-mode violations as collapsed tool details without permission actions', () => {
+    const { container } = renderToolMessage({
+      id: 'tool-4',
+      type: 'assistant',
+      content: '',
+      timestamp: '2026-05-18T08:00:00.000Z',
+      isToolUse: true,
+      toolName: 'edit_notebook',
+      toolId: 'tool-4',
+      toolInput: '{"file_path":"notebook.ipynb"}',
+      toolResult: {
+        isError: true,
+        content: PLAN_MODE_VIOLATION_MESSAGE,
+        errorCode: 'plan_mode_violation',
+      },
+    });
+
+    expect(container.querySelector('.border-l-red-500')).toBeNull();
+    expect(screen.queryByRole('button', { name: /permissions\.grant|Grant edit_notebook for this chat/ })).toBeNull();
+    expect(screen.queryByRole('button', { name: /permissions\.openSettings|Open settings/ })).toBeNull();
+
+    const summary = screen.getByText('Tool error').closest('summary');
+    expect(summary).not.toBeNull();
+    const details = summary?.closest('details') as HTMLDetailsElement | null;
+    expect(details?.open).toBe(false);
+
+    fireEvent.click(summary as HTMLElement);
+    expect(screen.getByText(/\[PLAN_MODE_VIOLATION\]/)).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary

- Clarify `todo_write` so it cannot be used as a substitute for the final markdown plan in plan mode.
- Treat both legacy `Plan mode denies side-effecting tool ...` messages and new `[PLAN_MODE_VIOLATION]` / `plan_mode_violation` results as plan-mode denials in the UI/server bridge.
- Add UI coverage for structured plan-mode violations so they stay neutral and do not show permission-grant actions.

## Validation

- `npm run build`
- `npm --prefix ui test -- MessageComponent.tool-error.test.tsx MessagesPaneV2.render.test.tsx processGrouping.test.ts`

## Notes

- `npm test` was also attempted, but it picks up the local untracked `tests/` directory from the superseded #217 worktree. That untracked test expects the old pre-#216 denial prefix and fails against the merged #216 `[PLAN_MODE_VIOLATION]` format; it is not part of this PR.