### PR TITLE
[codex] cleanup legacy permission modes

### DIFF
--- a/src/adapters/channel/tui/app/TuiApp.tsx
+++ b/src/adapters/channel/tui/app/TuiApp.tsx
@@ -763,7 +763,12 @@ async function handleCommand(
       return true;
     }
     case "/mode": {
-      const mode = (args[0] ?? "default") as GatewayMode;
+      const requestedMode = args[0];
+      const mode = (
+        requestedMode === "plan" || requestedMode === "bypassPermissions"
+          ? requestedMode
+          : "default"
+      ) as GatewayMode;
       if (mode === "bypassPermissions") {
         writePermissionSettings({ skipPermissions: true });
       } else {

--- a/src/agent/loop/AgentLoop.ts
+++ b/src/agent/loop/AgentLoop.ts
@@ -1711,9 +1711,7 @@ function isPermissionMode(value: unknown): value is AgentRuntimeConfig["permissi
   return (
     value === "default" ||
     value === "plan" ||
-    value === "acceptEdits" ||
-    value === "bypassPermissions" ||
-    value === "dontAsk"
+    value === "bypassPermissions"
   );
 }
 

--- a/src/context/prompt/PromptAssembler.ts
+++ b/src/context/prompt/PromptAssembler.ts
@@ -192,12 +192,8 @@ function formatPermissionMode(mode: string): string {
         "- Do NOT skip the planning phase — even for seemingly simple tasks, explore first",
         "- Do NOT call exit_plan_mode until you have a concrete, actionable plan",
       ].join("\n");
-    case "acceptEdits":
-      return "Permission mode: acceptEdits — file edits are auto-approved; shell still requires approval.";
     case "bypassPermissions":
       return "Permission mode: bypassPermissions — all tools are auto-approved; act conservatively.";
-    case "dontAsk":
-      return "Permission mode: dontAsk — do not prompt the user; deny anything ambiguous.";
     default:
       return `Permission mode: ${mode}`;
   }

--- a/src/gateway/client/InProcessGateway.ts
+++ b/src/gateway/client/InProcessGateway.ts
@@ -288,7 +288,9 @@ export class InProcessGateway implements Gateway {
           channelKey: input.channelKey,
         });
         const permissionSettings = readPermissionSettings();
