### PR TITLE
[codex] fix Cron unattended execution, timezone, and project stores

### DIFF
--- a/scripts/bootstrap-pilotdeck-config.mjs
+++ b/scripts/bootstrap-pilotdeck-config.mjs
@@ -106,6 +106,7 @@ cron:
   enabled: true
   timezone: Asia/Shanghai
   maxConcurrentRuns: 2
+  runTimeoutMinutes: 60
 `;
 
 function resolvePilotHome() {
@@ -201,6 +202,7 @@ cron:
   enabled: true
   timezone: Asia/Shanghai
   maxConcurrentRuns: 2
+  runTimeoutMinutes: 60
 `;
 
 const PATCH_SECTIONS = [

--- a/src/always-on/index.ts
+++ b/src/always-on/index.ts
@@ -78,7 +78,11 @@ export {
   type ExecutionRunContext,
   type ReportRunContext,
 } from "./runtime/AlwaysOnRunContextRegistry.js";
-export { SessionConfigOverrides, type SessionConfigOverride } from "./runtime/SessionConfigOverrides.js";
+export {
+  SessionConfigOverrides,
+  UNATTENDED_SESSION_EXCLUDED_TOOLS,
+  type SessionConfigOverride,
+} from "./runtime/SessionConfigOverrides.js";
 export {
   DiscoveryFire,
   acquireDiscoveryLock,

--- a/src/always-on/runtime/AlwaysOnManager.ts
+++ b/src/always-on/runtime/AlwaysOnManager.ts
@@ -18,6 +18,7 @@ import type { TelemetryClient } from "../../telemetry/index.js";
 export type CreateAlwaysOnManagerOptions = {
   config: AlwaysOnConfig;
   pilotHome: string;
+  sessionOverrides?: SessionConfigOverrides;
   now?: () => Date;
   uuid?: () => string;
   logger?: AlwaysOnRuntimeLogger;
@@ -39,13 +40,14 @@ export type CreateAlwaysOnManagerOptions = {
 export class AlwaysOnManager {
   private readonly runtimes: AlwaysOnRuntime[] = [];
   private readonly runContexts = new AlwaysOnRunContextRegistry();
-  private readonly sessionOverrides = new SessionConfigOverrides();
+  private readonly sessionOverrides: SessionConfigOverrides;
   private readonly tools: PilotDeckToolDefinition[];
   private readonly logger: AlwaysOnRuntimeLogger;
 
   constructor(private readonly options: CreateAlwaysOnManagerOptions) {
     const now = options.now ?? (() => new Date());
     const uuid = options.uuid;
+    this.sessionOverrides = options.sessionOverrides ?? new SessionConfigOverrides();
     this.logger = options.logger ?? { info: () => undefined, warn: () => undefined };
 
     this.tools = [

--- a/src/always-on/runtime/AlwaysOnRuntime.ts
+++ b/src/always-on/runtime/AlwaysOnRuntime.ts
@@ -243,7 +243,7 @@ export class AlwaysOnRuntime {
     this.scheduler = undefined;
     this.fire = undefined;
     this.runContexts.list().forEach((ctx) => this.runContexts.unregister(ctx.sessionKey));
-    this.sessionOverrides.clear();
+    this.sessionOverrides.deletePrefix("always-on/");
     this.logger.info("always-on runtime stopped", { projectKey: this.projectKey });
   }
 

--- a/src/always-on/runtime/DiscoveryFire.ts
+++ b/src/always-on/runtime/DiscoveryFire.ts
@@ -27,7 +27,10 @@ import type { WorkspaceProviderRegistry } from "../workspace/WorkspaceProviderRe
 import type { AlwaysOnRunContextRegistry, ExecutionRunContext, DiscoveryRunContext, WorkspaceRunContext, ReportRunContext } from "./AlwaysOnRunContextRegistry.js";
 import { generateWorkspaceDiff } from "../workspace/WorkspaceApply.js";
 import { buildDiscoveryPrompt, buildExecutionPrompt, buildWorkspacePrompt, buildReportPrompt, buildApplyPrompt } from "./discoveryPrompts.js";
-import type { SessionConfigOverrides } from "./SessionConfigOverrides.js";
+import {
+  UNATTENDED_SESSION_EXCLUDED_TOOLS,
+  type SessionConfigOverrides,
+} from "./SessionConfigOverrides.js";
 import type { PermissionRule } from "../../permission/index.js";
 import type { TelemetryClient } from "../../telemetry/index.js";
 
@@ -62,16 +65,6 @@ const WORKSPACE_CHANNEL: GatewayChannelKey = "always-on/workspace";
 const EXECUTION_CHANNEL: GatewayChannelKey = "always-on/execute";
 const REPORT_CHANNEL: GatewayChannelKey = "always-on/report";
 const APPLY_CHANNEL: GatewayChannelKey = "always-on/apply";
-
-/**
- * Tools that require user interaction or could block an unattended session.
- * Excluded from all Always-On agent loops via SessionConfigOverride.excludeTools.
- */
-const ALWAYS_ON_EXCLUDED_TOOLS = [
-  "enter_plan_mode",
-  "exit_plan_mode",
-  "ask_user_question",
-];
 
 /**
  * Deny rules injected into the execution phase session. These override
@@ -269,7 +262,7 @@ export class DiscoveryFire {
       permissionMode: "bypassPermissions",
       bypassAvailable: true,
       canPrompt: false,
-      excludeTools: ALWAYS_ON_EXCLUDED_TOOLS,
+      excludeTools: [...UNATTENDED_SESSION_EXCLUDED_TOOLS],
     });
 
     try {
@@ -387,7 +380,7 @@ export class DiscoveryFire {
       permissionMode: "bypassPermissions",
       bypassAvailable: true,
       canPrompt: false,
-      excludeTools: ALWAYS_ON_EXCLUDED_TOOLS,
+      excludeTools: [...UNATTENDED_SESSION_EXCLUDED_TOOLS],
       permissionRules: { deny: ALWAYS_ON_EXECUTION_DENY_RULES },
     });
 
@@ -443,7 +436,7 @@ export class DiscoveryFire {
     // Phase 4: Report
     this.emitEvent(runId, "report_started", { planId, title: planRecord.title });
     const reportSessionKey = DiscoveryFire.deriveReportSessionKey(this.deps.projectKey, runId);
-    this.deps.sessionOverrides.set(reportSessionKey, { cwd: workspace.cwd, permissionMode: "bypassPermissions", bypassAvailable: true, canPrompt: false, excludeTools: ALWAYS_ON_EXCLUDED_TOOLS });
+    this.deps.sessionOverrides.set(reportSessionKey, { cwd: workspace.cwd, permissionMode: "bypassPermissions", bypassAvailable: true, canPrompt: false, excludeTools: [...UNATTENDED_SESSION_EXCLUDED_TOOLS] });
 
     const reportCtx: ReportRunContext = {
       kind: "report",
@@ -558,7 +551,7 @@ export class DiscoveryFire {
       permissionMode: "bypassPermissions",
       bypassAvailable: true,
       canPrompt: false,
-      excludeTools: ALWAYS_ON_EXCLUDED_TOOLS,
+      excludeTools: [...UNATTENDED_SESSION_EXCLUDED_TOOLS],
     });
 
     const chatDigest = await buildChatDigest({
@@ -703,7 +696,7 @@ export class DiscoveryFire {
       permissionMode: "bypassPermissions",
       bypassAvailable: true,
       canPrompt: false,
-      excludeTools: ALWAYS_ON_EXCLUDED_TOOLS,
+      excludeTools: [...UNATTENDED_SESSION_EXCLUDED_TOOLS],
       permissionRules: {
         deny: ALWAYS_ON_EXECUTION_DENY_RULES,
       },
@@ -805,7 +798,7 @@ export class DiscoveryFire {
       permissionMode: "bypassPermissions",
       bypassAvailable: true,
       canPrompt: false,
-      excludeTools: ALWAYS_ON_EXCLUDED_TOOLS,
+      excludeTools: [...UNATTENDED_SESSION_EXCLUDED_TOOLS],
     });
 
     const reportCtx: ReportRunContext = {
@@ -981,7 +974,7 @@ export class DiscoveryFire {
       permissionMode: "bypassPermissions",
       bypassAvailable: true,
       canPrompt: false,
-      excludeTools: ALWAYS_ON_EXCLUDED_TOOLS,
+      excludeTools: [...UNATTENDED_SESSION_EXCLUDED_TOOLS],
     });
 
     try {

--- a/src/always-on/runtime/SessionConfigOverrides.ts
+++ b/src/always-on/runtime/SessionConfigOverrides.ts
@@ -1,5 +1,15 @@
 import type { PermissionMode, PermissionRule } from "../../permission/index.js";
 
+/**
+ * Tools that require a live user response and therefore cannot be exposed
+ * to unattended agent sessions such as Always-On and Cron.
+ */
+export const UNATTENDED_SESSION_EXCLUDED_TOOLS = [
+  "enter_plan_mode",
+  "exit_plan_mode",
+  "ask_user_question",
+] as const;
+
 export type SessionConfigOverride = {
   cwd?: string;
   permissionMode?: PermissionMode;
@@ -19,18 +29,17 @@ export type SessionConfigOverride = {
   };
   /**
    * Tool names to exclude from the session's tool registry. Used by
-   * Always-On phases to remove interactive/blocking tools (plan mode,
-   * ask_user_question) that cannot function without a human respondent.
+   * unattended runtimes to remove interactive/blocking tools that cannot
+   * function without a human respondent.
    */
   excludeTools?: string[];
 };
 
 /**
- * Keyed by `sessionKey`, this registry lets the AlwaysOnRuntime override the
- * `cwd` / `permissionMode` of the AgentSession created by
- * `ProjectRuntimeRegistry`. The runtime sets an entry before submitting the
- * execution turn (so its cwd points at the workspace handle and its mode is
- * `bypassPermissions`) and removes it after the turn completes.
+ * Keyed by `sessionKey`, this registry lets unattended runtimes override the
+ * `cwd`, permission mode, and tool set of AgentSessions created by
+ * `ProjectRuntimeRegistry`. Entries must be installed before the first turn
+ * creates the session.
  *
  * The registry is intentionally minimal — it does not own AgentSessions, only
  * the per-session inputs that the factory needs at creation time.
@@ -49,6 +58,14 @@ export class SessionConfigOverrides {
 
   delete(sessionKey: string): void {
     this.map.delete(sessionKey);
+  }
+
+  deletePrefix(prefix: string): void {
+    for (const sessionKey of this.map.keys()) {
+      if (sessionKey.startsWith(prefix)) {
+        this.map.delete(sessionKey);
+      }
+    }
   }
 
   clear(): void {

--- a/src/cli/createLocalGateway.ts
+++ b/src/cli/createLocalGateway.ts
@@ -135,7 +135,7 @@ export type CreateLocalGatewayResult = {
   /**
    * Replace subsystem-owned tools, session overrides, and cron controller.
    * Called by the server command after tearing down and rebuilding
-   * AlwaysOnManager / CronRuntime in response to a config change.
+   * AlwaysOnManager / CronManager in response to a config change.
    */
   updateSubsystems: (update: SubsystemUpdate) => void;
 };
@@ -807,7 +807,7 @@ class ProjectRuntimeRegistry {
       );
     }
 
-    // -- excludeTools filtering (Always-On headless sessions) -----------
+    // -- excludeTools filtering (unattended sessions) -------------------
     const override = this._sessionOverrides?.get(context.sessionKey);
     if (override?.excludeTools && override.excludeTools.length > 0) {
       if (sessionTools === runtime.tools) {
@@ -821,8 +821,7 @@ class ProjectRuntimeRegistry {
     // -- Strip always_on_* tools from non-Always-On sessions -------------
     // These tools require an AlwaysOnRunContext to execute; surfacing them
     // in regular user sessions just pollutes the model's tool list.
-    const isAlwaysOnSession = override?.permissionMode === "bypassPermissions"
-      && override?.canPrompt === false;
+    const isAlwaysOnSession = context.sessionKey.startsWith("always-on/");
     if (!isAlwaysOnSession) {
       const alwaysOnNames = this._extraTools
         .filter((t) => t.name.startsWith("always_on_"))

--- a/src/cli/pilotdeck.ts
+++ b/src/cli/pilotdeck.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { resolve } from "node:path";
 import { createAlwaysOnManager, createApplyHandler, SessionConfigOverrides, type AlwaysOnManager, type AlwaysOnConfig } from "../always-on/index.js";
-import { createCronRuntime, type CronRuntime, type CronConfig } from "../cron/index.js";
+import { createCronManager, type CronManager, type CronConfig } from "../cron/index.js";
 import { connectRemoteGatewayIfAvailable, type Gateway, type GatewayEvent, type GatewaySubmitTurnInput } from "../gateway/index.js";
 import { CliChannel, TuiChannel, FeishuChannel, WeixinChannel, QQChannel, loadEnabledChannels } from "../adapters/index.js";
 import {
@@ -38,8 +38,9 @@ async function main(argv = process.argv.slice(2)): Promise<void> {
     }
 
     let alwaysOn: AlwaysOnManager | undefined;
-    let cron: CronRuntime | undefined;
+    let cron: CronManager | undefined;
     let deferredBroadcast: ((name: string, payload?: unknown) => void) | undefined;
+    const sessionOverrides = new SessionConfigOverrides();
 
     const alwaysOnLogger = {
       info: (message: string, data?: Record<string, unknown>) =>
@@ -59,6 +60,7 @@ async function main(argv = process.argv.slice(2)): Promise<void> {
       return createAlwaysOnManager({
         config,
         pilotHome,
+        sessionOverrides,
         logger: alwaysOnLogger,
         telemetry,
         onWorktreeCreated: (runId, cwd) => {
@@ -73,12 +75,12 @@ async function main(argv = process.argv.slice(2)): Promise<void> {
       });
     }
 
-    function buildCron(config: CronConfig | undefined): CronRuntime | undefined {
+    function buildCron(config: CronConfig | undefined): CronManager | undefined {
       if (!config) return undefined;
-      return createCronRuntime({
+      return createCronManager({
         config,
         pilotHome,
-        projectKey: projectRoot,
+        sessionOverrides,
         logger: cronLogger,
         telemetry,
       });
@@ -96,7 +98,7 @@ async function main(argv = process.argv.slice(2)): Promise<void> {
       env,
       skipDefaultProject: !!env.PILOTDECK_SKIP_DEFAULT_PROJECT,
       extraTools: [...(alwaysOn?.getTools() ?? []), ...(cron?.getTools() ?? [])],
-      sessionOverrides: alwaysOn?.getSessionOverrides(),
+      sessionOverrides,
       cron,
       telemetry,
     });
@@ -104,7 +106,7 @@ async function main(argv = process.argv.slice(2)): Promise<void> {
     const standaloneApply = createApplyHandler({
       gateway,
       pilotHome,
-      sessionOverrides: alwaysOn?.getSessionOverrides() ?? new SessionConfigOverrides(),
+      sessionOverrides,
       alwaysOnConfig: snapshot.config.alwaysOn,
       telemetry,
       onTurnEvent: (sessionKey, channelKey, event) => {
@@ -118,7 +120,7 @@ async function main(argv = process.argv.slice(2)): Promise<void> {
     }
     updateSubsystems({
       extraTools: [...(alwaysOn?.getTools() ?? []), ...(cron?.getTools() ?? [])],
-      sessionOverrides: alwaysOn?.getSessionOverrides(),
+      sessionOverrides,
       cron,
       alwaysOnApply: alwaysOn
         ? (input) => alwaysOn!.applyCycle(input)
@@ -197,7 +199,7 @@ async function main(argv = process.argv.slice(2)): Promise<void> {
       const fallbackApply = createApplyHandler({
         gateway,
         pilotHome,
-        sessionOverrides: alwaysOn?.getSessionOverrides() ?? new SessionConfigOverrides(),
+        sessionOverrides,
         alwaysOnConfig: config.alwaysOn,
         telemetry,
         onTurnEvent: (sessionKey, channelKey, event) => {
@@ -207,7 +209,7 @@ async function main(argv = process.argv.slice(2)): Promise<void> {
 
       updateSubsystems({
         extraTools: [...(alwaysOn?.getTools() ?? []), ...(cron?.getTools() ?? [])],
-        sessionOverrides: alwaysOn?.getSessionOverrides(),
+        sessionOverrides,
         cron,
         alwaysOnApply: alwaysOn ? (input) => alwaysOn!.applyCycle(input) : fallbackApply,
         alwaysOnRerunPlan: alwaysOn ? (input) => alwaysOn!.rerunPlan(input) : undefined,

--- a/src/cron/CronTimezone.ts
+++ b/src/cron/CronTimezone.ts
@@ -1,0 +1,21 @@
+export function isValidCronTimezone(timezone: string): boolean {
+  try {
+    new Intl.DateTimeFormat("en-US", { timeZone: timezone }).format();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function resolveCronTimezone(
+  scheduleTimezone?: string,
+  taskTimezone?: string,
+  configTimezone?: string,
+): string {
+  for (const timezone of [scheduleTimezone, taskTimezone, configTimezone, "UTC"]) {
+    if (timezone && isValidCronTimezone(timezone)) {
+      return timezone;
+    }
+  }
+  return "UTC";
+}

--- a/src/cron/config/parseCronConfig.ts
+++ b/src/cron/config/parseCronConfig.ts
@@ -1,10 +1,12 @@
 import { isRecord } from "../../model/config/schema.js";
 import type { PilotConfigDiagnostic } from "../../pilot/config/types.js";
+import { isValidCronTimezone } from "../CronTimezone.js";
 
 export type CronConfig = {
   enabled: boolean;
   timezone: string;
   maxConcurrentRuns: number;
+  runTimeoutMinutes: number;
 };
 
 export function defaultCronConfig(): CronConfig {
@@ -12,10 +14,11 @@ export function defaultCronConfig(): CronConfig {
     enabled: true,
     timezone: "UTC",
     maxConcurrentRuns: 1,
+    runTimeoutMinutes: 60,
   };
 }
 
-const ALLOWED_KEYS = new Set(["enabled", "timezone", "maxConcurrentRuns"]);
+const ALLOWED_KEYS = new Set(["enabled", "timezone", "maxConcurrentRuns", "runTimeoutMinutes"]);
 
 export function parseCronConfig(
   raw: unknown,
@@ -37,11 +40,28 @@ export function parseCronConfig(
 
   const result = defaultCronConfig();
   result.enabled = booleanField(raw, "enabled", result.enabled);
-  result.timezone = nonEmptyString(raw.timezone, result.timezone, "cron.timezone", diagnostics);
+  const timezone = nonEmptyString(raw.timezone, result.timezone, "cron.timezone", diagnostics);
+  if (isValidCronTimezone(timezone)) {
+    result.timezone = timezone;
+  } else {
+    diagnostics.push({
+      code: "CRON_TIMEZONE_INVALID",
+      severity: "warning",
+      message: `cron.timezone must be a valid IANA timezone; falling back to ${result.timezone}.`,
+      path: "cron.timezone",
+      recoverable: true,
+    });
+  }
   result.maxConcurrentRuns = positiveInteger(
     raw.maxConcurrentRuns,
     result.maxConcurrentRuns,
     "cron.maxConcurrentRuns",
+    diagnostics,
+  );
+  result.runTimeoutMinutes = positiveInteger(
+    raw.runTimeoutMinutes,
+    result.runTimeoutMinutes,
+    "cron.runTimeoutMinutes",
     diagnostics,
   );
 

--- a/src/cron/index.ts
+++ b/src/cron/index.ts
@@ -5,8 +5,14 @@ export {
   type CreateCronRuntimeOptions,
   type CronRuntimeLogger,
 } from "./runtime/CronRuntime.js";
+export {
+  CronManager,
+  createCronManager,
+  type CreateCronManagerOptions,
+} from "./runtime/CronManager.js";
 export type { CronPhaseEventCallback } from "./runtime/CronFire.js";
 export { computeNextCronRunAt, computeNextRunAt } from "./runtime/CronSchedule.js";
+export { isValidCronTimezone, resolveCronTimezone } from "./CronTimezone.js";
 export { resolveCronPaths, cronRunEventsPath, type CronPaths } from "./storage/CronPaths.js";
 export { CronTaskStore } from "./storage/CronTaskStore.js";
 export type {
@@ -18,6 +24,8 @@ export type {
   CronListResult,
   CronRunOutcome,
   CronRunRecord,
+  CronRunNowInput,
+  CronRunNowResult,
   CronSchedule,
   CronStopInput,
   CronStopResult,

--- a/src/cron/protocol/types.ts
+++ b/src/cron/protocol/types.ts
@@ -28,6 +28,7 @@ export type CronTask = {
   updatedAt: string;
   nextRunAt?: string;
   lastRunId?: string;
+  scheduleComputationVersion?: 2;
 };
 
 export type CronRunOutcome = "completed" | "failed" | "aborted" | "stopped";
@@ -62,6 +63,7 @@ export type CronCreateResult = {
 };
 
 export type CronListInput = {
+  projectKey?: string;
   includeHistory?: boolean;
   limit?: number;
 };
@@ -73,6 +75,7 @@ export type CronListResult = {
 
 export type CronDeleteInput = {
   taskId: string;
+  projectKey?: string;
   stopRunning?: boolean;
 };
 
@@ -84,6 +87,7 @@ export type CronDeleteResult = {
 export type CronStopInput = {
   taskId?: string;
   runId?: string;
+  projectKey?: string;
 };
 
 export type CronStopResult = {
@@ -95,6 +99,7 @@ export type CronStopResult = {
 
 export type CronRunNowInput = {
   taskId: string;
+  projectKey?: string;
 };
 
 export type CronRunNowResult = {

--- a/src/cron/runtime/CronFire.ts
+++ b/src/cron/runtime/CronFire.ts
@@ -1,6 +1,7 @@
 import type { Gateway, GatewayEvent } from "../../gateway/index.js";
 import type { CronRunRecord, CronRunOutcome, CronTask } from "../protocol/types.js";
 import type { CronTaskStore } from "../storage/CronTaskStore.js";
+import { resolveCronTimezone } from "../CronTimezone.js";
 import { computeNextRunAt } from "./CronSchedule.js";
 
 export type CronActiveRun = {
@@ -28,6 +29,9 @@ export type CronFireDependencies = {
   registerActiveRun: (run: CronActiveRun) => void;
   unregisterActiveRun: (runId: string) => CronActiveRun | undefined;
   getActiveRun: (runId: string) => CronActiveRun | undefined;
+  runTimeoutMs: number;
+  defaultTimezone: string;
+  releaseTaskSession: (task: CronTask) => Promise<void>;
   logger?: {
     warn: (message: string, data?: Record<string, unknown>) => void;
   };
@@ -47,44 +51,76 @@ export class CronFire {
       stopRequested: false,
     };
     this.deps.registerActiveRun(activeRun);
-    await this.deps.store.putTask({
-      ...task,
-      status: "running",
-      lastRunId: runId,
-      updatedAt: startedAt.toISOString(),
-    });
-    this.deps.onPhaseEvent?.({
-      phase: "cron_started",
-      runId,
-      taskId: task.taskId,
-      projectKey: task.projectKey,
-      timestamp: startedAt.toISOString(),
-      title: task.message.trimStart().split(/\r?\n/, 1)[0]?.trim().slice(0, 120),
-    });
 
     let outcome: CronRunOutcome = "completed";
     let error: CronRunRecord["error"];
+    let forcedFailure = false;
+    let abortRequested = false;
     try {
+      await this.deps.store.putTask({
+        ...task,
+        status: "running",
+        lastRunId: runId,
+        updatedAt: startedAt.toISOString(),
+      });
+      this.deps.onPhaseEvent?.({
+        phase: "cron_started",
+        runId,
+        taskId: task.taskId,
+        projectKey: task.projectKey,
+        timestamp: startedAt.toISOString(),
+        title: task.message.trimStart().split(/\r?\n/, 1)[0]?.trim().slice(0, 120),
+      });
       for await (const event of this.deps.gateway.submitTurn({
         sessionKey: task.sessionKey,
         channelKey: task.channelKey,
         projectKey: task.projectKey,
         message: task.message,
-        mode: task.mode,
+        mode: "bypassPermissions",
         runId,
+        timeoutMs: this.deps.runTimeoutMs,
       })) {
         await this.deps.store.appendRunEvent(runId, event);
+        if (event.type === "elicitation_request" || event.type === "permission_request") {
+          outcome = "failed";
+          forcedFailure = true;
+          error = {
+            code: "cron_interaction_required",
+            message: `Cron run requested unsupported user interaction through ${event.type}.`,
+          };
+          if (!abortRequested) {
+            abortRequested = true;
+            void this.deps.gateway
+              .abortTurn({ sessionKey: task.sessionKey, runId })
+              .catch(() => undefined);
+          }
+          continue;
+        }
         if (event.type === "error") {
+          if (event.code === "turn_timeout") {
+            outcome = "failed";
+            forcedFailure = true;
+            error = {
+              code: "cron_run_timeout",
+              message: event.message,
+            };
+            continue;
+          }
+          if (forcedFailure) {
+            continue;
+          }
           outcome = event.code === "agent_aborted" ? "aborted" : "failed";
           error = { code: event.code ?? "cron_run_failed", message: event.message };
         }
       }
     } catch (caught) {
-      outcome = "failed";
-      error = {
-        code: "cron_run_failed",
-        message: caught instanceof Error ? caught.message : String(caught),
-      };
+      if (!forcedFailure) {
+        outcome = "failed";
+        error = {
+          code: "cron_run_failed",
+          message: caught instanceof Error ? caught.message : String(caught),
+        };
+      }
     } finally {
       const currentActive = this.deps.getActiveRun(runId);
       if (currentActive?.stopRequested) {
@@ -92,17 +128,25 @@ export class CronFire {
       }
       this.deps.unregisterActiveRun(runId);
       const finishedAt = this.deps.now();
-      await this.deps.store.appendRun({
-        schemaVersion: 1,
-        runId,
-        taskId: task.taskId,
-        sessionKey: task.sessionKey,
-        projectKey: task.projectKey,
-        startedAt: startedAt.toISOString(),
-        finishedAt: finishedAt.toISOString(),
-        outcome,
-        error,
-      });
+      await this.deps.store
+        .appendRun({
+          schemaVersion: 1,
+          runId,
+          taskId: task.taskId,
+          sessionKey: task.sessionKey,
+          projectKey: task.projectKey,
+          startedAt: startedAt.toISOString(),
+          finishedAt: finishedAt.toISOString(),
+          outcome,
+          error,
+        })
+        .catch((persistError: unknown) => {
+          this.deps.logger?.warn("cron run terminal record write failed", {
+            taskId: task.taskId,
+            runId,
+            error: persistError instanceof Error ? persistError.message : String(persistError),
+          });
+        });
       this.deps.onPhaseEvent?.({
         phase: outcome === "completed" ? "cron_completed" : "cron_failed",
         runId,
@@ -124,14 +168,27 @@ export class CronFire {
 
   private async updateTaskAfterRun(task: CronTask, finishedAt: Date, outcome: CronRunOutcome): Promise<void> {
     if (task.schedule.type === "once") {
-      await this.deps.store.deleteTask(task.taskId);
+      try {
+        await this.deps.store.deleteTask(task.taskId);
+      } finally {
+        await this.deps.releaseTaskSession(task);
+      }
       return;
     }
-    const nextRunAt = computeNextRunAt(task.schedule, finishedAt)?.toISOString();
+    const timezone = resolveCronTimezone(
+      task.schedule.timezone,
+      task.timezone,
+      this.deps.defaultTimezone,
+    );
+    const schedule = { ...task.schedule, timezone };
+    const nextRunAt = computeNextRunAt(schedule, finishedAt, timezone)?.toISOString();
     await this.deps.store.updateTask(task.taskId, (current) => ({
       ...current,
+      schedule,
+      timezone,
       status: "scheduled",
       nextRunAt,
+      scheduleComputationVersion: 2,
       updatedAt: finishedAt.toISOString(),
     }));
     void outcome;

--- a/src/cron/runtime/CronManager.ts
+++ b/src/cron/runtime/CronManager.ts
@@ -1,0 +1,323 @@
+import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
+import type { Dirent } from "node:fs";
+import { resolve } from "node:path";
+import type { SessionConfigOverrides } from "../../always-on/runtime/SessionConfigOverrides.js";
+import type { Gateway } from "../../gateway/index.js";
+import type { TelemetryClient } from "../../telemetry/index.js";
+import type { PilotDeckToolDefinition } from "../../tool/index.js";
+import type { CronConfig } from "../config/parseCronConfig.js";
+import type {
+  CronCreateInput,
+  CronCreateResult,
+  CronDeleteInput,
+  CronDeleteResult,
+  CronListInput,
+  CronListResult,
+  CronRunNowInput,
+  CronRunNowResult,
+  CronRunRecord,
+  CronStopInput,
+  CronStopResult,
+  CronTask,
+} from "../protocol/types.js";
+import { resolveCronPaths } from "../storage/CronPaths.js";
+import { createCronCreateTool } from "../tool/CronCreateTool.js";
+import { createCronDeleteTool } from "../tool/CronDeleteTool.js";
+import { createCronListTool } from "../tool/CronListTool.js";
+import { createCronStopTool } from "../tool/CronStopTool.js";
+import { migrateCronStores } from "../storage/CronStoreMigration.js";
+import { CronRuntime, type CronRuntimeLogger } from "./CronRuntime.js";
+
+export type CreateCronManagerOptions = {
+  config: CronConfig;
+  pilotHome: string;
+  sessionOverrides?: SessionConfigOverrides;
+  now?: () => Date;
+  uuid?: () => string;
+  logger?: CronRuntimeLogger;
+  telemetry?: TelemetryClient;
+};
+
+export class CronManager {
+  readonly config: CronConfig;
+
+  private readonly pilotHome: string;
+  private readonly runtimes = new Map<string, CronRuntime>();
+  private readonly starting = new Map<string, Promise<void>>();
+  private readonly tools: PilotDeckToolDefinition[];
+  private gateway?: Gateway;
+  private started = false;
+
+  constructor(private readonly options: CreateCronManagerOptions) {
+    this.config = options.config;
+    this.pilotHome = resolve(options.pilotHome);
+    this.tools = [
+      createCronCreateTool(this),
+      createCronListTool(this),
+      createCronDeleteTool(this),
+      createCronStopTool(this),
+    ];
+  }
+
+  getTools(): PilotDeckToolDefinition[] {
+    return this.config.enabled ? [...this.tools] : [];
+  }
+
+  bindGateway(gateway: Gateway): void {
+    if (this.gateway) {
+      throw new Error("CronManager.bindGateway already called.");
+    }
+    this.gateway = gateway;
+  }
+
+  async start(): Promise<void> {
+    if (!this.config.enabled) {
+      this.options.logger?.info("cron disabled in config; manager is a no-op.");
+      return;
+    }
+    if (!this.gateway) {
+      throw new Error("CronManager.start called before bindGateway.");
+    }
+    await migrateCronStores({
+      pilotHome: this.pilotHome,
+      logger: this.options.logger,
+    });
+    this.started = true;
+    const projectKeys = await discoverCronProjectKeys(this.pilotHome, this.options.logger);
+    for (const projectKey of projectKeys) {
+      await this.ensureRuntime(projectKey);
+    }
+    this.options.logger?.info("cron manager started", { projectCount: this.runtimes.size });
+  }
+
+  async stop(): Promise<void> {
+    this.started = false;
+    await Promise.all([...this.starting.values()].map((pending) => pending.catch(() => undefined)));
+    for (const runtime of this.runtimes.values()) {
+      await runtime.stop();
+    }
+    this.runtimes.clear();
+    this.starting.clear();
+  }
+
+  async createTask(input: CronCreateInput): Promise<CronCreateResult> {
+    const projectKey = requireProjectKey(input.projectKey);
+    const runtime = await this.ensureRuntime(projectKey);
+    return runtime.createTask({ ...input, projectKey });
+  }
+
+  async listTasks(input: CronListInput = {}): Promise<CronListResult> {
+    if (input.projectKey) {
+      const runtime = await this.ensureRuntime(input.projectKey);
+      return runtime.listTasks(input);
+    }
+    const tasks: CronTask[] = [];
+    const runs: CronRunRecord[] = [];
+    for (const runtime of this.runtimes.values()) {
+      const result = await runtime.listTasks(input);
+      tasks.push(...result.tasks);
+      if (result.recentRuns) runs.push(...result.recentRuns);
+    }
+    const result: CronListResult = {
+      tasks: tasks.sort((left, right) => (left.nextRunAt ?? "").localeCompare(right.nextRunAt ?? "")),
+    };
+    if (input.includeHistory) {
+      result.recentRuns = runs
+        .sort((left, right) => right.startedAt.localeCompare(left.startedAt))
+        .slice(0, input.limit ?? 50);
+    }
+    return result;
+  }
+
+  async deleteTask(input: CronDeleteInput): Promise<CronDeleteResult> {
+    const runtime = await this.resolveTaskRuntime(input.taskId, input.projectKey);
+    if (!runtime) return { deleted: false };
+    return runtime.deleteTask(input);
+  }
+
+  async stopTask(input: CronStopInput): Promise<CronStopResult> {
+    const runtime = await this.resolveStopRuntime(input);
+    if (!runtime) {
+      return { stopped: false, taskId: input.taskId, runId: input.runId };
+    }
+    return runtime.stopTask(input);
+  }
+
+  async runTaskNow(input: CronRunNowInput): Promise<CronRunNowResult> {
+    const runtime = await this.resolveTaskRuntime(input.taskId, input.projectKey);
+    if (!runtime) return { started: false, reason: "not_found" };
+    return runtime.runTaskNow(input);
+  }
+
+  /** Public for tests; runs one scheduler tick for one or all loaded projects. */
+  async runTickOnce(projectKey?: string): Promise<void> {
+    if (projectKey) {
+      await (await this.ensureRuntime(projectKey)).runTickOnce();
+      return;
+    }
+    for (const runtime of this.runtimes.values()) {
+      await runtime.runTickOnce();
+    }
+  }
+
+  private async ensureRuntime(projectKeyInput: string): Promise<CronRuntime> {
+    const projectKey = resolve(projectKeyInput);
+    const existing = this.runtimes.get(projectKey);
+    if (existing) {
+      await this.starting.get(projectKey);
+      return existing;
+    }
+
+    const runtime = new CronRuntime({
+      config: this.config,
+      pilotHome: this.pilotHome,
+      projectKey,
+      sessionOverrides: this.options.sessionOverrides,
+      now: this.options.now,
+      uuid: this.options.uuid,
+      logger: this.options.logger,
+      telemetry: this.options.telemetry,
+      activeRunCount: () => this.activeRunCount(),
+      skipToolCreation: true,
+    });
+    if (this.gateway) runtime.bindGateway(this.gateway);
+    this.runtimes.set(projectKey, runtime);
+    await writeProjectMarker(runtime.paths.projectDir, projectKey);
+
+    if (this.started) {
+      const pending = runtime.start().finally(() => this.starting.delete(projectKey));
+      this.starting.set(projectKey, pending);
+      await pending;
+    }
+    return runtime;
+  }
+
+  private activeRunCount(): number {
+    let count = 0;
+    for (const runtime of this.runtimes.values()) {
+      count += runtime.getActiveRunCount();
+    }
+    return count;
+  }
+
+  private async resolveTaskRuntime(
+    taskId: string,
+    projectKey?: string,
+  ): Promise<CronRuntime | undefined> {
+    if (projectKey) {
+      const runtime = await this.ensureRuntime(projectKey);
+      return (await runtime.listTasks()).tasks.some((task) => task.taskId === taskId)
+        ? runtime
+        : undefined;
+    }
+    const matches: CronRuntime[] = [];
+    for (const runtime of this.runtimes.values()) {
+      if ((await runtime.listTasks()).tasks.some((task) => task.taskId === taskId)) {
+        matches.push(runtime);
+      }
+    }
+    if (matches.length > 1) {
+      throw new Error(`Cron task id is ambiguous across projects: ${taskId}`);
+    }
+    return matches[0];
+  }
+
+  private async resolveStopRuntime(input: CronStopInput): Promise<CronRuntime | undefined> {
+    if (input.projectKey) {
+      return this.ensureRuntime(input.projectKey);
+    }
+    const matches: CronRuntime[] = [];
+    for (const runtime of this.runtimes.values()) {
+      const tasks = (await runtime.listTasks()).tasks;
+      if (tasks.some((task) =>
+        (input.taskId && task.taskId === input.taskId)
+        || (input.runId && task.lastRunId === input.runId))) {
+        matches.push(runtime);
+      }
+    }
+    if (matches.length > 1) {
+      throw new Error(`Cron run identifier is ambiguous across projects: ${input.runId ?? input.taskId}`);
+    }
+    return matches[0];
+  }
+}
+
+export function createCronManager(options: CreateCronManagerOptions): CronManager {
+  return new CronManager(options);
+}
+
+function requireProjectKey(projectKey: string | undefined): string {
+  if (!projectKey?.trim()) {
+    throw new Error("Cron task creation requires a projectKey.");
+  }
+  return resolve(projectKey);
+}
+
+async function discoverCronProjectKeys(
+  pilotHome: string,
+  logger?: CronRuntimeLogger,
+): Promise<string[]> {
+  const projectsDir = resolve(pilotHome, "cron", "projects");
+  let entries: Dirent<string>[];
+  try {
+    entries = await readdir(projectsDir, { withFileTypes: true });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+    throw error;
+  }
+  const projectKeys = new Set<string>();
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const projectDir = resolve(projectsDir, entry.name);
+    try {
+      const raw = await readFile(resolve(projectDir, "tasks.json"), "utf-8");
+      const parsed = JSON.parse(raw) as { tasks?: Array<{ projectKey?: unknown }> };
+      for (const task of parsed.tasks ?? []) {
+        if (typeof task.projectKey === "string" && task.projectKey.trim()) {
+          projectKeys.add(resolve(task.projectKey));
+        }
+      }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        logger?.warn("cron project discovery skipped unreadable task store", {
+          projectDir: entry.name,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+    try {
+      const raw = await readFile(resolve(projectDir, "run-history.jsonl"), "utf-8");
+      for (const line of raw.split("\n")) {
+        if (!line.trim()) continue;
+        try {
+          const run = JSON.parse(line) as { projectKey?: unknown };
+          if (typeof run.projectKey === "string" && run.projectKey.trim()) {
+            projectKeys.add(resolve(run.projectKey));
+          }
+        } catch {
+          // Preserve unreadable migration leftovers, but continue discovering
+          // project keys from the remaining valid records.
+        }
+      }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        logger?.warn("cron project discovery skipped unreadable run history", {
+          projectDir: entry.name,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+    try {
+      const marker = (await readFile(resolve(projectDir, ".cwd"), "utf-8")).trim();
+      if (marker) projectKeys.add(resolve(marker));
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    }
+  }
+  return [...projectKeys].sort();
+}
+
+async function writeProjectMarker(projectDir: string, projectKey: string): Promise<void> {
+  await mkdir(projectDir, { recursive: true });
+  await writeFile(resolve(projectDir, ".cwd"), `${projectKey}\n`, "utf-8");
+}

--- a/src/cron/runtime/CronRuntime.ts
+++ b/src/cron/runtime/CronRuntime.ts
@@ -1,5 +1,9 @@
 import { randomUUID } from "node:crypto";
 import { resolve } from "node:path";
+import {
+  SessionConfigOverrides,
+  UNATTENDED_SESSION_EXCLUDED_TOOLS,
+} from "../../always-on/runtime/SessionConfigOverrides.js";
 import type { Gateway } from "../../gateway/index.js";
 import type { PilotDeckToolDefinition } from "../../tool/index.js";
 import type { CronConfig } from "../config/parseCronConfig.js";
@@ -18,6 +22,7 @@ import type {
 } from "../protocol/types.js";
 import { resolveCronPaths, type CronPaths } from "../storage/CronPaths.js";
 import { CronTaskStore } from "../storage/CronTaskStore.js";
+import { isValidCronTimezone, resolveCronTimezone } from "../CronTimezone.js";
 import { createCronCreateTool } from "../tool/CronCreateTool.js";
 import { createCronDeleteTool } from "../tool/CronDeleteTool.js";
 import { createCronListTool } from "../tool/CronListTool.js";
@@ -41,6 +46,9 @@ export type CreateCronRuntimeOptions = {
   logger?: CronRuntimeLogger;
   store?: CronTaskStore;
   telemetry?: TelemetryClient;
+  sessionOverrides?: SessionConfigOverrides;
+  activeRunCount?: () => number;
+  skipToolCreation?: boolean;
 };
 
 const NOOP_LOGGER: CronRuntimeLogger = {
@@ -58,8 +66,10 @@ export class CronRuntime {
   private readonly uuid: () => string;
   private readonly logger: CronRuntimeLogger;
   private readonly telemetry?: TelemetryClient;
+  private readonly sessionOverrides: SessionConfigOverrides;
   private readonly tools: PilotDeckToolDefinition[];
   private readonly activeRuns = new Map<string, CronActiveRun>();
+  private readonly sharedActiveRunCount?: () => number;
   private gateway?: Gateway;
   private fire?: CronFire;
   private scheduler?: CronScheduler;
@@ -73,12 +83,16 @@ export class CronRuntime {
     this.uuid = options.uuid ?? randomUUID;
     this.logger = options.logger ?? NOOP_LOGGER;
     this.telemetry = options.telemetry;
-    this.tools = [
-      createCronCreateTool(this),
-      createCronListTool(this),
-      createCronDeleteTool(this),
-      createCronStopTool(this),
-    ];
+    this.sessionOverrides = options.sessionOverrides ?? new SessionConfigOverrides();
+    this.sharedActiveRunCount = options.activeRunCount;
+    this.tools = options.skipToolCreation
+      ? []
+      : [
+          createCronCreateTool(this),
+          createCronListTool(this),
+          createCronDeleteTool(this),
+          createCronStopTool(this),
+        ];
   }
 
   getTools(): PilotDeckToolDefinition[] {
@@ -99,6 +113,9 @@ export class CronRuntime {
       registerActiveRun: (run) => this.registerActiveRun(run),
       unregisterActiveRun: (runId) => this.unregisterActiveRun(runId),
       getActiveRun: (runId) => this.activeRuns.get(runId),
+      runTimeoutMs: this.config.runTimeoutMinutes * 60_000,
+      defaultTimezone: this.config.timezone,
+      releaseTaskSession: (task) => this.releaseTaskSession(task),
       onPhaseEvent: (event) => {
         this.telemetry?.trackFeatureLoopStage({
           module: "cron_job",
@@ -134,7 +151,7 @@ export class CronRuntime {
       uuid: this.uuid,
       now: this.now,
       logger: this.logger,
-      activeRunCount: () => this.activeRuns.size,
+      activeRunCount: () => this.sharedActiveRunCount?.() ?? this.activeRuns.size,
     });
   }
 
@@ -147,12 +164,33 @@ export class CronRuntime {
       throw new Error("CronRuntime.start called before bindGateway.");
     }
     await this.migrateLegacyTaskSessions();
+    await this.recoverInterruptedRuns();
+    await this.prepareTaskSessions();
     await this.scheduler.start();
     this.logger.info("cron runtime started", { projectKey: this.projectKey });
   }
 
   async stop(): Promise<void> {
     await this.scheduler?.stop();
+    if (this.gateway) {
+      const activeRuns = [...this.activeRuns.values()];
+      for (const active of activeRuns) {
+        active.stopRequested = true;
+      }
+      await Promise.all(
+        activeRuns.map((active) =>
+          this.gateway!
+            .abortTurn({ sessionKey: active.sessionKey, runId: active.runId })
+            .catch(() => undefined),
+        ),
+      );
+    }
+    const tasks = await this.store.listTasks();
+    await Promise.all(tasks.map((task) => this.releaseTaskSession(task)));
+  }
+
+  getActiveRunCount(): number {
+    return this.activeRuns.size;
   }
 
   async createTask(input: CronCreateInput): Promise<CronCreateResult> {
@@ -162,8 +200,11 @@ export class CronRuntime {
     const now = this.now();
     const taskId = this.uuid();
     const sessionKey = buildCronSessionKey(taskId);
-    const schedule = normalizeSchedule(input);
-    const nextRunAt = computeNextRunAt(schedule, now);
+    const schedule = normalizeSchedule(input, this.config.timezone);
+    const timezone = schedule.type === "cron"
+      ? schedule.timezone
+      : input.timezone ?? this.config.timezone;
+    const nextRunAt = computeNextRunAt(schedule, now, timezone);
     if (!nextRunAt) {
       throw new Error("Cron schedule does not produce a valid future run time.");
     }
@@ -182,12 +223,19 @@ export class CronRuntime {
       // Keep the runtime root only as a compatibility fallback for direct callers.
       projectKey: input.projectKey ?? this.projectKey,
       mode: input.mode,
-      timezone: input.timezone ?? (schedule.type === "cron" ? schedule.timezone : undefined) ?? this.config.timezone,
+      timezone,
       createdAt: now.toISOString(),
       updatedAt: now.toISOString(),
       nextRunAt: nextRunAt.toISOString(),
+      scheduleComputationVersion: schedule.type === "cron" ? 2 : undefined,
     };
-    await this.store.putTask(task);
+    this.registerTaskSession(task);
+    try {
+      await this.store.putTask(task);
+    } catch (error) {
+      await this.releaseTaskSession(task);
+      throw error;
+    }
     this.telemetry?.trackFeatureLoopStage({
       module: "cron_job",
       loopStage: "module_event",
@@ -219,6 +267,9 @@ export class CronRuntime {
       stoppedRunId = stopped.runId;
     }
     const deleted = await this.store.deleteTask(input.taskId);
+    if (deleted) {
+      await this.releaseTaskSessionById(input.taskId);
+    }
     this.scheduler?.poke();
     return { deleted, stoppedRunId };
   }
@@ -233,6 +284,7 @@ export class CronRuntime {
     let deletedOneTimeTask = false;
     if (active.scheduleType === "once") {
       deletedOneTimeTask = await this.store.deleteTask(active.taskId);
+      await this.releaseTaskSessionById(active.taskId);
     }
     this.scheduler?.poke();
     return {
@@ -300,6 +352,10 @@ export class CronRuntime {
         continue;
       }
       migratedCount += 1;
+      this.sessionOverrides.delete(task.sessionKey);
+      await this.gateway
+        ?.closeSession({ sessionKey: task.sessionKey, reason: "cron/legacy-session-migrated" })
+        .catch(() => undefined);
       await this.store.putTask({
         ...task,
         sessionKey: nextSessionKey,
@@ -311,20 +367,124 @@ export class CronRuntime {
       this.logger.info("cron runtime migrated legacy task sessions", { migratedCount });
     }
   }
+
+  private registerTaskSession(task: CronTask): void {
+    this.sessionOverrides.set(task.sessionKey, {
+      permissionMode: "bypassPermissions",
+      bypassAvailable: true,
+      canPrompt: false,
+      excludeTools: [...UNATTENDED_SESSION_EXCLUDED_TOOLS],
+    });
+  }
+
+  private async prepareTaskSessions(): Promise<void> {
+    const tasks = await this.store.listTasks();
+    for (const task of tasks) {
+      this.registerTaskSession(task);
+      await this.gateway
+        ?.closeSession({ sessionKey: task.sessionKey, reason: "cron/unattended-policy-refresh" })
+        .catch(() => undefined);
+    }
+  }
+
+  private async releaseTaskSession(task: CronTask): Promise<void> {
+    this.sessionOverrides.delete(task.sessionKey);
+    await this.gateway
+      ?.closeSession({ sessionKey: task.sessionKey, reason: "cron/task-finished" })
+      .catch(() => undefined);
+  }
+
+  private async releaseTaskSessionById(taskId: string): Promise<void> {
+    const sessionKey = buildCronSessionKey(taskId);
+    this.sessionOverrides.delete(sessionKey);
+    await this.gateway
+      ?.closeSession({ sessionKey, reason: "cron/task-removed" })
+      .catch(() => undefined);
+  }
+
+  private async recoverInterruptedRuns(): Promise<void> {
+    const now = this.now();
+    const tasks = await this.store.listTasks();
+    const terminalRunIds = new Set(
+      (await this.store.listRuns(Number.MAX_SAFE_INTEGER))
+        .filter((run) => run.finishedAt && run.outcome)
+        .map((run) => run.runId),
+    );
+    let recoveredCount = 0;
+
+    for (const task of tasks) {
+      if (task.status !== "running") continue;
+      recoveredCount += 1;
+      if (task.lastRunId && !terminalRunIds.has(task.lastRunId)) {
+        const startedAt = Number.isNaN(new Date(task.updatedAt).getTime())
+          ? now.toISOString()
+          : task.updatedAt;
+        await this.store.appendRun({
+          schemaVersion: 1,
+          runId: task.lastRunId,
+          taskId: task.taskId,
+          sessionKey: task.sessionKey,
+          projectKey: task.projectKey,
+          startedAt,
+          finishedAt: now.toISOString(),
+          outcome: "failed",
+          error: {
+            code: "cron_run_interrupted",
+            message: "Cron run was interrupted before the runtime restarted.",
+          },
+        });
+      }
+
+      if (task.schedule.type === "once") {
+        await this.store.deleteTask(task.taskId);
+        await this.releaseTaskSession(task);
+        continue;
+      }
+
+      const timezone = resolveCronTimezone(
+        task.schedule.timezone,
+        task.timezone,
+        this.config.timezone,
+      );
+      const schedule = { ...task.schedule, timezone };
+      await this.store.putTask({
+        ...task,
+        schedule,
+        timezone,
+        status: "scheduled",
+        nextRunAt: computeNextRunAt(schedule, now, timezone)?.toISOString(),
+        scheduleComputationVersion: 2,
+        updatedAt: now.toISOString(),
+      });
+    }
+
+    if (recoveredCount > 0) {
+      this.logger.warn("cron runtime recovered interrupted runs", { recoveredCount });
+    }
+  }
 }
 
 export function createCronRuntime(options: CreateCronRuntimeOptions): CronRuntime {
   return new CronRuntime(options);
 }
 
-function normalizeSchedule(input: CronCreateInput): CronTask["schedule"] {
+function normalizeSchedule(input: CronCreateInput, configTimezone: string): CronTask["schedule"] {
   if (input.schedule.type === "once") {
     return { type: "once", runAt: input.schedule.runAt };
   }
+  const requestedTimezone = input.schedule.timezone ?? input.timezone;
+  if (requestedTimezone && !isValidCronTimezone(requestedTimezone)) {
+    throw new Error(`Invalid Cron timezone: ${requestedTimezone}`);
+  }
+  const timezone = resolveCronTimezone(
+    requestedTimezone,
+    undefined,
+    configTimezone,
+  );
   return {
     type: "cron",
     expression: input.schedule.expression,
-    timezone: input.schedule.timezone ?? input.timezone,
+    timezone,
   };
 }
 

--- a/src/cron/runtime/CronSchedule.ts
+++ b/src/cron/runtime/CronSchedule.ts
@@ -1,22 +1,32 @@
 import type { CronSchedule } from "../protocol/types.js";
+import { isValidCronTimezone } from "../CronTimezone.js";
 
 const MINUTE_MS = 60_000;
 const MAX_SEARCH_MINUTES = 366 * 24 * 60;
 
-export function computeNextRunAt(schedule: CronSchedule, after: Date): Date | undefined {
+export function computeNextRunAt(
+  schedule: CronSchedule,
+  after: Date,
+  fallbackTimezone = "UTC",
+): Date | undefined {
   if (schedule.type === "once") {
     const runAt = new Date(schedule.runAt);
     return Number.isNaN(runAt.getTime()) ? undefined : runAt;
   }
-  return computeNextCronRunAt(schedule.expression, after);
+  return computeNextCronRunAt(schedule.expression, after, schedule.timezone ?? fallbackTimezone);
 }
 
-export function computeNextCronRunAt(expression: string, after: Date): Date | undefined {
+export function computeNextCronRunAt(
+  expression: string,
+  after: Date,
+  timezone = "UTC",
+): Date | undefined {
   const parsed = parseCronExpression(expression);
-  if (!parsed) return undefined;
+  if (!parsed || !isValidCronTimezone(timezone)) return undefined;
+  const formatter = createCronDateFormatter(timezone);
   let candidate = new Date(Math.floor(after.getTime() / MINUTE_MS) * MINUTE_MS + MINUTE_MS);
   for (let index = 0; index < MAX_SEARCH_MINUTES; index += 1) {
-    if (matchesCron(candidate, parsed)) {
+    if (matchesCron(candidate, parsed, formatter)) {
       return candidate;
     }
     candidate = new Date(candidate.getTime() + MINUTE_MS);
@@ -95,12 +105,68 @@ function parseField(field: string, min: number, max: number): Set<number> | unde
   return output;
 }
 
-function matchesCron(date: Date, cron: ParsedCron): boolean {
+type CronDateParts = {
+  minute: number;
+  hour: number;
+  dayOfMonth: number;
+  month: number;
+  dayOfWeek: number;
+};
+
+const WEEKDAY_INDEX: Record<string, number> = {
+  Sun: 0,
+  Mon: 1,
+  Tue: 2,
+  Wed: 3,
+  Thu: 4,
+  Fri: 5,
+  Sat: 6,
+};
+
+function createCronDateFormatter(timezone: string): Intl.DateTimeFormat {
+  return new Intl.DateTimeFormat("en-US-u-ca-gregory-nu-latn", {
+    timeZone: timezone,
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    weekday: "short",
+    hourCycle: "h23",
+  });
+}
+
+function readCronDateParts(date: Date, formatter: Intl.DateTimeFormat): CronDateParts | undefined {
+  const values: Record<string, string> = {};
+  for (const part of formatter.formatToParts(date)) {
+    if (part.type !== "literal") {
+      values[part.type] = part.value;
+    }
+  }
+  const minute = Number.parseInt(values.minute, 10);
+  const hour = Number.parseInt(values.hour, 10);
+  const dayOfMonth = Number.parseInt(values.day, 10);
+  const month = Number.parseInt(values.month, 10);
+  const dayOfWeek = WEEKDAY_INDEX[values.weekday];
+  if (
+    !Number.isInteger(minute) ||
+    !Number.isInteger(hour) ||
+    !Number.isInteger(dayOfMonth) ||
+    !Number.isInteger(month) ||
+    dayOfWeek === undefined
+  ) {
+    return undefined;
+  }
+  return { minute, hour, dayOfMonth, month, dayOfWeek };
+}
+
+function matchesCron(date: Date, cron: ParsedCron, formatter: Intl.DateTimeFormat): boolean {
+  const parts = readCronDateParts(date, formatter);
+  if (!parts) return false;
   return (
-    cron.minutes.has(date.getUTCMinutes()) &&
-    cron.hours.has(date.getUTCHours()) &&
-    cron.daysOfMonth.has(date.getUTCDate()) &&
-    cron.months.has(date.getUTCMonth() + 1) &&
-    cron.daysOfWeek.has(date.getUTCDay())
+    cron.minutes.has(parts.minute) &&
+    cron.hours.has(parts.hour) &&
+    cron.daysOfMonth.has(parts.dayOfMonth) &&
+    cron.months.has(parts.month) &&
+    cron.daysOfWeek.has(parts.dayOfWeek)
   );
 }

--- a/src/cron/runtime/CronScheduler.ts
+++ b/src/cron/runtime/CronScheduler.ts
@@ -1,6 +1,7 @@
 import type { CronConfig } from "../config/parseCronConfig.js";
 import type { CronTask } from "../protocol/types.js";
 import type { CronTaskStore } from "../storage/CronTaskStore.js";
+import { resolveCronTimezone } from "../CronTimezone.js";
 import { computeNextRunAt } from "./CronSchedule.js";
 import type { CronFire } from "./CronFire.js";
 
@@ -113,19 +114,38 @@ export class CronScheduler {
     const tasks = await this.deps.store.listTasks();
     await Promise.all(
       tasks.map(async (task) => {
-        if (task.status === "running") {
-          await this.deps.store.putTask({ ...task, status: "scheduled", updatedAt: now.toISOString() });
+        if (task.schedule.type === "once") {
+          if (task.nextRunAt) {
+            return;
+          }
+          const nextRunAt = computeNextRunAt(task.schedule, now)?.toISOString();
+          if (!nextRunAt) {
+            await this.deps.store.deleteTask(task.taskId);
+            return;
+          }
+          await this.deps.store.putTask({ ...task, nextRunAt, updatedAt: now.toISOString() });
           return;
         }
-        if (task.nextRunAt) {
+
+        if (task.scheduleComputationVersion === 2 && task.nextRunAt) {
           return;
         }
-        const nextRunAt = computeNextRunAt(task.schedule, now)?.toISOString();
-        if (!nextRunAt && task.schedule.type === "once") {
-          await this.deps.store.deleteTask(task.taskId);
-          return;
-        }
-        await this.deps.store.putTask({ ...task, nextRunAt, updatedAt: now.toISOString() });
+        const timezone = resolveCronTimezone(
+          task.schedule.timezone,
+          task.timezone,
+          this.deps.config.timezone,
+        );
+        const schedule = { ...task.schedule, timezone };
+        const nextRunAt = computeNextRunAt(schedule, now, timezone)?.toISOString();
+        await this.deps.store.putTask({
+          ...task,
+          schedule,
+          timezone,
+          status: "scheduled",
+          nextRunAt,
+          scheduleComputationVersion: 2,
+          updatedAt: now.toISOString(),
+        });
       }),
     );
   }

--- a/src/cron/storage/CronStoreMigration.ts
+++ b/src/cron/storage/CronStoreMigration.ts
@@ -1,0 +1,472 @@
+import {
+  copyFile,
+  mkdir,
+  open,
+  readFile,
+  readdir,
+  rename,
+  rm,
+  stat,
+  unlink,
+  writeFile,
+} from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import type { CronRuntimeLogger } from "../runtime/CronRuntime.js";
+import { cronRunEventsPath, resolveCronPaths } from "./CronPaths.js";
+
+type JsonRecord = Record<string, unknown>;
+
+type StoreSnapshot = {
+  dir: string;
+  tasks: unknown[];
+  taskFileWritable: boolean;
+  invalidRunLines: string[];
+  runs: JsonRecord[];
+};
+
+const LOCK_STALE_MS = 10 * 60_000;
+
+export async function migrateCronStores(input: {
+  pilotHome: string;
+  logger?: CronRuntimeLogger;
+}): Promise<void> {
+  const rootDir = resolve(input.pilotHome, "cron");
+  const releaseLock = await acquireMigrationLock(rootDir, input.logger);
+  try {
+    const snapshots = await readSnapshots(resolve(rootDir, "projects"));
+    if (snapshots.length === 0) return;
+
+    const blockedTaskDirs = new Set(
+      snapshots.filter((snapshot) => !snapshot.taskFileWritable).map((snapshot) => snapshot.dir),
+    );
+    for (const projectDir of blockedTaskDirs) {
+      input.logger?.warn("cron migration preserved an unreadable task store", { projectDir });
+    }
+    const taskProjects = buildTaskProjectIndex(snapshots);
+    const finalTasks = new Map<string, unknown[]>();
+    const finalRuns = new Map<string, { records: JsonRecord[]; invalidLines: string[] }>();
+    const runTargets = new Map<string, Set<string>>();
+
+    for (const snapshot of snapshots) {
+      for (const task of snapshot.tasks) {
+        const targetDir = resolveTaskTargetDir(
+          input.pilotHome,
+          snapshot.dir,
+          task,
+          blockedTaskDirs,
+        );
+        pushMapArray(finalTasks, targetDir, task);
+      }
+      for (const line of snapshot.invalidRunLines) {
+        const bucket = getRunBucket(finalRuns, snapshot.dir);
+        bucket.invalidLines.push(line);
+      }
+      for (const run of snapshot.runs) {
+        const targetDir = resolveRunTargetDir(
+          input.pilotHome,
+          snapshot.dir,
+          run,
+          taskProjects,
+          blockedTaskDirs,
+        );
+        getRunBucket(finalRuns, targetDir).records.push(run);
+        if (typeof run.runId === "string") {
+          const targets = runTargets.get(run.runId) ?? new Set<string>();
+          targets.add(targetDir);
+          runTargets.set(run.runId, targets);
+        }
+      }
+    }
+
+    for (const snapshot of snapshots) {
+      if (!finalTasks.has(snapshot.dir)) finalTasks.set(snapshot.dir, []);
+      if (!finalRuns.has(snapshot.dir)) {
+        finalRuns.set(snapshot.dir, { records: [], invalidLines: [] });
+      }
+    }
+
+    for (const [dir, tasks] of finalTasks) {
+      finalTasks.set(dir, dedupeTasks(tasks, input.logger, dir));
+    }
+    for (const [dir, bucket] of finalRuns) {
+      bucket.records = dedupeRuns(bucket.records);
+    }
+
+    await stageDestinationData(snapshots, finalTasks, finalRuns, input.logger);
+    await migrateRunEvents(snapshots, runTargets, input.logger);
+    await writeFinalSnapshots(snapshots, finalTasks, finalRuns);
+    await writeFile(
+      resolve(rootDir, "store-migration-v1.json"),
+      `${JSON.stringify({ version: 1, completedAt: new Date().toISOString() }, null, 2)}\n`,
+      "utf-8",
+    );
+  } finally {
+    await releaseLock();
+  }
+}
+
+async function readSnapshots(projectsDir: string): Promise<StoreSnapshot[]> {
+  let entries;
+  try {
+    entries = await readdir(projectsDir, { withFileTypes: true });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+    throw error;
+  }
+  const snapshots: StoreSnapshot[] = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const dir = resolve(projectsDir, entry.name);
+    snapshots.push({
+      dir,
+      ...(await readTasks(resolve(dir, "tasks.json"))),
+      ...(await readRuns(resolve(dir, "run-history.jsonl"))),
+    });
+  }
+  return snapshots;
+}
+
+async function readTasks(
+  path: string,
+): Promise<Pick<StoreSnapshot, "tasks" | "taskFileWritable">> {
+  try {
+    const parsed = JSON.parse(await readFile(path, "utf-8")) as { tasks?: unknown };
+    if (!Array.isArray(parsed.tasks)) {
+      return { tasks: [], taskFileWritable: false };
+    }
+    return { tasks: parsed.tasks, taskFileWritable: true };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return { tasks: [], taskFileWritable: true };
+    }
+    return { tasks: [], taskFileWritable: false };
+  }
+}
+
+async function readRuns(path: string): Promise<Pick<StoreSnapshot, "runs" | "invalidRunLines">> {
+  let raw: string;
+  try {
+    raw = await readFile(path, "utf-8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return { runs: [], invalidRunLines: [] };
+    }
+    throw error;
+  }
+  const runs: JsonRecord[] = [];
+  const invalidRunLines: string[] = [];
+  for (const line of raw.split("\n")) {
+    if (!line.trim()) continue;
+    try {
+      const parsed = JSON.parse(line);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        runs.push(parsed as JsonRecord);
+      } else {
+        invalidRunLines.push(line);
+      }
+    } catch {
+      invalidRunLines.push(line);
+    }
+  }
+  return { runs, invalidRunLines };
+}
+
+function buildTaskProjectIndex(snapshots: StoreSnapshot[]): Map<string, Set<string>> {
+  const index = new Map<string, Set<string>>();
+  for (const snapshot of snapshots) {
+    for (const task of snapshot.tasks) {
+      if (!isRecord(task) || typeof task.taskId !== "string") continue;
+      const projectKey = normalizedProjectKey(task.projectKey);
+      if (!projectKey) continue;
+      const projects = index.get(task.taskId) ?? new Set<string>();
+      projects.add(projectKey);
+      index.set(task.taskId, projects);
+    }
+  }
+  return index;
+}
+
+function resolveTaskTargetDir(
+  pilotHome: string,
+  sourceDir: string,
+  task: unknown,
+  blockedTaskDirs: Set<string>,
+): string {
+  if (!isRecord(task)) return sourceDir;
+  const projectKey = normalizedProjectKey(task.projectKey);
+  const targetDir = projectKey
+    ? resolveCronPaths({ pilotHome, projectKey }).projectDir
+    : sourceDir;
+  return blockedTaskDirs.has(targetDir) ? sourceDir : targetDir;
+}
+
+function resolveRunTargetDir(
+  pilotHome: string,
+  sourceDir: string,
+  run: JsonRecord,
+  taskProjects: Map<string, Set<string>>,
+  blockedTaskDirs: Set<string>,
+): string {
+  const explicitProject = normalizedProjectKey(run.projectKey);
+  if (explicitProject) {
+    const targetDir = resolveCronPaths({ pilotHome, projectKey: explicitProject }).projectDir;
+    return blockedTaskDirs.has(targetDir) ? sourceDir : targetDir;
+  }
+  if (typeof run.taskId !== "string") return sourceDir;
+  const projects = taskProjects.get(run.taskId);
+  if (projects?.size !== 1) return sourceDir;
+  const targetDir = resolveCronPaths({ pilotHome, projectKey: [...projects][0] }).projectDir;
+  return blockedTaskDirs.has(targetDir) ? sourceDir : targetDir;
+}
+
+async function stageDestinationData(
+  snapshots: StoreSnapshot[],
+  finalTasks: Map<string, unknown[]>,
+  finalRuns: Map<string, { records: JsonRecord[]; invalidLines: string[] }>,
+  logger?: CronRuntimeLogger,
+): Promise<void> {
+  const originals = new Map(snapshots.map((snapshot) => [snapshot.dir, snapshot]));
+  for (const [dir, tasks] of finalTasks) {
+    const original = originals.get(dir);
+    if (original && !original.taskFileWritable) continue;
+    await writeTaskFile(
+      dir,
+      dedupeTasks([...(original?.tasks ?? []), ...tasks], logger, dir),
+    );
+  }
+  for (const [dir, bucket] of finalRuns) {
+    const original = originals.get(dir);
+    await writeRunFile(dir, {
+      records: dedupeRuns([...(original?.runs ?? []), ...bucket.records]),
+      invalidLines: [...new Set([
+        ...(original?.invalidRunLines ?? []),
+        ...bucket.invalidLines,
+      ])],
+    });
+  }
+}
+
+async function writeFinalSnapshots(
+  snapshots: StoreSnapshot[],
+  finalTasks: Map<string, unknown[]>,
+  finalRuns: Map<string, { records: JsonRecord[]; invalidLines: string[] }>,
+): Promise<void> {
+  const originals = new Map(snapshots.map((snapshot) => [snapshot.dir, snapshot]));
+  for (const [dir, tasks] of finalTasks) {
+    const original = originals.get(dir);
+    if (original && !original.taskFileWritable) continue;
+    await writeTaskFile(dir, tasks);
+  }
+  for (const [dir, bucket] of finalRuns) {
+    await writeRunFile(dir, bucket);
+  }
+}
+
+async function writeTaskFile(dir: string, tasks: unknown[]): Promise<void> {
+  await atomicWrite(
+    resolve(dir, "tasks.json"),
+    `${JSON.stringify({ schemaVersion: 1, tasks }, null, 2)}\n`,
+  );
+}
+
+async function writeRunFile(
+  dir: string,
+  bucket: { records: JsonRecord[]; invalidLines: string[] },
+): Promise<void> {
+  const lines = [
+    ...bucket.records.map((record) => JSON.stringify(record)),
+    ...bucket.invalidLines,
+  ];
+  await atomicWrite(resolve(dir, "run-history.jsonl"), lines.length ? `${lines.join("\n")}\n` : "");
+}
+
+async function migrateRunEvents(
+  snapshots: StoreSnapshot[],
+  runTargets: Map<string, Set<string>>,
+  logger?: CronRuntimeLogger,
+): Promise<void> {
+  for (const snapshot of snapshots) {
+    for (const run of snapshot.runs) {
+      if (typeof run.runId !== "string") continue;
+      const targets = runTargets.get(run.runId);
+      if (!targets || targets.size !== 1) continue;
+      const targetDir = [...targets][0];
+      if (targetDir === snapshot.dir) continue;
+      const sourcePath = cronRunEventsPath(pathsForDir(snapshot.dir), run.runId);
+      const targetPath = cronRunEventsPath(pathsForDir(targetDir), run.runId);
+      let sourceRaw: string;
+      try {
+        sourceRaw = await readFile(sourcePath, "utf-8");
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === "ENOENT") continue;
+        throw error;
+      }
+      let targetRaw = "";
+      try {
+        targetRaw = await readFile(targetPath, "utf-8");
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+      }
+      const merged = mergeJsonLines(targetRaw, sourceRaw);
+      await atomicWrite(targetPath, merged);
+      await unlink(sourcePath).catch((error: NodeJS.ErrnoException) => {
+        if (error.code !== "ENOENT") {
+          logger?.warn("cron migration could not remove source run event file", {
+            sourcePath,
+            error: error.message,
+          });
+        }
+      });
+    }
+  }
+}
+
+function pathsForDir(projectDir: string) {
+  return {
+    pilotHome: "",
+    projectKey: "",
+    projectId: "",
+    rootDir: resolve(projectDir, "..", ".."),
+    projectDir,
+    tasksFile: resolve(projectDir, "tasks.json"),
+    runsDir: resolve(projectDir, "runs"),
+    runHistoryFile: resolve(projectDir, "run-history.jsonl"),
+  };
+}
+
+function dedupeTasks(
+  tasks: unknown[],
+  logger: CronRuntimeLogger | undefined,
+  projectDir: string,
+): unknown[] {
+  const anonymous: unknown[] = [];
+  const byId = new Map<string, unknown>();
+  for (const task of tasks) {
+    if (!isRecord(task) || typeof task.taskId !== "string") {
+      anonymous.push(task);
+      continue;
+    }
+    const current = byId.get(task.taskId);
+    if (!current || compareUpdatedAt(task, current) >= 0) {
+      if (current) {
+        logger?.warn("cron migration resolved duplicate task", {
+          taskId: task.taskId,
+          projectDir,
+        });
+      }
+      byId.set(task.taskId, task);
+    }
+  }
+  return [...byId.values(), ...anonymous];
+}
+
+function dedupeRuns(runs: JsonRecord[]): JsonRecord[] {
+  const anonymous: JsonRecord[] = [];
+  const byId = new Map<string, JsonRecord>();
+  for (const run of runs) {
+    if (typeof run.runId !== "string") {
+      anonymous.push(run);
+      continue;
+    }
+    const current = byId.get(run.runId);
+    if (!current || compareRun(run, current) >= 0) {
+      byId.set(run.runId, run);
+    }
+  }
+  return [...byId.values(), ...anonymous].sort((left, right) =>
+    String(left.startedAt ?? "").localeCompare(String(right.startedAt ?? "")));
+}
+
+function compareUpdatedAt(left: JsonRecord, right: unknown): number {
+  const rightRecord = isRecord(right) ? right : {};
+  return String(left.updatedAt ?? "").localeCompare(String(rightRecord.updatedAt ?? ""));
+}
+
+function compareRun(left: JsonRecord, right: JsonRecord): number {
+  const leftTerminal = typeof left.finishedAt === "string" ? 1 : 0;
+  const rightTerminal = typeof right.finishedAt === "string" ? 1 : 0;
+  if (leftTerminal !== rightTerminal) return leftTerminal - rightTerminal;
+  return String(left.finishedAt ?? left.startedAt ?? "")
+    .localeCompare(String(right.finishedAt ?? right.startedAt ?? ""));
+}
+
+function mergeJsonLines(left: string, right: string): string {
+  const lines = new Set(
+    `${left}\n${right}`.split("\n").filter((line) => line.trim().length > 0),
+  );
+  return lines.size ? `${[...lines].join("\n")}\n` : "";
+}
+
+async function atomicWrite(path: string, content: string): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  const tempPath = `${path}.${process.pid}.${Date.now()}.tmp`;
+  await writeFile(tempPath, content, "utf-8");
+  try {
+    await rename(tempPath, path);
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === "EPERM" || code === "EACCES") {
+      await copyFile(tempPath, path);
+      await unlink(tempPath).catch(() => undefined);
+      return;
+    }
+    throw error;
+  }
+}
+
+async function acquireMigrationLock(
+  rootDir: string,
+  logger?: CronRuntimeLogger,
+): Promise<() => Promise<void>> {
+  await mkdir(rootDir, { recursive: true });
+  const lockPath = resolve(rootDir, ".store-migration.lock");
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    try {
+      const handle = await open(lockPath, "wx");
+      await handle.writeFile(`${JSON.stringify({ pid: process.pid, startedAt: new Date().toISOString() })}\n`);
+      await handle.close();
+      return async () => {
+        await rm(lockPath, { force: true });
+      };
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+      let age: number;
+      try {
+        age = Date.now() - (await stat(lockPath)).mtimeMs;
+      } catch (statError) {
+        if ((statError as NodeJS.ErrnoException).code === "ENOENT") continue;
+        throw statError;
+      }
+      if (age > LOCK_STALE_MS) {
+        logger?.warn("cron store migration removed a stale lock", { lockPath, ageMs: age });
+        await rm(lockPath, { force: true });
+        continue;
+      }
+      await new Promise((resolveDelay) => setTimeout(resolveDelay, 100));
+    }
+  }
+  throw new Error(`Timed out waiting for Cron store migration lock: ${lockPath}`);
+}
+
+function normalizedProjectKey(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? resolve(value) : undefined;
+}
+
+function isRecord(value: unknown): value is JsonRecord {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function pushMapArray(map: Map<string, unknown[]>, key: string, value: unknown): void {
+  const values = map.get(key) ?? [];
+  values.push(value);
+  map.set(key, values);
+}
+
+function getRunBucket(
+  map: Map<string, { records: JsonRecord[]; invalidLines: string[] }>,
+  key: string,
+): { records: JsonRecord[]; invalidLines: string[] } {
+  const bucket = map.get(key) ?? { records: [], invalidLines: [] };
+  map.set(key, bucket);
+  return bucket;
+}

--- a/src/cron/storage/CronTaskStore.ts
+++ b/src/cron/storage/CronTaskStore.ts
@@ -174,6 +174,7 @@ function normalizeTask(value: unknown): CronTask | undefined {
     updatedAt: candidate.updatedAt,
     nextRunAt: typeof candidate.nextRunAt === "string" ? candidate.nextRunAt : undefined,
     lastRunId: typeof candidate.lastRunId === "string" ? candidate.lastRunId : undefined,
+    scheduleComputationVersion: candidate.scheduleComputationVersion === 2 ? 2 : undefined,
   };
 }
 

--- a/src/cron/tool/CronCreateTool.ts
+++ b/src/cron/tool/CronCreateTool.ts
@@ -18,7 +18,6 @@ export function createCronCreateTool(runtime: CronToolRuntime): PilotDeckToolDef
         schedule: CRON_SCHEDULE_SCHEMA,
         sessionKey: { type: "string" },
         channelKey: { type: "string" },
-        projectKey: { type: "string" },
         mode: { type: "string" },
         timezone: { type: "string" },
       },
@@ -28,7 +27,7 @@ export function createCronCreateTool(runtime: CronToolRuntime): PilotDeckToolDef
     execute: async (input, context) => {
       const result = await runtime.createTask({
         ...input,
-        projectKey: input.projectKey ?? context.cwd,
+        projectKey: context.cwd,
       });
       return {
         content: [{ type: "json", value: result.task }],

--- a/src/cron/tool/CronDeleteTool.ts
+++ b/src/cron/tool/CronDeleteTool.ts
@@ -20,8 +20,11 @@ export function createCronDeleteTool(runtime: CronToolRuntime): PilotDeckToolDef
     isReadOnly: () => false,
     isConcurrencySafe: () => false,
     isDestructive: () => true,
-    execute: async (input) => {
-      const result = await runtime.deleteTask(input);
+    execute: async (input, context) => {
+      const result = await runtime.deleteTask({
+        ...input,
+        projectKey: context.cwd,
+      });
       return {
         content: [{ type: "json", value: result }],
         data: result,

--- a/src/cron/tool/CronListTool.ts
+++ b/src/cron/tool/CronListTool.ts
@@ -18,8 +18,11 @@ export function createCronListTool(runtime: CronToolRuntime): PilotDeckToolDefin
     },
     isReadOnly: () => true,
     isConcurrencySafe: () => true,
-    execute: async (input) => {
-      const result = await runtime.listTasks(input ?? {});
+    execute: async (input, context) => {
+      const result = await runtime.listTasks({
+        ...(input ?? {}),
+        projectKey: context.cwd,
+      });
       return {
         content: [{ type: "json", value: result }],
         data: result,

--- a/src/cron/tool/CronStopTool.ts
+++ b/src/cron/tool/CronStopTool.ts
@@ -18,8 +18,11 @@ export function createCronStopTool(runtime: CronToolRuntime): PilotDeckToolDefin
     },
     isReadOnly: () => false,
     isConcurrencySafe: () => false,
-    execute: async (input) => {
-      const result = await runtime.stopTask(input);
+    execute: async (input, context) => {
+      const result = await runtime.stopTask({
+        ...input,
+        projectKey: context.cwd,
+      });
       return {
         content: [{ type: "json", value: result }],
         data: result,

--- a/src/gateway/client/InProcessGateway.ts
+++ b/src/gateway/client/InProcessGateway.ts
@@ -302,6 +302,8 @@ export class InProcessGateway implements Gateway {
     }
 
     const telemetryContext = resolveSubmitTurnTelemetry(input);
+    let timeoutHandle: NodeJS.Timeout | undefined;
+    let timedOut = false;
 
     // Background pump: agent events → queue.
     const pump = (async () => {
@@ -311,6 +313,28 @@ export class InProcessGateway implements Gateway {
           projectKey: input.projectKey,
           channelKey: input.channelKey,
         });
+        if (input.timeoutMs !== undefined && Number.isFinite(input.timeoutMs) && input.timeoutMs > 0) {
+          timeoutHandle = setTimeout(() => {
+            timedOut = true;
+            const gatewayEvent: GatewayEvent = {
+              type: "error",
+              code: "turn_timeout",
+              message: `Turn exceeded the ${input.timeoutMs}ms timeout.`,
+              recoverable: false,
+            };
+            this.recordActiveTurnEvent(input.sessionKey, gatewayEvent);
+            queue.enqueue(gatewayEvent);
+            this.elicitationBus.rejectSession(input.sessionKey, "turn_timeout");
+            this.permissionBus.rejectSession(input.sessionKey, "turn_timeout");
+            queue.close();
+            try {
+              session.abort(`timeout:${runId}`);
+            } catch {
+              // The queue is already closed, so a faulty abort implementation
+              // cannot defeat the hard turn timeout.
+            }
+          }, input.timeoutMs);
+        }
         const permissionSettings = readPermissionSettings();
         const permissionMode = input.mode ?? (permissionSettings.skipPermissions ? "bypassPermissions" : undefined);
         const persistedRules = permissionSettingsToRuleSet(permissionSettings);
@@ -349,6 +373,9 @@ export class InProcessGateway implements Gateway {
             },
           },
         )) {
+          if (this.turnCompletions.get(input.sessionKey) !== turnDone) {
+            break;
+          }
           emitSessionTelemetry(this.options.telemetry, event, {
             sessionId: input.sessionKey,
             runId,
@@ -377,15 +404,21 @@ export class InProcessGateway implements Gateway {
             channelKey: input.channelKey,
           },
         });
-        const gatewayEvent: GatewayEvent = {
-          type: "error",
-          code: "gateway_submit_failed",
-          message: error instanceof Error ? error.message : String(error),
-          recoverable: false,
-        };
-        this.recordActiveTurnEvent(input.sessionKey, gatewayEvent);
-        queue.enqueue(gatewayEvent);
+        if (this.turnCompletions.get(input.sessionKey) === turnDone) {
+          const gatewayEvent: GatewayEvent = {
+            type: "error",
+            code: "gateway_submit_failed",
+            message: error instanceof Error ? error.message : String(error),
+            recoverable: false,
+          };
+          this.recordActiveTurnEvent(input.sessionKey, gatewayEvent);
+          queue.enqueue(gatewayEvent);
+        }
       } finally {
+        if (timeoutHandle) {
+          clearTimeout(timeoutHandle);
+          timeoutHandle = undefined;
+        }
         queue.close();
       }
     })();
@@ -403,8 +436,15 @@ export class InProcessGateway implements Gateway {
       this.elicitationBus.rejectSession(input.sessionKey, "turn_ended");
       this.permissionBus.rejectSession(input.sessionKey, "turn_ended");
       this.router.endTurn(input.sessionKey, runId);
-      // Defensive — make sure the pump promise is settled before we resolve.
-      await pump.catch(() => undefined);
+      if (timedOut) {
+        // The timed-out AgentSession is never safe to reuse. Do not await a
+        // misbehaving tool here: the hard timeout must release the Cron run.
+        await this.router.close(input.sessionKey);
+        void pump.catch(() => undefined);
+      } else {
+        // Defensive — make sure the pump promise is settled before we resolve.
+        await pump.catch(() => undefined);
+      }
       // Signal any in-flight `abortTurn` awaiters that the session slot
       // has been released. Drop our deferred only if we still own it —
       // a later turn for the same session may have already installed

--- a/src/gateway/protocol/types.ts
+++ b/src/gateway/protocol/types.ts
@@ -81,6 +81,8 @@ export type GatewaySubmitTurnInput = {
   basePermissionMode?: GatewayMode;
   runId?: string;
   maxTurns?: number;
+  /** Hard wall-clock limit for this turn. The gateway aborts and closes the session when exceeded. */
+  timeoutMs?: number;
   telemetry?: {
     ownerModule?: TelemetryModule;
     executionKind?: TelemetryExecutionKind;

--- a/ui/server/always-on-slash.js
+++ b/ui/server/always-on-slash.js
@@ -383,7 +383,10 @@ export async function executeAlwaysOnSlashCommand(args = [], context = {}) {
 
     if (parsed.action === 'run' && parsed.target === 'cron') {
       const gateway = await getPilotDeckGateway();
-      const result = await gateway.cronRunNow({ taskId: parsed.id });
+      const result = await gateway.cronRunNow({
+        taskId: parsed.id,
+        projectKey: project.projectPath,
+      });
 
       if (result.reason === 'not_found') {
         return buildResponse(buildNotFoundMarkdown('cron job', parsed.id));

--- a/ui/server/index.js
+++ b/ui/server/index.js
@@ -532,7 +532,10 @@ app.get('/api/always-on/cron-jobs', authenticateToken, async (_req, res) => {
 app.post('/api/always-on/cron-jobs/:taskId/run-now', authenticateToken, async (req, res) => {
     try {
         const gateway = await getPilotDeckGateway();
-        const result = await gateway.cronRunNow({ taskId: req.params.taskId });
+        const result = await gateway.cronRunNow({
+            taskId: req.params.taskId,
+            projectKey: req.body?.projectKey || req.query?.projectKey || undefined,
+        });
         res.json(result);
     } catch (error) {
         console.error('[always-on-cron-run-now] failed:', error);
@@ -543,7 +546,10 @@ app.post('/api/always-on/cron-jobs/:taskId/run-now', authenticateToken, async (r
 app.post('/api/always-on/cron-jobs/:taskId/stop', authenticateToken, async (req, res) => {
     try {
         const gateway = await getPilotDeckGateway();
-        const result = await gateway.cronStop({ taskId: req.params.taskId });
+        const result = await gateway.cronStop({
+            taskId: req.params.taskId,
+            projectKey: req.body?.projectKey || req.query?.projectKey || undefined,
+        });
         res.json(result);
     } catch (error) {
         console.error('[always-on-cron-stop] failed:', error);
@@ -554,7 +560,11 @@ app.post('/api/always-on/cron-jobs/:taskId/stop', authenticateToken, async (req,
 app.delete('/api/always-on/cron-jobs/:taskId', authenticateToken, async (req, res) => {
     try {
         const gateway = await getPilotDeckGateway();
-        const result = await gateway.cronDelete({ taskId: req.params.taskId, stopRunning: true });
+        const result = await gateway.cronDelete({
+            taskId: req.params.taskId,
+            projectKey: req.body?.projectKey || req.query?.projectKey || undefined,
+            stopRunning: true,
+        });
         res.json(result);
     } catch (error) {
         console.error('[always-on-cron-delete] failed:', error);
@@ -1818,8 +1828,8 @@ function handleChatConnection(ws, request) {
     const userId = request?.user?.id ?? request?.user?.userId ?? null;
     ws.__pilotdeckUserId = userId;
     connectedClients.add(ws);
-    // PilotDeck's cron runtime lives inside `pilotdeck server`
-    // (src/cron via createCronRuntime); no legacy daemon lease needed.
+    // PilotDeck's cron manager lives inside `pilotdeck server`;
+    // no legacy daemon lease is needed.
     let cleanedUp = false;
 
     // Wrap WebSocket with writer for consistent interface with SSEStreamWriter

--- a/ui/server/projects.js
+++ b/ui/server/projects.js
@@ -486,10 +486,17 @@ async function resolveProjectIdForPathOrName(projectName, fullPath) {
     return createProjectId(fullPath);
 }
 
-async function getProjectCronJobsOverview(_projectName) {
+async function getProjectCronJobsOverview(projectName) {
     try {
         const gateway = await getPilotDeckGateway();
-        const result = await gateway.cronList({ includeHistory: true, limit: 50 });
+        const projectKey = projectName
+            ? await extractProjectDirectory(projectName)
+            : undefined;
+        const result = await gateway.cronList({
+            projectKey,
+            includeHistory: true,
+            limit: 50,
+        });
         const runsByTaskId = new Map();
         if (Array.isArray(result.recentRuns)) {
             for (const run of result.recentRuns) {


### PR DESCRIPTION
## Summary

- run Cron agent sessions as unattended work with `bypassPermissions`, no interactive tools, and a configurable hard timeout
- recover interrupted/running jobs and persist a single terminal run result
- evaluate recurring schedules in their effective IANA timezone, including DST transitions and legacy schedule migration
- replace the process-CWD-bound Cron runtime with a multi-project manager and project-scoped stores
- migrate misplaced tasks, run history, and event streams into the correct project store with locking and idempotent writes
- scope Web server Cron queries and actions by project while preserving unscoped Gateway compatibility

## Root cause

Cron previously used one runtime created with `process.cwd()`. Task `projectKey` controlled the execution session but not the task/run store, so jobs were persisted under the directory where PilotDeck was launched. Cron sessions could also wait indefinitely for interaction, and recurring schedule calculation did not consistently honor IANA timezones.

## Impact

Cron jobs now remain isolated to their originating workspace, existing misplaced data is migrated at startup, unattended runs cannot block on user interaction, stale `running` jobs recover after restart, and recurring schedules execute in their configured timezone.

## Validation

- `npm run build`
- before removing the requested local `tests` directory, the full local suite passed with 20/20 tests
- `node --check ui/server/projects.js`
- `node --check ui/server/always-on-slash.js`
- `node --check ui/server/index.js`
- `git diff --check`