### PR TITLE
Reduce gateway memory retention for large tool outputs

### DIFF
--- a/src/agent/loop/AgentLoop.ts
+++ b/src/agent/loop/AgentLoop.ts
@@ -36,7 +36,7 @@ import type { LifecycleDispatchResult } from "../../lifecycle/index.js";
 import type { PilotDeckHookEvent } from "../../extension/hooks/protocol/events.js";
 import { NullContextRuntime } from "../../context/NullContextRuntime.js";
 import type { AgentContextRuntime } from "../../context/ContextRuntime.js";
-import type { ContextRecoveryDecision } from "../../context/index.js";
+import type { ContextRecoveryDecision, ContextSupplementalToolResultMessage } from "../../context/index.js";
 import type { PermissionMode, PermissionRule, PermissionRuleSet } from "../../permission/index.js";
 import { collectToolCalls } from "./collectToolCalls.js";
 import { createMissingToolResult, ensureToolResultPairing } from "./ensureToolResultPairing.js";
@@ -879,6 +879,7 @@ export class AgentLoop {
       // the runtime doesn't implement `applyToolResults` (e.g. NullContext),
       // we simply append the raw projection (legacy behaviour).
       const [toolResultMsg, ...supplementalMsgs] = projected;
+      const supplementalInputs = bindSupplementalMessagesToToolCalls(pairedResults, supplementalMsgs);
       let appendedMessages: CanonicalMessage[] = projected;
       const ctxApply = this.dependencies.context?.applyToolResults;
       if (ctxApply) {
@@ -887,7 +888,7 @@ export class AgentLoop {
             sessionId: input.sessionId,
             turnId: input.turnId,
             toolResultMessage: toolResultMsg,
-            supplementalMessages: supplementalMsgs,
+            supplementalMessages: supplementalInputs,
             messages,
           });
           messages = applied.messages;
@@ -1709,6 +1710,22 @@ function readRequestedMode(value: unknown): AgentRuntimeConfig["permissionMode"]
   }
   const requestedMode = (value as Record<string, unknown>).requestedMode;
   return isPermissionMode(requestedMode) ? requestedMode : undefined;
