### PR TITLE
[codex] fix Cron run-now identity and settings state

### DIFF
--- a/src/cron/runtime/CronRuntime.ts
+++ b/src/cron/runtime/CronRuntime.ts
@@ -301,13 +301,13 @@ export class CronRuntime {
     if (!task) return { started: false, reason: "not_found" };
     if (task.status === "running") return { started: false, reason: "already_running", taskId: task.taskId };
 
-    await this.createTask({
+    const created = await this.createTask({
       message: task.message,
       schedule: { type: "once", runAt: new Date().toISOString() },
       projectKey: task.projectKey,
       mode: task.mode,
     });
-    return { started: true, taskId: task.taskId };
+    return { started: true, taskId: created.task.taskId };
   }
 
   runTickOnce(): Promise<void> {

--- a/ui/src/components/settings/view/tabs/PilotDeckConfigTab.cron.test.ts
+++ b/ui/src/components/settings/view/tabs/PilotDeckConfigTab.cron.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { isCronConfigEnabled, patch } from './pilotDeckConfigForm';
+
+describe('PilotDeckConfigTab Cron settings', () => {
+  it.each([
+    { label: 'missing cron section', config: {}, expected: false },
+    { label: 'cron section without enabled', config: { cron: {} }, expected: true },
+    { label: 'explicitly enabled cron section', config: { cron: { enabled: true } }, expected: true },
+    { label: 'explicitly disabled cron section', config: { cron: { enabled: false } }, expected: false },
+  ])('treats $label as enabled=$expected', ({ config, expected }) => {
+    expect(isCronConfigEnabled(config)).toBe(expected);
+  });
+
+  it('creates cron.enabled when enabling a missing cron section without changing other config', () => {
+    const config = {
+      schemaVersion: 1,
+      agent: { model: 'provider/model' },
+      customEnv: { EXISTING_VALUE: 'preserved' },
+    };
+
+    const updated = patch(config, ['cron', 'enabled'], true);
+
+    expect(updated).toEqual({
+      ...config,
+      cron: { enabled: true },
+    });
+    expect(config).not.toHaveProperty('cron');
+  });
+});

--- a/ui/src/components/settings/view/tabs/PilotDeckConfigTab.tsx
+++ b/ui/src/components/settings/view/tabs/PilotDeckConfigTab.tsx
@@ -51,6 +51,7 @@ import {
   type CatalogModel,
 } from '../../../../shared/catalogProviders';
 import type { SettingsProject } from '../../types/types';
+import { isCronConfigEnabled, patch } from './pilotDeckConfigForm';
 
 // ── V2 schema types ────────────────────────────────────────────────────
 // Schema mirrors ~/.pilotdeck/pilotdeck.yaml exactly. No more
@@ -357,21 +358,6 @@ function safeParseYaml(text: string): PilotDeckConfig | null {
  */
 function configToYamlString(config: PilotDeckConfig): string {
   return stringifyYaml(config, { indent: 2, lineWidth: 0 });
-}
-
-type Path = readonly (string | number)[];
-
-function patch<T extends PilotDeckConfig>(config: T, path: Path, value: unknown): T {
-  // Immutable deep set. Each key cloned along the way so React picks up the
-  // change. Numeric segments materialise arrays; everything else materialises
-  // objects.
-  if (path.length === 0) return value as T;
-  const [head, ...rest] = path;
-  const isArrayKey = typeof head === 'number';
-  const current: any = config ?? (isArrayKey ? [] : {});
-  const next: any = isArrayKey ? [...(current as unknown[])] : { ...(current as object) };
-  next[head as string | number] = rest.length === 0 ? value : patch(current?.[head as string | number] ?? (typeof rest[0] === 'number' ? [] : {}), rest, value);
-  return next as T;
 }
 
 function rewriteProviderRef(value: unknown, oldProviderId: string, newProviderId: string): unknown {
@@ -1831,7 +1817,7 @@ function AlwaysOnSection({
 function CronSection({ config, onChange }: { config: PilotDeckConfig; onChange: (next: PilotDeckConfig) => void }) {
   const { t } = useTranslation('settings');
   const cron = config.cron ?? {};
-  const enabled = cron.enabled !== false;
+  const enabled = isCronConfigEnabled(config);
 
   return (
     <SettingsSection

--- a/ui/src/components/settings/view/tabs/pilotDeckConfigForm.ts
+++ b/ui/src/components/settings/view/tabs/pilotDeckConfigForm.ts
@@ -1,0 +1,30 @@
+type Path = readonly (string | number)[];
+
+type CronConfigShape = {
+  cron?: {
+    enabled?: boolean;
+  };
+};
+
+export function patch<T>(config: T, path: Path, value: unknown): T {
+  // Immutable deep set. Each key cloned along the way so React picks up the
+  // change. Numeric segments materialise arrays; everything else materialises
+  // objects.
+  if (path.length === 0) return value as T;
+  const [head, ...rest] = path;
+  const isArrayKey = typeof head === 'number';
+  const current: any = config ?? (isArrayKey ? [] : {});
+  const next: any = isArrayKey ? [...(current as unknown[])] : { ...(current as object) };
+  next[head as string | number] = rest.length === 0
+    ? value
+    : patch(
+        current?.[head as string | number] ?? (typeof rest[0] === 'number' ? [] : {}),
+        rest,
+        value,
+      );
+  return next as T;
+}
+
+export function isCronConfigEnabled(config: CronConfigShape): boolean {
+  return config.cron !== undefined && config.cron.enabled !== false;
+}


### PR DESCRIPTION
## Summary

- make Cron Run Now return the newly created one-shot task ID instead of the source recurring task ID
- align the Settings Cron toggle with runtime behavior when the `cron` section is missing

## Root cause

`CronRuntime.runTaskNow` created a new one-shot task but discarded the `createTask` result and returned the original recurring task ID. Separately, Settings treated a missing `cron` section as enabled even though the runtime does not create a Cron manager in that case.

## Impact

API callers can now address the actual task created for an immediate run. Settings also reflects whether Cron is actually configured.

## Validation

- `npm run build`
- `npm test` before removing the requested root `tests` directory
- `npm --prefix ui test -- --run src/components/settings/view/tabs/PilotDeckConfigTab.cron.test.ts`
- `git diff --check`

Closes #244
Closes #255
