### PR TITLE
fix: multi-subagent concurrency and detail rendering

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -241,8 +241,8 @@ importers:
         specifier: ^4.1.2
         version: 4.1.2(react@18.3.1)
       react-i18next:
-        specifier: ^16.5.3
-        version: 16.6.6(i18next@26.3.0(typescript@5.9.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+        specifier: ^15.7.4
+        version: 15.7.4(i18next@26.3.0(typescript@5.9.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
       react-markdown:
         specifier: ^10.1.0
         version: 10.1.0(@types/react@18.3.29)(react@18.3.1)
@@ -4683,14 +4683,14 @@ packages:
     peerDependencies:
       react: '>=16.13.1'
 
-  react-i18next@16.6.6:
-    resolution: {integrity: sha512-ZgL2HUoW34UKUkOV7uSQFE1CDnRPD+tCR3ywSuWH7u2iapnz86U8Bi3Vrs620qNDzCf1F47NxglCEkchCTDOHw==}
+  react-i18next@15.7.4:
+    resolution: {integrity: sha512-nyU8iKNrI5uDJch0z9+Y5XEr34b0wkyYj3Rp+tfbahxtlswxSCjcUL9H0nqXo9IR3/t5Y5PKIA3fx3MfUyR9Xw==}
     peerDependencies:
-      i18next: '>= 25.10.9'
+      i18next: '>= 23.4.0'
       react: '>= 16.8.0'
       react-dom: '*'
       react-native: '*'
-      typescript: ^5 || ^6
+      typescript: ^5
     peerDependenciesMeta:
       react-dom:
         optional: true
@@ -5426,11 +5426,6 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
-
-  use-sync-external-store@1.6.0:
-    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -10539,13 +10534,12 @@ snapshots:
       '@babel/runtime': 7.29.7
       react: 18.3.1
 
-  react-i18next@16.6.6(i18next@26.3.0(typescript@5.9.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3):
+  react-i18next@15.7.4(i18next@26.3.0(typescript@5.9.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3):
     dependencies:
       '@babel/runtime': 7.29.7
       html-parse-stringify: 3.0.1
       i18next: 26.3.0(typescript@5.9.3)
       react: 18.3.1
-      use-sync-external-store: 1.6.0(react@18.3.1)
     optionalDependencies:
       react-dom: 18.3.1(react@18.3.1)
       typescript: 5.9.3
@@ -11594,10 +11588,6 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
-
-  use-sync-external-store@1.6.0(react@18.3.1):
-    dependencies:
-      react: 18.3.1
 
   util-deprecate@1.0.2: {}
 

--- a/scripts/dev-launcher.mjs
+++ b/scripts/dev-launcher.mjs
@@ -54,7 +54,7 @@ function parsePort(value, fallback) {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
 }
 
-function isPortFree(port, host = '0.0.0.0') {
+function isPortFreeOnHost(port, host) {
   return new Promise((resolveCheck) => {
     const probe = createServer();
     probe.once('error', () => resolveCheck(false));
@@ -63,6 +63,14 @@ function isPortFree(port, host = '0.0.0.0') {
     });
     probe.listen(port, host);
   });
+}
+
+async function isPortFree(port) {
+  const [loopback, wildcard] = await Promise.all([
+    isPortFreeOnHost(port, '127.0.0.1'),
+    isPortFreeOnHost(port, '0.0.0.0'),
+  ]);
+  return loopback && wildcard;
 }
 
 async function findFreePort(label, base, hardOverride) {

--- a/src/agent/loop/AgentLoop.ts
+++ b/src/agent/loop/AgentLoop.ts
@@ -1186,7 +1186,7 @@ export class AgentLoop {
           description: d.description,
         })),
       isAllowedDefinition: (id: string) => getSubagentDefinition(id) !== undefined,
-      fork: async ({ definitionId, directive, subagentId, abortSignal, timeoutMs }) => {
+      fork: async ({ definitionId, directive, subagentId, toolCallId, abortSignal, timeoutMs }) => {
         // Defer SubAgentSession import to avoid the runtime cycle (sub → loop → sub).
         const { SubAgentSession } = await import("../sub/SubAgentSession.js");
         const def = getSubagentDefinition(definitionId);
@@ -1220,12 +1220,12 @@ export class AgentLoop {
           turnId: input.turnId,
           subagentId,
           subagentType: def.id,
+          toolCallId,
         });
 
         const subSession = new SubAgentSession({
           definition: def,
           directive,
-          parentMessages: messages,
           parentConfig: {
             ...this.config,
             subagentDepth: depth + 1,

--- a/src/agent/protocol/events.ts
+++ b/src/agent/protocol/events.ts
@@ -29,7 +29,7 @@ export type AgentEvent =
   | { type: "compact_started"; sessionId: string; turnId: string; trigger: string; preTokens: number }
   | { type: "compact_completed"; sessionId: string; turnId: string; status: string; preTokens: number; postTokens?: number }
   | { type: "context_budget"; sessionId: string; turnId: string; snapshot: TokenBudgetSnapshot }
-  | { type: "subagent_started"; sessionId: string; turnId: string; subagentId: string; subagentType: string }
+  | { type: "subagent_started"; sessionId: string; turnId: string; subagentId: string; subagentType: string; toolCallId?: string }
   | { type: "subagent_completed"; sessionId: string; turnId: string; subagentId: string; subagentType: string; success: boolean; durationMs: number }
   | {
       type: "subagent_status";

--- a/src/agent/sub/SubAgentSession.ts
+++ b/src/agent/sub/SubAgentSession.ts
@@ -44,7 +44,7 @@ import {
   cloneReadFileState,
   cloneWriteSnapshots,
 } from "./contextInheritance.js";
-import { filterIncompleteToolCalls } from "./filterIncompleteToolCalls.js";
+
 
 const SUMMARY_FIELDS = ["Scope", "Result", "Key files", "Files changed", "Issues"] as const;
 const SUBAGENT_DEFAULT_MAX_TURNS = 16;
@@ -54,12 +54,6 @@ export type SubAgentSessionOptions = {
   definition: SubagentDefinition;
   /** Free-text directive from the parent (becomes the subagent's user prompt). */
   directive: string;
-  /**
-   * Parent's accumulated message history. We slice off the *last* assistant
-   * message to seed the fork (S1). Caller should pass parent's full history
-   * up to and including the assistant turn that issued the `agent` tool call.
-   */
-  parentMessages: CanonicalMessage[];
   /** Parent agent's runtime config (provider, model, permission mode, ...). */
   parentConfig: AgentRuntimeConfig;
   /** Parent agent's runtime dependencies (model, scheduler factory, ...). */
@@ -185,25 +179,7 @@ export class SubAgentSession {
   }
 
   private buildInitialMessages(): CanonicalMessage[] {
-    const parentLast = this.options.parentMessages[this.options.parentMessages.length - 1];
-    if (!parentLast || parentLast.role !== "assistant") {
-      // Fall back to a synthetic assistant message that just references the
-      // directive (rare; happens for tool-driven invocations where the parent
-      // hasn't produced an assistant message yet).
-      const synthetic: CanonicalMessage = {
-        role: "assistant",
-        content: [
-          {
-            type: "text",
-            text: "(parent did not produce an assistant message before forking)",
-          },
-        ],
-      };
-      return filterIncompleteToolCalls(buildForkedMessages(this.options.directive, synthetic));
-    }
-    return filterIncompleteToolCalls(
-      buildForkedMessages(this.options.directive, parentLast),
-    );
+    return buildForkedMessages(this.options.directive);
   }
 
   private buildScopedRegistry(): ToolRegistry {

--- a/src/agent/sub/buildForkedMessages.ts
+++ b/src/agent/sub/buildForkedMessages.ts
@@ -1,83 +1,26 @@
 /**
- * S1-S3 — fork the parent's assistant message into a child-side message
- * sequence so the subagent inherits the parent's reasoning trace cache-safely.
+ * Build the initial message sequence for a subagent fork.
  *
- * The exact byte-for-byte placeholder string and message shape are critical
- * for prompt-cache hits — do not casually tweak the wording or block order
- * here, even when it looks harmless.
+ * Each subagent starts with a clean context — only the directive from the
+ * parent's `agent` tool call is forwarded. No parent assistant messages
+ * (thinking, text, or sibling tool_calls) are included, so the child model
+ * cannot infer or attempt tasks belonging to other sibling subagents.
  */
 
-import type {
-  CanonicalContentBlock,
-  CanonicalMessage,
-  CanonicalToolCallBlock,
-} from "../../model/index.js";
-
-/**
- * S2 — placeholder string injected into every synthetic `tool_result` so the
- * fork is byte-identical across siblings (= cache hit on Anthropic / OpenAI).
- *
- * **Do not change** without a coordinated cache invalidation plan; both legacy
- * and parity tests assert the literal value.
- */
-export const FORK_PLACEHOLDER_RESULT =
-  "<pilotdeck-fork-placeholder>Subtask handled by forked subagent — see child transcript.</pilotdeck-fork-placeholder>";
+import type { CanonicalMessage } from "../../model/index.js";
 
 /** Tag used in the boilerplate that wraps the directive. */
 export const FORK_BOILERPLATE_TAG = "pilotdeck-fork";
 
-/**
- * S1 — Build the canonical message sequence handed to the subagent's
- * `AgentLoop`:
- *
- *   1. Parent's assistant message verbatim (thinking + every tool_use + text).
- *   2. A user message containing one synthetic `tool_result` (with
- *      `FORK_PLACEHOLDER_RESULT`) per `tool_use`, followed by the directive
- *      wrapped in `<pilotdeck-fork>` boilerplate.
- *
- * Returns a fresh array (never mutates `assistantMessage`).
- */
-export function buildForkedMessages(
-  directive: string,
-  assistantMessage: CanonicalMessage,
-): CanonicalMessage[] {
-  if (assistantMessage.role !== "assistant") {
-    throw new Error(
-      "buildForkedMessages: parent message must be role=assistant; got " +
-        assistantMessage.role,
-    );
-  }
-  const userBlocks: CanonicalContentBlock[] = [];
-  for (const block of assistantMessage.content) {
-    if (block.type === "tool_call") {
-      const tc = block as CanonicalToolCallBlock;
-      userBlocks.push({
-        type: "tool_result",
-        toolCallId: tc.id,
-        content: [{ type: "text", text: FORK_PLACEHOLDER_RESULT }],
-      });
-    }
-  }
-  userBlocks.push({ type: "text", text: buildChildMessage(directive) });
+export const FORK_PLACEHOLDER_RESULT =
+  "<pilotdeck-fork-placeholder>Subtask handled by forked subagent — see child transcript.</pilotdeck-fork-placeholder>";
+
+export function buildForkedMessages(directive: string): CanonicalMessage[] {
   return [
-    cloneMessage(assistantMessage),
-    { role: "user", content: userBlocks },
+    { role: "user", content: [{ type: "text", text: directive }] },
   ];
 }
 
-/**
- * S3 — child directive wrapped in fork boilerplate. Rules and output format
- * live in the system prompt ({@link buildSubagentSystemPrompt}) and are NOT
- * duplicated here — keeping the user message slim improves memory-retrieval
- * signal-to-noise and saves ~200-300 tokens per sub-agent.
- */
 export function buildChildMessage(directive: string): string {
   return `<${FORK_BOILERPLATE_TAG}>\nDirective:\n${directive.trim()}\n</${FORK_BOILERPLATE_TAG}>`;
-}
-
-function cloneMessage(message: CanonicalMessage): CanonicalMessage {
-  return {
-    role: message.role,
-    content: message.content.map((block) => ({ ...block })),
-  };
 }

--- a/src/gateway/client/InProcessGateway.ts
+++ b/src/gateway/client/InProcessGateway.ts
@@ -1190,7 +1190,7 @@ export function mapAgentEvent(event: AgentEvent, runId: string): GatewayEvent[] 
       return [{
         type: "agent_status",
         event: "subagent_started",
-        detail: { subagentId: event.subagentId, subagentType: event.subagentType },
+        detail: { subagentId: event.subagentId, subagentType: event.subagentType, toolCallId: event.toolCallId },
       }];
     case "subagent_completed":
       return [{

--- a/src/tool/builtin/agent.ts
+++ b/src/tool/builtin/agent.ts
@@ -150,7 +150,7 @@ export function createAgentTool(
     },
     maxResultBytes: 200_000,
     isReadOnly: () => false,
-    isConcurrencySafe: () => false,
+    isConcurrencySafe: () => true,
     isOpenWorld: () => true,
     checkPermissions: async (): Promise<PermissionResult> => ({
       type: "allow",
@@ -337,6 +337,7 @@ async function runFullFork(args: {
       definitionId: requestedType,
       directive,
       subagentId,
+      toolCallId: context.currentToolCallId,
       abortSignal: context.abortSignal,
       timeoutMs,
     });

--- a/src/tool/execution/ToolRuntime.ts
+++ b/src/tool/execution/ToolRuntime.ts
@@ -195,17 +195,18 @@ export class ToolRuntime {
     }
 
     executeInput = decision.updatedInput ?? executeInput;
-    const executeContext: PilotDeckToolRuntimeContext = context.progress
+    const baseContext: PilotDeckToolRuntimeContext = { ...context, currentToolCallId: call.id };
+    const executeContext: PilotDeckToolRuntimeContext = baseContext.progress
       ? {
-          ...context,
+          ...baseContext,
           progress: (event) =>
-            context.progress!({
+            baseContext.progress!({
               ...event,
               toolCallId: event.toolCallId || call.id,
               toolName: event.toolName || tool.name,
             }),
         }
-      : context;
+      : baseContext;
     try {
       const output = await tool.execute(executeInput, executeContext);
       const maxResultBytes = tool.maxResultBytes ?? context.maxResultBytes;

--- a/src/tool/protocol/types.ts
+++ b/src/tool/protocol/types.ts
@@ -54,6 +54,7 @@ export type PilotDeckSubagentForkApi = {
     definitionId: string;
     directive: string;
     subagentId: string;
+    toolCallId?: string;
     abortSignal?: AbortSignal;
     timeoutMs?: number;
   }): Promise<{
@@ -181,6 +182,8 @@ export type PilotDeckToolRuntimeContext = {
   cwd: string;
   abortSignal?: AbortSignal;
   subagentTimeoutMs?: number;
+  /** The tool call ID assigned by the model for the current invocation. */
+  currentToolCallId?: string;
   permissionMode: PermissionMode;
   permissionContext: PermissionContext;
   auditRecorder?: PilotDeckToolAuditRecorder;

--- a/ui/server/pilotdeck-bridge.js
+++ b/ui/server/pilotdeck-bridge.js
@@ -645,12 +645,22 @@ function createSubagentStatusFrames(event, base) {
     const frames = [activity];
 
     if (event.event === 'subagent_started') {
-        const pending = pendingAgentToolCalls.get(base.sessionId) || [];
-        const toolCallId = pending.shift();
-        if (pending.length === 0) {
-            pendingAgentToolCalls.delete(base.sessionId);
+        let toolCallId = detail.toolCallId;
+        if (!toolCallId) {
+            const pending = pendingAgentToolCalls.get(base.sessionId) || [];
+            toolCallId = pending.shift();
+            if (pending.length === 0) {
+                pendingAgentToolCalls.delete(base.sessionId);
+            } else {
+                pendingAgentToolCalls.set(base.sessionId, pending);
+            }
         } else {
-            pendingAgentToolCalls.set(base.sessionId, pending);
+            const pending = pendingAgentToolCalls.get(base.sessionId);
+            if (pending) {
+                const idx = pending.indexOf(toolCallId);
+                if (idx !== -1) pending.splice(idx, 1);
+                if (pending.length === 0) pendingAgentToolCalls.delete(base.sessionId);
+            }
         }
         frames.push(createNormalizedMessage({
             ...base,

--- a/ui/src/components/chat-v2/MessagesPaneV2.tsx
+++ b/ui/src/components/chat-v2/MessagesPaneV2.tsx
@@ -90,6 +90,11 @@ function isStreamingThinkingMessage(message: ChatMessage): boolean {
   return Boolean(message.isThinking && String(message.id || '').startsWith('__streaming_thinking_'));
 }
 
+function isSubagentThinkingPlaceholder(message: ChatMessage): boolean {
+  const id = String(message.id || '');
+  return Boolean(message.isThinking && (id.startsWith('subagent_thinking_') || id.startsWith('__subagent_thinking_')));
+}
+
 function clampNumber(value: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, value));
 }
@@ -397,6 +402,7 @@ export default function MessagesPaneV2({
     () => {
       const filtered = visibleMessages.filter((message) =>
         !message.isAgentActivity &&
+        !isSubagentThinkingPlaceholder(message) &&
         (!inlineThinking && isStreamingThinkingMessage(message) ? false : true) &&
         !(message.isThinking && !showThinking)
       );
@@ -677,7 +683,6 @@ export default function MessagesPaneV2({
   const renderLiveProcessGroup = useCallback((group: LiveProcessGroup, index: number) => {
     const isLatestGroup = liveProcessGroups[liveProcessGroups.length - 1]?.id === group.id;
     const step = getLiveProcessGroupStep(group, t, group.isRunning && isLatestGroup ? liveStatusStep : null);
-
     return (
       <ProcessLiveStatus
         key={group.id || `${group.afterOriginalIndex}-${index}`}
@@ -953,7 +958,7 @@ export default function MessagesPaneV2({
           {shouldRenderBottomLiveStatus ? (
             <>
               <ProcessLiveStatus step={liveStatusStep}>
-                {liveProcessDetailMessages.length > 0
+                {liveProcessDetailMessages.length > 0 && liveProcessGroups.length === 0
                   ? renderLiveProcessDetailMessages(liveProcessDetailMessages, 'bottom-live-process')
                   : null}
               </ProcessLiveStatus>

--- a/ui/src/components/chat-v2/SubagentCard.tsx
+++ b/ui/src/components/chat-v2/SubagentCard.tsx
@@ -42,12 +42,21 @@ export default function SubagentCard({ message, liveActivity, onOpenDetail, thin
         return { icon: 'failed' as const, text: text || t('subagent.status.failed') };
       }
       if (state === 'completed' || state === 'cancelled') {
+        if (!isSessionRunning && !hasToolResult) {
+          return { icon: 'failed' as const, text: t('subagent.status.stopped') };
+        }
         return { icon: 'completed' as const, text: text || t('subagent.status.completed') };
+      }
+      if (!isSessionRunning) {
+        return { icon: 'failed' as const, text: t('subagent.status.stopped') };
       }
       return { icon: 'running' as const, text: text || t('subagent.status.thinking') };
     }
     if (isFailed) {
       return { icon: 'failed' as const, text: t('subagent.status.stopped') };
+    }
+    if (isSessionRunning && !subagentId) {
+      return { icon: 'running' as const, text: t('subagent.status.connecting', '连接中…') };
     }
     if (isComplete || hasToolResult) {
       return { icon: 'completed' as const, text: t('subagent.status.completed') };

--- a/ui/src/components/chat-v2/SubagentDetailMessageFlow.tsx
+++ b/ui/src/components/chat-v2/SubagentDetailMessageFlow.tsx
@@ -3,11 +3,12 @@ import { useTranslation } from 'react-i18next';
 import type { ChatMessage, ChatRunMode } from '../chat/types/types';
 import type { Project, SessionProvider } from '../../types/app';
 import MessageRowV2 from './MessageRowV2';
-import { ProcessLiveStatus, StreamingThinkingPreview, type ProcessTraceStep } from './ProcessTrace';
+import { ProcessLiveStatus, type ProcessTraceStep } from './ProcessTrace';
 import {
   buildRenderableMessageItems,
   getLiveProcessGroups,
   getLiveProcessGroupStep,
+  getProcessToolKind,
   shouldRenderLiveProcessGroup,
   type LiveProcessGroup,
   type RenderableMessageItem,
@@ -58,33 +59,49 @@ export default function SubagentDetailMessageFlow({
   const { t } = useTranslation('chat');
   const [expandedProcessRows, setExpandedProcessRows] = useState<Map<string, boolean>>(() => new Map());
 
-  const streamingThinkingContent = useMemo(() => {
-    if (!showThinking || !isRunning) return null;
-    for (let i = messages.length - 1; i >= 0; i--) {
-      const message = messages[i];
-      if (
-        isStreamingSubagentThinkingMessage(message) &&
-        typeof message.content === 'string' &&
-        message.content.trim()
-      ) {
-        return message.content;
+  const thinkingStatusStep = useMemo<ProcessTraceStep>(() => {
+    const lastToolMsg = [...messages].reverse().find(
+      (m) => m.isToolUse && m.toolName && !m.isSubagentContainer,
+    );
+    if (lastToolMsg) {
+      const kind = getProcessToolKind(lastToolMsg);
+      const toolKindTitleMap: Record<string, string> = {
+        search: t('process.live.runningSearch', { defaultValue: 'Searching' }),
+        edit: t('process.live.runningEdit', { defaultValue: 'Editing file' }),
+        read: t('process.live.runningRead', { defaultValue: 'Reading file' }),
+        command: t('process.live.runningCommand', { defaultValue: 'Running command' }),
+      };
+      if (toolKindTitleMap[kind]) {
+        return {
+          id: 'subagent-detail-thinking',
+          title: toolKindTitleMap[kind],
+          phase: kind === 'search' ? 'rag' : 'tool',
+          state: 'running' as const,
+        };
       }
     }
-    return null;
-  }, [isRunning, messages, showThinking]);
-  const thinkingStatusStep = useMemo<ProcessTraceStep>(() => ({
-    id: 'subagent-detail-thinking',
-    title: t('working.thinking', { defaultValue: 'thinking' }),
-    phase: 'thinking',
-    state: 'running',
-  }), [t]);
+    return {
+      id: 'subagent-detail-thinking',
+      title: t('subagent.status.thinking', { defaultValue: 'Thinking' }),
+      phase: 'thinking',
+      state: 'running' as const,
+    };
+  }, [messages, t]);
 
   const renderableMessages = useMemo(
-    () => messages.filter((message) =>
-      !message.isAgentActivity &&
-      !isStreamingSubagentThinkingMessage(message) &&
-      !(message.isThinking && !showThinking)
-    ),
+    () => {
+      const result = messages
+        .filter((message) =>
+          !message.isAgentActivity &&
+          !isStreamingSubagentThinkingMessage(message) &&
+          !(message.isThinking && !showThinking)
+        )
+        .map((message) => message.isSubagentContainer
+          ? { ...message, isSubagentContainer: false }
+          : message
+        );
+      return result;
+    },
     [messages, showThinking],
   );
   const renderableItems = useMemo(
@@ -122,6 +139,8 @@ export default function SubagentDetailMessageFlow({
     () => liveProcessGroups.filter((group) => !visibleOriginalIndices.has(group.afterOriginalIndex)),
     [liveProcessGroups, visibleOriginalIndices],
   );
+  const hasOpenEndedLiveProcessGroup = liveProcessGroups.some((group) => group.isRunning);
+  const shouldRenderBottomLiveStatus = isRunning && !hasOpenEndedLiveProcessGroup;
 
   const isProcessExpanded = useCallback((processKey: string, defaultExpanded = false) => (
     expandedProcessRows.get(processKey) ?? defaultExpanded
@@ -135,10 +154,10 @@ export default function SubagentDetailMessageFlow({
     });
   }, []);
 
-  const renderLiveProcessDetailMessages = useCallback((detailMessages: ChatMessage[], groupId: string) => (
-    detailMessages.map((message, index) => (
+  const renderLiveProcessDetailMessages = useCallback((detailMessages: ChatMessage[], groupId: string) => {
+    return detailMessages.map((message, index) => (
       <MessageRowV2
-        key={`${groupId}-${getMessageKey(message, index)}`}
+        key={`${groupId}-${index}-${getMessageKey(message, index)}`}
         message={message}
         prevMessage={index > 0 ? detailMessages[index - 1] : null}
         nextMessage={index < detailMessages.length - 1 ? detailMessages[index + 1] : null}
@@ -150,8 +169,8 @@ export default function SubagentDetailMessageFlow({
         isProcessExpanded={isProcessExpanded}
         onProcessExpandedChange={handleProcessExpandedChange}
       />
-    ))
-  ), [
+    ));
+  }, [
     createDiff,
     handleProcessExpandedChange,
     isProcessExpanded,
@@ -162,7 +181,8 @@ export default function SubagentDetailMessageFlow({
   ]);
 
   const renderLiveProcessGroup = useCallback((group: LiveProcessGroup, index: number) => {
-    const step = getLiveProcessGroupStep(group, t, null);
+    const isLatestGroup = liveProcessGroups[liveProcessGroups.length - 1]?.id === group.id;
+    const step = getLiveProcessGroupStep(group, t, group.isRunning && isLatestGroup ? thinkingStatusStep : null);
     return (
       <ProcessLiveStatus
         key={group.id || `${group.afterOriginalIndex}-${index}`}
@@ -179,14 +199,16 @@ export default function SubagentDetailMessageFlow({
   }, [
     handleProcessExpandedChange,
     isProcessExpanded,
+    liveProcessGroups,
     renderLiveProcessDetailMessages,
     t,
+    thinkingStatusStep,
   ]);
 
   if (
     keyedItems.length === 0 &&
     unanchoredLiveProcessGroups.length === 0 &&
-    !streamingThinkingContent
+    !shouldRenderBottomLiveStatus
   ) {
     return null;
   }
@@ -229,11 +251,8 @@ export default function SubagentDetailMessageFlow({
           </Fragment>
         );
       })}
-      {streamingThinkingContent ? (
-        <div className="flex min-w-0 flex-col">
-          <ProcessLiveStatus step={thinkingStatusStep} />
-          <StreamingThinkingPreview content={streamingThinkingContent} />
-        </div>
+      {shouldRenderBottomLiveStatus ? (
+        <ProcessLiveStatus step={thinkingStatusStep} />
       ) : null}
     </div>
   );

--- a/ui/src/components/chat-v2/processGrouping.ts
+++ b/ui/src/components/chat-v2/processGrouping.ts
@@ -885,14 +885,16 @@ export function getLiveProcessGroups(
     }
 
     const first = groupMessages[0];
+    const detail = groupMessages.filter(isExpandableProcessMessage);
+    const gid = getStableProcessSegmentId(messages, liveTurn, first, groupStartIndex);
     groups.push({
-      id: getStableProcessSegmentId(messages, liveTurn, first, groupStartIndex),
+      id: gid,
       afterOriginalIndex: previousVisibleIndex,
       beforeOriginalIndex,
       startIndex: groupStartIndex,
       endIndex: beforeOriginalIndex ?? messages.length,
       messages: groupMessages,
-      detailMessages: groupMessages.filter(isExpandableProcessMessage),
+      detailMessages: detail,
     });
     groupStartIndex = -1;
     groupMessages = [];
@@ -918,7 +920,7 @@ export function getLiveProcessGroups(
 
   finishGroup(null);
 
-  return groups.map((group, index) => {
+  const result = groups.map((group, index) => {
     const isLatestGroup = index === groups.length - 1;
     const isOpenEnded = group.beforeOriginalIndex == null;
     return {
@@ -926,6 +928,7 @@ export function getLiveProcessGroups(
       isRunning: Boolean(options.isAssistantWorking && isLatestGroup && isOpenEnded),
     };
   });
+  return result;
 }
 
 export function shouldRenderLiveProcessGroup(group: LiveProcessGroup, runMode: ChatRunMode): boolean {

--- a/ui/src/components/chat/hooks/useChatMessages.ts
+++ b/ui/src/components/chat/hooks/useChatMessages.ts
@@ -276,17 +276,27 @@ function convertNormalizedMessages(
 ): ChatMessage[] {
   const converted: ChatMessage[] = [];
 
-  // First pass: collect tool results for attachment to tool_use messages
-  const toolResultMap = new Map<string, NormalizedMessage>();
+  // First pass: collect tool results as ordered queues per toolId so that
+  // cross-turn reuse of the same toolId (call_0, call_1, …) pairs correctly.
+  const toolResultQueues = new Map<string, NormalizedMessage[]>();
   for (const msg of messages) {
     if (msg.kind === 'tool_result' && msg.toolId) {
-      toolResultMap.set(msg.toolId, msg);
+      const queue = toolResultQueues.get(msg.toolId);
+      if (queue) queue.push(msg);
+      else toolResultQueues.set(msg.toolId, [msg]);
     }
   }
+  const toolResultMap = new Map<string, NormalizedMessage>();
 
   for (const msg of messages) {
     // tool_use messages depend on toolResultMap + subagentLinks (external state) so skip cache
     if (msg.kind === 'tool_use') {
+      if (msg.toolId && !msg.toolResult) {
+        const queue = toolResultQueues.get(msg.toolId);
+        const next = queue?.shift();
+        if (next) toolResultMap.set(msg.toolId, next);
+        else toolResultMap.delete(msg.toolId);
+      }
       const result = convertSingleMessage(msg, toolResultMap, subagentLinks);
       if (result) converted.push(result);
       continue;

--- a/ui/src/hooks/useUiPreferences.ts
+++ b/ui/src/hooks/useUiPreferences.ts
@@ -37,7 +37,7 @@ const DEFAULTS: UiPreferences = {
   autoExpandTools: false,
   showRawParameters: false,
   showThinking: true,
-  inlineThinking: true,
+  inlineThinking: false,
   autoScrollToBottom: true,
   sendByCtrlEnter: false,
   sidebarVisible: true,

--- a/ui/src/stores/useSessionStore.ts
+++ b/ui/src/stores/useSessionStore.ts
@@ -323,17 +323,25 @@ function computeMerged(server: NormalizedMessage[], realtime: NormalizedMessage[
   return result;
 }
 
+function getUpsertKey(message: NormalizedMessage): string {
+  if ((message.kind === 'tool_use' || message.kind === 'tool_result') && message.toolId) {
+    return `${message.id}::${message.kind}::${message.toolId}`;
+  }
+  return message.id;
+}
+
 function upsertRealtimeMessages(
   existing: NormalizedMessage[],
   incoming: NormalizedMessage[],
 ): NormalizedMessage[] {
   if (incoming.length === 0) return existing;
   const updated = [...existing];
-  const indexById = new Map(updated.map((message, index) => [message.id, index]));
+  const indexByKey = new Map(updated.map((message, index) => [getUpsertKey(message), index]));
   for (const message of incoming) {
-    const existingIndex = indexById.get(message.id);
+    const key = getUpsertKey(message);
+    const existingIndex = indexByKey.get(key);
     if (existingIndex === undefined) {
-      indexById.set(message.id, updated.length);
+      indexByKey.set(key, updated.length);
       updated.push(message);
     } else {
       updated[existingIndex] = message;
@@ -681,7 +689,18 @@ export function useSessionStore() {
   ) => {
     const slot = getSlot(sessionId);
     const current = slot.subagentDetailMessages.get(subagentId) ?? [];
-    const updated = upsertRealtimeMessages(current, [msg]);
+    let msgToStore = msg;
+    if ((msg.kind === 'tool_use' || msg.kind === 'tool_result') && msg.toolId) {
+      const existing = current.find(
+        (m) => m.kind === msg.kind && m.toolId === msg.toolId && m.id === msg.id,
+      );
+      if (!existing || existing.toolName !== msg.toolName) {
+        msgToStore = { ...msg, id: `${msg.id}::${msg.kind}::${msg.toolId}::${current.length}` };
+      } else {
+        msgToStore = { ...msg, id: existing.id };
+      }
+    }
+    const updated = upsertRealtimeMessages(current, [msgToStore]);
     const nextMap = new Map(slot.subagentDetailMessages);
     nextMap.set(subagentId, updated);
     slot.subagentDetailMessages = nextMap;


### PR DESCRIPTION
## Summary

- **Pass toolCallId through fork API**: Eliminate FIFO race condition when multiple subagents are spawned concurrently by propagating `toolCallId` directly through the event chain instead of relying on a queue
- **Simplify subagent fork context**: Remove parent assistant message inheritance so sibling subagents cannot infer each other's tasks (directive-only context)
- **Fix tool call overwriting in store**: Use composite upsert key (`id::kind::toolId`) and queue-based tool result pairing to prevent real-time tool calls from overwriting each other when `toolId`s are reused across turns
- **Align subagent detail rendering with main flow**: Mirror `MessagesPaneV2`'s process group and thinking logic in `SubagentDetailMessageFlow` — correct thinking position, eliminate duplicate titles, fuse `thinkingStatusStep` into running groups
- **Misc**: SubagentCard stopped state display, dev-launcher port check fix, react-i18next downgrade

## Test plan

- [ ] Trigger concurrent subagent calls and verify each resolves to the correct tool_use frame
- [ ] Open subagent detail modal during execution — verify thinking renders at correct position (not bottom), no duplicate titles, tool calls not overwritten
- [ ] Close and reopen modal after completion — verify final render matches live render
- [ ] Stop a session mid-execution — verify SubagentCard shows stopped state


Made with [Cursor](https://cursor.com)