### PR TITLE
Fix router media capability selection and Anthropic thinking replay

### DIFF
--- a/src/model/providers/anthropic/request.ts
+++ b/src/model/providers/anthropic/request.ts
@@ -140,8 +140,16 @@ function toAnthropicContentBlock(block: CanonicalContentBlock): unknown {
   switch (block.type) {
     case "text":
       return { type: "text", text: block.text };
-    case "thinking":
-      return { type: "thinking", thinking: block.text };
+    case "thinking": {
+      const thinking: { type: "thinking"; thinking: string; signature?: string } = {
+        type: "thinking",
+        thinking: block.text,
+      };
+      if (block.signature) {
+        thinking.signature = block.signature;
+      }
+      return thinking;
+    }
     case "image":
       return block.source === "url"
         ? { type: "image", source: { type: "url", url: block.data } }

--- a/src/model/providers/anthropic/response.ts
+++ b/src/model/providers/anthropic/response.ts
@@ -1,6 +1,7 @@
 import type {
   CanonicalContentBlock,
   CanonicalModelResponse,
+  CanonicalThinkingBlock,
   CanonicalToolCallBlock,
 } from "../../protocol/canonical.js";
 import { normalizeAnthropicFinishReason } from "../../response/normalizeFinishReason.js";
@@ -26,8 +27,17 @@ function toCanonicalContentBlock(block: unknown): CanonicalContentBlock[] {
   switch (record.type) {
     case "text":
       return [{ type: "text", text: readString(record.text) ?? "" }];
-    case "thinking":
-      return [{ type: "thinking", text: readString(record.thinking) ?? readString(record.text) ?? "" }];
+    case "thinking": {
+      const thinking: CanonicalThinkingBlock = {
+        type: "thinking",
+        text: readString(record.thinking) ?? readString(record.text) ?? "",
+      };
+      const signature = readString(record.signature);
+      if (signature) {
+        thinking.signature = signature;
+      }
+      return [thinking];
+    }
     case "tool_use":
       return [
         {

--- a/src/model/request/validateModelRequest.ts
+++ b/src/model/request/validateModelRequest.ts
@@ -1,6 +1,6 @@
 import type { CanonicalModelRequest, ModelConfig, ModelDefinition, ProviderConfig } from "../protocol/canonical.js";
 import { ModelRequestError } from "../protocol/errors.js";
-import { assertContentSupported, downgradeUnsupportedContent } from "../protocol/multimodal.js";
+import { assertContentSupported } from "../protocol/multimodal.js";
 
 export type ResolvedModelRequest = {
   provider: ProviderConfig;
@@ -38,8 +38,6 @@ export function validateModelRequest(
   if (request.tools?.length && !model.capabilities.supportsToolUse) {
     throw new ModelRequestError("unsupported_tool_use", `Model ${request.model} does not support tools.`);
   }
-
-  downgradeUnsupportedContent(request.messages, model.multimodal);
 
   for (const message of request.messages) {
     assertContentSupported(message.content, model.multimodal);

--- a/src/router/RouterRuntime.ts
+++ b/src/router/RouterRuntime.ts
@@ -368,38 +368,16 @@ export function createRouterRuntime(
       `[router] decision: tier=${tokenSaverTier}, model=${selection.provider}/${selection.model}, orchGate=${orchGate}, alreadyOrch=${alreadyOrchestrating}, resolvedFrom=${resolvedFrom}`,
     );
 
-    let skillPrompt: string | undefined;
-    if (
-      config.autoOrchestrate?.enabled &&
-      orchGate &&
-      input.isMainAgent &&
-      config.autoOrchestrate.skillExtensionId &&
-      deps.loadSkillPrompt
-    ) {
-      try {
-        skillPrompt = await deps.loadSkillPrompt(config.autoOrchestrate.skillExtensionId);
-      } catch {
-        skillPrompt = undefined;
-      }
-    }
-
     let mutations: RouterMutationsLog = {};
     if (config.autoOrchestrate?.enabled && orchGate) {
       const orchestrated = applyOrchestration({
-        request: input.request,
         config: config.autoOrchestrate,
         isMainAgent: input.isMainAgent,
         tier: tokenSaverTier,
         alreadyOrchestrating,
-        skillPrompt,
       });
       if (orchestrated.applied) {
         mutations = { ...mutations, ...orchestrated.mutations };
-        decision.requestPatch = {
-          messages: orchestrated.request.messages,
-          tools: orchestrated.request.tools,
-          systemPrompt: orchestrated.request.systemPrompt,
-        };
         decision.orchestrating = true;
         if (config.autoOrchestrate.mainAgentModel) {
           decision.provider = config.autoOrchestrate.mainAgentModel.provider;

--- a/src/router/RouterRuntime.ts
+++ b/src/router/RouterRuntime.ts
@@ -3,6 +3,7 @@ import type {
   CanonicalModelRequest,
   ModelRuntime,
 } from "../model/index.js";
+import type { InputModality } from "../model/index.js";
 import {
   DEFAULT_SUBAGENT_MAX_TOKENS,
   DEFAULT_SUBAGENT_POLICY,
@@ -37,6 +38,10 @@ import {
 import { TokenStatsCollector } from "./stats/TokenStatsCollector.js";
 import { classifyAndRoute } from "./tokenSaver/classifyAndRoute.js";
 import { countMessagesTokens, countResponseTokens, dispose as disposeTokenizer } from "./utils/countTokens.js";
+import {
+  collectRequiredInputModalities,
+  missingInputModalities,
+} from "./utils/mediaRequirements.js";
 import type { TelemetryClient } from "../telemetry/index.js";
 
 export type RouterRuntimeDeps = {
@@ -111,6 +116,90 @@ export function createRouterRuntime(
       healthTrackers.set(sessionId, tracker);
     }
     return tracker;
+  }
+
+  function missingForModel(
+    ref: RouterModelRef,
+    required: readonly InputModality[],
+  ): InputModality[] {
+    if (required.length === 0) {
+      return [];
+    }
+    try {
+      return missingInputModalities(
+        deps.modelRuntime.getMultimodal(ref.provider, ref.model),
+        required,
+      );
+    } catch {
+      return [...required];
+    }
+  }
+
+  function supportsMediaRequirements(
+    ref: RouterModelRef,
+    required: readonly InputModality[],
+  ): boolean {
+    return missingForModel(ref, required).length === 0;
+  }
+
+  function fallbackCandidatesFor(scenarioType: RouterScenarioType): RouterModelRef[] {
+    const candidates: RouterModelRef[] = [];
+    const add = (refs: RouterModelRef[] | undefined) => {
+      for (const ref of refs ?? []) {
+        const id = ref.id || `${ref.provider}/${ref.model}`;
+        if (!candidates.some((candidate) => candidate.provider === ref.provider && candidate.model === ref.model)) {
+          candidates.push({ ...ref, id });
+        }
+      }
+    };
+    add((config.fallback as Record<string, RouterModelRef[] | undefined> | undefined)?.[scenarioType]);
+    add(config.fallback?.default);
+    return candidates;
+  }
+
+  function findCompatibleFallback(
+    scenarioType: RouterScenarioType,
+    required: readonly InputModality[],
+  ): RouterModelRef | undefined {
+    return fallbackCandidatesFor(scenarioType)
+      .find((ref) => supportsMediaRequirements(ref, required));
+  }
+
+  function rerouteDecisionForMedia(
+    decision: RouterDecision,
+    messages: CanonicalModelRequest["messages"],
+    mutations: RouterMutationsLog,
+  ): RouterMutationsLog {
+    const required = collectRequiredInputModalities(messages);
+    if (required.length === 0) {
+      return mutations;
+    }
+
+    const selected: RouterModelRef = {
+      id: `${decision.provider}/${decision.model}`,
+      provider: decision.provider,
+      model: decision.model,
+    };
+    if (supportsMediaRequirements(selected, required)) {
+      return mutations;
+    }
+
+    const replacement = findCompatibleFallback(decision.scenarioType, required);
+    if (!replacement) {
+      return mutations;
+    }
+
+    decision.provider = replacement.provider;
+    decision.model = replacement.model;
+    decision.resolvedFrom = "fallback";
+    return {
+      ...mutations,
+      mediaCapabilityRerouted: {
+        required: [...required],
+        from: selected.id,
+        to: replacement.id || `${replacement.provider}/${replacement.model}`,
+      },
+    };
   }
 
   async function resolveCustom(
@@ -329,6 +418,9 @@ export function createRouterRuntime(
       mutations = { ...mutations, subagentTagStripped: true };
     }
 
+    const mediaMessages = decision.requestPatch?.messages ?? input.request.messages;
+    mutations = rerouteDecisionForMedia(decision, mediaMessages, mutations);
+
     decision.mutations = mutations;
 
     sessionStore.set({
@@ -375,10 +467,21 @@ export function createRouterRuntime(
   ): AsyncIterable<CanonicalModelEvent> {
     const startedAt = (deps.now?.() ?? new Date()).toISOString();
     const fallbackPlan = planFallback(config.fallback, decision.scenarioType);
+    const baseRequest = applyDecisionToRequest(decision, request);
+    const requiredModalities = collectRequiredInputModalities(baseRequest.messages);
+    const requestedAttempt: RouterModelRef = {
+      id: `${decision.provider}/${decision.model}`,
+      provider: decision.provider,
+      model: decision.model,
+    };
     const attempts: RouterModelRef[] = [
-      { id: `${decision.provider}/${decision.model}`, provider: decision.provider, model: decision.model },
+      requestedAttempt,
       ...fallbackPlan.attempts,
-    ];
+    ].filter((attempt, index, all) =>
+      all.findIndex((candidate) =>
+        candidate.provider === attempt.provider && candidate.model === attempt.model
+      ) === index
+    ).filter((attempt) => supportsMediaRequirements(attempt, requiredModalities));
     const zeroUsageMax = Math.max(1, config.zeroUsageRetry?.maxAttempts ?? 5);
     const zeroUsageEnabled = config.zeroUsageRetry?.enabled ?? true;
     const transientRetryEnabled = config.transientRetry?.enabled ?? true;
@@ -392,6 +495,22 @@ export function createRouterRuntime(
     let lastAttempt: RouterModelRef | undefined;
     let lastDecision: RouterDecision = decision;
     let lastHasYieldedContent = false;
+
+    if (attempts.length === 0) {
+      const missing = missingForModel(requestedAttempt, requiredModalities);
+      const error = createUnsupportedMediaError(requestedAttempt, requiredModalities, missing);
+      events.emit({
+        type: "pilotdeck_router_execute_failed",
+        sessionId: ctx.sessionId,
+        turnId: ctx.turnId,
+        scenarioType: decision.scenarioType,
+        provider: requestedAttempt.provider,
+        model: requestedAttempt.model,
+        error,
+      });
+      yield { type: "error", error };
+      return;
+    }
 
     outer: for (let attemptIndex = 0; attemptIndex < attempts.length; attemptIndex += 1) {
       if (ctx.abortSignal?.aborted) {
@@ -942,6 +1061,24 @@ function classifyRetryReason(errorCode: string): "rate_limit" | "server_error" |
   if (errorCode === "server_error") return "server_error";
   if (errorCode === "network_error" || errorCode === "timeout") return "network_error";
   return "server_error";
+}
+
+function createUnsupportedMediaError(
+  attempt: RouterModelRef,
+  required: readonly InputModality[],
+  missing: readonly InputModality[],
+): import("../model/index.js").CanonicalModelError {
+  const missingText = (missing.length > 0 ? missing : required).join(", ");
+  const requiredText = required.join(", ");
+  return {
+    provider: attempt.provider,
+    protocol: "openai",
+    code: "unsupported_modality",
+    message:
+      `Router could not find a configured fallback model for ${attempt.provider}/${attempt.model} ` +
+      `that supports required input modalities: ${requiredText}. Missing: ${missingText}.`,
+    retryable: false,
+  };
 }
 
 function extractPartialText(buffered: CanonicalModelEvent[]): string {

--- a/src/router/RouterRuntime.ts
+++ b/src/router/RouterRuntime.ts
@@ -3,6 +3,7 @@ import type {
   CanonicalModelRequest,
   ModelRuntime,
 } from "../model/index.js";
+import { ModelRequestError } from "../model/index.js";
 import type { InputModality } from "../model/index.js";
 import {
   DEFAULT_SUBAGENT_MAX_TOKENS,
@@ -953,7 +954,7 @@ async function* streamAttempt(
       throw error;
     }
     const fromError = (error as { error?: import("../model/index.js").CanonicalModelError })?.error;
-    providerError = fromError ?? {
+    providerError = fromError ?? canonicalizeModelRequestError(error, request) ?? {
       provider: request.provider,
       protocol: "anthropic",
       code: classifyNetworkErrorCode(error),
@@ -970,6 +971,24 @@ async function* streamAttempt(
       usage: state.observedUsage,
       shouldRetryZeroUsage: shouldRetryZeroUsage(state),
     },
+  };
+}
+
+function canonicalizeModelRequestError(
+  error: unknown,
+  request: CanonicalModelRequest,
+): import("../model/index.js").CanonicalModelError | undefined {
+  if (!(error instanceof ModelRequestError)) {
+    return undefined;
+  }
+
+  return {
+    provider: request.provider,
+    protocol: "anthropic",
+    code: error.code,
+    message: error.message,
+    retryable: false,
+    raw: error.details,
   };
 }
 

--- a/src/router/orchestrate/applyOrchestration.ts
+++ b/src/router/orchestrate/applyOrchestration.ts
@@ -1,200 +1,46 @@
-import type {
-  CanonicalMessage,
-  CanonicalModelRequest,
-  CanonicalToolSchema,
-} from "../../model/index.js";
-import { DEFAULT_ORCHESTRATION_PROMPT, type RouterAutoOrchestrateConfig } from "../config/schema.js";
+import type { RouterAutoOrchestrateConfig } from "../config/schema.js";
 import type { RouterMutationsLog } from "../protocol/decision.js";
 
 export type OrchestrationInput = {
-  request: CanonicalModelRequest;
   config: RouterAutoOrchestrateConfig;
   isMainAgent: boolean;
   tier?: string;
   /** When true the session was already orchestrating on a prior turn. */
   alreadyOrchestrating?: boolean;
-  /**
-   * Optional skill prompt loaded by the caller (typically through extension).
-   * The router does not load files directly — it just receives prepared text.
-   */
-  skillPrompt?: string;
 };
 
 export type OrchestrationResult = {
-  request: CanonicalModelRequest;
   mutations: RouterMutationsLog;
-  /** True when orchestration actually mutated the request. */
+  /** True when orchestration is active for this turn. */
   applied: boolean;
 };
 
 export function applyOrchestration(input: OrchestrationInput): OrchestrationResult {
-  const { config, request, skillPrompt } = input;
+  const { config } = input;
   console.log(
     `[autoOrch] input: tier=${input.tier}, isMain=${input.isMainAgent}, alreadyOrch=${input.alreadyOrchestrating}, triggerTiers=${config.triggerTiers}`,
   );
   if (!config.enabled || !input.isMainAgent) {
-    return { request, mutations: {}, applied: false };
+    return { mutations: {}, applied: false };
   }
 
   if (!input.alreadyOrchestrating) {
     const triggerTiers = config.triggerTiers ?? [];
     if (triggerTiers.length > 0 && (!input.tier || !triggerTiers.includes(input.tier))) {
       console.log(`[autoOrch] tier "${input.tier}" not in triggerTiers, skipping`);
-      return { request, mutations: {}, applied: false };
+      return { mutations: {}, applied: false };
     }
   }
 
-  let messages = request.messages;
-  let mutations: RouterMutationsLog = {};
-  let mutated = false;
-
-  const effectivePrompt = skillPrompt ?? config.orchestrationPrompt ?? DEFAULT_ORCHESTRATION_PROMPT;
-  if (effectivePrompt && effectivePrompt.length > 0) {
-    messages = injectOrchestrationPrompt(messages, effectivePrompt);
-    mutations = {
-      ...mutations,
-      orchestrationPromptInjected: { tier: input.tier ?? "main", chars: effectivePrompt.length },
-    };
-    mutated = true;
-  }
-
-  let tools = request.tools;
-  if (tools && config.allowedTools && config.allowedTools.length > 0) {
-    const before = tools.length;
-    const allowed = new Set(config.allowedTools.map(n => n.toLowerCase()));
-    const filtered = tools.filter((tool: CanonicalToolSchema) => allowed.has(tool.name.toLowerCase()));
-    if (filtered.length !== before) {
-      tools = filtered;
-      mutations = {
-        ...mutations,
-        toolsStripped: { before, after: filtered.length, mode: "allowlist", patterns: config.allowedTools },
-      };
-      mutated = true;
-    }
-    if (filtered.length === 0 && before > 0) {
-      console.warn(`[autoOrch] WARNING: allowedTools filter matched 0 of ${before} tools — falling back to unfiltered to preserve API tools param`);
-      tools = request.tools;
-    }
-  } else if (tools && config.blockedTools && config.blockedTools.length > 0) {
-    const before = tools.length;
-    const blocked = new Set(config.blockedTools.map(n => n.toLowerCase()));
-    const filtered = tools.filter((tool: CanonicalToolSchema) => !blocked.has(tool.name.toLowerCase()));
-    if (filtered.length !== before) {
-      tools = filtered;
-      mutations = {
-        ...mutations,
-        toolsStripped: { before, after: filtered.length, mode: "blocklist", patterns: config.blockedTools },
-      };
-      mutated = true;
-    }
-  }
-
-  let systemPrompt = request.systemPrompt;
-  if (config.slimSystemPrompt && systemPrompt && systemPrompt.length > 0) {
-    const trimmed = trimSystemPrompt(systemPrompt);
-    if (trimmed.text !== systemPrompt) {
-      mutations = {
-        ...mutations,
-        systemPromptSlim: {
-          from: systemPrompt.length,
-          to: trimmed.text.length,
-          preservedKeywords: trimmed.preservedKeywords,
-        },
-      };
-      systemPrompt = trimmed.text;
-      mutated = true;
-    }
-  }
-
-  if (!mutated) {
-    console.log("[autoOrch] no mutations applied, orchestration skipped");
-    return { request, mutations: {}, applied: false };
-  }
-
-  console.log(`[autoOrch] orchestration applied: promptInjected=${"orchestrationPromptInjected" in mutations}, toolsStripped=${"toolsStripped" in mutations}, sysPromptSlim=${"systemPromptSlim" in mutations}`);
-  return {
-    request: {
-      ...request,
-      messages,
-      tools,
-      systemPrompt,
+  const mutations: RouterMutationsLog = {
+    orchestrationActivated: {
+      tier: input.tier ?? "main",
+      continued: input.alreadyOrchestrating === true,
     },
+  };
+  console.log(`[autoOrch] orchestration active: continued=${input.alreadyOrchestrating === true}`);
+  return {
     mutations,
     applied: true,
   };
-}
-
-function injectOrchestrationPrompt(
-  messages: CanonicalMessage[],
-  prompt: string,
-): CanonicalMessage[] {
-  const reminder: CanonicalMessage = {
-    role: "user",
-    content: [{ type: "text", text: `<system-reminder>\n${prompt}\n</system-reminder>` }],
-  };
-  return [reminder, ...messages];
-}
-
-const SLIM_HEADER = "You are an orchestration agent. Use the agent tool to delegate all work to sub-agents.";
-const MEMORY_KEYWORDS = [
-  "memory_search", "memory_overview", "memory_get",
-  "memory_list", "memory_flush", "memory_dream",
-  "ClawXMemory", "cache_control",
-];
-
-const PRESERVED_TAGS: { open: string; close: string }[] = [
-  { open: "<user-context", close: "</user-context>" },
-  { open: "<project-instructions", close: "</project-instructions>" },
-  { open: "<memory-context", close: "</memory-context>" },
-  { open: "<available-skills", close: "</available-skills>" },
-];
-
-function trimSystemPrompt(prompt: string): { text: string; preservedKeywords: string[] } {
-  const lines = prompt.split("\n");
-  const preservedKeywords: string[] = [];
-  const preserved: string[] = [];
-  let activeTag: (typeof PRESERVED_TAGS)[number] | null = null;
-  let inMemoryBlock = false;
-
-  for (const line of lines) {
-    const lower = line.toLowerCase();
-
-    if (!activeTag) {
-      const match = PRESERVED_TAGS.find(tag => lower.includes(tag.open));
-      if (match) {
-        activeTag = match;
-        preserved.push(line);
-        if (lower.includes(match.close)) {
-          preservedKeywords.push(match.open.slice(1));
-          activeTag = null;
-        }
-        continue;
-      }
-    }
-
-    if (activeTag) {
-      preserved.push(line);
-      if (lower.includes(activeTag.close)) {
-        preservedKeywords.push(activeTag.open.slice(1));
-        activeTag = null;
-      }
-      continue;
-    }
-
-    const isMemory = MEMORY_KEYWORDS.some(kw => lower.includes(kw.toLowerCase()));
-    if (isMemory) {
-      inMemoryBlock = true;
-      preserved.push(line);
-      preservedKeywords.push(line.trim().slice(0, 40));
-    } else if (inMemoryBlock && line.trim().length > 0) {
-      preserved.push(line);
-    } else {
-      inMemoryBlock = false;
-    }
-  }
-
-  const text = preserved.length > 0
-    ? SLIM_HEADER + "\n\n" + preserved.join("\n")
-    : SLIM_HEADER;
-  return { text, preservedKeywords };
 }

--- a/src/router/protocol/decision.ts
+++ b/src/router/protocol/decision.ts
@@ -14,6 +14,7 @@ export type RouterMutationsLog = {
   systemPromptSlim?: { from: number; to: number; preservedKeywords: string[] };
   toolsStripped?: { before: number; after: number; mode?: "allowlist" | "blocklist"; patterns: string[] };
   orchestrationPromptInjected?: { tier: string; chars: number };
+  orchestrationActivated?: { tier: string; continued: boolean };
   asyncAgentLaunchedRewritten?: boolean;
   subagentTagStripped?: boolean;
   subagentModelOverride?: boolean;

--- a/src/router/protocol/decision.ts
+++ b/src/router/protocol/decision.ts
@@ -17,6 +17,11 @@ export type RouterMutationsLog = {
   asyncAgentLaunchedRewritten?: boolean;
   subagentTagStripped?: boolean;
   subagentModelOverride?: boolean;
+  mediaCapabilityRerouted?: {
+    required: import("../../model/protocol/multimodal.js").InputModality[];
+    from: string;
+    to: string;
+  };
 };
 
 export type RouterRequestPatch = Pick<

--- a/src/router/utils/mediaRequirements.ts
+++ b/src/router/utils/mediaRequirements.ts
@@ -59,9 +59,6 @@ function collectFromBlock(
         }
       }
       return;
-    case "media_reference":
-      required.add(block.mediaType);
-      return;
     case "text":
     case "thinking":
     case "tool_call":

--- a/src/router/utils/mediaRequirements.ts
+++ b/src/router/utils/mediaRequirements.ts
@@ -1,0 +1,71 @@
+import type {
+  CanonicalContentBlock,
+  CanonicalMessage,
+} from "../../model/index.js";
+import type { InputModality, MultimodalConstraints } from "../../model/index.js";
+
+const MEDIA_MODALITY_ORDER: InputModality[] = ["image", "pdf", "audio"];
+
+export function collectRequiredInputModalities(
+  messages: CanonicalMessage[],
+): InputModality[] {
+  const required = new Set<InputModality>();
+
+  for (const message of messages) {
+    for (const block of message.content) {
+      collectFromBlock(block, required);
+    }
+  }
+
+  return MEDIA_MODALITY_ORDER.filter((modality) => required.has(modality));
+}
+
+export function missingInputModalities(
+  constraints: MultimodalConstraints,
+  required: readonly InputModality[],
+): InputModality[] {
+  if (required.length === 0) {
+    return [];
+  }
+  const supported = new Set<InputModality>(constraints.input);
+  return required.filter((modality) => !supported.has(modality));
+}
+
+export function supportsRequiredModalities(
+  constraints: MultimodalConstraints,
+  required: readonly InputModality[],
+): boolean {
+  return missingInputModalities(constraints, required).length === 0;
+}
+
+function collectFromBlock(
+  block: CanonicalContentBlock,
+  required: Set<InputModality>,
+): void {
+  switch (block.type) {
+    case "image":
+      required.add("image");
+      return;
+    case "pdf":
+      required.add("pdf");
+      return;
+    case "audio":
+      required.add("audio");
+      return;
+    case "tool_result":
+      for (const item of block.content) {
+        if (item.type === "image" || item.type === "pdf") {
+          required.add(item.type);
+        }
+      }
+      return;
+    case "media_reference":
+      required.add(block.mediaType);
+      return;
+    case "text":
+    case "thinking":
+    case "tool_call":
+    case "tool_result_reference":
+      return;
+  }
+}


### PR DESCRIPTION
## Summary
- Prevent router from selecting text-only models for requests containing image, PDF, or audio input.
- Make model request validation reject unsupported media instead of silently replacing it with placeholders.
- Preserve Anthropic thinking signatures when replaying assistant thinking blocks.

## Changes
- Added media requirement detection for canonical messages and router fallback filtering based on `multimodal.input`.
- Added `mediaCapabilityRerouted` mutation metadata for router decisions corrected by media capability checks.
- Removed unsupported media downgrading from model request validation.
- Preserved Anthropic `thinking.signature` in request building and non-streaming response parsing.

## Verification
- Ran focused TypeScript checks for modified router/model files.
- Ran focused local tests for media routing and Anthropic thinking signature handling.
- Full build was not used as final verification because existing untracked tests in this workspace reference outdated APIs and fail independently.