### PR TITLE
fix: preserve proxy for model requests and suppress startup update-check toast

### DIFF
--- a/src/cli/proxy.ts
+++ b/src/cli/proxy.ts
@@ -1,5 +1,12 @@
 type EnvLike = Record<string, string | undefined>;
 
+export const UNDICI_TRANSPORT_TIMEOUT_MS = 600_000;
+
+type ProxyInstallSource = "env" | "config";
+type DispatcherState =
+  | { mode: "direct" }
+  | { mode: "proxy"; source: ProxyInstallSource; proxyUrl: string; noProxy: string };
+
 /**
  * Read the active proxy URL from environment variables.
  * Priority: PILOTDECK_PROXY > https_proxy > HTTPS_PROXY > http_proxy > HTTP_PROXY
@@ -27,21 +34,44 @@ export function getProxyUrl(env: EnvLike = process.env): string | undefined {
  * standard HTTPS_PROXY / HTTP_PROXY env vars — unlike curl or Python
  * requests. This function bridges that gap via `setGlobalDispatcher`.
  *
- * Safe to call multiple times; only the first effective call installs.
+ * Safe to call multiple times. Env-based proxy settings keep precedence over
+ * the first config-based proxy install during startup; hot reload paths should
+ * use {@link reinstallGlobalProxy}.
  * Use {@link reinstallGlobalProxy} when the proxy URL changes at runtime.
  * Returns the proxy URL that was activated, or undefined if none.
  */
-let installed = false;
+let dispatcherState: DispatcherState | undefined;
 let pendingInstall: Promise<string | undefined> | null = null;
 
