### PR TITLE
fix(agent): handle max output token truncation for pure-text output and empty responses

### DIFF
--- a/src/agent/loop/AgentLoop.ts
+++ b/src/agent/loop/AgentLoop.ts
@@ -140,7 +140,7 @@ export class AgentLoop {
      * resume from where it was cut off — up to MAX_OUTPUT_RECOVERY_LIMIT
      * times.
      */
-    const MAX_OUTPUT_RECOVERY_LIMIT = 3;
+    const MAX_OUTPUT_RECOVERY_LIMIT = 50;
     let maxOutputRecoveryCount = 0;
     const MAX_JSON_SELF_CORRECT_RETRIES = 3;
     let jsonSelfCorrectCount = 0;
@@ -535,6 +535,40 @@ export class AgentLoop {
       }
 
       if (toolCalls.length === 0) {
+        const assistantText = textFromMessage(assembled.message);
+
+        // Pure-text output truncated by max_output_tokens: the model was
+        // mid-sentence with no tool calls. Unlike tool-call truncation we
+        // skip the "strip-and-retry-with-doubled-tokens" phase (Phase A)
+        // because (a) the text already generated is valid and discarding it
+        // wastes tokens, and (b) blindly doubling maxOutputTokens may
+        // exceed the provider's model cap and trigger a 400 error.
+        // Instead, keep the truncated assistant message in context and
+        // inject a continuation prompt so the model resumes from the cut.
+        if (assembled.finishReason === "length") {
+          if (maxOutputRecoveryCount < MAX_OUTPUT_RECOVERY_LIMIT) {
+            maxOutputRecoveryCount++;
+            messages.push({
+              role: "user",
+              content: [{
+                type: "text",
+                text: "Output token limit hit. Resume directly — no apology, no recap of what you were doing. "
+                  + "Pick up mid-sentence if that is where the cut happened.",
+              }],
+              metadata: { synthetic: true, purpose: "max_output_recovery" },
+            });
+            yield {
+              type: "turn_continued",
+              sessionId: input.sessionId,
+              turnId: input.turnId,
+              reason: "model_error",
+            };
+            continue;
+          }
+          // Exhausted — fall through to normal completion with whatever
+          // text was produced so far.
+        }
+
         const largeFileDecision = largeFileRepair.onNoToolCalls();
         if (largeFileDecision) {
           const continued = await continueWithSyntheticPrompt(largeFileDecision);

--- a/src/agent/loop/AgentLoop.ts
+++ b/src/agent/loop/AgentLoop.ts
@@ -134,6 +134,12 @@ export class AgentLoop {
      */
     let hasAttemptedOutputRetry = false;
     /**
+     * Single-shot guard for empty assistant responses (no text, no tool
+     * calls). The model's thinking may have consumed the full output
+     * budget leaving nothing visible; we prompt it once to retry.
+     */
+    let hasAttemptedEmptyRetry = false;
+    /**
      * Multi-turn continuation recovery counter for `max_output_reached`.
      * After the single-shot token bump, the loop injects a continuation
      * prompt and preserves the truncated assistant message so the model can
@@ -142,6 +148,8 @@ export class AgentLoop {
      */
     const MAX_OUTPUT_RECOVERY_LIMIT = 50;
     let maxOutputRecoveryCount = 0;
+    const MAX_CONSECUTIVE_EMPTY = 3;
+    let consecutiveEmptyCount = 0;
     const MAX_JSON_SELF_CORRECT_RETRIES = 3;
     let jsonSelfCorrectCount = 0;
     const largeFileRepair = new LargeFileRepair();
@@ -537,6 +545,92 @@ export class AgentLoop {
       if (toolCalls.length === 0) {
         const assistantText = textFromMessage(assembled.message);
 
+        // Global guard: empty assistant response (no text, no tool calls).
+        // The model produced nothing visible — typically because extended
+        // thinking consumed the entire output budget.
+        if (assistantText.length === 0) {
+          messages.pop();
+
+          if (maxOutputRecoveryCount > 0) {
+            consecutiveEmptyCount++;
+            if (consecutiveEmptyCount < MAX_CONSECUTIVE_EMPTY
+              && maxOutputRecoveryCount < MAX_OUTPUT_RECOVERY_LIMIT) {
+              maxOutputRecoveryCount++;
+              messages.push({
+                role: "user",
+                content: [{
+                  type: "text",
+                  text: "Output token limit hit. Resume directly — no apology, no recap of what you were doing. "
+                    + "Pick up mid-sentence if that is where the cut happened.",
+                }],
+                metadata: { synthetic: true, purpose: "max_output_recovery" },
+              });
+              yield {
+                type: "turn_continued",
+                sessionId: input.sessionId,
+                turnId: input.turnId,
+                reason: "model_error",
+              };
+              continue;
+            }
+            // Exhausted consecutive empty retries — surface error via frontend banner.
+            finalMessage = messages.filter((m) => m.role === "assistant").at(-1);
+            const result = this.createTurnResult(input, {
+              type: "error",
+              stopReason: "model_error",
+              usage,
+              permissionDenials,
+              turns: turnCount,
+              startedAt,
+              finalMessage,
+              errors: [agentError(
+                "agent_model_error",
+                "The model returned multiple consecutive empty responses. "
+                  + "The max output token limit is likely too low — "
+                  + "try increasing it so the model has room for visible output after reasoning.",
+              )],
+            });
+            yield { type: "turn_failed", sessionId: input.sessionId, turnId: input.turnId, error: result.errors![0]! };
+            await captureTurn(result.type === "error");
+            yield { type: "turn_completed", sessionId: input.sessionId, turnId: input.turnId, result };
+            return { result, messages };
+          } else if (!hasAttemptedEmptyRetry) {
+            // First occurrence: prompt the model to produce visible output.
+            hasAttemptedEmptyRetry = true;
+            messages.push({
+              role: "user",
+              content: [{
+                type: "text",
+                text: "Your previous response was empty (thinking only, no visible text). "
+                  + "Please provide your answer as visible text output.",
+              }],
+              metadata: { synthetic: true, purpose: "empty_response_retry" },
+            });
+            yield {
+              type: "turn_continued",
+              sessionId: input.sessionId,
+              turnId: input.turnId,
+              reason: "model_error",
+            };
+            continue;
+          } else {
+            // Retry also returned empty — give user a diagnostic hint.
+            finalMessage = {
+              role: "assistant",
+              content: [{
+                type: "text",
+                text: "[The model returned an empty response. "
+                  + "This usually means the max output token limit is too low — "
+                  + "the model's reasoning/thinking consumed all available output "
+                  + "tokens before producing visible text. "
+                  + "Try increasing the max output tokens setting.]",
+              }],
+            };
+            messages.push(finalMessage);
+          }
+          // fall through to normal stop
+        }
+
         // Pure-text output truncated by max_output_tokens: the model was
         // mid-sentence with no tool calls. Unlike tool-call truncation we
         // skip the "strip-and-retry-with-doubled-tokens" phase (Phase A)
@@ -546,6 +640,7 @@ export class AgentLoop {
         // Instead, keep the truncated assistant message in context and
         // inject a continuation prompt so the model resumes from the cut.
         if (assembled.finishReason === "length") {
+          consecutiveEmptyCount = 0;
           if (maxOutputRecoveryCount < MAX_OUTPUT_RECOVERY_LIMIT) {
             maxOutputRecoveryCount++;
             messages.push({
@@ -872,7 +967,9 @@ export class AgentLoop {
       } else {
         consecutiveAllInvalidTurns = 0;
         maxOutputRecoveryCount = 0;
+        consecutiveEmptyCount = 0;
         hasAttemptedOutputRetry = false;
+        hasAttemptedEmptyRetry = false;
       }
 
       if (this.config.stopOnStructuredOutput && structuredOutput !== undefined) {


### PR DESCRIPTION
## Summary

When the model hits `maxOutputTokens` during pure-text generation (no tool calls), the agent previously terminated the turn immediately. This PR adds two recovery mechanisms:

- **Pure-text continuation recovery**: when `finishReason === "length"` with no tool calls, inject a continuation prompt so the model resumes from the cut-off point. Skips the token-doubling phase (Phase A) to avoid exceeding provider model caps. `MAX_OUTPUT_RECOVERY_LIMIT` raised from 3 to 50.
- **Empty response guard**: detect when the model returns no visible text (thinking consumed the entire output budget). Includes single-shot retry, consecutive empty retry during recovery (up to 3), and a frontend error banner when retries are exhausted.

## Changes

Single file: `src/agent/loop/AgentLoop.ts` (+132 lines)

### Commit 1: Pure-text output continuation recovery
- Detect `finishReason === "length"` when `toolCalls.length === 0`
- Inject synthetic continuation prompt to resume output
- Raise `MAX_OUTPUT_RECOVERY_LIMIT` from 3 → 50

### Commit 2: Empty response guard with recovery retry and error banner
- Global guard for empty assistant responses (0 text + 0 tool calls)
- `hasAttemptedEmptyRetry`: single-shot retry outside recovery
- `consecutiveEmptyCount` / `MAX_CONSECUTIVE_EMPTY`: up to 3 retries during recovery
- `turn_failed` error banner when consecutive empty retries exhausted
- Diagnostic hint message when non-recovery empty retries fail

## Test plan

- [x] Verified with `maxOutputTokens: 50` — continuation recovery produces multi-part output across 14+ iterations
- [x] Verified empty response during recovery triggers retry and model successfully produces text on next attempt
- [x] Verified `consecutiveEmptyCount` resets to 0 after successful non-empty response
- [x] Runtime evidence collected via debug instrumentation confirming all code paths


Made with [Cursor](https://cursor.com)