### PR TITLE
feat(always-on): degrade gracefully when report phase fails after successful execution

### DIFF
--- a/src/always-on/protocol/types.ts
+++ b/src/always-on/protocol/types.ts
@@ -57,6 +57,7 @@ export type DiscoveryPlanStatus =
   | "ready"
   | "executing"
   | "completed"
+  | "completed_no_report"
   | "failed"
   | "archived";
 

--- a/src/always-on/runtime/DiscoveryFire.ts
+++ b/src/always-on/runtime/DiscoveryFire.ts
@@ -471,7 +471,7 @@ export class DiscoveryFire {
 
     const finishedAt = this.deps.now();
 
-    if (!reportCtx.report && !reportError) {
+    if (!reportCtx.report) {
       const assistantText = extractAssistantText(reportEvents);
       if (assistantText) {
         const metadata: ReportMetadata = {
@@ -489,25 +489,25 @@ export class DiscoveryFire {
       }
     }
 
-    const outcome: AlwaysOnDiscoveryOutcome = reportCtx.report && !reportError ? "executed" : "failed";
+    const reportDegraded = !reportCtx.report || !!reportError;
+    const outcome: AlwaysOnDiscoveryOutcome = "executed";
+    const planStatus = reportDegraded ? "completed_no_report" as const : "completed" as const;
 
-    if (reportCtx.report && !reportError) {
+    if (!reportDegraded) {
       this.emitEvent(runId, "report_produced", { planId, title: planRecord.title, outcome });
-      this.emitEvent(runId, "run_completed", { planId, title: planRecord.title, outcome });
-    } else {
-      this.emitEvent(runId, "run_failed", { planId, error: reportError ? { code: reportError.code ?? "report_failed", message: reportError.message } : { code: "report_tool_not_invoked", message: "Report tool was not invoked" }, outcome, telemetryPhase: "report" });
     }
+    this.emitEvent(runId, "run_completed", { planId, title: planRecord.title, outcome });
 
     let reportFilePath = reportCtx.report?.filePath;
     if (!reportCtx.report) {
       reportFilePath = await this.writeFallbackReport({ runId, plan: planRecord, startedAt: startedAt.toISOString(), finishedAt: finishedAt.toISOString(), reason: reportError ? `report_failed: ${reportError.message}` : "report_tool_not_invoked", workspaceStrategy: workspace.strategy, workspaceHandle: workspace.cwd });
     }
 
-    await this.deps.planStore.updateStatus(planId, { status: outcome === "executed" ? "completed" : "failed", reportFilePath, workCycleId: workCycle.id });
+    await this.deps.planStore.updateStatus(planId, { status: planStatus, reportFilePath, workCycleId: workCycle.id });
     await this.deps.stateStore.markFireCompleted({ outcome, runId, planId, now: finishedAt });
-    await this.deps.reportStore.appendHistory({ ...baseHistory, outcome, finishedAt: finishedAt.toISOString(), workCycleId: workCycle.id, workspace: { strategy: workspace.strategy, handle: workspace.cwd }, error: reportError ? { code: reportError.code ?? "report_failed", message: reportError.message } : undefined });
+    await this.deps.reportStore.appendHistory({ ...baseHistory, outcome, finishedAt: finishedAt.toISOString(), workCycleId: workCycle.id, workspace: { strategy: workspace.strategy, handle: workspace.cwd }, error: reportError ? { code: reportError.code ?? "report_degraded", message: reportError.message } : undefined });
 
-    return { outcome, runId, startedAt: startedAt.toISOString(), finishedAt: finishedAt.toISOString(), planId, workspace, reportFilePath, error: reportError ? { code: reportError.code ?? "report_failed", message: reportError.message } : undefined };
+    return { outcome, runId, startedAt: startedAt.toISOString(), finishedAt: finishedAt.toISOString(), planId, workspace, reportFilePath, error: reportError ? { code: reportError.code ?? "report_degraded", message: reportError.message } : undefined };
   }
 
   async run(input: DiscoveryFireRunInput): Promise<DiscoveryFireResult> {
@@ -842,7 +842,7 @@ export class DiscoveryFire {
 
     const finishedAt = this.deps.now();
 
-    if (!reportCtx.report && !reportError) {
+    if (!reportCtx.report) {
       const assistantText = extractAssistantText(reportEvents);
       if (assistantText) {
         const metadata: ReportMetadata = {
@@ -860,21 +860,14 @@ export class DiscoveryFire {
       }
     }
 
-    const outcome: AlwaysOnDiscoveryOutcome = reportCtx.report && !reportError ? "executed" : "failed";
+    const reportDegraded = !reportCtx.report || !!reportError;
+    const outcome: AlwaysOnDiscoveryOutcome = "executed";
+    const planStatus = reportDegraded ? "completed_no_report" as const : "completed" as const;
 
-    if (reportCtx.report && !reportError) {
+    if (!reportDegraded) {
       this.emitEvent(runId, "report_produced", { planId: planRecord.id, title: planRecord.title, outcome });
-      this.emitEvent(runId, "run_completed", { planId: planRecord.id, title: planRecord.title, outcome });
-    } else {
-      this.emitEvent(runId, "run_failed", {
-        planId: planRecord.id,
-        error: reportError
-          ? { code: reportError.code ?? "report_failed", message: reportError.message }
-          : { code: "report_tool_not_invoked", message: "Report tool was not invoked" },
-        outcome,
-        telemetryPhase: "report",
-      });
     }
+    this.emitEvent(runId, "run_completed", { planId: planRecord.id, title: planRecord.title, outcome });
 
     let reportFilePath = reportCtx.report?.filePath;
     if (!reportCtx.report) {
@@ -892,7 +885,7 @@ export class DiscoveryFire {
     }
 
     await this.deps.planStore.updateStatus(planRecord.id, {
-      status: outcome === "executed" ? "completed" : "failed",
+      status: planStatus,
       reportFilePath,
       workCycleId: workCycle.id,
     });
@@ -909,7 +902,7 @@ export class DiscoveryFire {
       finishedAt: finishedAt.toISOString(),
       workCycleId: workCycle.id,
       workspace: { strategy: workspace.strategy, handle: workspace.cwd },
-      error: reportError ? { code: reportError.code ?? "report_failed", message: reportError.message } : undefined,
+      error: reportError ? { code: reportError.code ?? "report_degraded", message: reportError.message } : undefined,
     });
 
     return {
@@ -920,7 +913,7 @@ export class DiscoveryFire {
       planId: planRecord.id,
       workspace,
       reportFilePath,
-      error: reportError ? { code: reportError.code ?? "report_failed", message: reportError.message } : undefined,
+      error: reportError ? { code: reportError.code ?? "report_degraded", message: reportError.message } : undefined,
     };
   }
 

--- a/src/always-on/storage/DiscoveryPlanStore.ts
+++ b/src/always-on/storage/DiscoveryPlanStore.ts
@@ -80,7 +80,7 @@ export class DiscoveryPlanStore {
     if (update.status !== undefined) {
       target.status = update.status;
       const raw = target as Record<string, unknown>;
-      if ("executionStatus" in raw && (update.status === "completed" || update.status === "failed")) {
+      if ("executionStatus" in raw && (update.status === "completed" || update.status === "completed_no_report" || update.status === "failed")) {
         raw.executionStatus = update.status;
       }
     }

--- a/src/always-on/web/DiscoveryPlanService.ts
+++ b/src/always-on/web/DiscoveryPlanService.ts
@@ -439,7 +439,9 @@ export class DiscoveryPlanService {
 
     const store = await readPlanStore(projectDir);
     const cyclePlans = store.plans.filter((p) => cycle.planIds.includes(p.id));
-    const hasCompleted = cyclePlans.some((p) => p.status === "completed");
+    const hasCompleted = cyclePlans.some(
+      (p) => p.status === "completed" || p.status === "completed_no_report",
+    );
     if (!hasCompleted) {
       throw makeError("Cycle has no completed plans to apply", "INVALID_STATE");
     }

--- a/src/always-on/web/DiscoveryPlanStatus.ts
+++ b/src/always-on/web/DiscoveryPlanStatus.ts
@@ -16,6 +16,7 @@ export type WebPlanStatus =
   | "ready"
   | "failed"
   | "completed"
+  | "completed_no_report"
   | "archived";
 
 export type WebPlanRecord = {
@@ -85,6 +86,7 @@ export const PLAN_STATUS_ORDER: Record<string, number> = {
   ready: 3,
   failed: 4,
   completed: 5,
+  completed_no_report: 5,
   archived: 7,
 };
 
@@ -116,6 +118,7 @@ export function computeExecutionStatus(
     plan.status === "queued" ||
     plan.status === "running" ||
     plan.status === "completed" ||
+    plan.status === "completed_no_report" ||
     plan.status === "failed"
   ) {
     return plan.status;

--- a/ui/src/components/main-content-v2/PlansAndCronJobs.tsx
+++ b/ui/src/components/main-content-v2/PlansAndCronJobs.tsx
@@ -35,6 +35,7 @@ type PlanDisplayStatus =
   | 'preparingWorkspace'
   | 'executing'
   | 'completedWaiting'
+  | 'completedNoReport'
   | 'failed'
   | 'archived';
 
@@ -48,6 +49,8 @@ function mapPlanStatus(status: DiscoveryPlanStatus): PlanDisplayStatus {
       return 'executing';
     case 'completed':
       return 'completedWaiting';
+    case 'completed_no_report':
+      return 'completedNoReport';
     case 'failed':
       return 'failed';
     case 'archived':
@@ -62,6 +65,7 @@ const PLAN_STATUS_STYLE: Record<PlanDisplayStatus, string> = {
   preparingWorkspace: 'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300',
   executing: 'bg-indigo-100 text-indigo-700 dark:bg-indigo-900/40 dark:text-indigo-300',
   completedWaiting: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300',
+  completedNoReport: 'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300',
   failed: 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300',
   archived: 'bg-neutral-100 text-neutral-500 dark:bg-neutral-800 dark:text-neutral-400',
 };
@@ -71,6 +75,7 @@ const PLAN_STATUS_LABEL: Record<PlanDisplayStatus, { key: string; defaultValue: 
   preparingWorkspace: { key: 'plansCron.status.preparingWorkspace', defaultValue: 'Preparing Workspace' },
   executing: { key: 'plansCron.status.executing', defaultValue: 'Executing' },
   completedWaiting: { key: 'plansCron.status.completedWaiting', defaultValue: 'Completed' },
+  completedNoReport: { key: 'plansCron.status.completedNoReport', defaultValue: 'Report Unavailable' },
   failed: { key: 'plansCron.status.failed', defaultValue: 'Failed' },
   archived: { key: 'plansCron.status.archived', defaultValue: 'Archived' },
 };
@@ -365,7 +370,10 @@ export default function PlansAndCronJobs({ onApplyWorkCycle, onOpenPlanDetail }:
                   const cronItems = items.filter((i) => i.kind === 'cron');
                   const cycles = cyclesByProject.get(projectKey) ?? [];
                   const activeCycle = cycles.find((c) => c.status === 'active' || c.status === 'applying');
-                  const hasCompletedPlan = planItems.some((p) => (p.data as DiscoveryPlanOverview).status === 'completed');
+                  const hasCompletedPlan = planItems.some((p) => {
+                    const s = (p.data as DiscoveryPlanOverview).status;
+                    return s === 'completed' || s === 'completed_no_report';
+                  });
                   const canApply = !!activeCycle && activeCycle.status === 'active' && hasCompletedPlan;
                   const canArchive = !!activeCycle && activeCycle.status === 'active';
                   const isApplying = activeCycle?.status === 'applying';

--- a/ui/src/types/app.ts
+++ b/ui/src/types/app.ts
@@ -64,6 +64,7 @@ export type DiscoveryPlanStatus =
   | 'queued'
   | 'running'
   | 'completed'
+  | 'completed_no_report'
   | 'failed'
   | 'archived';
 


### PR DESCRIPTION
## Summary

- When Always-On execution succeeds but the report phase fails (e.g. transient model error), the plan is now marked `completed_no_report` instead of `failed`.
- This new status shows an amber "Report Unavailable" badge in the Web UI (no Retry button), and the work cycle remains eligible for Apply.
- The fallback text extraction from assistant output is now attempted even when a model error occurs, improving report salvage chances.

## Motivation

Previously, a transient model provider error during the report phase would mark the entire run as `failed` — even though the execution phase completed successfully and code changes were applied in the isolated workspace. This caused:
1. A red "Failed" badge with a misleading Retry button
2. The work cycle being blocked from Apply (if no other completed plans existed)
3. `consecutiveFailures` counter incrementing, delaying the next scheduled run

## Changes

| Layer | File | Change |
|-------|------|--------|
| Protocol | `src/always-on/protocol/types.ts` | Add `"completed_no_report"` to `DiscoveryPlanStatus` |
| Runtime | `src/always-on/runtime/DiscoveryFire.ts` | Relax fallback text extraction guard; set outcome to `"executed"` and plan status to `"completed_no_report"` when report degrades (both `run()` and `rerunPlan()`) |
| Storage | `src/always-on/storage/DiscoveryPlanStore.ts` | Include new status in `executionStatus` sync condition |
| Web service | `src/always-on/web/DiscoveryPlanStatus.ts` | Add to `WebPlanStatus`, sort order, and `computeExecutionStatus` |
| Web service | `src/always-on/web/DiscoveryPlanService.ts` | Include new status in `queueCycleApply` eligibility check |
| Frontend | `ui/src/types/app.ts` | Add to `DiscoveryPlanStatus` union |
| Frontend | `ui/src/components/main-content-v2/PlansAndCronJobs.tsx` | Add `completedNoReport` display status with amber styling, include in `hasCompletedPlan` check |

## Test plan

- [ ] Trigger an Always-On run where execution succeeds but report phase encounters a model error → verify plan status is `completed_no_report` in `plans/index.json`
- [ ] Verify Web UI shows amber "Report Unavailable" badge (not red "Failed")
- [ ] Verify no Retry button appears for `completed_no_report` plans
- [ ] Verify "Apply All" button is enabled when cycle contains `completed_no_report` plans
- [ ] Verify `consecutiveFailures` resets to 0 (outcome is `"executed"`)
- [ ] Verify fallback report `.md` file is still written to disk with degradation reason


Made with [Cursor](https://cursor.com)