-export async function installGlobalProxy(explicitUrl?: string): Promise<string | undefined> {
-  if (installed) return undefined;
+export async function installGlobalProxy(explicitUrl?: string, extraNoProxy?: string): Promise<string | undefined> {
   if (pendingInstall) return pendingInstall;
 
   const proxyUrl = explicitUrl ?? getProxyUrl();
-  if (!proxyUrl) return undefined;
+  if (!proxyUrl) {
+    pendingInstall = applyDirectDispatcher().finally(() => {
+      pendingInstall = null;
+    });
+    return pendingInstall;
+  }
 
-  pendingInstall = applyGlobalProxy(proxyUrl).finally(() => {
+  const source: ProxyInstallSource = explicitUrl ? "config" : "env";
+  if (
+    source === "config" &&
+    dispatcherState?.mode === "proxy" &&
+    dispatcherState.source === "env"
+  ) {
+    return undefined;
+  }
+
+  if (
+    dispatcherState?.mode === "proxy" &&
+    dispatcherState.source === source &&
+    dispatcherState.proxyUrl === proxyUrl
+  ) {
+    return undefined;
+  }
+
+  pendingInstall = applyGlobalProxy(proxyUrl, source, extraNoProxy).finally(() => {
     pendingInstall = null;
   });
   return pendingInstall;
@@ -50,8 +80,8 @@ export async function installGlobalProxy(explicitUrl?: string): Promise<string |
 /**
  * Unconditionally (re-)install the global proxy dispatcher.
  * Called by hot-reload paths when `proxy.*` config changes at runtime.
- * Passing `undefined` or empty string removes the proxy (resets to
- * a no-op agent so outbound requests go direct).
+ * Passing `undefined` or empty string removes the proxy but keeps the
+ * long-timeout undici transport agent for direct outbound requests.
  */
 export async function reinstallGlobalProxy(
   proxyUrl: string | undefined,
@@ -60,36 +90,45 @@ export async function reinstallGlobalProxy(
   if (pendingInstall) await pendingInstall;
 
   if (!proxyUrl) {
-    try {
-      const { Agent, setGlobalDispatcher } = await import("undici");
-      setGlobalDispatcher(new Agent());
-      installed = false;
-      console.log("[proxy] Global fetch proxy removed");
-    } catch {
-      // best effort
-    }
-    return undefined;
+    return applyDirectDispatcher(true);
   }
-  return applyGlobalProxy(proxyUrl, extraNoProxy);
+  return applyGlobalProxy(proxyUrl, "config", extraNoProxy);
+}
+
+export function getGlobalProxyStateForTesting(): DispatcherState | undefined {
+  return dispatcherState ? { ...dispatcherState } : undefined;
+}
+
+async function applyDirectDispatcher(logRemoval = false): Promise<string | undefined> {
+  try {
+    const { Agent, setGlobalDispatcher } = await import("undici");
+    setGlobalDispatcher(new Agent(createLongTimeoutOptions()));
+    dispatcherState = { mode: "direct" };
+    if (logRemoval) {
+      console.log("[proxy] Global fetch proxy removed");
+    }
+  } catch {
+    // best effort
+  }
+  return undefined;
 }
 
 async function applyGlobalProxy(
   proxyUrl: string,
+  source: ProxyInstallSource,
   extraNoProxy?: string,
 ): Promise<string | undefined> {
   try {
     const { EnvHttpProxyAgent, setGlobalDispatcher } = await import("undici");
-    const userNoProxy = process.env.no_proxy || process.env.NO_PROXY || "";
-    const noProxy = [userNoProxy, extraNoProxy, "127.0.0.1", "localhost"]
-      .filter(Boolean)
-      .join(",");
+    const noProxy = buildNoProxy(extraNoProxy);
     const agent = new EnvHttpProxyAgent({
       httpProxy: proxyUrl,
       httpsProxy: proxyUrl,
       noProxy,
+      ...createLongTimeoutOptions(),
     });
     setGlobalDispatcher(agent);
-    installed = true;
+    dispatcherState = { mode: "proxy", source, proxyUrl, noProxy };
     console.log(`[proxy] Global fetch proxy → ${proxyUrl} (noProxy: ${noProxy})`);
     return proxyUrl;
   } catch (error) {
@@ -99,4 +138,18 @@ async function applyGlobalProxy(
     );
     return undefined;
   }
+}
+
+function createLongTimeoutOptions(): { headersTimeout: number; bodyTimeout: number } {
+  return {
+    headersTimeout: UNDICI_TRANSPORT_TIMEOUT_MS,
+    bodyTimeout: UNDICI_TRANSPORT_TIMEOUT_MS,
+  };
+}
+
+function buildNoProxy(extraNoProxy?: string): string {
+  const userNoProxy = process.env.no_proxy || process.env.NO_PROXY || "";
+  return [userNoProxy, extraNoProxy, "127.0.0.1", "localhost"]
+    .filter(Boolean)
+    .join(",");
 }

--- a/src/model/streaming/streamModel.ts
+++ b/src/model/streaming/streamModel.ts
@@ -256,22 +256,6 @@ function delay(ms: number, signal?: AbortSignal): Promise<void> {
 }
 
 const DEFAULT_REQUEST_TIMEOUT_MS = 300_000; // 5 minutes
-const UNDICI_LONG_TIMEOUT_MS = 600_000; // 10 minutes — must exceed application-level timeout
-
-let longTimeoutDispatcher: unknown;
-async function getLongTimeoutDispatcher(): Promise<unknown> {
-  if (longTimeoutDispatcher) return longTimeoutDispatcher;
-  try {
-    const { Agent } = await import("undici");
-    longTimeoutDispatcher = new Agent({
-      headersTimeout: UNDICI_LONG_TIMEOUT_MS,
-      bodyTimeout: UNDICI_LONG_TIMEOUT_MS,
-    });
-    return longTimeoutDispatcher;
-  } catch {
-    return undefined;
-  }
-}
 
 async function sendProviderRequest(
   provider: ProviderConfig,
@@ -291,19 +275,14 @@ async function sendProviderRequest(
     ? { ...(body as Record<string, unknown>), ...provider.extraBody }
     : body;
 
-  const dispatcher = await getLongTimeoutDispatcher();
-
   try {
-    const fetchOptions: RequestInit & { dispatcher?: unknown } = {
+    const fetchOptions: RequestInit = {
       method: "POST",
       headers: buildHeaders(provider),
       body: JSON.stringify(finalBody),
       signal: controller.signal,
     };
-    if (dispatcher) {
-      fetchOptions.dispatcher = dispatcher;
-    }
-    return await transport(buildEndpoint(provider, stream), fetchOptions as RequestInit);
+    return await transport(buildEndpoint(provider, stream), fetchOptions);
   } catch (error) {
     if (signal?.aborted) {
       throw createAbortError(signal.reason);

--- a/ui/server/routes/update.js
+++ b/ui/server/routes/update.js
@@ -1,10 +1,11 @@
 import express from 'express';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { spawn, exec } from 'child_process';
+import { spawn, exec, execFile } from 'child_process';
 import { promisify } from 'util';
 
 const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -19,19 +20,114 @@ function execInProject(cmd) {
   return execAsync(cmd, { cwd: PROJECT_ROOT, maxBuffer: 10 * 1024 * 1024 });
 }
 
+function execGit(args) {
+  return execFileAsync('git', args, { cwd: PROJECT_ROOT, maxBuffer: 10 * 1024 * 1024 });
+}
+
+function parseUpstreamRef(value) {
+  const upstream = String(value || '').trim();
+  const slashIndex = upstream.indexOf('/');
+  if (slashIndex <= 0 || slashIndex >= upstream.length - 1) return null;
+  return {
+    remote: upstream.slice(0, slashIndex),
+    remoteBranch: upstream.slice(slashIndex + 1),
+    ref: upstream,
+  };
+}
+
+function unavailableUpdateCheck(res, {
+  currentBranch = 'unknown',
+  localHead = '',
+  currentCommit = '',
+  message,
+}) {
+  return res.json({
+    hasUpdate: false,
+    currentBranch,
+    localHead: localHead ? localHead.slice(0, 8) : 'unknown',
+    remoteHead: '',
+    behindCount: 0,
+    newCommits: [],
+    currentCommit,
+    checkUnavailable: true,
+    message,
+  });
+}
+
 /**
  * POST /api/update/check
  * Check if there are updates available (git fetch + compare HEAD)
  */
 router.post('/check', async (req, res) => {
   try {
-    const { stdout: branch } = await execInProject('git branch --show-current');
-    const currentBranch = branch.trim() || 'main';
+    let currentBranch = 'unknown';
+    let localHead = '';
+    let currentCommit = '';
 
-    await execInProject(`git fetch origin ${currentBranch}`);
+    try {
+      const { stdout: branch } = await execGit(['branch', '--show-current']);
+      currentBranch = branch.trim() || 'HEAD';
 
-    const { stdout: localHead } = await execInProject('git rev-parse HEAD');
-    const { stdout: remoteHead } = await execInProject(`git rev-parse origin/${currentBranch}`);
+      const { stdout: head } = await execGit(['rev-parse', 'HEAD']);
+      localHead = head.trim();
+
+      const { stdout: commit } = await execGit(['log', '--oneline', '-1', 'HEAD']);
+      currentCommit = commit.trim();
+    } catch (error) {
+      return unavailableUpdateCheck(res, {
+        currentBranch,
+        localHead,
+        currentCommit,
+        message: `Git version check unavailable: ${error.message}`,
+      });
+    }
+
+    let upstream = null;
+    try {
+      const { stdout } = await execGit([
+        'rev-parse',
+        '--abbrev-ref',
+        '--symbolic-full-name',
+        '@{u}',
+      ]);
+      upstream = parseUpstreamRef(stdout);
+    } catch {
+      upstream = null;
+    }
+
+    if (!upstream && currentBranch !== 'HEAD' && currentBranch !== 'unknown') {
+      upstream = {
+        remote: 'origin',
+        remoteBranch: currentBranch,
+        ref: `origin/${currentBranch}`,
+      };
+    }
+
+    if (!upstream) {
+      return unavailableUpdateCheck(res, {
+        currentBranch,
+        localHead,
+        currentCommit,
+        message: 'No upstream branch is configured for update checks.',
+      });
+    }
+
+    try {
+      await execGit([
+        'fetch',
+        upstream.remote,
+        `${upstream.remoteBranch}:refs/remotes/${upstream.remote}/${upstream.remoteBranch}`,
+      ]);
+    } catch (error) {
+      return unavailableUpdateCheck(res, {
+        currentBranch,
+        localHead,
+        currentCommit,
+        message: `Unable to fetch ${upstream.ref}: ${error.message}`,
+      });
+    }
+
+    const { stdout: remoteHead } = await execGit(['rev-parse', upstream.ref]);
 
     const local = localHead.trim();
     const remote = remoteHead.trim();
@@ -40,18 +136,21 @@ router.post('/check', async (req, res) => {
     let behindCount = 0;
     let newCommits = [];
     if (hasUpdate) {
-      const { stdout: countOut } = await execInProject(
-        `git rev-list --count HEAD..origin/${currentBranch}`,
-      );
+      const { stdout: countOut } = await execGit([
+        'rev-list',
+        '--count',
+        `HEAD..${upstream.ref}`,
+      ]);
       behindCount = parseInt(countOut.trim(), 10) || 0;
 
-      const { stdout: logOut } = await execInProject(
-        `git log --oneline HEAD..origin/${currentBranch} -10`,
-      );
+      const { stdout: logOut } = await execGit([
+        'log',
+        '--oneline',
+        `HEAD..${upstream.ref}`,
+        '-10',
+      ]);
       newCommits = logOut.trim().split('\n').filter(Boolean);
     }
-
-    const { stdout: currentCommit } = await execInProject('git log --oneline -1 HEAD');
 
     res.json({
       hasUpdate,
@@ -60,12 +159,12 @@ router.post('/check', async (req, res) => {
       remoteHead: remote.slice(0, 8),
       behindCount,
       newCommits,
-      currentCommit: currentCommit.trim(),
+      currentCommit,
+      upstream: upstream.ref,
     });
   } catch (error) {
-    res.status(500).json({
-      error: 'Failed to check for updates',
-      message: error.message,
+    return unavailableUpdateCheck(res, {
+      message: `Failed to check for updates: ${error.message}`,
     });
   }
 });

--- a/ui/server/utils/proxy.js
+++ b/ui/server/utils/proxy.js
@@ -13,7 +13,9 @@
  * Living in `ui/server/utils/` lets the express bridge run from
  * source without depending on `dist/src/cli/proxy.js`.
  */
-import { EnvHttpProxyAgent, setGlobalDispatcher } from 'undici';
+import { Agent, EnvHttpProxyAgent, setGlobalDispatcher } from 'undici';
+
+export const UNDICI_TRANSPORT_TIMEOUT_MS = 600_000;
 
 function getProxyUrl(env = process.env) {
     return (
@@ -25,32 +27,77 @@ function getProxyUrl(env = process.env) {
     );
 }
 
-let installed = false;
+let dispatcherState;
 
 /**
- * Install a global undici EnvHttpProxyAgent. Safe to call multiple
- * times — only the first effective call wins. Returns the proxy URL
- * that was activated, or undefined if no proxy is configured.
+ * Install a global undici dispatcher. Env proxy settings keep precedence over
+ * the first config-based proxy install during startup.
  *
  * @param {string} [explicitUrl] Override the env-driven proxy URL.
  * @returns {string | undefined} The activated proxy URL.
  */
-export function installGlobalProxy(explicitUrl) {
-    if (installed) return undefined;
+export function installGlobalProxy(explicitUrl, extraNoProxy) {
     const proxyUrl = explicitUrl ?? getProxyUrl();
-    if (!proxyUrl) return undefined;
+    if (!proxyUrl) {
+        applyDirectDispatcher();
+        return undefined;
+    }
+
+    const source = explicitUrl ? 'config' : 'env';
+    if (
+        source === 'config'
+        && dispatcherState?.mode === 'proxy'
+        && dispatcherState.source === 'env'
+    ) {
+        return undefined;
+    }
+
+    if (
+        dispatcherState?.mode === 'proxy'
+        && dispatcherState.source === source
+        && dispatcherState.proxyUrl === proxyUrl
+    ) {
+        return undefined;
+    }
+
+    return applyGlobalProxy(proxyUrl, source, extraNoProxy);
+}
+
+export function getGlobalProxyStateForTesting() {
+    return dispatcherState ? { ...dispatcherState } : undefined;
+}
+
+export function reinstallGlobalProxy(proxyUrl, extraNoProxy) {
+    if (!proxyUrl) {
+        applyDirectDispatcher(true);
+        return undefined;
+    }
+    return applyGlobalProxy(proxyUrl, 'config', extraNoProxy);
+}
+
+function applyDirectDispatcher(logRemoval = false) {
     try {
-        const userNoProxy = process.env.no_proxy || process.env.NO_PROXY || '';
-        const noProxy = [userNoProxy, '127.0.0.1', 'localhost']
-            .filter(Boolean)
-            .join(',');
+        setGlobalDispatcher(new Agent(createLongTimeoutOptions()));
+        dispatcherState = { mode: 'direct' };
+        if (logRemoval) {
+            console.log('[proxy] Global fetch proxy removed');
+        }
+    } catch {
+        // best effort
+    }
+}
+
+function applyGlobalProxy(proxyUrl, source, extraNoProxy) {
+    try {
+        const noProxy = buildNoProxy(extraNoProxy);
         const agent = new EnvHttpProxyAgent({
             httpProxy: proxyUrl,
             httpsProxy: proxyUrl,
             noProxy,
+            ...createLongTimeoutOptions(),
         });
         setGlobalDispatcher(agent);
-        installed = true;
+        dispatcherState = { mode: 'proxy', source, proxyUrl, noProxy };
         console.log(`[proxy] Global fetch proxy → ${proxyUrl} (noProxy: ${noProxy})`);
         return proxyUrl;
     } catch (error) {
@@ -60,4 +107,18 @@ export function installGlobalProxy(explicitUrl) {
         );
         return undefined;
     }
+}
+
+function createLongTimeoutOptions() {
+    return {
+        headersTimeout: UNDICI_TRANSPORT_TIMEOUT_MS,
+        bodyTimeout: UNDICI_TRANSPORT_TIMEOUT_MS,
+    };
+}
+
+function buildNoProxy(extraNoProxy) {
+    const userNoProxy = process.env.no_proxy || process.env.NO_PROXY || '';
+    return [userNoProxy, extraNoProxy, '127.0.0.1', 'localhost']
+        .filter(Boolean)
+        .join(',');
 }


### PR DESCRIPTION
## Summary
- Preserve configured proxy dispatching while extending undici transport timeouts.
- Remove per-request model dispatcher so native fetch uses the global dispatcher.
- Make update checks tolerate fork/local branch upstreams without surfacing startup 500 toasts.

## Test Plan
- npm run build
- npm test

Note: test files are intentionally not included in this PR.