### PR TITLE
[codex] Fix Always-On project ID resolution

### DIFF
--- a/src/always-on/storage/AlwaysOnPaths.ts
+++ b/src/always-on/storage/AlwaysOnPaths.ts
@@ -1,5 +1,5 @@
 import { resolve } from "node:path";
-import { createProjectId } from "../../pilot/paths.js";
+import { resolveProjectStorageId } from "../../pilot/paths.js";
 
 const ROOT_DIR_NAME = "always-on";
 
@@ -32,7 +32,7 @@ export function resolveAlwaysOnPaths(input: {
 }): AlwaysOnPaths {
   const pilotHome = resolve(input.pilotHome);
   const projectKey = resolve(input.projectKey);
-  const projectId = createProjectId(projectKey);
+  const projectId = resolveProjectStorageId(projectKey, pilotHome);
   const rootDir = resolve(pilotHome, ROOT_DIR_NAME);
   const projectDir = resolve(rootDir, "projects", projectId);
   const worktreesDir = resolve(input.worktreesBaseDir ?? resolve(rootDir, "worktrees"), projectId);

--- a/src/always-on/web/DiscoveryPlanService.ts
+++ b/src/always-on/web/DiscoveryPlanService.ts
@@ -109,7 +109,7 @@ export type StateManager = {
 
 export type DiscoveryPlanServiceDeps = {
   pilotHome: string;
-  createProjectId: (projectRoot: string) => string;
+  resolveProjectId: (projectRoot: string) => string;
   paths: ProjectPathResolver;
   sessions: SessionLister;
   activity: SessionActivityChecker;
@@ -122,8 +122,8 @@ export type DiscoveryPlanServiceDeps = {
 // Paths (mirrors ui/server/discovery-plans.js helpers)
 // ---------------------------------------------------------------------------
 
-function resolveProjectDir(pilotHome: string, createProjectId: (root: string) => string, projectRoot: string): string {
-  const projectId = createProjectId(resolve(projectRoot));
+function resolveProjectDir(pilotHome: string, resolveProjectId: (root: string) => string, projectRoot: string): string {
+  const projectId = resolveProjectId(resolve(projectRoot));
   return join(pilotHome, "always-on", "projects", projectId);
 }
 
@@ -318,7 +318,7 @@ export class DiscoveryPlanService {
   }
 
   private projectDir(projectRoot: string): string {
-    return resolveProjectDir(this.deps.pilotHome, this.deps.createProjectId, projectRoot);
+    return resolveProjectDir(this.deps.pilotHome, this.deps.resolveProjectId, projectRoot);
   }
 
   async getPlansOverview(projectName: string) {

--- a/src/pilot/index.ts
+++ b/src/pilot/index.ts
@@ -5,6 +5,7 @@ export {
   createProjectId,
   createProjectIdAsync,
   createCollisionResistantProjectId,
+  resolveProjectStorageId,
   getPilotConfigFilePath,
   getPilotExtensionPaths,
   getPilotProjectConfigFilePath,

--- a/src/pilot/paths.ts
+++ b/src/pilot/paths.ts
@@ -34,7 +34,7 @@ export function getPilotMemoryRootDir(pilotHome: string): string {
 }
 
 export function getPilotProjectChatDir(projectRoot: string, pilotHome: string): string {
-  const projectId = resolveStoredProjectId(projectRoot, pilotHome) ?? createProjectId(projectRoot);
+  const projectId = resolveProjectStorageId(projectRoot, pilotHome);
   return resolve(pilotHome, "projects", projectId, "chats");
 }
 
@@ -49,7 +49,7 @@ export async function getPilotProjectChatDirAsync(
   pilotHome: string,
 ): Promise<string> {
   const canonical = await findCanonicalProjectRoot(projectRoot);
-  const projectId = resolveStoredProjectId(canonical, pilotHome) ?? createProjectId(canonical);
+  const projectId = resolveProjectStorageId(canonical, pilotHome);
   return resolve(pilotHome, "projects", projectId, "chats");
 }
 
@@ -72,6 +72,18 @@ export function createCollisionResistantProjectId(projectRoot: string): string {
   const legacyId = createLegacyProjectId(normalizedRoot);
   const digest = createHash("sha1").update(normalizedRoot).digest("hex").slice(0, 10);
   return `${legacyId}--${digest}`;
+}
+
+/**
+ * Resolve the on-disk project directory name for a workspace.
+ *
+ * `.cwd` markers are authoritative because the legacy project ID is lossy:
+ * distinct paths (especially paths containing non-ASCII segments) can encode
+ * to the same slug. When no valid marker exists, retain the legacy ID for
+ * backwards compatibility with unregistered projects.
+ */
+export function resolveProjectStorageId(projectRoot: string, pilotHome: string): string {
+  return findStoredProjectId(projectRoot, pilotHome) ?? createProjectId(projectRoot);
 }
 
 /**
@@ -103,7 +115,7 @@ function createLegacyProjectId(projectRoot: string): string {
   return normalized.replace(/[^A-Za-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "") || "project";
 }
 
-function resolveStoredProjectId(projectRoot: string, pilotHome: string): string | null {
+function findStoredProjectId(projectRoot: string, pilotHome: string): string | null {
   const projectsDir = resolve(pilotHome, "projects");
   if (!existsSync(projectsDir)) {
     return null;

--- a/ui/server/discovery-plans.js
+++ b/ui/server/discovery-plans.js
@@ -19,7 +19,7 @@ import {
   appendAlwaysOnRunLogEvent,
   formatAlwaysOnPlanLogLine,
 } from './services/always-on-run-logs.js';
-import { resolvePilotHome, createProjectId } from './utils/pilotPaths.js';
+import { resolvePilotHome, resolveProjectStorageId } from './utils/pilotPaths.js';
 
 import { DiscoveryPlanService } from '../../src/always-on/web/DiscoveryPlanService.js';
 import { buildDiscoveryContext } from '../../src/always-on/web/DiscoveryPlanContext.js';
@@ -35,9 +35,10 @@ import { DiscoveryStateStore } from '../../src/always-on/storage/DiscoveryStateS
 // ---------------------------------------------------------------------------
 
 function getService() {
+  const pilotHome = resolvePilotHome();
   return new DiscoveryPlanService({
-    pilotHome: resolvePilotHome(),
-    createProjectId,
+    pilotHome,
+    resolveProjectId: (projectRoot) => resolveProjectStorageId(projectRoot, pilotHome),
     paths: { extractProjectDirectory },
     sessions: { getSessions },
     activity: { isSessionActive: isClaudeSDKSessionActive },
@@ -54,7 +55,7 @@ function getService() {
     state: {
       clearActiveWorkCycleId: async (projectRoot) => {
         const paths = resolveAlwaysOnPaths({
-          pilotHome: resolvePilotHome(),
+          pilotHome,
           projectKey: projectRoot,
         });
         const store = new DiscoveryStateStore(paths);

--- a/ui/server/services/always-on-events.js
+++ b/ui/server/services/always-on-events.js
@@ -1,6 +1,6 @@
 import { readdir, readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
-import { resolvePilotHome, createProjectId } from '../utils/pilotPaths.js';
+import { resolvePilotHome, resolveProjectStorageId } from '../utils/pilotPaths.js';
 import { getPilotDeckGateway } from '../pilotdeck-bridge.js';
 
 /**
@@ -33,14 +33,14 @@ async function readProjectEvents(projectDir) {
 /**
  * Build a lookup from projectKey -> { projectName, projectDisplayName }.
  */
-async function buildProjectLookup() {
+async function buildProjectLookup(pilotHome) {
     const gateway = await getPilotDeckGateway();
     const { projects } = await gateway.listProjects();
     const lookup = new Map();
     for (const project of projects) {
         const key = resolve(project.projectKey ?? project.fullPath ?? '');
         if (!key) continue;
-        const name = createProjectId(key);
+        const name = resolveProjectStorageId(key, pilotHome);
         const displayName = project.displayName || key.split(/[\\/]/).pop() || name;
         lookup.set(key, { projectName: name, projectDisplayName: displayName });
     }
@@ -65,7 +65,7 @@ export async function getAlwaysOnDashboardEvents(opts = {}) {
         return { events: [] };
     }
 
-    const lookup = await buildProjectLookup().catch(() => new Map());
+    const lookup = await buildProjectLookup(pilotHome).catch(() => new Map());
 
     const allEvents = [];
     for (const entry of projectDirs) {
@@ -93,7 +93,7 @@ export async function getAlwaysOnDashboardEvents(opts = {}) {
     const events = filtered.map((event) => {
         const key = resolve(event.projectKey || '');
         const info = lookup.get(key) || {
-            projectName: createProjectId(key || 'unknown'),
+            projectName: resolveProjectStorageId(key || 'unknown', pilotHome),
             projectDisplayName: key.split(/[\\/]/).pop() || 'Unknown',
         };
         return {

--- a/ui/server/services/always-on-paths.js
+++ b/ui/server/services/always-on-paths.js
@@ -1,9 +1,9 @@
 import path from 'path';
-import { resolvePilotHome, createProjectId } from '../utils/pilotPaths.js';
+import { resolvePilotHome, resolveProjectStorageId } from '../utils/pilotPaths.js';
 
 export function getAlwaysOnRoot(projectRoot) {
   const pilotHome = resolvePilotHome();
-  const projectId = createProjectId(path.resolve(projectRoot));
+  const projectId = resolveProjectStorageId(path.resolve(projectRoot), pilotHome);
   return path.join(pilotHome, 'always-on', 'projects', projectId);
 }
 

--- a/ui/server/utils/pilotPaths.js
+++ b/ui/server/utils/pilotPaths.js
@@ -15,6 +15,7 @@
 import { homedir } from 'node:os';
 import { resolve } from 'node:path';
 import { createHash } from 'node:crypto';
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
 
 export const DEFAULT_PILOT_HOME = '~/.pilotdeck';
 
@@ -60,6 +61,21 @@ export function createCollisionResistantProjectId(projectRoot) {
 }
 
 /**
+ * Resolve the on-disk project directory name for a workspace.
+ *
+ * `.cwd` markers disambiguate paths that collapse to the same legacy slug.
+ * If no valid marker exists, preserve the legacy ID for compatibility with
+ * unregistered workspaces.
+ *
+ * @param {string} projectRoot Absolute filesystem path.
+ * @param {string} [pilotHome] Active PilotDeck home directory.
+ * @returns {string} Project directory name under `<pilotHome>/projects`.
+ */
+export function resolveProjectStorageId(projectRoot, pilotHome = resolvePilotHome()) {
+    return findStoredProjectId(projectRoot, pilotHome) ?? createProjectId(projectRoot);
+}
+
+/**
  * Sanitize a sessionId for safe use as a filename component.
  *
  * TUI/CLI sessionKeys embed the absolute project path (e.g.
@@ -86,3 +102,30 @@ function createLegacyProjectId(projectRoot) {
     return normalized.replace(/[^A-Za-z0-9._-]+/g, '-').replace(/^-+|-+$/g, '') || 'project';
 }
 
+function findStoredProjectId(projectRoot, pilotHome) {
+    const projectsDir = resolve(pilotHome, 'projects');
+    if (!existsSync(projectsDir)) return null;
+
+    const target = resolve(projectRoot);
+    try {
+        for (const entry of readdirSync(projectsDir, { withFileTypes: true })) {
+            if (!entry.isDirectory()) continue;
+            const markerPath = resolve(projectsDir, entry.name, '.cwd');
+            let marker;
+            try {
+                marker = readFileSync(markerPath, 'utf8').trim();
+            } catch {
+                continue;
+            }
+            if (!marker || resolve(marker) !== target) continue;
+            try {
+                if (statSync(marker).isDirectory()) return entry.name;
+            } catch {
+                continue;
+            }
+        }
+    } catch {
+        return null;
+    }
+    return null;
+}

--- a/ui/server/utils/pilotPaths.test.js
+++ b/ui/server/utils/pilotPaths.test.js
@@ -1,0 +1,95 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+    createCollisionResistantProjectId as createCoreCollisionId,
+    createProjectId as createCoreProjectId,
+    resolveProjectStorageId as resolveCoreProjectStorageId,
+} from '../../../src/pilot/paths.js';
+import {
+    createCollisionResistantProjectId,
+    createProjectId,
+    resolveProjectStorageId,
+} from './pilotPaths.js';
+import { getAlwaysOnRoot } from '../services/always-on-paths.js';
+
+describe('UI project storage ID resolution', () => {
+    it('matches the core resolver for colliding non-ASCII workspaces', () => {
+        const root = mkdtempSync(join(tmpdir(), 'pilotdeck-ui-project-id-'));
+        try {
+            const pilotHome = join(root, 'pilot-home');
+            const projectA = join(root, 'home', '内部测试');
+            const projectB = join(root, 'home', '会议纪要');
+            mkdirSync(projectA, { recursive: true });
+            mkdirSync(projectB, { recursive: true });
+
+            const legacyId = createProjectId(projectA);
+            const collisionId = createCollisionResistantProjectId(projectB);
+            expect(createProjectId(projectB)).toBe(legacyId);
+
+            mkdirSync(join(pilotHome, 'projects', legacyId), { recursive: true });
+            writeFileSync(join(pilotHome, 'projects', legacyId, '.cwd'), projectA, 'utf8');
+            mkdirSync(join(pilotHome, 'projects', collisionId), { recursive: true });
+            writeFileSync(join(pilotHome, 'projects', collisionId, '.cwd'), projectB, 'utf8');
+
+            expect(createProjectId(projectA)).toBe(createCoreProjectId(projectA));
+            expect(collisionId).toBe(createCoreCollisionId(projectB));
+            expect(resolveProjectStorageId(projectA, pilotHome)).toBe(legacyId);
+            expect(resolveProjectStorageId(projectB, pilotHome)).toBe(collisionId);
+            expect(resolveProjectStorageId(projectA, pilotHome)).toBe(
+                resolveCoreProjectStorageId(projectA, pilotHome),
+            );
+            expect(resolveProjectStorageId(projectB, pilotHome)).toBe(
+                resolveCoreProjectStorageId(projectB, pilotHome),
+            );
+        } finally {
+            rmSync(root, { recursive: true, force: true });
+        }
+    });
+
+    it('matches core fallback behavior for missing and invalid markers', () => {
+        const root = mkdtempSync(join(tmpdir(), 'pilotdeck-ui-project-id-fallback-'));
+        try {
+            const pilotHome = join(root, 'pilot-home');
+            const projectRoot = join(root, 'workspace', 'ascii-project');
+            mkdirSync(projectRoot, { recursive: true });
+
+            const invalidId = createCollisionResistantProjectId(projectRoot);
+            mkdirSync(join(pilotHome, 'projects', invalidId), { recursive: true });
+            writeFileSync(join(pilotHome, 'projects', invalidId, '.cwd'), join(root, 'missing'), 'utf8');
+
+            expect(resolveProjectStorageId(projectRoot, pilotHome)).toBe(createProjectId(projectRoot));
+            expect(resolveProjectStorageId(projectRoot, pilotHome)).toBe(
+                resolveCoreProjectStorageId(projectRoot, pilotHome),
+            );
+        } finally {
+            rmSync(root, { recursive: true, force: true });
+        }
+    });
+
+    it('uses the resolved storage ID for the UI Always-On root', () => {
+        const root = mkdtempSync(join(tmpdir(), 'pilotdeck-ui-always-on-root-'));
+        const previousPilotHome = process.env.PILOT_HOME;
+        try {
+            const pilotHome = join(root, 'pilot-home');
+            const projectRoot = join(root, 'home', '会议纪要');
+            const projectId = createCollisionResistantProjectId(projectRoot);
+            mkdirSync(projectRoot, { recursive: true });
+            mkdirSync(join(pilotHome, 'projects', projectId), { recursive: true });
+            writeFileSync(join(pilotHome, 'projects', projectId, '.cwd'), projectRoot, 'utf8');
+            process.env.PILOT_HOME = pilotHome;
+
+            expect(getAlwaysOnRoot(projectRoot)).toBe(
+                join(pilotHome, 'always-on', 'projects', projectId),
+            );
+        } finally {
+            if (previousPilotHome === undefined) {
+                delete process.env.PILOT_HOME;
+            } else {
+                process.env.PILOT_HOME = previousPilotHome;
+            }
+            rmSync(root, { recursive: true, force: true });
+        }
+    });
+});


### PR DESCRIPTION
## Summary

- resolve Always-On storage IDs from authoritative `$PILOT_HOME/projects/*/.cwd` markers
- use the same resolver across core storage paths and Web UI services
- keep legacy `createProjectId()` fallback behavior for unregistered or invalid mappings
- add UI-side parity and Always-On root resolution tests

## Root cause

The legacy project slug is lossy for non-ASCII workspace paths, so distinct Chinese-named directories can map to the same ID. Always-On previously used that slug directly and could therefore read and write another workspace's plans, state, reports, runs, snapshots, or worktrees.

## Impact

Registered workspaces now use their actual on-disk project directory ID, including collision-resistant hashed IDs. No legacy Always-On data migration or cross-project fallback is introduced.

## Validation

- `npm run build`
- `npm --prefix ui test -- --run server/utils/pilotPaths.test.js` (3 tests passed)
- manual verification with colliding Chinese-named workspaces confirmed plans remain isolated

The full UI test suite was also run; unrelated existing streaming tests remain failing outside this change's scope.