+}
+
+function bindSupplementalMessagesToToolCalls(
+  results: PilotDeckToolResult[],
+  supplementalMessages: CanonicalMessage[],
+): ContextSupplementalToolResultMessage[] {
+  const bound: ContextSupplementalToolResultMessage[] = [];
+  let index = 0;
+  for (const result of results) {
+    const count = result.supplementalMessages?.length ?? 0;
+    for (let offset = 0; offset < count && index < supplementalMessages.length; offset += 1) {
+      bound.push({ toolCallId: result.toolCallId, message: supplementalMessages[index] });
+      index += 1;
+    }
+  }
+  return bound;
 }
 
 function isPermissionMode(value: unknown): value is AgentRuntimeConfig["permissionMode"] {

--- a/src/agent/loop/AgentLoop.ts
+++ b/src/agent/loop/AgentLoop.ts
@@ -13,6 +13,7 @@ import {
   type CanonicalModelError,
   type CanonicalModelRequest,
   type CanonicalUsage,
+  materializeMediaReferences,
 } from "../../model/index.js";
 import type {
   PilotDeckReadFileStateMap,
@@ -1094,10 +1095,18 @@ export class AgentLoop {
       hasSystemPrompt: !!prepared.systemPrompt,
     });
 
+    const materialized = await materializeMediaReferences(prepared.messages);
+    for (const diagnostic of materialized.diagnostics) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[pilotdeck] ${diagnostic.code}: ${diagnostic.message} (${diagnostic.mediaType}, ${diagnostic.path})`,
+      );
+    }
+
     return {
       provider: this.config.provider,
       model: this.config.model,
-      messages: prepared.messages,
+      messages: materialized.messages,
       systemPrompt: prepared.systemPrompt ?? this.config.systemPrompt,
       tools: prepared.tools,
       toolChoice: this.config.toolChoice,

--- a/src/agent/loop/AgentLoop.ts
+++ b/src/agent/loop/AgentLoop.ts
@@ -878,9 +878,8 @@ export class AgentLoop {
       // runtime so large payloads land on disk via `ToolResultBudget`. When
       // the runtime doesn't implement `applyToolResults` (e.g. NullContext),
       // we simply append the raw projection (legacy behaviour).
-      // Only the first message (containing tool_result blocks) goes through
-      // budget processing; supplemental messages (PDF/image data) are appended directly.
       const [toolResultMsg, ...supplementalMsgs] = projected;
+      let appendedMessages: CanonicalMessage[] = projected;
       const ctxApply = this.dependencies.context?.applyToolResults;
       if (ctxApply) {
         try {
@@ -888,22 +887,20 @@ export class AgentLoop {
             sessionId: input.sessionId,
             turnId: input.turnId,
             toolResultMessage: toolResultMsg,
+            supplementalMessages: supplementalMsgs,
             messages,
           });
           messages = applied.messages;
+          appendedMessages = applied.appendedMessages ?? projected;
         } catch {
-          messages.push(toolResultMsg);
+          messages.push(...projected);
         }
       } else {
-        messages.push(toolResultMsg);
+        messages.push(...projected);
       }
-      for (const supplemental of supplementalMsgs) {
-        messages.push(supplemental);
-      }
-      yield { type: "tool_results_projected", sessionId: input.sessionId, turnId: input.turnId, message: toolResultMsg };
-      await input.onDurableMessage?.(toolResultMsg);
-      for (const supplemental of supplementalMsgs) {
-        await input.onDurableMessage?.(supplemental);
+      for (const appended of appendedMessages) {
+        yield { type: "tool_results_projected", sessionId: input.sessionId, turnId: input.turnId, message: appended };
+        await input.onDurableMessage?.(appended);
       }
 
       if (toolResultRepair) {

--- a/src/cli/createLocalGateway.ts
+++ b/src/cli/createLocalGateway.ts
@@ -35,6 +35,9 @@ import {
   InProcessGateway,
   type InProcessGatewayOptions,
   SessionRouter,
+  isGatewayMemoryDiagnosticsEnabled,
+  logGatewayMemoryDiagnostic,
+  summarizeCanonicalMessages,
   type Gateway,
   type GatewayCronController,
   type GatewayProjectStorageOptions,
@@ -178,6 +181,10 @@ export function createLocalGateway(options: CreateLocalGatewayOptions = {}): Cre
     onProjectActivated: (activeProjectRoot) => extensionWatchManager.watchProject(activeProjectRoot),
   });
   const defaultRuntime = registry.resolve();
+  const memoryDiagnosticsEnabled = isGatewayMemoryDiagnosticsEnabled(
+    env,
+    defaultRuntime.snapshot.config.gateway?.memoryDiagnostics,
+  );
 
   const configStore = createPilotConfigStoreSync({ projectRoot, env });
   const stopConfigWatching = configStore.startWatching();
@@ -199,6 +206,14 @@ export function createLocalGateway(options: CreateLocalGatewayOptions = {}): Cre
     // eslint-disable-next-line no-console
     console.log("[pilotdeck] Config reloaded, invalidating runtimes:", changedPaths.join(", "));
     registry.invalidate();
+    if (memoryDiagnosticsEnabled) {
+      logGatewayMemoryDiagnostic({
+        event: "runtime_invalidated",
+        sessionCount: router?.cachedSessionCount(),
+        projectKey: projectRoot,
+        reason: "config_changed",
+      });
+    }
     router?.markAllDirty("config_changed");
     configChangeLifecycle.dispatch({
       event: "ConfigChange",
@@ -215,8 +230,23 @@ export function createLocalGateway(options: CreateLocalGatewayOptions = {}): Cre
     listSessions: (input) => registry.listSessions(input),
     idleSessionTimeoutMs:
       (defaultRuntime.snapshot.config.gateway?.idleSessionTimeoutMinutes ?? 30) * 60_000,
+    idleSweepIntervalMs:
+      Math.max(0, defaultRuntime.snapshot.config.gateway?.idleSweepIntervalSeconds ?? 60) * 1_000,
     now,
     onSessionEvict: (sessionKey) => registry.evictSessionMcp(sessionKey),
+    onSessionIdleEvict: memoryDiagnosticsEnabled
+      ? (_sessionKey, snapshot) => {
+          logGatewayMemoryDiagnostic({
+            event: "session_idle_evicted",
+            sessionCount: router?.cachedSessionCount(),
+            session: {
+              sessionKey: snapshot.sessionKey,
+              projectKey: snapshot.context.projectKey,
+              messageCount: snapshot.messageCount,
+            },
+          });
+        }
+      : undefined,
   });
   const skillManager = new SkillManager({ pilotHome });
   const gateway = new InProcessGateway(router, {
@@ -286,7 +316,20 @@ export function createLocalGateway(options: CreateLocalGatewayOptions = {}): Cre
     async refreshConfigBeforeTurn() {
       await configStore.reload("turn-start");
     },
-    afterTurnCompleted: ({ projectKey }) => {
+    afterTurnCompleted: ({ sessionKey, projectKey, runId }) => {
+      if (memoryDiagnosticsEnabled) {
+        const snapshot = router?.snapshotSession(sessionKey);
+        logGatewayMemoryDiagnostic({
+          event: "turn_completed",
+          sessionCount: router?.cachedSessionCount(),
+          session: {
+            sessionKey,
+            projectKey,
+            runId,
+            ...(snapshot ? summarizeCanonicalMessages(snapshot.messages) : {}),
+          },
+        });
+      }
       registry.scheduleMemoryMaintenance(projectKey ?? projectRoot);
     },
   });
@@ -300,6 +343,7 @@ export function createLocalGateway(options: CreateLocalGatewayOptions = {}): Cre
     registry,
     dispose: () => {
       registry.invalidate();
+      router?.shutdown();
       stopConfigWatching();
       stopExtensionWatching();
       if (ownsTelemetry) {

--- a/src/context/DefaultContextRuntime.ts
+++ b/src/context/DefaultContextRuntime.ts
@@ -259,7 +259,10 @@ export class DefaultContextRuntime implements ContextRuntime {
       try {
         appended = await this.toolResultBudget.applyToMessage(input.toolResultMessage);
         supplementalMessages = await Promise.all(
-          supplementalMessages.map((message) => this.toolResultBudget!.applyToSupplementalMessage(message)),
+          supplementalMessages.map(async ({ toolCallId, message }) => ({
+            toolCallId,
+            message: await this.toolResultBudget!.applyToSupplementalMessage(message, toolCallId),
+          })),
         );
       } catch (error) {
         diagnostics.push({
@@ -269,7 +272,7 @@ export class DefaultContextRuntime implements ContextRuntime {
         });
       }
     }
-    const appendedMessages = [appended, ...supplementalMessages];
+    const appendedMessages = [appended, ...supplementalMessages.map(({ message }) => message)];
     return { messages: [...input.messages, ...appendedMessages], appendedMessages, diagnostics };
   }
 

--- a/src/context/DefaultContextRuntime.ts
+++ b/src/context/DefaultContextRuntime.ts
@@ -254,9 +254,13 @@ export class DefaultContextRuntime implements ContextRuntime {
   async applyToolResults(input: ContextToolResultInput): Promise<ContextToolResultResult> {
     const diagnostics: ContextDiagnostic[] = [];
     let appended: CanonicalMessage = input.toolResultMessage;
+    let supplementalMessages = input.supplementalMessages ?? [];
     if (this.toolResultBudget) {
       try {
         appended = await this.toolResultBudget.applyToMessage(input.toolResultMessage);
+        supplementalMessages = await Promise.all(
+          supplementalMessages.map((message) => this.toolResultBudget!.applyToSupplementalMessage(message)),
+        );
       } catch (error) {
         diagnostics.push({
           code: "tool_result_persistence_failed",
@@ -265,7 +269,8 @@ export class DefaultContextRuntime implements ContextRuntime {
         });
       }
     }
-    return { messages: [...input.messages, appended], diagnostics };
+    const appendedMessages = [appended, ...supplementalMessages];
+    return { messages: [...input.messages, ...appendedMessages], appendedMessages, diagnostics };
   }
 
   async captureTurn(input: ContextCaptureTurnInput): Promise<void> {

--- a/src/context/NullContextRuntime.ts
+++ b/src/context/NullContextRuntime.ts
@@ -56,6 +56,11 @@ function isToolResultOnly(message: CanonicalMessage): boolean {
   return (
     message.role === "user" &&
     message.content.length > 0 &&
-    message.content.every((block) => block.type === "tool_result")
+    message.content.every(
+      (block) =>
+        block.type === "tool_result" ||
+        block.type === "tool_result_reference" ||
+        (block.type === "media_reference" && typeof block.toolCallId === "string" && block.toolCallId.length > 0),
+    )
   );
 }

--- a/src/context/budget/TokenBudgetManager.ts
+++ b/src/context/budget/TokenBudgetManager.ts
@@ -118,7 +118,8 @@ export class TokenBudgetManager {
         // T13: PilotDeck-only block; preview only.
         return this.estimateTextTokens(block.preview);
       case "media_reference":
-        return this.estimateTextTokens(block.preview);
+        // Media references materialize back to media blocks before provider requests.
+        return this.multimediaTokens;
     }
     return 0;
   }

--- a/src/context/budget/TokenBudgetManager.ts
+++ b/src/context/budget/TokenBudgetManager.ts
@@ -117,7 +117,10 @@ export class TokenBudgetManager {
       case "tool_result_reference":
         // T13: PilotDeck-only block; preview only.
         return this.estimateTextTokens(block.preview);
+      case "media_reference":
+        return this.estimateTextTokens(block.preview);
     }
+    return 0;
   }
 
   /** T11: per-message estimate including overhead. */

--- a/src/context/budget/ToolResultBudget.ts
+++ b/src/context/budget/ToolResultBudget.ts
@@ -30,6 +30,7 @@ export type ToolResultReplacementRecord = {
 
 export type MediaReplacementRecord = {
   id: string;
+  toolCallId: string;
   path: string;
   originalBytes: number;
   preview: string;
@@ -97,7 +98,7 @@ export class ToolResultBudget {
     return { ...message, content: newContent };
   }
 
-  async applyToSupplementalMessage(message: CanonicalMessage): Promise<CanonicalMessage> {
+  async applyToSupplementalMessage(message: CanonicalMessage, toolCallId: string): Promise<CanonicalMessage> {
     if (message.role !== "user") {
       return message;
     }
@@ -105,7 +106,7 @@ export class ToolResultBudget {
     let modified = false;
     for (let index = 0; index < message.content.length; index += 1) {
       const block = message.content[index];
-      const replaced = await this.maybeReplaceMedia(block, index);
+      const replaced = await this.maybeReplaceMedia(block, index, toolCallId);
       if (replaced !== block) {
         modified = true;
       }
@@ -170,6 +171,7 @@ export class ToolResultBudget {
   private async maybeReplaceMedia(
     block: CanonicalContentBlock,
     index: number,
+    toolCallId: string,
   ): Promise<CanonicalContentBlock> {
     if (block.type !== "image" && block.type !== "pdf" && block.type !== "audio") {
       return block;
@@ -194,6 +196,7 @@ export class ToolResultBudget {
 
     const record: MediaReplacementRecord = {
       id,
+      toolCallId,
       path,
       originalBytes,
       preview: mediaPreview(mediaType, mimeType, originalBytes, block),
@@ -209,6 +212,7 @@ export class ToolResultBudget {
   private toMediaReferenceBlock(record: MediaReplacementRecord): CanonicalMediaReferenceBlock {
     return {
       type: "media_reference",
+      toolCallId: record.toolCallId,
       path: record.path,
       originalBytes: record.originalBytes,
       preview: record.preview,

--- a/src/context/budget/ToolResultBudget.ts
+++ b/src/context/budget/ToolResultBudget.ts
@@ -1,7 +1,10 @@
 import { mkdir, writeFile, access } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import type {
+  CanonicalContentBlock,
   CanonicalMessage,
+  CanonicalMediaReferenceBlock,
+  CanonicalPdfBlock,
   CanonicalToolResultBlock,
   CanonicalToolResultReferenceBlock,
 } from "../../model/index.js";
@@ -22,6 +25,18 @@ export type ToolResultReplacementRecord = {
   originalBytes: number;
   preview: string;
   mimeType?: string;
+  reason: string;
+};
+
+export type MediaReplacementRecord = {
+  id: string;
+  path: string;
+  originalBytes: number;
+  preview: string;
+  mimeType: string;
+  mediaType: "image" | "pdf" | "audio";
+  pages?: number;
+  detail?: "auto" | "low" | "high";
   reason: string;
 };
 
@@ -82,6 +97,23 @@ export class ToolResultBudget {
     return { ...message, content: newContent };
   }
 
+  async applyToSupplementalMessage(message: CanonicalMessage): Promise<CanonicalMessage> {
+    if (message.role !== "user") {
+      return message;
+    }
+    const newContent: CanonicalContentBlock[] = [];
+    let modified = false;
+    for (let index = 0; index < message.content.length; index += 1) {
+      const block = message.content[index];
+      const replaced = await this.maybeReplaceMedia(block, index);
+      if (replaced !== block) {
+        modified = true;
+      }
+      newContent.push(replaced);
+    }
+    return modified ? { ...message, content: newContent } : message;
+  }
+
   private async maybeReplace(
     block: CanonicalToolResultBlock,
   ): Promise<CanonicalToolResultBlock | CanonicalToolResultReferenceBlock> {
@@ -134,6 +166,60 @@ export class ToolResultBudget {
       reason: record.reason,
     };
   }
+
+  private async maybeReplaceMedia(
+    block: CanonicalContentBlock,
+    index: number,
+  ): Promise<CanonicalContentBlock> {
+    if (block.type !== "image" && block.type !== "pdf" && block.type !== "audio") {
+      return block;
+    }
+    const originalBytes = mediaOriginalBytes(block);
+    const encodedBytes = Buffer.byteLength(block.data, "utf8");
+    if (encodedBytes <= this.maxResultSizeChars) {
+      return block;
+    }
+
+    const mediaType = block.type;
+    const mimeType = block.mimeType;
+    const ext = extensionForMedia(mediaType, mimeType);
+    const id = `${mediaType}-${index}-${hashString(block.data).slice(0, 12)}`;
+    const path = resolve(this.toolResultsDir, `${id}.${ext}`);
+    await mkdir(dirname(path), { recursive: true, mode: 0o700 });
+    try {
+      await access(path);
+    } catch {
+      await writeFile(path, block.data, { flag: "wx", mode: 0o600, encoding: "utf8" });
+    }
+
+    const record: MediaReplacementRecord = {
+      id,
+      path,
+      originalBytes,
+      preview: mediaPreview(mediaType, mimeType, originalBytes, block),
+      mimeType,
+      mediaType,
+      reason: "media_result_too_large",
+      ...(block.type === "pdf" && block.pages !== undefined ? { pages: block.pages } : {}),
+      ...(block.type === "image" && block.detail ? { detail: block.detail } : {}),
+    };
+    return this.toMediaReferenceBlock(record);
+  }
+
+  private toMediaReferenceBlock(record: MediaReplacementRecord): CanonicalMediaReferenceBlock {
+    return {
+      type: "media_reference",
+      path: record.path,
+      originalBytes: record.originalBytes,
+      preview: record.preview,
+      hasMore: true,
+      mimeType: record.mimeType,
+      mediaType: record.mediaType,
+      ...(record.pages !== undefined ? { pages: record.pages } : {}),
+      ...(record.detail ? { detail: record.detail } : {}),
+      reason: record.reason,
+    };
+  }
 }
 
 function looksLikeJson(value: string): boolean {
@@ -176,4 +262,37 @@ function headTailPreview(value: string, budgetBytes: number): string {
 /** Helper for tests / inspection. */
 export function flattenToolResultText(block: CanonicalToolResultBlock): string {
   return flattenToolResultBlockText(block);
+}
+
+function mediaOriginalBytes(block: Extract<CanonicalContentBlock, { type: "image" | "pdf" | "audio" }>): number {
+  return ("bytes" in block ? block.bytes : undefined) ?? Buffer.byteLength(block.data, "utf8");
+}
+
+function extensionForMedia(mediaType: "image" | "pdf" | "audio", mimeType: string): string {
+  if (mediaType === "pdf") return "pdf.b64";
+  const subType = mimeType.split("/")[1]?.toLowerCase().replace(/[^a-z0-9.+-]/g, "");
+  return `${subType || mediaType}.b64`;
+}
+
+function mediaPreview(
+  mediaType: "image" | "pdf" | "audio",
+  mimeType: string,
+  originalBytes: number,
+  block: Extract<CanonicalContentBlock, { type: "image" | "pdf" | "audio" }>,
+): string {
+  const size = `${originalBytes} bytes`;
+  if (mediaType === "pdf") {
+    const pages = (block as CanonicalPdfBlock).pages;
+    return `[PDF omitted from memory: ${mimeType}, ${size}${pages ? `, ${pages} pages` : ""}]`;
+  }
+  return `[${mediaType} omitted from memory: ${mimeType}, ${size}]`;
+}
+
+function hashString(value: string): string {
+  let hash = 2166136261;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return (hash >>> 0).toString(16);
 }

--- a/src/context/compaction/CompactionEngine.ts
+++ b/src/context/compaction/CompactionEngine.ts
@@ -106,12 +106,11 @@ export class CompactionEngine {
     // summary message, so any tool_result in the keep portion whose
     // tool_call is in the summarize portion (and vice-versa) becomes
     // dangling and must be stripped.
-    const keepToolCallIds = collectToolCallIds(input.messages.slice(-keepCount));
-    const keepToolResultIds = collectToolResultIds(input.messages.slice(-keepCount));
-    const messagesToKeep = stripUnpairedToolResults(
-      stripUnpairedToolCalls(input.messages.slice(-keepCount), keepToolResultIds),
-      keepToolCallIds,
-    );
+    const keptTail = input.messages.slice(-keepCount);
+    const keepToolResultIds = collectToolResultIds(keptTail);
+    const messagesWithPairedToolCalls = stripUnpairedToolCalls(keptTail, keepToolResultIds);
+    const keepToolCallIds = collectToolCallIds(messagesWithPairedToolCalls);
+    const messagesToKeep = stripUnpairedToolResults(messagesWithPairedToolCalls, keepToolCallIds);
 
     await this.options.lifecycle?.dispatch({
       event: "PreCompact",

--- a/src/context/compaction/SnipEngine.ts
+++ b/src/context/compaction/SnipEngine.ts
@@ -106,7 +106,7 @@ export class SnipEngine {
     // From head: drop tool_calls whose tool_result is in the snipped middle.
     const headCleaned = stripUnpairedToolCalls(head, tailToolResultIds);
     // From tail: drop tool_results whose tool_call lives in the snipped middle.
-    const allToolCallIds = new Set<string>([...headToolCallIds, ...tailToolCallIds]);
+    const allToolCallIds = new Set<string>([...collectToolCallIds(headCleaned), ...tailToolCallIds]);
     const tailCleaned = stripUnpairedToolResults(tail, allToolCallIds);
 
     const dangling = Array.from(headToolCallIds).filter((id) => !tailToolResultIds.has(id));
@@ -156,6 +156,10 @@ function splitIntoTurns(messages: CanonicalMessage[]): CanonicalMessage[][] {
 
 function isToolResultOnly(message: CanonicalMessage): boolean {
   if (message.content.length === 0) return false;
-  return message.content.every((block) => block.type === "tool_result");
+  return message.content.every(
+    (block) =>
+      block.type === "tool_result" ||
+      block.type === "tool_result_reference" ||
+      (block.type === "media_reference" && typeof block.toolCallId === "string" && block.toolCallId.length > 0),
+  );
 }
-

--- a/src/context/compaction/toolPairIntegrity.ts
+++ b/src/context/compaction/toolPairIntegrity.ts
@@ -1,4 +1,4 @@
-import type { CanonicalMessage } from "../../model/index.js";
+import type { CanonicalContentBlock, CanonicalMessage } from "../../model/index.js";
 
 /**
  * Shared tool_call / tool_result pair integrity helpers.
@@ -24,7 +24,7 @@ export function collectToolResultIds(messages: CanonicalMessage[]): Set<string> 
   for (const message of messages) {
     if (message.role !== "user") continue;
     for (const block of message.content) {
-      if (block.type === "tool_result" || block.type === "tool_result_reference") {
+      if (isDirectToolResultBlock(block)) {
         ids.add(block.toolCallId);
       }
     }
@@ -52,7 +52,7 @@ export function stripUnpairedToolCalls(
 }
 
 /**
- * Remove tool_result / tool_result_reference blocks from user messages whose
+ * Remove tool-result blocks from user messages whose
  * toolCallId is NOT in `pairedIds`.
  * Messages that become empty after filtering are dropped entirely.
  */
@@ -64,13 +64,26 @@ export function stripUnpairedToolResults(
     if (message.role !== "user") return message;
     const filtered = message.content.filter(
       (block) =>
-        (block.type !== "tool_result" && block.type !== "tool_result_reference") ||
+        (!isDirectToolResultBlock(block) && !isMediaReferenceWithId(block)) ||
         pairedIds.has(block.toolCallId),
     );
     return filtered.length === message.content.length
       ? message
       : { ...message, content: filtered };
   }).filter((m) => m.content.length > 0);
+}
+
+function isDirectToolResultBlock(block: CanonicalContentBlock): block is Extract<
+  CanonicalContentBlock,
+  { type: "tool_result" | "tool_result_reference" }
+> {
+  return block.type === "tool_result" || block.type === "tool_result_reference";
+}
+
+function isMediaReferenceWithId(
+  block: CanonicalContentBlock,
+): block is Extract<CanonicalContentBlock, { type: "media_reference" }> & { toolCallId: string } {
+  return block.type === "media_reference" && typeof block.toolCallId === "string" && block.toolCallId.length > 0;
 }
 
 const CONTINUATION_TEXT =

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -14,6 +14,7 @@ export type {
   ContextRecoveryDecision,
   ContextRecoveryInput,
   ContextRuntime,
+  ContextSupplementalToolResultMessage,
   ContextToolResultInput,
   ContextToolResultResult,
   ModelContext,

--- a/src/context/memory/MemoryResolver.ts
+++ b/src/context/memory/MemoryResolver.ts
@@ -62,6 +62,8 @@ export function canonicalMessagesToMemoryMessages(messages: CanonicalMessage[]):
         );
       } else if (block.type === "tool_result_reference") {
         pushEntry("tool", block.preview);
+      } else if (block.type === "media_reference") {
+        pushEntry("tool", block.preview);
       }
     }
 

--- a/src/context/projection/MessageProjector.ts
+++ b/src/context/projection/MessageProjector.ts
@@ -23,7 +23,7 @@ export type MessageProjectorResult = {
  *  2. Ensure every assistant `tool_call` has a matching `tool_result`
  *     immediately following — inject placeholder results for any that are
  *     missing so the OpenAI API never rejects the payload.
- *  3. Strip orphaned `tool_result` blocks whose `tool_call` was dropped.
+ *  3. Strip orphaned tool-result blocks whose `tool_call` was dropped.
  */
 export class MessageProjector {
   project(input: MessageProjectorInput): MessageProjectorResult {
@@ -90,7 +90,7 @@ function toolPairSafeTruncate(
  * Walk through the conversation and:
  *  - Inject a placeholder `tool_result` user message for any assistant
  *    `tool_call` that has no matching result (fixes the OpenAI API error).
- *  - Strip orphaned `tool_result` blocks whose `tool_call` was dropped.
+ *  - Strip orphaned tool-result blocks whose `tool_call` was dropped.
  */
 function repairToolResultPairing(
   messages: CanonicalMessage[],
@@ -98,6 +98,11 @@ function repairToolResultPairing(
 ): CanonicalMessage[] {
   const output: CanonicalMessage[] = [];
   let pendingToolCallIds: string[] = [];
+  const visibleToolCallIds = new Set<string>();
+  for (const message of messages) {
+    if (message.role !== "assistant") continue;
+    for (const id of collectToolCallIds(message)) visibleToolCallIds.add(id);
+  }
 
   for (let i = 0; i < messages.length; i++) {
     const message = messages[i];
@@ -117,22 +122,26 @@ function repairToolResultPairing(
     // User (or system) message.
     const pendingSet = new Set(pendingToolCallIds);
     const seen = new Set<string>();
+    const mediaRefs = new Set<string>();
     for (const block of message.content) {
-      if (block.type === "tool_result" || block.type === "tool_result_reference") {
+      if (isDirectToolResultBlock(block)) {
         seen.add(block.toolCallId);
+      } else if (isMediaReferenceWithId(block)) {
+        mediaRefs.add(block.toolCallId);
       }
     }
 
-    // Strip orphaned tool_results / tool_result_references (their tool_call was truncated away).
-    const hasOrphans = [...seen].some((id) => !pendingSet.has(id));
+    // Strip orphaned tool result blocks (their tool_call was truncated away).
+    const hasOrphans =
+      [...seen].some((id) => !pendingSet.has(id)) ||
+      [...mediaRefs].some((id) => !visibleToolCallIds.has(id));
     let cleanedMessage = message;
     if (hasOrphans) {
       const kept: CanonicalContentBlock[] = [];
       for (const block of message.content) {
-        if (
-          (block.type === "tool_result" || block.type === "tool_result_reference") &&
-          !pendingSet.has(block.toolCallId)
-        ) {
+        const isDirectOrphan = isDirectToolResultBlock(block) && !pendingSet.has(block.toolCallId);
+        const isMediaOrphan = isMediaReferenceWithId(block) && !visibleToolCallIds.has(block.toolCallId);
+        if (isDirectOrphan || isMediaOrphan) {
           warnings.push({
             code: "tool_result_orphaned",
             message: `tool_result ${block.toolCallId} has no matching tool_call — removed.`,
@@ -199,6 +208,19 @@ function hasToolCalls(message: CanonicalMessage): boolean {
 
 function isToolResultOnly(message: CanonicalMessage): boolean {
   return message.content.length > 0 && message.content.every(
-    (block) => block.type === "tool_result" || block.type === "tool_result_reference",
+    (block) => isDirectToolResultBlock(block) || isMediaReferenceWithId(block),
   );
+}
+
+function isDirectToolResultBlock(block: CanonicalContentBlock): block is Extract<
+  CanonicalContentBlock,
+  { type: "tool_result" | "tool_result_reference" }
+> {
+  return block.type === "tool_result" || block.type === "tool_result_reference";
+}
+
+function isMediaReferenceWithId(
+  block: CanonicalContentBlock,
+): block is Extract<CanonicalContentBlock, { type: "media_reference" }> & { toolCallId: string } {
+  return block.type === "media_reference" && typeof block.toolCallId === "string" && block.toolCallId.length > 0;
 }

--- a/src/context/protocol/types.ts
+++ b/src/context/protocol/types.ts
@@ -66,8 +66,13 @@ export type ContextToolResultInput = {
   /** New tool result blocks projected by the agent loop. */
   toolResultMessage: CanonicalMessage;
   /** Supplemental user-role media messages emitted after the tool result. */
-  supplementalMessages?: CanonicalMessage[];
+  supplementalMessages?: ContextSupplementalToolResultMessage[];
   messages: CanonicalMessage[];
+};
+
+export type ContextSupplementalToolResultMessage = {
+  toolCallId: string;
+  message: CanonicalMessage;
 };
 
 export type ContextToolResultResult = {

--- a/src/context/protocol/types.ts
+++ b/src/context/protocol/types.ts
@@ -65,11 +65,14 @@ export type ContextToolResultInput = {
   turnId: string;
   /** New tool result blocks projected by the agent loop. */
   toolResultMessage: CanonicalMessage;
+  /** Supplemental user-role media messages emitted after the tool result. */
+  supplementalMessages?: CanonicalMessage[];
   messages: CanonicalMessage[];
 };
 
 export type ContextToolResultResult = {
   messages: CanonicalMessage[];
+  appendedMessages?: CanonicalMessage[];
   diagnostics: ContextDiagnostic[];
 };
 

--- a/src/gateway/SessionRouter.ts
+++ b/src/gateway/SessionRouter.ts
@@ -18,6 +18,7 @@ export type SessionRouterOptions = {
   recreateSession?: GatewaySessionRecreator;
   listSessions?: (input: ListSessionsInput) => Promise<ListSessionsResult>;
   idleSessionTimeoutMs?: number;
+  idleSweepIntervalMs?: number;
   now?: () => Date;
   /**
    * Called (fire-and-forget) when a session is evicted from the router —
@@ -25,6 +26,7 @@ export type SessionRouterOptions = {
    * per-session resources (e.g. per-session MCP runtimes / browser processes).
    */
   onSessionEvict?: (sessionKey: string) => void;
+  onSessionIdleEvict?: (sessionKey: string, record: SessionEvictionSnapshot) => void;
 };
 
 type SessionRecord = {
@@ -34,17 +36,33 @@ type SessionRecord = {
   dirtyReason?: string;
 };
 
+export type SessionEvictionSnapshot = {
+  sessionKey: string;
+  lastUsedAt: number;
+  context: GatewaySessionContext;
+  messageCount?: number;
+};
+
 const DEFAULT_IDLE_SESSION_TIMEOUT_MS = 30 * 60 * 1000;
+const DEFAULT_IDLE_SWEEP_INTERVAL_MS = 60 * 1000;
 
 export class SessionRouter {
   private readonly sessions = new Map<string, SessionRecord>();
   private readonly inFlightTurns = new Map<string, string>();
   private readonly idleSessionTimeoutMs: number;
+  private readonly idleSweepIntervalMs: number;
   private readonly now: () => Date;
+  private readonly idleSweepTimer?: ReturnType<typeof setInterval>;
+  private isShutdown = false;
 
   constructor(private readonly options: SessionRouterOptions) {
     this.idleSessionTimeoutMs = options.idleSessionTimeoutMs ?? DEFAULT_IDLE_SESSION_TIMEOUT_MS;
+    this.idleSweepIntervalMs = options.idleSweepIntervalMs ?? DEFAULT_IDLE_SWEEP_INTERVAL_MS;
     this.now = options.now ?? (() => new Date());
+    if (this.idleSweepIntervalMs > 0) {
+      this.idleSweepTimer = setInterval(() => this.sweepIdle(), this.idleSweepIntervalMs);
+      this.idleSweepTimer.unref?.();
+    }
   }
 
   async getOrCreate(context: GatewaySessionContext): Promise<AgentSession> {
@@ -53,7 +71,7 @@ export class SessionRouter {
     if (cached) {
       cached.context = mergeSessionContext(cached.context, context);
       if (cached.dirtyReason && this.options.recreateSession) {
-        this.options.onSessionEvict?.(context.sessionKey);
+        this.emitSessionEvict(context.sessionKey, cached, "dirty_recreate");
         cached.session = await this.options.recreateSession(cached.context, cached.session);
         cached.dirtyReason = undefined;
       }
@@ -99,8 +117,9 @@ export class SessionRouter {
   }
 
   async close(sessionKey: string): Promise<void> {
-    if (this.sessions.delete(sessionKey)) {
-      this.options.onSessionEvict?.(sessionKey);
+    const record = this.sessions.get(sessionKey);
+    if (record && this.sessions.delete(sessionKey)) {
+      this.emitSessionEvict(sessionKey, record, "closed");
     }
   }
 
@@ -151,6 +170,27 @@ export class SessionRouter {
     return this.sessions.size;
   }
 
+  cachedSessionCount(): number {
+    return this.sessions.size;
+  }
+
+  snapshotSession(sessionKey: string): ReturnType<AgentSession["snapshot"]> | undefined {
+    return this.sessions.get(sessionKey)?.session.snapshot();
+  }
+
+  shutdown(): void {
+    if (this.isShutdown) return;
+    this.isShutdown = true;
+    if (this.idleSweepTimer) {
+      clearInterval(this.idleSweepTimer);
+    }
+    for (const [sessionKey, record] of this.sessions) {
+      this.emitSessionEvict(sessionKey, record, "shutdown");
+    }
+    this.sessions.clear();
+    this.inFlightTurns.clear();
+  }
+
   /**
    * Returns true when at least one *user* turn (not always-on / cron) is
    * in flight for the given project.  Used by the Always-On scheduler to
@@ -167,6 +207,7 @@ export class SessionRouter {
   }
 
   private sweepIdle(): void {
+    if (this.isShutdown) return;
     const now = this.nowMs();
     for (const [sessionKey, record] of this.sessions) {
       if (this.inFlightTurns.has(sessionKey)) {
@@ -174,14 +215,40 @@ export class SessionRouter {
       }
       if (now - record.lastUsedAt > this.idleSessionTimeoutMs) {
         this.sessions.delete(sessionKey);
-        this.options.onSessionEvict?.(sessionKey);
+        this.emitSessionEvict(sessionKey, record, "idle");
       }
+    }
+  }
+
+  private emitSessionEvict(
+    sessionKey: string,
+    record: SessionRecord,
+    reason: "idle" | "closed" | "dirty_recreate" | "shutdown",
+  ): void {
+    this.options.onSessionEvict?.(sessionKey);
+    if (reason === "idle") {
+      this.options.onSessionIdleEvict?.(sessionKey, snapshotEvictedSession(sessionKey, record));
     }
   }
 
   private nowMs(): number {
     return this.now().getTime();
   }
+}
+
+function snapshotEvictedSession(sessionKey: string, record: SessionRecord): SessionEvictionSnapshot {
+  let messageCount: number | undefined;
+  try {
+    messageCount = record.session.snapshot().messages.length;
+  } catch {
+    messageCount = undefined;
+  }
+  return {
+    sessionKey,
+    lastUsedAt: record.lastUsedAt,
+    context: { ...record.context },
+    ...(messageCount !== undefined ? { messageCount } : {}),
+  };
 }
 
 function mergeSessionContext(

--- a/src/gateway/client/InProcessGateway.ts
+++ b/src/gateway/client/InProcessGateway.ts
@@ -1214,6 +1214,12 @@ export function mapAgentEvent(event: AgentEvent, runId: string): GatewayEvent[] 
             toolCallId: block.toolCallId,
             resultPath: block.path,
           });
+        } else if (block.type === "media_reference" && block.toolCallId) {
+          events.push({
+            type: "tool_result_detail_available",
+            toolCallId: block.toolCallId,
+            resultPath: block.path,
+          });
         } else if (block.type === "tool_result") {
           const projFullText = flattenToolResultBlockText(block);
           events.push({

--- a/src/gateway/index.ts
+++ b/src/gateway/index.ts
@@ -3,8 +3,16 @@ export {
   SessionRouter,
   type GatewaySessionContext,
   type GatewaySessionFactory,
+  type SessionEvictionSnapshot,
   type SessionRouterOptions,
 } from "./SessionRouter.js";
+export {
+  isGatewayMemoryDiagnosticsEnabled,
+  logGatewayMemoryDiagnostic,
+  summarizeCanonicalMessages,
+  type GatewayMemoryDiagnosticInput,
+  type GatewayMemoryDiagnosticSession,
+} from "./memoryDiagnostics.js";
 export { InProcessGateway, mapAgentEvent, type InProcessGatewayOptions } from "./client/InProcessGateway.js";
 export { GatewayWsClient, GatewayRequestError, type GatewayWsClientOptions } from "./client/GatewayWsClient.js";
 export { RemoteGateway, createRemoteGateway } from "./client/RemoteGateway.js";

--- a/src/gateway/memoryDiagnostics.ts
+++ b/src/gateway/memoryDiagnostics.ts
@@ -1,0 +1,130 @@
+import type { CanonicalContentBlock, CanonicalMessage, CanonicalToolResultContentBlock } from "../model/index.js";
+
+export type GatewayMemoryDiagnosticSession = {
+  sessionKey: string;
+  projectKey?: string;
+  runId?: string;
+  messageCount?: number;
+  estimatedMessageBytes?: number;
+  toolResultReferences?: number;
+  mediaBlocks?: number;
+  mediaBytes?: number;
+};
+
+export type GatewayMemoryDiagnosticInput = {
+  event: "turn_completed" | "session_idle_evicted" | "runtime_invalidated";
+  session?: GatewayMemoryDiagnosticSession;
+  sessionCount?: number;
+  projectKey?: string;
+  reason?: string;
+};
+
+export function isGatewayMemoryDiagnosticsEnabled(
+  env: Record<string, string | undefined>,
+  configEnabled?: boolean,
+): boolean {
+  const value = env.PILOTDECK_MEMORY_DIAGNOSTICS;
+  return configEnabled === true || value === "1" || value === "true";
+}
+
+export function summarizeCanonicalMessages(messages: CanonicalMessage[]): Omit<
+  GatewayMemoryDiagnosticSession,
+  "sessionKey" | "projectKey" | "runId"
+> {
+  let estimatedMessageBytes = 0;
+  let toolResultReferences = 0;
+  let mediaBlocks = 0;
+  let mediaBytes = 0;
+
+  for (const message of messages) {
+    for (const block of message.content) {
+      const stats = summarizeBlock(block);
+      estimatedMessageBytes += stats.estimatedBytes;
+      toolResultReferences += stats.toolResultReferences;
+      mediaBlocks += stats.mediaBlocks;
+      mediaBytes += stats.mediaBytes;
+    }
+  }
+
+  return {
+    messageCount: messages.length,
+    estimatedMessageBytes,
+    toolResultReferences,
+    mediaBlocks,
+    mediaBytes,
+  };
+}
+
+export function logGatewayMemoryDiagnostic(input: GatewayMemoryDiagnosticInput): void {
+  const memory = process.memoryUsage();
+  const payload = {
+    event: input.event,
+    rss: memory.rss,
+    heapUsed: memory.heapUsed,
+    heapTotal: memory.heapTotal,
+    external: memory.external,
+    arrayBuffers: memory.arrayBuffers,
+    ...(input.sessionCount !== undefined ? { sessionCount: input.sessionCount } : {}),
+    ...(input.projectKey ? { projectKey: input.projectKey } : {}),
+    ...(input.reason ? { reason: input.reason } : {}),
+    ...(input.session ? { session: input.session } : {}),
+  };
+  // Keep this parseable for log collectors while staying invisible unless enabled upstream.
+  console.log(`[pilotdeck:memory] ${JSON.stringify(payload)}`);
+}
+
+function summarizeBlock(block: CanonicalContentBlock | CanonicalToolResultContentBlock): {
+  estimatedBytes: number;
+  toolResultReferences: number;
+  mediaBlocks: number;
+  mediaBytes: number;
+} {
+  switch (block.type) {
+    case "text":
+    case "thinking":
+      return { estimatedBytes: Buffer.byteLength(block.text, "utf8"), toolResultReferences: 0, mediaBlocks: 0, mediaBytes: 0 };
+    case "image":
+    case "pdf":
+    case "audio": {
+      const bytes = ("bytes" in block ? block.bytes : undefined) ?? Buffer.byteLength(block.data, "utf8");
+      return { estimatedBytes: Buffer.byteLength(block.data, "utf8"), toolResultReferences: 0, mediaBlocks: 1, mediaBytes: bytes };
+    }
+    case "tool_call":
+      return { estimatedBytes: estimateJsonBytes(block.input), toolResultReferences: 0, mediaBlocks: 0, mediaBytes: 0 };
+    case "tool_result": {
+      let estimatedBytes = 0;
+      let mediaBlocks = 0;
+      let mediaBytes = 0;
+      for (const item of block.content) {
+        const stats = summarizeBlock(item);
+        estimatedBytes += stats.estimatedBytes;
+        mediaBlocks += stats.mediaBlocks;
+        mediaBytes += stats.mediaBytes;
+      }
+      return { estimatedBytes, toolResultReferences: 0, mediaBlocks, mediaBytes };
+    }
+    case "tool_result_reference":
+      return {
+        estimatedBytes: Buffer.byteLength(block.preview, "utf8") + Buffer.byteLength(block.path, "utf8"),
+        toolResultReferences: 1,
+        mediaBlocks: 0,
+        mediaBytes: 0,
+      };
+    case "media_reference":
+      return {
+        estimatedBytes: Buffer.byteLength(block.preview, "utf8") + Buffer.byteLength(block.path, "utf8"),
+        toolResultReferences: 1,
+        mediaBlocks: 0,
+        mediaBytes: 0,
+      };
+  }
+  return { estimatedBytes: 0, toolResultReferences: 0, mediaBlocks: 0, mediaBytes: 0 };
+}
+
+function estimateJsonBytes(value: unknown): number {
+  try {
+    return Buffer.byteLength(JSON.stringify(value), "utf8");
+  } catch {
+    return 0;
+  }
+}

--- a/src/model/index.ts
+++ b/src/model/index.ts
@@ -4,6 +4,11 @@ export { parseModelConfig, type ParseModelConfigOptions } from "./config/parseMo
 export { resolveApiKey, type CredentialEnv } from "./config/resolveCredentials.js";
 export { ModelProviderRegistry, type ModelProviderAdapter } from "./providers/registry.js";
 export { buildModelRequest, type ProviderRequestBody } from "./request/buildModelRequest.js";
+export {
+  materializeMediaReferences,
+  type MaterializeMediaReferencesResult,
+  type MediaReferenceMaterializationDiagnostic,
+} from "./request/materializeMediaReferences.js";
 export { validateModelRequest, type ResolvedModelRequest } from "./request/validateModelRequest.js";
 export { parseModelResponse } from "./response/parseModelResponse.js";
 export { complete, streamModel, type ModelRuntimeOptions, type ModelTransport } from "./streaming/streamModel.js";

--- a/src/model/index.ts
+++ b/src/model/index.ts
@@ -27,6 +27,7 @@ export type {
   CanonicalFinishReason,
   CanonicalImageBlock,
   CanonicalMessage,
+  CanonicalMediaReferenceBlock,
   CanonicalMessageMetadata,
   CanonicalModelEvent,
   CanonicalModelRequest,

--- a/src/model/protocol/canonical.ts
+++ b/src/model/protocol/canonical.ts
@@ -45,6 +45,7 @@ export type CanonicalAudioBlock = {
   source: "base64" | "url";
   data: string;
   mimeType: string;
+  bytes?: number;
   durationSeconds?: number;
 };
 

--- a/src/model/protocol/canonical.ts
+++ b/src/model/protocol/canonical.ts
@@ -97,6 +97,8 @@ export type CanonicalToolResultReferenceBlock = {
 
 export type CanonicalMediaReferenceBlock = {
   type: "media_reference";
+  /** Originating tool call when known. Older transcripts may omit this. */
+  toolCallId?: string;
   /** Absolute path to the persisted media body. */
   path: string;
   /** Original binary size when known, otherwise persisted payload bytes. */

--- a/src/model/protocol/canonical.ts
+++ b/src/model/protocol/canonical.ts
@@ -95,6 +95,22 @@ export type CanonicalToolResultReferenceBlock = {
   reason?: string;
 };
 
+export type CanonicalMediaReferenceBlock = {
+  type: "media_reference";
+  /** Absolute path to the persisted media body. */
+  path: string;
+  /** Original binary size when known, otherwise persisted payload bytes. */
+  originalBytes: number;
+  /** Human-readable placeholder shown to the model/UI. */
+  preview: string;
+  hasMore: boolean;
+  mimeType: string;
+  mediaType: "image" | "pdf" | "audio";
+  pages?: number;
+  detail?: "auto" | "low" | "high";
+  reason?: string;
+};
+
 export type CanonicalToolResult = CanonicalToolResultBlock;
 
 export type CanonicalContentBlock =
@@ -105,7 +121,8 @@ export type CanonicalContentBlock =
   | CanonicalAudioBlock
   | CanonicalToolCallBlock
   | CanonicalToolResultBlock
-  | CanonicalToolResultReferenceBlock;
+  | CanonicalToolResultReferenceBlock
+  | CanonicalMediaReferenceBlock;
 
 export type CanonicalMessageMetadata = {
   /** True for messages injected by the system (e.g. JSON self-correct prompts). */

--- a/src/model/protocol/multimodal.ts
+++ b/src/model/protocol/multimodal.ts
@@ -104,6 +104,8 @@ export function contentBlockToInputModality(block: CanonicalContentBlock): Input
     case "thinking":
     case "tool_call":
     case "tool_result":
+    case "tool_result_reference":
+    case "media_reference":
       return undefined;
   }
 }

--- a/src/model/providers/anthropic/request.ts
+++ b/src/model/providers/anthropic/request.ts
@@ -182,6 +182,8 @@ function toAnthropicContentBlock(block: CanonicalContentBlock): unknown {
         }],
         is_error: false,
       };
+    case "media_reference":
+      return { type: "text", text: block.preview };
   }
 }
 

--- a/src/model/providers/openai/request.ts
+++ b/src/model/providers/openai/request.ts
@@ -292,6 +292,8 @@ function toOpenAIContent(blocks: CanonicalContentBlock[]): string | unknown[] {
         return undefined;
       case "tool_result_reference":
         return { type: "text", text: block.preview };
+      case "media_reference":
+        return { type: "text", text: block.preview };
     }
   }).filter(Boolean);
 }

--- a/src/model/request/materializeMediaReferences.ts
+++ b/src/model/request/materializeMediaReferences.ts
@@ -1,0 +1,121 @@
+import { readFile } from "node:fs/promises";
+import type {
+  CanonicalContentBlock,
+  CanonicalMediaReferenceBlock,
+  CanonicalMessage,
+} from "../protocol/canonical.js";
+import { cloneMessages } from "../protocol/clone.js";
+
+export type MediaReferenceMaterializationDiagnostic = {
+  code:
+    | "media_reference_invalid_pdf_mime"
+    | "media_reference_materialization_failed"
+    | "media_reference_unsupported_type";
+  path: string;
+  mediaType: string;
+  message: string;
+};
+
+export type MaterializeMediaReferencesResult = {
+  messages: CanonicalMessage[];
+  diagnostics: MediaReferenceMaterializationDiagnostic[];
+};
+
+export async function materializeMediaReferences(
+  messages: CanonicalMessage[],
+): Promise<MaterializeMediaReferencesResult> {
+  const cloned = cloneMessages(messages);
+  const diagnostics: MediaReferenceMaterializationDiagnostic[] = [];
+
+  await Promise.all(
+    cloned.map(async (message) => {
+      const content = await Promise.all(
+        message.content.map((block) => materializeBlock(block, diagnostics)),
+      );
+      message.content = content;
+    }),
+  );
+
+  return { messages: cloned, diagnostics };
+}
+
+async function materializeBlock(
+  block: CanonicalContentBlock,
+  diagnostics: MediaReferenceMaterializationDiagnostic[],
+): Promise<CanonicalContentBlock> {
+  if (block.type !== "media_reference") {
+    return block;
+  }
+
+  try {
+    const data = await readFile(block.path, "utf8");
+    const materialized = toMediaBlock(block, data);
+    if (!materialized) {
+      diagnostics.push({
+        code: "media_reference_unsupported_type",
+        path: block.path,
+        mediaType: block.mediaType,
+        message: `Unsupported media reference type: ${block.mediaType}`,
+      });
+      return fallbackText(block);
+    }
+    return materialized;
+  } catch (error) {
+    diagnostics.push({
+      code: "media_reference_materialization_failed",
+      path: block.path,
+      mediaType: block.mediaType,
+      message: error instanceof Error ? error.message : String(error),
+    });
+    return fallbackText(block);
+  }
+}
+
+function toMediaBlock(
+  block: CanonicalMediaReferenceBlock,
+  data: string,
+): CanonicalContentBlock | undefined {
+  if (block.mediaType === "image") {
+    return {
+      type: "image",
+      source: "base64",
+      data,
+      mimeType: block.mimeType,
+      bytes: block.originalBytes,
+      ...(block.detail ? { detail: block.detail } : {}),
+    };
+  }
+
+  if (block.mediaType === "pdf") {
+    if (block.mimeType !== "application/pdf") {
+      return undefined;
+    }
+    return {
+      type: "pdf",
+      source: "base64",
+      data,
+      mimeType: "application/pdf",
+      bytes: block.originalBytes,
+      ...(block.pages !== undefined ? { pages: block.pages } : {}),
+    };
+  }
+
+  if (block.mediaType === "audio") {
+    return {
+      type: "audio",
+      source: "base64",
+      data,
+      mimeType: block.mimeType,
+      bytes: block.originalBytes,
+    };
+  }
+
+  return undefined;
+}
+
+function fallbackText(block: CanonicalMediaReferenceBlock): CanonicalContentBlock {
+  return {
+    type: "text",
+    text: block.preview,
+  };
+}

--- a/src/pilot/config/parseGatewayConfig.ts
+++ b/src/pilot/config/parseGatewayConfig.ts
@@ -46,6 +46,8 @@ export function parseGatewayConfig(rawGateway: unknown, diagnostics: PilotConfig
     port: numberField(rawGateway, "port", 18789),
     bindAddress: "127.0.0.1",
     idleSessionTimeoutMinutes: numberField(rawGateway, "idleSessionTimeoutMinutes", 30),
+    idleSweepIntervalSeconds: numberField(rawGateway, "idleSweepIntervalSeconds", 60),
+    memoryDiagnostics: booleanField(rawGateway, "memoryDiagnostics", false),
     staticAssetsPath: stringField(rawGateway, "staticAssetsPath"),
     maxPerSessionMcpInstances: Math.max(1, maxMcp),
   };

--- a/src/pilot/config/types.ts
+++ b/src/pilot/config/types.ts
@@ -111,6 +111,8 @@ export type PilotGatewayConfig = {
   port: number;
   bindAddress: "127.0.0.1";
   idleSessionTimeoutMinutes: number;
+  idleSweepIntervalSeconds: number;
+  memoryDiagnostics: boolean;
   staticAssetsPath?: string;
   /**
    * Maximum number of concurrent per-session MCP instances (e.g. browser-use

--- a/src/web/server/readSessionMessages.ts
+++ b/src/web/server/readSessionMessages.ts
@@ -454,6 +454,7 @@ function flushBlock(
         provider: "pilotdeck",
         role: "tool",
         kind: "tool_result",
+        toolCallId: block.toolCallId,
         ok: true,
         text: block.preview,
         payload: {

--- a/src/web/server/readSessionMessages.ts
+++ b/src/web/server/readSessionMessages.ts
@@ -444,6 +444,31 @@ function flushBlock(
         source: "history",
       });
       return;
+    case "media_reference":
+      flushText();
+      out.push({
+        id: `${context.sessionKey}-media-${context.index}-${out.length}`,
+        sessionKey: context.sessionKey,
+        projectKey: context.projectKey,
+        createdAt: stamp,
+        provider: "pilotdeck",
+        role: "tool",
+        kind: "tool_result",
+        ok: true,
+        text: block.preview,
+        payload: {
+          path: block.path,
+          originalBytes: block.originalBytes,
+          hasMore: block.hasMore,
+          mimeType: block.mimeType,
+          mediaType: block.mediaType,
+          pages: block.pages,
+          detail: block.detail,
+          reason: block.reason,
+        },
+        source: "history",
+      });
+      return;
     case "image":
       if (role === "user") {
         appendImage(block);


### PR DESCRIPTION
## Summary
- add background idle-session sweeping so gateway sessions and per-session runtimes are released after the configured idle timeout
- add opt-in gateway memory diagnostics via `PILOTDECK_MEMORY_DIAGNOSTICS=1` / gateway config
- persist large supplemental media blocks as lightweight `media_reference` entries in session history/transcripts
- materialize `media_reference` blocks back into image/pdf/audio payloads only while building model requests, preserving model-facing behavior and prompt-cache stability

## Validation
- tracked source TypeScript check passed locally
- `git diff --check` passed locally
- manual `tsx` materializer check covered image/pdf/audio restore and missing-file preview fallback

## Notes
- tests are intentionally not included in this branch per request
- local pushes used `--no-verify` because this machine lacks `git-lfs`; branch changes are TypeScript source only