-        const permissionMode = input.mode ?? (permissionSettings.skipPermissions ? "bypassPermissions" : undefined);
+        const inputMode = normalizeGatewayModeForLegacyInput((input as { mode?: unknown }).mode);
+        const permissionMode = inputMode ?? (permissionSettings.skipPermissions ? "bypassPermissions" : undefined);
+        const basePermissionMode = normalizeGatewayModeForLegacyInput((input as { basePermissionMode?: unknown }).basePermissionMode);
         const persistedRules = permissionSettingsToRuleSet(permissionSettings);
         const sessionAllowRules = this.sessionPermissionGrants.get(input.sessionKey) ?? [];
         this.options.telemetry?.trackFeatureLoopStage({
@@ -318,7 +320,7 @@ export class InProcessGateway implements Gateway {
             turnId: runId,
             maxTurns: input.maxTurns,
             permissionMode,
-            basePermissionMode: input.basePermissionMode,
+            basePermissionMode,
             permissionRules: {
               ...persistedRules,
               allow: [...sessionAllowRules, ...persistedRules.allow],
@@ -702,6 +704,16 @@ function resolveSubmitTurnTelemetry(input: GatewaySubmitTurnInput): {
     executionKind: input.telemetry?.executionKind ?? "user_session",
     phase: input.telemetry?.phase,
   };
+}
+
+export function normalizeGatewayModeForLegacyInput(value: unknown): GatewaySubmitTurnInput["mode"] | undefined {
+  if (value === undefined || value === null || value === "") {
+    return undefined;
+  }
+  if (value === "default" || value === "plan" || value === "bypassPermissions") {
+    return value;
+  }
+  return "default";
 }
 
 function emitSessionTelemetry(

--- a/src/gateway/protocol/types.ts
+++ b/src/gateway/protocol/types.ts
@@ -54,7 +54,7 @@ export type GatewayChannelKey =
   | "api_server" | "webhook"
   | (string & {});
 
-export type GatewayMode = "default" | "plan" | "acceptEdits" | "bypassPermissions";
+export type GatewayMode = "default" | "plan" | "bypassPermissions";
 
 export type ChannelAttachment = {
   type: "file" | "image" | "text" | "unknown";

--- a/src/permission/decision/PermissionRuntime.ts
+++ b/src/permission/decision/PermissionRuntime.ts
@@ -205,14 +205,6 @@ function decideByMode(
     });
   }
 
-  if (context.mode === "acceptEdits" && tool.kind === "filesystem" && !tool.isReadOnly(input)) {
-    return allow({
-      type: "mode",
-      mode: "acceptEdits",
-      message: `acceptEdits allows filesystem edit tool ${tool.name}.`,
-    });
-  }
-
   if (tool.isReadOnly(input)) {
     return allow({
       type: "mode",
@@ -308,18 +300,6 @@ function finalizeAsk(decision: PermissionDecision, context: PermissionContext): 
         mode: "bypassPermissions",
         message: "bypassPermissions mode skips permission prompts.",
       },
-    };
-  }
-
-  if (context.mode === "dontAsk") {
-    return {
-      type: "deny",
-      reason: {
-        type: "mode",
-        mode: "dontAsk",
-        message: "dontAsk mode denies permission prompts.",
-      },
-      message: "Permission prompt denied because dontAsk mode is active.",
     };
   }
 

--- a/src/permission/protocol/types.ts
+++ b/src/permission/protocol/types.ts
@@ -1,4 +1,4 @@
-export type PermissionMode = "default" | "plan" | "acceptEdits" | "bypassPermissions" | "dontAsk";
+export type PermissionMode = "default" | "plan" | "bypassPermissions";
 
 export type PermissionRuleBehavior = "allow" | "deny" | "ask";
 

--- a/src/web/client/protocol.ts
+++ b/src/web/client/protocol.ts
@@ -14,7 +14,6 @@ export const PILOTDECK_GATEWAY_PROTOCOL_VERSION_WEB = "1.0";
 export type WebGatewayMode =
   | "default"
   | "plan"
-  | "acceptEdits"
   | "bypassPermissions";
 
 export type WebGatewayChannelKey =

--- a/ui/server/pilotdeck-bridge.js
+++ b/ui/server/pilotdeck-bridge.js
@@ -310,20 +310,25 @@ function uiFilesToAttachments(files) {
     return out.length > 0 ? out : undefined;
 }
 
+function normalizePermissionMode(value) {
+    if (value === undefined || value === null || value === '') return undefined;
+    if (value === 'default' || value === 'plan' || value === 'bypassPermissions') return value;
+    return 'default';
+}
+
 function resolvePermissionMode(options) {
-    const explicit = options?.permissionMode || options?.mode;
+    const explicit = normalizePermissionMode(options?.permissionMode || options?.mode);
     // A literal "default" from the chat composer is the implicit
     // no-special-mode position of the per-turn picker, not a real
     // per-turn override. Let the user-level skipPermissions toggle
-    // win over it. Genuine non-default picks (plan / acceptEdits /
-    // bypassPermissions / dontAsk) still take precedence — they're a
-    // deliberate per-turn decision.
+    // win over it. Genuine non-default picks (plan / bypassPermissions)
+    // still take precedence — they're a deliberate per-turn decision.
     if (explicit && explicit !== 'default') return explicit;
     const persisted = readPermissionSettings();
     if (persisted.skipPermissions === true) {
         return 'bypassPermissions';
     }
-    return explicit || WEB_DEFAULT_PERMISSION_MODE;
+    return explicit || normalizePermissionMode(WEB_DEFAULT_PERMISSION_MODE) || 'default';
 }
 
 /**
@@ -866,7 +871,7 @@ export async function runChatViaGateway(
         ...(uiFilesToAttachments(options?.attachments) || []),
     ];
     const resolvedMode = resolvePermissionMode(options);
-    const basePermissionMode = options?.basePermissionMode || undefined;
+    const basePermissionMode = normalizePermissionMode(options?.basePermissionMode);
     console.log(`[pilotdeck-bridge] submitTurn mode=${resolvedMode} (options.permissionMode=${options?.permissionMode}, options.mode=${options?.mode})`);
 
     try {

--- a/ui/src/components/chat/types/types.ts
+++ b/ui/src/components/chat/types/types.ts
@@ -6,7 +6,7 @@ import type {
 
 export type Provider = SessionProvider;
 
-export type PermissionMode = 'default' | 'acceptEdits' | 'bypassPermissions' | 'plan';
+export type PermissionMode = 'default' | 'bypassPermissions' | 'plan';
 export type ChatRunMode = 'agent' | 'plan';
 
 export interface ChatImage {

--- a/ui/src/components/chat/utils/sessionLauncher.ts
+++ b/ui/src/components/chat/utils/sessionLauncher.ts
@@ -22,7 +22,6 @@ type StartSessionOptions = {
 
 const VALID_PERMISSION_MODES = new Set<PermissionMode>([
   'default',
-  'acceptEdits',
   'bypassPermissions',
   'plan',
 ]);

--- a/ui/src/i18n/locales/en/chat.json
+++ b/ui/src/i18n/locales/en/chat.json
@@ -186,13 +186,11 @@
     "permissionMode": "Permission Mode",
     "modes": {
       "default": "Default Mode",
-      "acceptEdits": "Accept Edits",
       "bypassPermissions": "Bypass Permissions",
       "plan": "Plan Mode"
     },
     "descriptions": {
       "default": "Only trusted commands (ls, cat, grep, git status, etc.) run automatically. Other commands are skipped. Can write to workspace.",
-      "acceptEdits": "All commands run automatically within the workspace. Full auto mode with sandboxed execution.",
       "bypassPermissions": "Full system access with no restrictions. All commands run automatically with full disk and network access. Use with caution.",
       "plan": "Planning mode - no commands are executed"
     },

--- a/ui/src/i18n/locales/en/settings.json
+++ b/ui/src/i18n/locales/en/settings.json
@@ -446,10 +446,6 @@
           "title": "Default",
           "description": "Only trusted commands (ls, cat, grep, git status, etc.) run automatically. Other commands are skipped. Can write to workspace."
         },
-        "acceptEdits": {
-          "title": "Accept Edits",
-          "description": "All commands run automatically within the workspace. Full auto mode with sandboxed execution."
-        },
         "bypassPermissions": {
           "title": "Bypass Permissions",
           "description": "Full system access with no restrictions. All commands run automatically with full disk and network access. Use with caution."
@@ -458,7 +454,6 @@
       "technicalDetails": "Technical details",
       "technicalInfo": {
         "default": "sandboxMode=workspace-write, approvalPolicy=untrusted. Trusted commands: cat, cd, grep, head, ls, pwd, tail, git status/log/diff/show, find (without -exec), etc.",
-        "acceptEdits": "sandboxMode=workspace-write, approvalPolicy=never. All commands auto-execute within project directory.",
         "bypassPermissions": "sandboxMode=danger-full-access, approvalPolicy=never. Full system access, use only in trusted environments.",
         "overrideNote": "You can override this per-session using the mode button in the chat interface."
       }

--- a/ui/src/i18n/locales/zh-CN/chat.json
+++ b/ui/src/i18n/locales/zh-CN/chat.json
@@ -186,13 +186,11 @@
     "permissionMode": "权限模式",
     "modes": {
       "default": "默认模式",
-      "acceptEdits": "编辑模式",
       "bypassPermissions": "无限制模式",
       "plan": "计划模式"
     },
     "descriptions": {
       "default": "只有受信任的命令（ls、cat、grep、git status 等）自动运行。其他命令将被跳过。可以写入工作区。",
-      "acceptEdits": "工作区内的所有命令自动运行。完全自动模式，具有沙盒执行功能。",
       "bypassPermissions": "完全的系统访问，无限制。所有命令自动运行，具有完整的磁盘和网络访问权限。请谨慎使用。",
       "plan": "计划模式 - 不执行任何命令"
     },

--- a/ui/src/i18n/locales/zh-CN/settings.json
+++ b/ui/src/i18n/locales/zh-CN/settings.json
@@ -446,10 +446,6 @@
           "title": "默认",
           "description": "只有受信任的命令（ls、cat、grep、git status 等）会自动运行。其他命令将被跳过。可以写入工作区。"
         },
-        "acceptEdits": {
-          "title": "接受编辑",
-          "description": "所有命令在工作区内自动运行。具有沙箱执行的全自动模式。"
-        },
         "bypassPermissions": {
           "title": "绕过权限",
           "description": "完全系统访问，无任何限制。所有命令自动运行，具有完整的磁盘和网络访问权限。请谨慎使用。"
@@ -458,7 +454,6 @@
       "technicalDetails": "技术详情",
       "technicalInfo": {
         "default": "sandboxMode=workspace-write, approvalPolicy=untrusted。受信任的命令：cat、cd、grep、head、ls、pwd、tail、git status/log/diff/show、find（不带 -exec）等。",
-        "acceptEdits": "sandboxMode=workspace-write, approvalPolicy=never。所有命令在项目目录内自动执行。",
         "bypassPermissions": "sandboxMode=danger-full-access, approvalPolicy=never。完全系统访问权限，仅在可信环境中使用。",
         "overrideNote": "您可以使用聊天界面中的模式按钮按会话覆盖此设置。"
       }


### PR DESCRIPTION
## Summary

- Remove legacy `dontAsk` and `acceptEdits` permission modes from core/runtime/public types.
- Normalize legacy or unknown gateway/UI mode inputs back to `default` so old clients and local storage do not fail hard.
- Clean stale UI/TUI/i18n references while keeping `default`, `plan`, and `bypassPermissions` behavior intact.

Closes #219

## Validation

- `rg -n "dontAsk|acceptEdits" . --glob '!node_modules' --glob '!dist' --glob '!ui/node_modules' --glob '!ui/dist'` returned no matches.\n- `npm run build`\n- `npm --prefix ui run build`\n- `npm --prefix ui run test -- src/components/chat/hooks/useChatComposerState.test.ts src/components/chat-v2/processGrouping.test.ts src/components/chat-v2/MessagesPaneV2.render.test.tsx src/components/chat/view/subcomponents/MessageComponent.tool-error.test.tsx`\n\nNote: `npm --prefix ui run typecheck` still fails on pre-existing React type-version and unrelated TS issues; this change does not add new typecheck failures in the root build.