### PR TITLE
feat(web): add history fork for conversations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -190,6 +190,11 @@ package-lock.json
 # Test output
 test-results/
 
+# Local test drafts (force-add intentional new tests with git add -f)
+test/
+test.ts
+*.test.ts
+
 # Auto-Research-Skills (local-only)
 Auto-Research-Skills/
 

--- a/scripts/tui-e2e-permission.tsx
+++ b/scripts/tui-e2e-permission.tsx
@@ -98,6 +98,7 @@ class MockGateway implements Gateway {
   grantSessionPermission = stub({ granted: false }) as Gateway["grantSessionPermission"];
   readSessionMessages = stub({ messages: [], hasMore: false, session: {} as any }) as unknown as Gateway["readSessionMessages"];
   readSubagentMessages = stub({ messages: [], total: 0 }) as unknown as Gateway["readSubagentMessages"];
+  forkSession = stub({ newSessionKey: "web:s_fork", prefillText: "", carriedMessageCount: 0 }) as unknown as Gateway["forkSession"];
   listProjects = stub({ projects: [] }) as Gateway["listProjects"];
   describeProject = stub({ projectKey: "", name: "", root: "", fullPath: "", sessionCount: 0 }) as unknown as Gateway["describeProject"];
 }

--- a/src/agent/runtime/AgentRuntimeDependencies.ts
+++ b/src/agent/runtime/AgentRuntimeDependencies.ts
@@ -69,7 +69,12 @@ export type AgentSubagentTranscriptHooks = {
     errored?: boolean;
   }): Promise<void>;
   subagentTranscriptResolver?(subagentId: string): {
-    recordAcceptedInput(sessionId: string, turnId: string, messages: CanonicalMessage[]): Promise<void>;
+    recordAcceptedInput(
+      sessionId: string,
+      turnId: string,
+      messages: CanonicalMessage[],
+      metadata?: Record<string, unknown>,
+    ): Promise<void>;
     recordDurableMessage(sessionId: string, turnId: string, message: CanonicalMessage): Promise<void>;
     transcriptRelativePath: string;
   };

--- a/src/agent/sub/SubAgentSession.ts
+++ b/src/agent/sub/SubAgentSession.ts
@@ -87,7 +87,12 @@ export type SubAgentSessionOptions = {
  * (the parent constructs the writer and passes it in).
  */
 export type SidechainTranscriptWriter = {
-  recordAcceptedInput(sessionId: string, turnId: string, messages: CanonicalMessage[]): Promise<void>;
+  recordAcceptedInput(
+    sessionId: string,
+    turnId: string,
+    messages: CanonicalMessage[],
+    metadata?: Record<string, unknown>,
+  ): Promise<void>;
   recordDurableMessage(sessionId: string, turnId: string, message: CanonicalMessage): Promise<void>;
 };
 

--- a/src/agent/turn/TurnRunner.ts
+++ b/src/agent/turn/TurnRunner.ts
@@ -59,7 +59,12 @@ export class TurnRunner {
     const messages = [...options.messages, ...accepted.messages];
 
     try {
-      await this.transcript.recordAcceptedInput(options.sessionId, options.turnId, accepted.messages);
+      await this.transcript.recordAcceptedInput(
+        options.sessionId,
+        options.turnId,
+        accepted.messages,
+        acceptedInputMetadata(options),
+      );
     } catch (error) {
       const agentTranscriptError = agentError("agent_transcript_error", "Failed to record accepted input.", error);
       const result = this.createErrorResult(options, agentTranscriptError);
@@ -154,6 +159,20 @@ export class TurnRunner {
       errors: [error],
     };
   }
+}
+
+function acceptedInputMetadata(options: TurnRunnerOptions): Record<string, unknown> | undefined {
+  const metadata: Record<string, unknown> = {};
+  if (options.permissionMode) {
+    metadata.permissionMode = options.permissionMode;
+  }
+  if (options.basePermissionMode) {
+    metadata.basePermissionMode = options.basePermissionMode;
+  }
+  if (options.allowPlanModeTools !== undefined) {
+    metadata.allowPlanModeTools = options.allowPlanModeTools;
+  }
+  return Object.keys(metadata).length > 0 ? metadata : undefined;
 }
 
 function emptyUsage(): CanonicalUsage {

--- a/src/cli/createLocalGateway.ts
+++ b/src/cli/createLocalGateway.ts
@@ -64,6 +64,7 @@ import { DEFAULT_JUDGE_TIMEOUT_MS, DEFAULT_SUBAGENT_MAX_TOKENS, DEFAULT_ALLOWED_
 import { createAgentProjectSessionStorage, listProjectSessions, resumeAgentSession } from "../session/index.js";
 import { sanitizeSessionIdForPath } from "../session/storage/ProjectSessionStorage.js";
 import { readWebSessionMessages, readSubagentWebMessages } from "../web/server/readSessionMessages.js";
+import { forkWebSession } from "../web/server/forkSession.js";
 import { describeWebProject, listWebProjects } from "../web/server/listProjects.js";
 import { BackgroundTaskRuntime } from "../task/runtime/BackgroundTaskRuntime.js";
 import { createBuiltinRegistry, createPlanFileManager } from "../tool/index.js";
@@ -265,6 +266,12 @@ export function createLocalGateway(options: CreateLocalGatewayOptions = {}): Cre
       }),
     readSubagentMessages: (input) =>
       readSubagentWebMessages(input, {
+        projectRoot: input.projectKey ? input.projectKey : projectRoot,
+        pilotHome,
+        now,
+      }),
+    forkSession: (input) =>
+      forkWebSession(input, {
         projectRoot: input.projectKey ? input.projectKey : projectRoot,
         pilotHome,
         now,

--- a/src/cli/pilotdeck.ts
+++ b/src/cli/pilotdeck.ts
@@ -680,6 +680,9 @@ function createFallbackGateway(): Gateway {
     readSubagentMessages: async () => {
       throw new Error("read_subagent_messages is not configured.");
     },
+    forkSession: async () => {
+      throw new Error("fork_session is not configured.");
+    },
     listProjects: async () => ({ projects: [] }),
     describeProject: async (input) => ({
       projectKey: input.projectKey,

--- a/src/context/DefaultContextRuntime.ts
+++ b/src/context/DefaultContextRuntime.ts
@@ -282,7 +282,7 @@ export class DefaultContextRuntime implements ContextRuntime {
       await this.memoryResolver.captureTurn({
         sessionId: input.sessionId,
         projectRoot: this.projectRoot ?? "",
-        messages: input.messages,
+        messages: input.messages.filter((message) => !message.metadata?.forkCarryover),
         errored: input.errored,
       });
     } catch {

--- a/src/context/memory/EdgeClawMemoryProvider.ts
+++ b/src/context/memory/EdgeClawMemoryProvider.ts
@@ -163,7 +163,9 @@ export class EdgeClawMemoryProvider implements MemoryResolver {
   }
 
   async captureTurn(input: MemoryCaptureTurnInput): Promise<void> {
-    const normalizedMessages = canonicalMessagesToMemoryMessages(input.messages);
+    const normalizedMessages = canonicalMessagesToMemoryMessages(input.messages, {
+      includeForkCarryover: false,
+    });
     this.options.telemetry?.trackFeatureLoopStage({
       module: "memory",
       ownerModule: "memory",

--- a/src/context/memory/MemoryResolver.ts
+++ b/src/context/memory/MemoryResolver.ts
@@ -38,8 +38,19 @@ export type MemoryResolver = {
   captureTurn(input: MemoryCaptureTurnInput): Promise<void>;
 };
 
-export function canonicalMessagesToMemoryMessages(messages: CanonicalMessage[]): ContextMemoryMessage[] {
+export type CanonicalMessagesToMemoryMessagesOptions = {
+  includeForkCarryover?: boolean;
+};
+
+export function canonicalMessagesToMemoryMessages(
+  messages: CanonicalMessage[],
+  options: CanonicalMessagesToMemoryMessagesOptions = {},
+): ContextMemoryMessage[] {
   return messages.flatMap((message, index) => {
+    if (options.includeForkCarryover === false && message.metadata?.forkCarryover) {
+      return [];
+    }
+
     const entries: Array<Omit<ContextMemoryMessage, "msgId">> = [];
     const pushEntry = (role: string, text: string) => {
       const content = text.trim();

--- a/src/gateway/client/InProcessGateway.ts
+++ b/src/gateway/client/InProcessGateway.ts
@@ -40,6 +40,8 @@ import type {
   WebReadSessionMessagesResult,
   WebReadSubagentMessagesInput,
   WebReadSubagentMessagesResult,
+  WebForkSessionInput,
+  WebForkSessionResult,
 } from "../protocol/types.js";
 import type {
   CronCreateInput,
@@ -92,6 +94,7 @@ export type InProcessGatewayOptions = {
    */
   readSessionMessages?: (input: WebReadSessionMessagesInput) => Promise<WebReadSessionMessagesResult>;
   readSubagentMessages?: (input: WebReadSubagentMessagesInput) => Promise<WebReadSubagentMessagesResult>;
+  forkSession?: (input: WebForkSessionInput) => Promise<WebForkSessionResult>;
   /**
    * Web Phase 3 — pluggable project enumerator + describer.
    */
@@ -614,6 +617,15 @@ export class InProcessGateway implements Gateway {
       );
     }
     return this.options.readSubagentMessages(input);
+  }
+
+  async forkSession(input: WebForkSessionInput): Promise<WebForkSessionResult> {
+    if (!this.options.forkSession) {
+      throw new Error(
+        "fork_session is not configured. Wire `forkSession` via createLocalGateway.",
+      );
+    }
+    return this.options.forkSession(input);
   }
 
   async listProjects(): Promise<WebListProjectsResult> {

--- a/src/gateway/client/RemoteGateway.ts
+++ b/src/gateway/client/RemoteGateway.ts
@@ -22,6 +22,8 @@ import type {
   WebReadSessionMessagesResult,
   WebReadSubagentMessagesInput,
   WebReadSubagentMessagesResult,
+  WebForkSessionInput,
+  WebForkSessionResult,
 } from "../protocol/types.js";
 import type {
   SkillAddressInput,
@@ -132,6 +134,10 @@ export class RemoteGateway implements Gateway {
 
   async readSubagentMessages(input: WebReadSubagentMessagesInput): Promise<WebReadSubagentMessagesResult> {
     return (await this.client.request("read_subagent_messages", input)) as WebReadSubagentMessagesResult;
+  }
+
+  async forkSession(input: WebForkSessionInput): Promise<WebForkSessionResult> {
+    return (await this.client.request("fork_session", input)) as WebForkSessionResult;
   }
 
   async listProjects(): Promise<WebListProjectsResult> {

--- a/src/gateway/protocol/frames.ts
+++ b/src/gateway/protocol/frames.ts
@@ -36,6 +36,7 @@ export type WsGatewayMethod =
   | "grant_session_permission"
   | "read_session_messages"
   | "read_subagent_messages"
+  | "fork_session"
   | "list_projects"
   | "describe_project"
   | "reload_config"

--- a/src/gateway/protocol/types.ts
+++ b/src/gateway/protocol/types.ts
@@ -25,6 +25,8 @@ import type {
   WebReadSessionMessagesResult as WebUiReadSessionMessagesResult,
   WebReadSubagentMessagesInput as WebUiReadSubagentMessagesInput,
   WebReadSubagentMessagesResult as WebUiReadSubagentMessagesResult,
+  WebForkSessionInput as WebUiForkSessionInput,
+  WebForkSessionResult as WebUiForkSessionResult,
 } from "../../web/client/protocol.js";
 import type {
   SkillCreateInput,
@@ -222,6 +224,8 @@ export type WebReadSessionMessagesInput = WebUiReadSessionMessagesInput;
 export type WebReadSessionMessagesResult = WebUiReadSessionMessagesResult;
 export type WebReadSubagentMessagesInput = WebUiReadSubagentMessagesInput;
 export type WebReadSubagentMessagesResult = WebUiReadSubagentMessagesResult;
+export type WebForkSessionInput = WebUiForkSessionInput;
+export type WebForkSessionResult = WebUiForkSessionResult;
 export type WebProjectSummary = WebUiProjectSummary;
 export type WebListProjectsResult = WebUiListProjectsResult;
 export type WebDescribeProjectInput = { projectKey: string };
@@ -343,6 +347,10 @@ export interface Gateway {
    * the Web `WebMessage` DTO.
    */
   readSessionMessages(input: WebReadSessionMessagesInput): Promise<WebReadSessionMessagesResult>;
+  /**
+   * Fork a session transcript at a prior user turn into a new session file.
+   */
+  forkSession(input: WebForkSessionInput): Promise<WebForkSessionResult>;
   /**
    * Read a subagent's sidechain transcript and return its messages in WebMessage format.
    */

--- a/src/gateway/server/GatewayWsConnection.ts
+++ b/src/gateway/server/GatewayWsConnection.ts
@@ -210,6 +210,8 @@ export class GatewayWsConnection {
         return this.options.gateway.readSessionMessages(frame.params as never);
       case "read_subagent_messages":
         return this.options.gateway.readSubagentMessages(frame.params as never);
+      case "fork_session":
+        return this.options.gateway.forkSession(frame.params as never);
       case "list_projects":
         return this.options.gateway.listProjects();
       case "describe_project":

--- a/src/model/protocol/canonical.ts
+++ b/src/model/protocol/canonical.ts
@@ -131,6 +131,10 @@ export type CanonicalMessageMetadata = {
   /** True for messages injected by the system (e.g. JSON self-correct prompts). */
   synthetic?: boolean;
   purpose?: string;
+  forkCarryover?: {
+    sourceSessionId: string;
+    sourceTurnId?: string;
+  };
 };
 
 export type CanonicalMessage = {

--- a/src/session/storage/SessionList.ts
+++ b/src/session/storage/SessionList.ts
@@ -20,6 +20,8 @@ export type SessionInfo = {
   cwd?: string;
   tag?: string;
   createdAt?: number;
+  parentSessionId?: string;
+  forkedFromTurnId?: string;
 };
 
 export type ListProjectSessionsOptions = {
@@ -73,6 +75,8 @@ export function parseSessionInfoFromLite(
   const customTitle = lastMetadataStringField(source, "title");
   const aiTitle = lastMetadataStringField(source, "aiTitle");
   const tag = lastMetadataStringField(source, "tag");
+  const parentSessionId = lastMetadataStringField(source, "parentSessionId");
+  const forkedFromTurnId = lastMetadataStringField(source, "forkedFromTurnId");
   const firstPrompt = firstAcceptedInputText(lite.head);
   const lastPrompt = lastAcceptedInputText(lite.tail) ?? firstPrompt;
   const summary = customTitle ?? aiTitle ?? lastPrompt;
@@ -92,6 +96,8 @@ export function parseSessionInfoFromLite(
     cwd: projectRoot,
     tag,
     createdAt: firstCreatedAt ? Date.parse(firstCreatedAt) : undefined,
+    parentSessionId,
+    forkedFromTurnId,
   };
 }
 

--- a/src/session/transcript/InMemoryTranscriptWriter.ts
+++ b/src/session/transcript/InMemoryTranscriptWriter.ts
@@ -4,7 +4,13 @@ import type { AgentControlBoundaryTranscriptEntry, SessionMetadataValue } from "
 import type { AgentTranscriptWriter, AgentTranscriptWriterState } from "./TranscriptWriter.js";
 
 export type InMemoryTranscriptEntry =
-  | { type: "accepted_input"; sessionId: string; turnId: string; messages: CanonicalMessage[] }
+  | {
+      type: "accepted_input";
+      sessionId: string;
+      turnId: string;
+      messages: CanonicalMessage[];
+      metadata?: Record<string, unknown>;
+    }
   | { type: "durable_message"; sessionId: string; turnId: string; message: CanonicalMessage }
   | { type: "turn_result"; sessionId: string; turnId: string; result: AgentTurnResult }
   | { type: "session_metadata"; sessionId: string; turnId: string; metadata: SessionMetadataValue }
@@ -18,8 +24,19 @@ export type InMemoryTranscriptEntry =
 export class InMemoryTranscriptWriter implements AgentTranscriptWriter {
   readonly entries: InMemoryTranscriptEntry[] = [];
 
-  recordAcceptedInput(sessionId: string, turnId: string, messages: CanonicalMessage[]): void {
-    this.entries.push({ type: "accepted_input", sessionId, turnId, messages });
+  recordAcceptedInput(
+    sessionId: string,
+    turnId: string,
+    messages: CanonicalMessage[],
+    metadata?: Record<string, unknown>,
+  ): void {
+    this.entries.push({
+      type: "accepted_input",
+      sessionId,
+      turnId,
+      messages,
+      ...(metadata && Object.keys(metadata).length > 0 ? { metadata } : {}),
+    });
   }
 
   recordDurableMessage(sessionId: string, turnId: string, message: CanonicalMessage): void {

--- a/src/session/transcript/JsonlTranscriptWriter.ts
+++ b/src/session/transcript/JsonlTranscriptWriter.ts
@@ -66,11 +66,17 @@ export class JsonlTranscriptWriter implements AgentTranscriptWriter {
     };
   }
 
-  recordAcceptedInput(sessionId: string, turnId: string, messages: CanonicalMessage[]): Promise<void> {
+  recordAcceptedInput(
+    sessionId: string,
+    turnId: string,
+    messages: CanonicalMessage[],
+    metadata?: Record<string, unknown>,
+  ): Promise<void> {
     return this.recordEntry({
       type: "accepted_input",
       ...this.baseEntry(sessionId, turnId),
       messages,
+      ...(metadata && Object.keys(metadata).length > 0 ? { metadata } : {}),
     });
   }
 

--- a/src/session/transcript/TranscriptEntry.ts
+++ b/src/session/transcript/TranscriptEntry.ts
@@ -97,6 +97,10 @@ export type SessionMetadataValue = {
     url: string;
     repository: string;
   };
+  /** Parent session when this transcript was created via history fork. */
+  parentSessionId?: string;
+  /** Turn id of the fork point in the parent session. */
+  forkedFromTurnId?: string;
   updatedAt?: string;
 };
 

--- a/src/session/transcript/TranscriptEntry.ts
+++ b/src/session/transcript/TranscriptEntry.ts
@@ -25,6 +25,7 @@ export type AgentTranscriptEntryBase = {
 export type AgentAcceptedInputTranscriptEntry = AgentTranscriptEntryBase & {
   type: "accepted_input";
   messages: CanonicalMessage[];
+  metadata?: Record<string, unknown>;
 };
 
 export type AgentMessageTranscriptEntry = AgentTranscriptEntryBase & {

--- a/src/session/transcript/TranscriptWriter.ts
+++ b/src/session/transcript/TranscriptWriter.ts
@@ -12,7 +12,12 @@ export type AgentTranscriptWriterState = {
 };
 
 export type AgentTranscriptWriter = {
-  recordAcceptedInput(sessionId: string, turnId: string, messages: CanonicalMessage[]): void | Promise<void>;
+  recordAcceptedInput(
+    sessionId: string,
+    turnId: string,
+    messages: CanonicalMessage[],
+    metadata?: Record<string, unknown>,
+  ): void | Promise<void>;
   recordDurableMessage(sessionId: string, turnId: string, message: CanonicalMessage): void | Promise<void>;
   recordTurnResult(sessionId: string, turnId: string, result: AgentTurnResult): void | Promise<void>;
   recordSessionMetadata?(sessionId: string, turnId: string, metadata: SessionMetadataValue): void | Promise<void>;

--- a/src/web/client/GatewayBrowserClient.ts
+++ b/src/web/client/GatewayBrowserClient.ts
@@ -204,6 +204,15 @@ export class GatewayBrowserClient {
     );
   }
 
+  readSubagentMessages(
+    input: import("./protocol.js").WebReadSubagentMessagesInput,
+  ) {
+    return this.request<import("./protocol.js").WebReadSubagentMessagesResult>(
+      "read_subagent_messages",
+      input,
+    );
+  }
+
   listProjects(): Promise<import("./protocol.js").WebListProjectsResult> {
     return this.request<import("./protocol.js").WebListProjectsResult>("list_projects", {});
   }

--- a/src/web/client/index.ts
+++ b/src/web/client/index.ts
@@ -26,6 +26,8 @@ export {
   type WebProjectSummary,
   type WebReadSessionMessagesInput,
   type WebReadSessionMessagesResult,
+  type WebReadSubagentMessagesInput,
+  type WebReadSubagentMessagesResult,
   type WebRequestFrame,
   type WebResponseFrame,
   type WebSessionInfo,

--- a/src/web/client/protocol.ts
+++ b/src/web/client/protocol.ts
@@ -265,6 +265,7 @@ export type WebForkSessionResult = {
   newSessionKey: string;
   prefillText: string;
   carriedMessageCount: number;
+  mode?: WebGatewayMode;
 };
 
 export type WebActiveTurnSnapshotInput = {

--- a/src/web/client/protocol.ts
+++ b/src/web/client/protocol.ts
@@ -108,6 +108,7 @@ export type WebGatewayMethod =
   | "permission_decide"
   | "grant_session_permission"
   | "read_session_messages"
+  | "fork_session"
   | "rename_session"
   | "delete_session"
   | "list_projects"
@@ -159,6 +160,8 @@ export type WebSessionInfo = {
   cwd?: string;
   tag?: string;
   createdAt?: number;
+  parentSessionId?: string;
+  forkedFromTurnId?: string;
 };
 
 export type WebListSessionsInput = {
@@ -249,6 +252,19 @@ export type WebReadSubagentMessagesInput = {
 export type WebReadSubagentMessagesResult = {
   messages: import("./webMessage.js").WebMessage[];
   total: number;
+};
+
+export type WebForkSessionInput = {
+  sessionKey: string;
+  projectKey?: string;
+  /** Transcript entry id of the user turn to fork from (accepted_input entryId). */
+  fromEntryId: string;
+};
+
+export type WebForkSessionResult = {
+  newSessionKey: string;
+  prefillText: string;
+  carriedMessageCount: number;
 };
 
 export type WebActiveTurnSnapshotInput = {

--- a/src/web/client/protocol.ts
+++ b/src/web/client/protocol.ts
@@ -108,6 +108,7 @@ export type WebGatewayMethod =
   | "permission_decide"
   | "grant_session_permission"
   | "read_session_messages"
+  | "read_subagent_messages"
   | "fork_session"
   | "rename_session"
   | "delete_session"
@@ -160,7 +161,9 @@ export type WebSessionInfo = {
   cwd?: string;
   tag?: string;
   createdAt?: number;
+  sessionKind?: "background_task";
   parentSessionId?: string;
+  relativeTranscriptPath?: string;
   forkedFromTurnId?: string;
 };
 
@@ -231,6 +234,9 @@ export type WebSessionPermissionGrant = {
 export type WebReadSessionMessagesInput = {
   sessionKey: string;
   projectKey?: string;
+  sessionKind?: "background_task";
+  parentSessionId?: string;
+  relativeTranscriptPath?: string;
   limit?: number;
   cursor?: string;
   direction?: "forward" | "backward";
@@ -247,6 +253,9 @@ export type WebReadSubagentMessagesInput = {
   sessionKey: string;
   subagentId: string;
   projectKey?: string;
+  sessionKind?: "background_task";
+  parentSessionId?: string;
+  relativeTranscriptPath?: string;
 };
 
 export type WebReadSubagentMessagesResult = {

--- a/src/web/client/webMessage.ts
+++ b/src/web/client/webMessage.ts
@@ -89,6 +89,8 @@ export type WebMessage = {
   source: "live" | "history";
   finishReason?: string;
   usage?: Record<string, number>;
+  /** Transcript entry id when projected from history (used for history fork). */
+  entryId?: string;
 };
 
 export type WebMessageReducerOptions = {

--- a/src/web/server/forkSession.ts
+++ b/src/web/server/forkSession.ts
@@ -1,0 +1,217 @@
+/**
+ * Fork a web session transcript at a prior user turn.
+ *
+ * Creates a new session file containing all entries strictly before the
+ * fork turn, copies auxiliary session dirs, and returns the forked user
+ * message text for composer prefill.
+ */
+
+import { randomUUID } from "node:crypto";
+import { cp, mkdir, writeFile, chmod } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { platform } from "node:process";
+import type { CanonicalContentBlock } from "../../model/index.js";
+import { getPilotProjectChatDir } from "../../pilot/index.js";
+import { readTranscript } from "../../session/transcript/TranscriptReader.js";
+import {
+  sanitizeSessionIdForPath,
+} from "../../session/storage/ProjectSessionStorage.js";
+import type {
+  AgentAcceptedInputTranscriptEntry,
+  AgentSessionMetadataTranscriptEntry,
+  AgentTranscriptEntry,
+} from "../../session/transcript/TranscriptEntry.js";
+import type { WebForkSessionInput, WebForkSessionResult } from "../client/protocol.js";
+
+export type ForkWebSessionOptions = {
+  projectRoot: string;
+  pilotHome: string;
+  now?: () => Date;
+};
+
+function newWebSessionKey(): string {
+  const sep = platform === "win32" ? "-" : ":";
+  return `web${sep}s_${randomUUID()}`;
+}
+
+function extractAcceptedInputText(entry: AgentAcceptedInputTranscriptEntry): string {
+  for (const message of entry.messages) {
+    for (const block of message.content as CanonicalContentBlock[]) {
+      if (block.type === "text" && block.text.trim()) {
+        return block.text.trim();
+      }
+    }
+  }
+  return "";
+}
+
+function buildForkTitle(
+  prefillText: string,
+  carriedMessageCount: number,
+  inheritedTitle: string | undefined,
+): string {
+  const normalized = prefillText.replace(/\s+/g, " ").trim();
+  if (normalized) {
+    const max = 48;
+    const snippet = normalized.length > max ? `${normalized.slice(0, max).trimEnd()}…` : normalized;
+    // A leading branch glyph keeps forks scannable even when titles collide.
+    return `⑂ ${snippet}`;
+  }
+  if (inheritedTitle) {
+    return `⑂ ${inheritedTitle}`;
+  }
+  return carriedMessageCount > 0 ? "⑂ Forked session" : "⑂ New branch";
+}
+
+function findForkTurnAcceptedInput(
+  entries: AgentTranscriptEntry[],
+  fromEntryId: string,
+): AgentAcceptedInputTranscriptEntry {
+  const target = entries.find((entry) => entry.entryId === fromEntryId);
+  if (!target) {
+    throw new ForkSessionError("fork_entry_not_found", `Transcript entry not found: ${fromEntryId}`);
+  }
+
+  if (target.type === "accepted_input") {
+    return target;
+  }
+
+  const accepted = entries.find(
+    (entry): entry is AgentAcceptedInputTranscriptEntry =>
+      entry.type === "accepted_input" && entry.turnId === target.turnId,
+  );
+  if (!accepted) {
+    throw new ForkSessionError(
+      "fork_turn_not_found",
+      `No accepted_input found for turn ${target.turnId}`,
+    );
+  }
+  return accepted;
+}
+
+function lastSessionMetadata(entries: AgentTranscriptEntry[]): Record<string, unknown> | undefined {
+  for (let index = entries.length - 1; index >= 0; index -= 1) {
+    const entry = entries[index];
+    if (entry.type === "session_metadata") {
+      return entry.metadata as Record<string, unknown>;
+    }
+  }
+  return undefined;
+}
+
+function countCarriedUserAssistantMessages(entries: AgentTranscriptEntry[]): number {
+  let count = 0;
+  for (const entry of entries) {
+    switch (entry.type) {
+      case "accepted_input":
+        count += entry.messages.length;
+        break;
+      case "assistant_message":
+      case "tool_result_message":
+      case "durable_message":
+        count += 1;
+        break;
+      default:
+        break;
+    }
+  }
+  return count;
+}
+
+async function copySessionAuxDirs(sourceSessionDir: string, targetSessionDir: string): Promise<void> {
+  for (const subdir of ["tool-results", "file-history"] as const) {
+    const source = join(sourceSessionDir, subdir);
+    const target = join(targetSessionDir, subdir);
+    try {
+      await cp(source, target, { recursive: true, force: true });
+    } catch {
+      // Missing auxiliary dirs are normal for early sessions.
+    }
+  }
+}
+
+export class ForkSessionError extends Error {
+  constructor(
+    readonly code: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = "ForkSessionError";
+  }
+}
+
+export async function forkWebSession(
+  input: WebForkSessionInput,
+  options: ForkWebSessionOptions,
+): Promise<WebForkSessionResult> {
+  const effectiveProjectRoot = input.projectKey ?? options.projectRoot;
+  const chatDir = getPilotProjectChatDir(effectiveProjectRoot, options.pilotHome);
+  const sourceSafeId = sanitizeSessionIdForPath(input.sessionKey);
+  const sourceTranscriptPath = resolve(chatDir, `${sourceSafeId}.jsonl`);
+  const sourceSessionDir = resolve(chatDir, sourceSafeId);
+
+  const { entries } = await readTranscript(sourceTranscriptPath);
+  if (entries.length === 0) {
+    throw new ForkSessionError("fork_empty_transcript", "Cannot fork an empty session transcript.");
+  }
+
+  const forkAcceptedInput = findForkTurnAcceptedInput(entries, input.fromEntryId);
+  const cutoffSequence = forkAcceptedInput.sequence;
+  const preserved = entries.filter((entry) => entry.sequence < cutoffSequence);
+  const prefillText = extractAcceptedInputText(forkAcceptedInput);
+  const carriedMessageCount = countCarriedUserAssistantMessages(preserved);
+
+  const newSessionKey = newWebSessionKey();
+  const newSafeId = sanitizeSessionIdForPath(newSessionKey);
+  const newTranscriptPath = resolve(chatDir, `${newSafeId}.jsonl`);
+  const newSessionDir = resolve(chatDir, newSafeId);
+
+  await mkdir(chatDir, { recursive: true, mode: 0o700 });
+  await mkdir(newSessionDir, { recursive: true, mode: 0o700 });
+
+  const preservedLines = preserved.map((entry) => `${JSON.stringify(entry)}\n`).join("");
+  const lastPreserved = preserved[preserved.length - 1];
+  const lastEntryId = lastPreserved?.entryId ?? null;
+  const maxSequence = preserved.reduce((max, entry) => Math.max(max, entry.sequence), 0);
+
+  const parentMetadata = lastSessionMetadata(entries);
+  const inheritedTitle =
+    (typeof parentMetadata?.title === "string" && parentMetadata.title) ||
+    (typeof parentMetadata?.aiTitle === "string" && parentMetadata.aiTitle) ||
+    undefined;
+
+  // Title the fork by the message it branches from so siblings are
+  // distinguishable in the lineage tree (the branch icon + "forked from"
+  // subtitle already convey that it is a fork).
+  const forkTitle = buildForkTitle(prefillText, carriedMessageCount, inheritedTitle);
+
+  const now = options.now ?? (() => new Date());
+  const metadataEntry: AgentSessionMetadataTranscriptEntry = {
+    type: "session_metadata",
+    sessionId: newSessionKey,
+    turnId: `fork-${randomUUID()}`,
+    sequence: maxSequence + 1,
+    createdAt: now().toISOString(),
+    entryId: randomUUID(),
+    parentEntryId: lastEntryId,
+    metadata: {
+      parentSessionId: input.sessionKey,
+      forkedFromTurnId: forkAcceptedInput.turnId,
+      title: forkTitle,
+      firstPrompt: prefillText || undefined,
+      updatedAt: now().toISOString(),
+    },
+  };
+
+  const body = preservedLines + `${JSON.stringify(metadataEntry)}\n`;
+  await writeFile(newTranscriptPath, body, { encoding: "utf8", mode: 0o600 });
+  await chmod(dirname(newTranscriptPath), 0o700);
+
+  await copySessionAuxDirs(sourceSessionDir, newSessionDir);
+
+  return {
+    newSessionKey,
+    prefillText,
+    carriedMessageCount,
+  };
+}

--- a/src/web/server/forkSession.ts
+++ b/src/web/server/forkSession.ts
@@ -7,8 +7,9 @@
  */
 
 import { randomUUID } from "node:crypto";
-import { cp, mkdir, writeFile, chmod } from "node:fs/promises";
-import { dirname, join, resolve } from "node:path";
+import type { Dirent } from "node:fs";
+import { chmod, cp, mkdir, readdir, readFile, stat, writeFile } from "node:fs/promises";
+import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { platform } from "node:process";
 import type { CanonicalContentBlock } from "../../model/index.js";
 import { getPilotProjectChatDir } from "../../pilot/index.js";
@@ -21,7 +22,7 @@ import type {
   AgentSessionMetadataTranscriptEntry,
   AgentTranscriptEntry,
 } from "../../session/transcript/TranscriptEntry.js";
-import type { WebForkSessionInput, WebForkSessionResult } from "../client/protocol.js";
+import type { WebGatewayMode, WebForkSessionInput, WebForkSessionResult } from "../client/protocol.js";
 
 export type ForkWebSessionOptions = {
   projectRoot: string;
@@ -35,14 +36,25 @@ function newWebSessionKey(): string {
 }
 
 function extractAcceptedInputText(entry: AgentAcceptedInputTranscriptEntry): string {
+  const chunks: string[] = [];
   for (const message of entry.messages) {
     for (const block of message.content as CanonicalContentBlock[]) {
       if (block.type === "text" && block.text.trim()) {
-        return block.text.trim();
+        chunks.push(block.text.trim());
       }
     }
   }
-  return "";
+  return chunks.join("\n\n").trim();
+}
+
+function hasUnsupportedPrefillContent(entry: AgentAcceptedInputTranscriptEntry): boolean {
+  return entry.messages.some((message) =>
+    (message.content as CanonicalContentBlock[]).some((block) => block.type !== "text"),
+  );
+}
+
+function getForkMode(entry: AgentAcceptedInputTranscriptEntry): WebGatewayMode | undefined {
+  return entry.metadata?.permissionMode === "plan" ? "plan" : undefined;
 }
 
 function buildForkTitle(
@@ -118,14 +130,230 @@ function countCarriedUserAssistantMessages(entries: AgentTranscriptEntry[]): num
   return count;
 }
 
+function retargetAuxiliaryPath(
+  path: string,
+  sourceSessionDir: string,
+  targetSessionDir: string,
+): string {
+  const absolutePath = resolve(path);
+  const relativePath = relative(sourceSessionDir, absolutePath);
+  if (
+    relativePath === "" ||
+    relativePath.startsWith("..") ||
+    isAbsolute(relativePath)
+  ) {
+    return path;
+  }
+  return resolve(targetSessionDir, relativePath);
+}
+
+function retargetRelativeSessionPath(
+  path: string,
+  sourceSafeId: string,
+  targetSafeId: string,
+): string {
+  const parts = path.split(/[\\/]/);
+  if (parts[0] !== sourceSafeId) {
+    return path;
+  }
+  return [targetSafeId, ...parts.slice(1)].join("/");
+}
+
+function retargetContentBlock(
+  block: CanonicalContentBlock,
+  sourceSessionDir: string,
+  targetSessionDir: string,
+): CanonicalContentBlock {
+  if (block.type === "tool_result_reference" || block.type === "media_reference") {
+    return {
+      ...block,
+      path: retargetAuxiliaryPath(block.path, sourceSessionDir, targetSessionDir),
+    };
+  }
+  return block;
+}
+
+function retargetTranscriptEntryAuxiliaryPaths(
+  entry: AgentTranscriptEntry,
+  sourceSessionDir: string,
+  targetSessionDir: string,
+): AgentTranscriptEntry {
+  if (entry.type === "accepted_input") {
+    return {
+      ...entry,
+      messages: entry.messages.map((message) => ({
+        ...message,
+        content: message.content.map((block) =>
+          retargetContentBlock(block, sourceSessionDir, targetSessionDir),
+        ),
+      })),
+    };
+  }
+  if (
+    entry.type === "assistant_message" ||
+    entry.type === "tool_result_message" ||
+    entry.type === "durable_message"
+  ) {
+    return {
+      ...entry,
+      message: {
+        ...entry.message,
+        content: entry.message.content.map((block) =>
+          retargetContentBlock(block, sourceSessionDir, targetSessionDir),
+        ),
+      },
+    };
+  }
+  return entry;
+}
+
+function retargetAcceptedInputEntry(
+  entry: AgentAcceptedInputTranscriptEntry,
+  sessionId: string,
+  sourceSessionDir: string,
+  targetSessionDir: string,
+): AgentAcceptedInputTranscriptEntry {
+  const retargeted = retargetTranscriptEntryAuxiliaryPaths(
+    entry,
+    sourceSessionDir,
+    targetSessionDir,
+  );
+  if (retargeted.type !== "accepted_input") {
+    return entry;
+  }
+  return {
+    ...retargeted,
+    sessionId,
+  };
+}
+
+function retargetEntriesToSession(
+  entries: AgentTranscriptEntry[],
+  options: {
+    sessionId: string;
+    sourceSafeId: string;
+    targetSafeId: string;
+    sourceSessionDir: string;
+    targetSessionDir: string;
+  },
+): AgentTranscriptEntry[] {
+  return entries.map((entry) => {
+    if (entry.type === "accepted_input") {
+      return retargetAcceptedInputEntry(
+        entry,
+        options.sessionId,
+        options.sourceSessionDir,
+        options.targetSessionDir,
+      );
+    }
+    if (
+      entry.type === "assistant_message" ||
+      entry.type === "tool_result_message" ||
+      entry.type === "durable_message"
+    ) {
+      return {
+        ...retargetTranscriptEntryAuxiliaryPaths(
+          entry,
+          options.sourceSessionDir,
+          options.targetSessionDir,
+        ),
+        sessionId: options.sessionId,
+      };
+    }
+    if (entry.type === "subagent_started") {
+      return {
+        ...entry,
+        sessionId: options.sessionId,
+        transcriptRelativePath: retargetRelativeSessionPath(
+          entry.transcriptRelativePath,
+          options.sourceSafeId,
+          options.targetSafeId,
+        ),
+      };
+    }
+    return {
+      ...entry,
+      sessionId: options.sessionId,
+    };
+  });
+}
+
+function isNotFoundError(error: unknown): boolean {
+  return Boolean(
+    error &&
+      typeof error === "object" &&
+      "code" in error &&
+      (error as { code?: unknown }).code === "ENOENT",
+  );
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch (error) {
+    if (isNotFoundError(error)) {
+      return false;
+    }
+    throw error;
+  }
+}
+
+async function retargetCopiedSubagentTranscripts(
+  targetSubagentsDir: string,
+  sourceSessionDir: string,
+  targetSessionDir: string,
+): Promise<void> {
+  let entries: Dirent<string>[];
+  try {
+    entries = await readdir(targetSubagentsDir, { withFileTypes: true });
+  } catch (error) {
+    if (isNotFoundError(error)) {
+      return;
+    }
+    throw error;
+  }
+
+  for (const entry of entries) {
+    const path = join(targetSubagentsDir, entry.name);
+    if (entry.isDirectory()) {
+      await retargetCopiedSubagentTranscripts(path, sourceSessionDir, targetSessionDir);
+      continue;
+    }
+    if (!entry.isFile() || !entry.name.endsWith(".jsonl")) {
+      continue;
+    }
+    const content = await readFile(path, "utf8");
+    const rewritten = content
+      .split(/\r?\n/)
+      .map((line) => {
+        if (!line.trim()) {
+          return line;
+        }
+        try {
+          const parsed = JSON.parse(line) as AgentTranscriptEntry;
+          return JSON.stringify(
+            retargetTranscriptEntryAuxiliaryPaths(parsed, sourceSessionDir, targetSessionDir),
+          );
+        } catch {
+          return line;
+        }
+      })
+      .join("\n");
+    await writeFile(path, rewritten, "utf8");
+  }
+}
+
 async function copySessionAuxDirs(sourceSessionDir: string, targetSessionDir: string): Promise<void> {
-  for (const subdir of ["tool-results", "file-history"] as const) {
+  for (const subdir of ["tool-results", "file-history", "subagents"] as const) {
     const source = join(sourceSessionDir, subdir);
     const target = join(targetSessionDir, subdir);
-    try {
-      await cp(source, target, { recursive: true, force: true });
-    } catch {
-      // Missing auxiliary dirs are normal for early sessions.
+    if (!(await pathExists(source))) {
+      continue;
+    }
+    await cp(source, target, { recursive: true, force: true });
+    if (subdir === "subagents") {
+      await retargetCopiedSubagentTranscripts(target, sourceSessionDir, targetSessionDir);
     }
   }
 }
@@ -156,18 +384,33 @@ export async function forkWebSession(
   }
 
   const forkAcceptedInput = findForkTurnAcceptedInput(entries, input.fromEntryId);
+  if (hasUnsupportedPrefillContent(forkAcceptedInput)) {
+    throw new ForkSessionError(
+      "fork_unsupported_content",
+      "Forking messages with attachments or non-text input is not supported yet.",
+    );
+  }
+  const forkMode = getForkMode(forkAcceptedInput);
   const cutoffSequence = forkAcceptedInput.sequence;
-  const preserved = entries.filter((entry) => entry.sequence < cutoffSequence);
+  const preservedSourceEntries = entries.filter((entry) => entry.sequence < cutoffSequence);
   const prefillText = extractAcceptedInputText(forkAcceptedInput);
-  const carriedMessageCount = countCarriedUserAssistantMessages(preserved);
+  const carriedMessageCount = countCarriedUserAssistantMessages(preservedSourceEntries);
 
   const newSessionKey = newWebSessionKey();
   const newSafeId = sanitizeSessionIdForPath(newSessionKey);
   const newTranscriptPath = resolve(chatDir, `${newSafeId}.jsonl`);
   const newSessionDir = resolve(chatDir, newSafeId);
+  const preserved = retargetEntriesToSession(preservedSourceEntries, {
+    sessionId: newSessionKey,
+    sourceSafeId,
+    targetSafeId: newSafeId,
+    sourceSessionDir,
+    targetSessionDir: newSessionDir,
+  });
 
   await mkdir(chatDir, { recursive: true, mode: 0o700 });
   await mkdir(newSessionDir, { recursive: true, mode: 0o700 });
+  await copySessionAuxDirs(sourceSessionDir, newSessionDir);
 
   const preservedLines = preserved.map((entry) => `${JSON.stringify(entry)}\n`).join("");
   const lastPreserved = preserved[preserved.length - 1];
@@ -207,11 +450,10 @@ export async function forkWebSession(
   await writeFile(newTranscriptPath, body, { encoding: "utf8", mode: 0o600 });
   await chmod(dirname(newTranscriptPath), 0o700);
 
-  await copySessionAuxDirs(sourceSessionDir, newSessionDir);
-
   return {
     newSessionKey,
     prefillText,
     carriedMessageCount,
+    ...(forkMode ? { mode: forkMode } : {}),
   };
 }

--- a/src/web/server/forkSession.ts
+++ b/src/web/server/forkSession.ts
@@ -11,7 +11,7 @@ import type { Dirent } from "node:fs";
 import { chmod, cp, mkdir, readdir, readFile, stat, writeFile } from "node:fs/promises";
 import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { platform } from "node:process";
-import type { CanonicalContentBlock } from "../../model/index.js";
+import type { CanonicalContentBlock, CanonicalMessage } from "../../model/index.js";
 import { getPilotProjectChatDir } from "../../pilot/index.js";
 import { readTranscript } from "../../session/transcript/TranscriptReader.js";
 import {
@@ -173,6 +173,23 @@ function retargetContentBlock(
   return block;
 }
 
+function markMessageAsForkCarryover(
+  message: CanonicalMessage,
+  sourceSessionId: string,
+  sourceTurnId: string,
+): CanonicalMessage {
+  return {
+    ...message,
+    metadata: {
+      ...message.metadata,
+      forkCarryover: {
+        sourceSessionId,
+        sourceTurnId,
+      },
+    },
+  };
+}
+
 function retargetTranscriptEntryAuxiliaryPaths(
   entry: AgentTranscriptEntry,
   sourceSessionDir: string,
@@ -202,6 +219,31 @@ function retargetTranscriptEntryAuxiliaryPaths(
           retargetContentBlock(block, sourceSessionDir, targetSessionDir),
         ),
       },
+    };
+  }
+  return entry;
+}
+
+function markTranscriptEntryAsForkCarryover(
+  entry: AgentTranscriptEntry,
+  sourceSessionId: string,
+): AgentTranscriptEntry {
+  if (entry.type === "accepted_input") {
+    return {
+      ...entry,
+      messages: entry.messages.map((message) =>
+        markMessageAsForkCarryover(message, sourceSessionId, entry.turnId),
+      ),
+    };
+  }
+  if (
+    entry.type === "assistant_message" ||
+    entry.type === "tool_result_message" ||
+    entry.type === "durable_message"
+  ) {
+    return {
+      ...entry,
+      message: markMessageAsForkCarryover(entry.message, sourceSessionId, entry.turnId),
     };
   }
   return entry;
@@ -239,19 +281,20 @@ function retargetEntriesToSession(
 ): AgentTranscriptEntry[] {
   return entries.map((entry) => {
     if (entry.type === "accepted_input") {
-      return retargetAcceptedInputEntry(
+      const retargeted = retargetAcceptedInputEntry(
         entry,
         options.sessionId,
         options.sourceSessionDir,
         options.targetSessionDir,
       );
+      return markTranscriptEntryAsForkCarryover(retargeted, entry.sessionId);
     }
     if (
       entry.type === "assistant_message" ||
       entry.type === "tool_result_message" ||
       entry.type === "durable_message"
     ) {
-      return {
+      const retargeted = {
         ...retargetTranscriptEntryAuxiliaryPaths(
           entry,
           options.sourceSessionDir,
@@ -259,6 +302,7 @@ function retargetEntriesToSession(
         ),
         sessionId: options.sessionId,
       };
+      return markTranscriptEntryAsForkCarryover(retargeted, entry.sessionId);
     }
     if (entry.type === "subagent_started") {
       return {

--- a/src/web/server/readSessionMessages.ts
+++ b/src/web/server/readSessionMessages.ts
@@ -56,6 +56,7 @@ export async function readWebSessionMessages(
   const { entries } = await readTranscript(transcriptPath);
   const webReplay = extractWebVisibleMessages(entries);
   const entryTimestamps = webReplay.timestamps;
+  const entryIds = webReplay.entryIds;
   const incompleteTurnIds = extractIncompleteTurnIds(entries);
 
   const flattenedPerMessage: WebMessage[][] = webReplay.messages
@@ -67,6 +68,7 @@ export async function readWebSessionMessages(
         projectKey: input.projectKey,
         now: options.now,
         entryTimestamp: entryTimestamps[index],
+        entryId: entryIds[index],
       }),
     );
 
@@ -130,6 +132,8 @@ export async function readWebSessionMessages(
       cwd: sessionInfo?.cwd,
       tag: sessionInfo?.tag,
       createdAt: sessionInfo?.createdAt,
+      parentSessionId: sessionInfo?.parentSessionId,
+      forkedFromTurnId: sessionInfo?.forkedFromTurnId,
     },
   };
 }
@@ -279,6 +283,8 @@ type ProjectionContext = {
   now?: () => Date;
   /** Actual transcript entry timestamp — preferred over now(). */
   entryTimestamp?: string;
+  /** Transcript entry id for fork targeting. */
+  entryId?: string;
 };
 
 /**
@@ -317,6 +323,7 @@ export function flattenCanonicalMessage(
       kind: "text",
       text: textBuffer,
       ...(pendingImages.length > 0 ? { images: pendingImages } : {}),
+      ...(context.entryId ? { entryId: context.entryId } : {}),
       source: "history",
     });
     textBuffer = "";
@@ -532,11 +539,13 @@ type CompactBoundaryInfo = {
 function extractWebVisibleMessages(entries: AgentTranscriptEntry[]): {
   messages: CanonicalMessage[];
   timestamps: string[];
+  entryIds: Array<string | undefined>;
   compactBoundaries: CompactBoundaryInfo[];
 } {
   const lastBoundaryIndex = findLastCompactBoundaryIndex(entries);
   const messages: CanonicalMessage[] = [];
   const timestamps: string[] = [];
+  const entryIds: Array<string | undefined> = [];
   const compactBoundaries: CompactBoundaryInfo[] = [];
 
   for (let index = 0; index < entries.length; index += 1) {
@@ -549,6 +558,7 @@ function extractWebVisibleMessages(entries: AgentTranscriptEntry[]): {
           for (const message of entry.messages) {
             messages.push(cloneMessage(message));
             timestamps.push(entry.createdAt);
+            entryIds.push(entry.entryId);
           }
         }
         break;
@@ -558,6 +568,7 @@ function extractWebVisibleMessages(entries: AgentTranscriptEntry[]): {
         if (!beforeBoundary) {
           messages.push(cloneMessage(entry.message));
           timestamps.push(entry.createdAt);
+          entryIds.push(entry.entryId);
         }
         break;
       case "control_boundary": {
@@ -582,7 +593,7 @@ function extractWebVisibleMessages(entries: AgentTranscriptEntry[]): {
     }
   }
 
-  return { messages, timestamps, compactBoundaries };
+  return { messages, timestamps, entryIds, compactBoundaries };
 }
 
 function extractSubagentExecutionMessages(entries: AgentTranscriptEntry[]): {

--- a/src/web/server/readSessionMessages.ts
+++ b/src/web/server/readSessionMessages.ts
@@ -24,7 +24,7 @@ import {
 } from "../../model/index.js";
 import { listProjectSessions, readTranscript, findLastCompactBoundaryIndex, type SessionInfo } from "../../session/index.js";
 import type { AgentTranscriptEntry } from "../../session/transcript/TranscriptEntry.js";
-import { resolve, dirname } from "node:path";
+import { dirname, isAbsolute, relative, resolve } from "node:path";
 import { getPilotProjectChatDir } from "../../pilot/index.js";
 import { sanitizeSessionIdForPath } from "../../session/storage/ProjectSessionStorage.js";
 import type {
@@ -45,14 +45,13 @@ export async function readWebSessionMessages(
   options: ReadWebSessionMessagesOptions,
 ): Promise<WebReadSessionMessagesResult> {
   const effectiveProjectRoot = input.projectKey ?? options.projectRoot;
-  const sessionInfo = await locateSession(input.sessionKey, {
+  const chatDir = getPilotProjectChatDir(effectiveProjectRoot, options.pilotHome);
+  const transcriptPath = resolveTranscriptPath(input, chatDir);
+  const isBackgroundTask = isBackgroundTaskInput(input);
+  const sessionInfo = isBackgroundTask ? undefined : await locateSession(input.sessionKey, {
     ...options,
     projectRoot: effectiveProjectRoot,
   });
-  const transcriptPath = resolve(
-    getPilotProjectChatDir(effectiveProjectRoot, options.pilotHome),
-    `${sanitizeSessionIdForPath(input.sessionKey)}.jsonl`,
-  );
   const { entries } = await readTranscript(transcriptPath);
   const webReplay = extractWebVisibleMessages(entries);
   const entryTimestamps = webReplay.timestamps;
@@ -60,7 +59,6 @@ export async function readWebSessionMessages(
   const incompleteTurnIds = extractIncompleteTurnIds(entries);
 
   const flattenedPerMessage: WebMessage[][] = webReplay.messages
-    .filter((message) => !message.metadata?.synthetic)
     .map((message, index) =>
       flattenCanonicalMessage(message, {
         index,
@@ -69,6 +67,7 @@ export async function readWebSessionMessages(
         now: options.now,
         entryTimestamp: entryTimestamps[index],
         entryId: entryIds[index],
+        forkUnsupportedContent: webReplay.forkUnsupportedContents[index],
       }),
     );
 
@@ -132,7 +131,9 @@ export async function readWebSessionMessages(
       cwd: sessionInfo?.cwd,
       tag: sessionInfo?.tag,
       createdAt: sessionInfo?.createdAt,
-      parentSessionId: sessionInfo?.parentSessionId,
+      ...(isBackgroundTask ? { sessionKind: "background_task" as const } : {}),
+      parentSessionId: input.parentSessionId ?? sessionInfo?.parentSessionId,
+      relativeTranscriptPath: input.relativeTranscriptPath,
       forkedFromTurnId: sessionInfo?.forkedFromTurnId,
     },
   };
@@ -144,15 +145,19 @@ export async function readWebSessionMessages(
  * session transcript path + subagentId.
  */
 export async function readSubagentWebMessages(
-  input: { sessionKey: string; subagentId: string; projectKey?: string },
+  input: {
+    sessionKey: string;
+    subagentId: string;
+    projectKey?: string;
+    sessionKind?: "background_task";
+    parentSessionId?: string;
+    relativeTranscriptPath?: string;
+  },
   options: ReadWebSessionMessagesOptions,
 ): Promise<{ messages: WebMessage[]; total: number }> {
   const effectiveProjectRoot = input.projectKey ?? options.projectRoot;
   const chatDir = getPilotProjectChatDir(effectiveProjectRoot, options.pilotHome);
-  const parentTranscriptPath = resolve(
-    chatDir,
-    `${sanitizeSessionIdForPath(input.sessionKey)}.jsonl`,
-  );
+  const parentTranscriptPath = resolveTranscriptPath(input, chatDir);
 
   const { entries: parentEntries } = await readTranscript(parentTranscriptPath);
   let sidechainRelative: string | undefined;
@@ -167,7 +172,11 @@ export async function readSubagentWebMessages(
     return { messages: [], total: 0 };
   }
 
-  const sidechainPath = resolve(dirname(parentTranscriptPath), sidechainRelative);
+  const sidechainPath = resolveRelativeTranscriptPath(
+    sidechainRelative,
+    dirname(parentTranscriptPath),
+    chatDir,
+  );
   const { entries } = await readTranscript(sidechainPath);
   const webReplay = extractSubagentExecutionMessages(entries);
 
@@ -213,6 +222,49 @@ export async function readSubagentWebMessages(
   }
 
   return { messages: allMessages, total: allMessages.length };
+}
+
+function isBackgroundTaskInput(input: {
+  sessionKind?: string;
+  relativeTranscriptPath?: string;
+}): input is { sessionKind: "background_task"; relativeTranscriptPath: string } {
+  return input.sessionKind === "background_task" &&
+    typeof input.relativeTranscriptPath === "string" &&
+    input.relativeTranscriptPath.length > 0;
+}
+
+function resolveTranscriptPath(
+  input: {
+    sessionKey: string;
+    sessionKind?: string;
+    relativeTranscriptPath?: string;
+  },
+  chatDir: string,
+): string {
+  if (isBackgroundTaskInput(input)) {
+    return resolveRelativeTranscriptPath(input.relativeTranscriptPath, chatDir, chatDir);
+  }
+  return resolve(chatDir, `${sanitizeSessionIdForPath(input.sessionKey)}.jsonl`);
+}
+
+function resolveRelativeTranscriptPath(
+  path: string,
+  baseDir: string,
+  allowedRoot: string,
+): string {
+  if (!path || isAbsolute(path)) {
+    throw new Error("relativeTranscriptPath must be a relative path.");
+  }
+  const candidate = resolve(baseDir, path);
+  if (!isWithinDirectory(allowedRoot, candidate) || !candidate.endsWith(".jsonl")) {
+    throw new Error("relativeTranscriptPath points outside the project transcript directory.");
+  }
+  return candidate;
+}
+
+function isWithinDirectory(parentDir: string, candidatePath: string): boolean {
+  const rel = relative(parentDir, candidatePath);
+  return Boolean(rel) && !rel.startsWith("..") && !isAbsolute(rel);
 }
 
 function createIncompleteTurnStatusMessage(
@@ -285,6 +337,8 @@ type ProjectionContext = {
   entryTimestamp?: string;
   /** Transcript entry id for fork targeting. */
   entryId?: string;
+  /** True when this entry cannot be fork-prefilled losslessly by the web UI. */
+  forkUnsupportedContent?: boolean;
 };
 
 /**
@@ -323,6 +377,14 @@ export function flattenCanonicalMessage(
       kind: "text",
       text: textBuffer,
       ...(pendingImages.length > 0 ? { images: pendingImages } : {}),
+      ...(context.forkUnsupportedContent
+        ? {
+            payload: {
+              forkUnsupportedContent: true,
+              forkUnsupportedReason: "This turn contains attachments or media.",
+            },
+          }
+        : {}),
       ...(context.entryId ? { entryId: context.entryId } : {}),
       source: "history",
     });
@@ -540,12 +602,14 @@ function extractWebVisibleMessages(entries: AgentTranscriptEntry[]): {
   messages: CanonicalMessage[];
   timestamps: string[];
   entryIds: Array<string | undefined>;
+  forkUnsupportedContents: boolean[];
   compactBoundaries: CompactBoundaryInfo[];
 } {
   const lastBoundaryIndex = findLastCompactBoundaryIndex(entries);
   const messages: CanonicalMessage[] = [];
   const timestamps: string[] = [];
   const entryIds: Array<string | undefined> = [];
+  const forkUnsupportedContents: boolean[] = [];
   const compactBoundaries: CompactBoundaryInfo[] = [];
 
   for (let index = 0; index < entries.length; index += 1) {
@@ -555,10 +619,17 @@ function extractWebVisibleMessages(entries: AgentTranscriptEntry[]): {
     switch (entry.type) {
       case "accepted_input":
         if (!beforeBoundary) {
+          const entryForkUnsupported = entry.messages.some((message) =>
+            message.content.some((block) => block.type !== "text"),
+          );
           for (const message of entry.messages) {
+            if (message.metadata?.synthetic) {
+              continue;
+            }
             messages.push(cloneMessage(message));
             timestamps.push(entry.createdAt);
             entryIds.push(entry.entryId);
+            forkUnsupportedContents.push(entryForkUnsupported);
           }
         }
         break;
@@ -566,9 +637,13 @@ function extractWebVisibleMessages(entries: AgentTranscriptEntry[]): {
       case "tool_result_message":
       case "durable_message":
         if (!beforeBoundary) {
+          if (entry.message.metadata?.synthetic) {
+            break;
+          }
           messages.push(cloneMessage(entry.message));
           timestamps.push(entry.createdAt);
           entryIds.push(entry.entryId);
+          forkUnsupportedContents.push(false);
         }
         break;
       case "control_boundary": {
@@ -593,7 +668,7 @@ function extractWebVisibleMessages(entries: AgentTranscriptEntry[]): {
     }
   }
 
-  return { messages, timestamps, entryIds, compactBoundaries };
+  return { messages, timestamps, entryIds, forkUnsupportedContents, compactBoundaries };
 }
 
 function extractSubagentExecutionMessages(entries: AgentTranscriptEntry[]): {
@@ -668,8 +743,13 @@ function attachSubagentIds(
   entries: AgentTranscriptEntry[],
   allMessages: WebMessage[],
 ): void {
+  const lastBoundaryIndex = findLastCompactBoundaryIndex(entries);
   const subagentQueue: string[] = [];
-  for (const entry of entries) {
+  for (let index = 0; index < entries.length; index += 1) {
+    const entry = entries[index];
+    if (lastBoundaryIndex !== -1 && index < lastBoundaryIndex) {
+      continue;
+    }
     if (entry.type === "subagent_started") {
       subagentQueue.push(entry.subagentId);
     }

--- a/tests/web/forkSession.test.ts
+++ b/tests/web/forkSession.test.ts
@@ -1,11 +1,12 @@
 import assert from "node:assert/strict";
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test } from "node:test";
-import { forkWebSession } from "../../src/web/server/forkSession.js";
+import { ForkSessionError, forkWebSession } from "../../src/web/server/forkSession.js";
 import { readTranscript } from "../../src/session/transcript/TranscriptReader.js";
 import { createProjectId } from "../../src/pilot/paths.js";
+import { sanitizeSessionIdForPath } from "../../src/session/storage/ProjectSessionStorage.js";
 
 test("forkWebSession copies history before target turn and returns prefill text", async () => {
   const pilotHome = await mkdtemp(join(tmpdir(), "pilotdeck-fork-"));
@@ -14,7 +15,7 @@ test("forkWebSession copies history before target turn and returns prefill text"
   const sessionKey = "web:s_parent";
   const transcriptPath = join(chatDir, `${sessionKey}.jsonl`);
 
-  await import("node:fs/promises").then((fs) => fs.mkdir(chatDir, { recursive: true }));
+  await mkdir(chatDir, { recursive: true });
 
   const lines = [
     {
@@ -59,9 +60,7 @@ test("forkWebSession copies history before target turn and returns prefill text"
     },
   ];
 
-  await import("node:fs/promises").then((fs) =>
-    fs.writeFile(transcriptPath, `${lines.map((line) => JSON.stringify(line)).join("\n")}\n`, "utf8"),
-  );
+  await writeFile(transcriptPath, `${lines.map((line) => JSON.stringify(line)).join("\n")}\n`, "utf8");
 
   const result = await forkWebSession(
     { sessionKey, projectKey: projectRoot, fromEntryId: "entry-4" },
@@ -70,17 +69,351 @@ test("forkWebSession copies history before target turn and returns prefill text"
 
   assert.equal(result.prefillText, "second question");
   assert.equal(result.carriedMessageCount, 2);
-  assert.match(result.newSessionKey, /^web[:_]s_/);
+  assert.match(result.newSessionKey, /^web[:-]s_/);
 
   const newTranscriptPath = join(chatDir, `${result.newSessionKey}.jsonl`);
   const { entries } = await readTranscript(newTranscriptPath);
   assert.equal(entries.length, 4);
+  assert.deepEqual(entries.map((entry) => entry.sessionId), [
+    result.newSessionKey,
+    result.newSessionKey,
+    result.newSessionKey,
+    result.newSessionKey,
+  ]);
   assert.equal(entries[0].sequence, 1);
   assert.equal(entries[2].type, "turn_result");
   assert.equal(entries[3].type, "session_metadata");
   if (entries[3].type === "session_metadata") {
     assert.equal(entries[3].metadata.parentSessionId, sessionKey);
     assert.equal(entries[3].metadata.forkedFromTurnId, "turn-2");
+  }
+
+  await rm(pilotHome, { recursive: true, force: true });
+});
+
+
+test("forkWebSession rejects non-text target turns instead of dropping attachments", async () => {
+  const pilotHome = await mkdtemp(join(tmpdir(), "pilotdeck-fork-unsupported-"));
+  const projectRoot = join(pilotHome, "workspace");
+  const chatDir = join(pilotHome, "projects", createProjectId(projectRoot), "chats");
+  const sessionKey = "web:s_unsupported";
+  const transcriptPath = join(chatDir, `${sessionKey}.jsonl`);
+
+  await mkdir(chatDir, { recursive: true });
+
+  const lines = [
+    {
+      type: "accepted_input",
+      sessionId: sessionKey,
+      turnId: "turn-1",
+      sequence: 1,
+      createdAt: "2026-06-24T00:00:00.000Z",
+      entryId: "entry-1",
+      parentEntryId: null,
+      messages: [{ role: "user", content: [{ type: "text", text: "first question" }] }],
+    },
+    {
+      type: "turn_result",
+      sessionId: sessionKey,
+      turnId: "turn-1",
+      sequence: 2,
+      createdAt: "2026-06-24T00:00:01.000Z",
+      entryId: "entry-2",
+      parentEntryId: "entry-1",
+      result: { stopReason: "completed", usage: {} },
+    },
+    {
+      type: "accepted_input",
+      sessionId: sessionKey,
+      turnId: "turn-2",
+      sequence: 3,
+      createdAt: "2026-06-24T00:01:00.000Z",
+      entryId: "entry-3",
+      parentEntryId: "entry-2",
+      messages: [
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "look at this" },
+            {
+              type: "image",
+              source: "base64",
+              data: "aW1hZ2U=",
+              mimeType: "image/png",
+            },
+          ],
+        },
+      ],
+    },
+  ];
+
+  await writeFile(transcriptPath, `${lines.map((line) => JSON.stringify(line)).join("\n")}\n`, "utf8");
+
+  await assert.rejects(
+    () =>
+      forkWebSession(
+        { sessionKey, projectKey: projectRoot, fromEntryId: "entry-3" },
+        { projectRoot, pilotHome },
+      ),
+    (error) => {
+      assert.equal(error instanceof ForkSessionError, true);
+      assert.equal((error as ForkSessionError).code, "fork_unsupported_content");
+      return true;
+    },
+  );
+
+  await rm(pilotHome, { recursive: true, force: true });
+});
+
+
+test("forkWebSession preserves plan mode for forked plan turns", async () => {
+  const pilotHome = await mkdtemp(join(tmpdir(), "pilotdeck-fork-plan-"));
+  const projectRoot = join(pilotHome, "workspace");
+  const chatDir = join(pilotHome, "projects", createProjectId(projectRoot), "chats");
+  const sessionKey = "web:s_plan_fork";
+  const transcriptPath = join(chatDir, `${sessionKey}.jsonl`);
+
+  await mkdir(chatDir, { recursive: true });
+
+  const lines = [
+    {
+      type: "accepted_input",
+      sessionId: sessionKey,
+      turnId: "turn-plan",
+      sequence: 1,
+      createdAt: "2026-06-24T00:00:00.000Z",
+      entryId: "entry-plan",
+      parentEntryId: null,
+      metadata: {
+        permissionMode: "plan",
+        basePermissionMode: "default",
+        allowPlanModeTools: true,
+      },
+      messages: [{ role: "user", content: [{ type: "text", text: "design this safely" }] }],
+    },
+  ];
+
+  await writeFile(transcriptPath, `${lines.map((line) => JSON.stringify(line)).join("\n")}\n`, "utf8");
+
+  const result = await forkWebSession(
+    { sessionKey, projectKey: projectRoot, fromEntryId: "entry-plan" },
+    { projectRoot, pilotHome },
+  );
+
+  assert.equal(result.prefillText, "design this safely");
+  assert.equal(result.mode, "plan");
+
+  await rm(pilotHome, { recursive: true, force: true });
+});
+
+
+test("forkWebSession rewrites copied auxiliary references to the new session", async () => {
+  const pilotHome = await mkdtemp(join(tmpdir(), "pilotdeck-fork-aux-"));
+  const projectRoot = join(pilotHome, "workspace");
+  const chatDir = join(pilotHome, "projects", createProjectId(projectRoot), "chats");
+  const sessionKey = "web:s_parent_aux";
+  const safeSessionKey = sanitizeSessionIdForPath(sessionKey);
+  const sourceSessionDir = join(chatDir, safeSessionKey);
+  const transcriptPath = join(chatDir, `${safeSessionKey}.jsonl`);
+  const sourceToolResultPath = join(sourceSessionDir, "tool-results", "tc-1.txt");
+  const sourceMediaPath = join(sourceSessionDir, "tool-results", "media-1.png");
+  const sourceSubagentPath = join(sourceSessionDir, "subagents", "sub-1.jsonl");
+  const sourceSubagentRelativePath = `${safeSessionKey}/subagents/sub-1.jsonl`;
+
+  await mkdir(join(sourceSessionDir, "tool-results"), { recursive: true });
+  await mkdir(join(sourceSessionDir, "subagents"), { recursive: true });
+  await writeFile(sourceToolResultPath, "full tool result", "utf8");
+  await writeFile(sourceMediaPath, "base64-media", "utf8");
+  const sidechainSessionId = `${projectRoot}::sub::sub-1`;
+  const sidechainLines = [
+    {
+      type: "accepted_input",
+      sessionId: sidechainSessionId,
+      turnId: "sub-turn-1",
+      sequence: 1,
+      createdAt: "2026-06-24T00:00:02.100Z",
+      entryId: "sub-entry-1",
+      parentEntryId: null,
+      messages: [{ role: "user", content: [{ type: "text", text: "inspect" }] }],
+    },
+    {
+      type: "durable_message",
+      sessionId: sidechainSessionId,
+      turnId: "sub-turn-1",
+      sequence: 2,
+      createdAt: "2026-06-24T00:00:02.200Z",
+      entryId: "sub-entry-2",
+      parentEntryId: "sub-entry-1",
+      message: {
+        role: "user",
+        content: [
+          {
+            type: "tool_result_reference",
+            toolCallId: "sub-tc-1",
+            path: sourceToolResultPath,
+            originalBytes: 16,
+            preview: "full",
+            hasMore: true,
+            mimeType: "text/plain",
+            reason: "tool_result_too_large",
+          },
+          {
+            type: "media_reference",
+            toolCallId: "sub-tc-1",
+            path: sourceMediaPath,
+            originalBytes: 12,
+            preview: "media",
+            hasMore: true,
+            mimeType: "image/png",
+            mediaType: "image",
+            reason: "media_result_too_large",
+          },
+        ],
+      },
+    },
+    {
+      type: "turn_result",
+      sessionId: sidechainSessionId,
+      turnId: "sub-turn-1",
+      sequence: 3,
+      createdAt: "2026-06-24T00:00:02.300Z",
+      entryId: "sub-entry-3",
+      parentEntryId: "sub-entry-2",
+      result: { stopReason: "completed", usage: {} },
+    },
+  ];
+  await writeFile(
+    sourceSubagentPath,
+    `${sidechainLines.map((line) => JSON.stringify(line)).join("\n")}\n`,
+    "utf8",
+  );
+
+  const lines = [
+    {
+      type: "accepted_input",
+      sessionId: sessionKey,
+      turnId: "turn-1",
+      sequence: 1,
+      createdAt: "2026-06-24T00:00:00.000Z",
+      entryId: "entry-1",
+      parentEntryId: null,
+      messages: [{ role: "user", content: [{ type: "text", text: "first question" }] }],
+    },
+    {
+      type: "durable_message",
+      sessionId: sessionKey,
+      turnId: "turn-1",
+      sequence: 2,
+      createdAt: "2026-06-24T00:00:01.000Z",
+      entryId: "entry-2",
+      parentEntryId: "entry-1",
+      message: {
+        role: "user",
+        content: [
+          {
+            type: "tool_result_reference",
+            toolCallId: "tc-1",
+            path: sourceToolResultPath,
+            originalBytes: 16,
+            preview: "full",
+            hasMore: true,
+            mimeType: "text/plain",
+            reason: "tool_result_too_large",
+          },
+          {
+            type: "media_reference",
+            toolCallId: "tc-1",
+            path: sourceMediaPath,
+            originalBytes: 12,
+            preview: "media",
+            hasMore: true,
+            mimeType: "image/png",
+            mediaType: "image",
+            reason: "media_result_too_large",
+          },
+        ],
+      },
+    },
+    {
+      type: "subagent_started",
+      sessionId: sessionKey,
+      turnId: "turn-1",
+      sequence: 3,
+      createdAt: "2026-06-24T00:00:02.000Z",
+      entryId: "entry-3",
+      parentEntryId: "entry-2",
+      subagentId: "sub-1",
+      subagentType: "general-purpose",
+      promptPreview: "inspect",
+      promptTruncated: false,
+      transcriptRelativePath: sourceSubagentRelativePath,
+      subagentSessionId: sidechainSessionId,
+    },
+    {
+      type: "turn_result",
+      sessionId: sessionKey,
+      turnId: "turn-1",
+      sequence: 4,
+      createdAt: "2026-06-24T00:00:03.000Z",
+      entryId: "entry-4",
+      parentEntryId: "entry-3",
+      result: { stopReason: "completed", usage: {} },
+    },
+    {
+      type: "accepted_input",
+      sessionId: sessionKey,
+      turnId: "turn-2",
+      sequence: 5,
+      createdAt: "2026-06-24T00:01:00.000Z",
+      entryId: "entry-5",
+      parentEntryId: "entry-4",
+      messages: [{ role: "user", content: [{ type: "text", text: "second question" }] }],
+    },
+  ];
+
+  await writeFile(transcriptPath, `${lines.map((line) => JSON.stringify(line)).join("\n")}\n`, "utf8");
+
+  const result = await forkWebSession(
+    { sessionKey, projectKey: projectRoot, fromEntryId: "entry-5" },
+    { projectRoot, pilotHome, now: () => new Date("2026-06-24T01:00:00.000Z") },
+  );
+  const newSafeId = sanitizeSessionIdForPath(result.newSessionKey);
+  const { entries } = await readTranscript(join(chatDir, `${newSafeId}.jsonl`));
+  const durable = entries.find((entry) => entry.entryId === "entry-2");
+  assert.equal(durable?.type, "durable_message");
+  if (durable?.type === "durable_message") {
+    const [toolReference, mediaReference] = durable.message.content;
+    assert.equal(toolReference.type, "tool_result_reference");
+    assert.equal(mediaReference.type, "media_reference");
+    if (toolReference.type === "tool_result_reference") {
+      assert.equal(toolReference.path, join(chatDir, newSafeId, "tool-results", "tc-1.txt"));
+      assert.equal(await readFile(toolReference.path, "utf8"), "full tool result");
+    }
+    if (mediaReference.type === "media_reference") {
+      assert.equal(mediaReference.path, join(chatDir, newSafeId, "tool-results", "media-1.png"));
+      assert.equal(await readFile(mediaReference.path, "utf8"), "base64-media");
+    }
+  }
+  const subagentStarted = entries.find((entry) => entry.entryId === "entry-3");
+  assert.equal(subagentStarted?.type, "subagent_started");
+  if (subagentStarted?.type === "subagent_started") {
+    assert.equal(subagentStarted.transcriptRelativePath, `${newSafeId}/subagents/sub-1.jsonl`);
+    const { entries: sidechainEntries } = await readTranscript(
+      join(chatDir, subagentStarted.transcriptRelativePath),
+    );
+    const sidechainDurable = sidechainEntries.find((entry) => entry.entryId === "sub-entry-2");
+    assert.equal(sidechainDurable?.type, "durable_message");
+    if (sidechainDurable?.type === "durable_message") {
+      const [toolReference, mediaReference] = sidechainDurable.message.content;
+      assert.equal(toolReference.type, "tool_result_reference");
+      assert.equal(mediaReference.type, "media_reference");
+      if (toolReference.type === "tool_result_reference") {
+        assert.equal(toolReference.path, join(chatDir, newSafeId, "tool-results", "tc-1.txt"));
+      }
+      if (mediaReference.type === "media_reference") {
+        assert.equal(mediaReference.path, join(chatDir, newSafeId, "tool-results", "media-1.png"));
+      }
+    }
   }
 
   await rm(pilotHome, { recursive: true, force: true });

--- a/tests/web/forkSession.test.ts
+++ b/tests/web/forkSession.test.ts
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import { forkWebSession } from "../../src/web/server/forkSession.js";
+import { readTranscript } from "../../src/session/transcript/TranscriptReader.js";
+import { createProjectId } from "../../src/pilot/paths.js";
+
+test("forkWebSession copies history before target turn and returns prefill text", async () => {
+  const pilotHome = await mkdtemp(join(tmpdir(), "pilotdeck-fork-"));
+  const projectRoot = join(pilotHome, "workspace");
+  const chatDir = join(pilotHome, "projects", createProjectId(projectRoot), "chats");
+  const sessionKey = "web:s_parent";
+  const transcriptPath = join(chatDir, `${sessionKey}.jsonl`);
+
+  await import("node:fs/promises").then((fs) => fs.mkdir(chatDir, { recursive: true }));
+
+  const lines = [
+    {
+      type: "accepted_input",
+      sessionId: sessionKey,
+      turnId: "turn-1",
+      sequence: 1,
+      createdAt: "2026-06-24T00:00:00.000Z",
+      entryId: "entry-1",
+      parentEntryId: null,
+      messages: [{ role: "user", content: [{ type: "text", text: "first question" }] }],
+    },
+    {
+      type: "assistant_message",
+      sessionId: sessionKey,
+      turnId: "turn-1",
+      sequence: 2,
+      createdAt: "2026-06-24T00:00:01.000Z",
+      entryId: "entry-2",
+      parentEntryId: "entry-1",
+      message: { role: "assistant", content: [{ type: "text", text: "first answer" }] },
+    },
+    {
+      type: "turn_result",
+      sessionId: sessionKey,
+      turnId: "turn-1",
+      sequence: 3,
+      createdAt: "2026-06-24T00:00:02.000Z",
+      entryId: "entry-3",
+      parentEntryId: "entry-2",
+      result: { stopReason: "completed", usage: {} },
+    },
+    {
+      type: "accepted_input",
+      sessionId: sessionKey,
+      turnId: "turn-2",
+      sequence: 4,
+      createdAt: "2026-06-24T00:01:00.000Z",
+      entryId: "entry-4",
+      parentEntryId: "entry-3",
+      messages: [{ role: "user", content: [{ type: "text", text: "second question" }] }],
+    },
+  ];
+
+  await import("node:fs/promises").then((fs) =>
+    fs.writeFile(transcriptPath, `${lines.map((line) => JSON.stringify(line)).join("\n")}\n`, "utf8"),
+  );
+
+  const result = await forkWebSession(
+    { sessionKey, projectKey: projectRoot, fromEntryId: "entry-4" },
+    { projectRoot, pilotHome, now: () => new Date("2026-06-24T01:00:00.000Z") },
+  );
+
+  assert.equal(result.prefillText, "second question");
+  assert.equal(result.carriedMessageCount, 2);
+  assert.match(result.newSessionKey, /^web[:_]s_/);
+
+  const newTranscriptPath = join(chatDir, `${result.newSessionKey}.jsonl`);
+  const { entries } = await readTranscript(newTranscriptPath);
+  assert.equal(entries.length, 4);
+  assert.equal(entries[0].sequence, 1);
+  assert.equal(entries[2].type, "turn_result");
+  assert.equal(entries[3].type, "session_metadata");
+  if (entries[3].type === "session_metadata") {
+    assert.equal(entries[3].metadata.parentSessionId, sessionKey);
+    assert.equal(entries[3].metadata.forkedFromTurnId, "turn-2");
+  }
+
+  await rm(pilotHome, { recursive: true, force: true });
+});

--- a/tests/web/forkSession.test.ts
+++ b/tests/web/forkSession.test.ts
@@ -3,11 +3,21 @@ import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test } from "node:test";
+import { DefaultContextRuntime } from "../../src/context/DefaultContextRuntime.js";
+import type { MemoryResolver } from "../../src/context/memory/MemoryResolver.js";
+import type { CanonicalMessage } from "../../src/model/index.js";
 import { ForkSessionError, forkWebSession } from "../../src/web/server/forkSession.js";
 import { readSubagentWebMessages, readWebSessionMessages } from "../../src/web/server/readSessionMessages.js";
 import { readTranscript } from "../../src/session/transcript/TranscriptReader.js";
 import { createProjectId } from "../../src/pilot/paths.js";
 import { sanitizeSessionIdForPath } from "../../src/session/storage/ProjectSessionStorage.js";
+
+function textFromMessage(message: CanonicalMessage): string {
+  return message.content
+    .filter((block) => block.type === "text")
+    .map((block) => block.text)
+    .join("\n");
+}
 
 test("forkWebSession copies history before target turn and returns prefill text", async () => {
   const pilotHome = await mkdtemp(join(tmpdir(), "pilotdeck-fork-"));
@@ -84,6 +94,18 @@ test("forkWebSession copies history before target turn and returns prefill text"
   assert.equal(entries[0].sequence, 1);
   assert.equal(entries[2].type, "turn_result");
   assert.equal(entries[3].type, "session_metadata");
+  if (entries[0].type === "accepted_input") {
+    assert.deepEqual(entries[0].messages[0]?.metadata?.forkCarryover, {
+      sourceSessionId: sessionKey,
+      sourceTurnId: "turn-1",
+    });
+  }
+  if (entries[1].type === "assistant_message") {
+    assert.deepEqual(entries[1].message.metadata?.forkCarryover, {
+      sourceSessionId: sessionKey,
+      sourceTurnId: "turn-1",
+    });
+  }
   if (entries[3].type === "session_metadata") {
     assert.equal(entries[3].metadata.parentSessionId, sessionKey);
     assert.equal(entries[3].metadata.forkedFromTurnId, "turn-2");
@@ -92,6 +114,43 @@ test("forkWebSession copies history before target turn and returns prefill text"
   await rm(pilotHome, { recursive: true, force: true });
 });
 
+test("DefaultContextRuntime skips fork carryover messages during memory capture", async () => {
+  const captured: CanonicalMessage[][] = [];
+  const memoryResolver: MemoryResolver = {
+    async retrieve() {
+      return { diagnostics: [] };
+    },
+    async captureTurn(input) {
+      captured.push(input.messages);
+    },
+  };
+  const runtime = new DefaultContextRuntime({ memoryResolver });
+
+  await runtime.captureTurn({
+    sessionId: "web:s_fork",
+    turnId: "turn-2",
+    errored: false,
+    messages: [
+      {
+        role: "user",
+        content: [{ type: "text", text: "parent history" }],
+        metadata: {
+          forkCarryover: {
+            sourceSessionId: "web:s_parent",
+            sourceTurnId: "turn-1",
+          },
+        },
+      },
+      {
+        role: "user",
+        content: [{ type: "text", text: "new fork turn" }],
+      },
+    ],
+  });
+
+  assert.equal(captured.length, 1);
+  assert.deepEqual(captured[0]?.map(textFromMessage), ["new fork turn"]);
+});
 
 test("forkWebSession rejects non-text target turns instead of dropping attachments", async () => {
   const pilotHome = await mkdtemp(join(tmpdir(), "pilotdeck-fork-unsupported-"));
@@ -166,7 +225,6 @@ test("forkWebSession rejects non-text target turns instead of dropping attachmen
   await rm(pilotHome, { recursive: true, force: true });
 });
 
-
 test("forkWebSession preserves plan mode for forked plan turns", async () => {
   const pilotHome = await mkdtemp(join(tmpdir(), "pilotdeck-fork-plan-"));
   const projectRoot = join(pilotHome, "workspace");
@@ -207,6 +265,214 @@ test("forkWebSession preserves plan mode for forked plan turns", async () => {
   await rm(pilotHome, { recursive: true, force: true });
 });
 
+test("readWebSessionMessages marks hidden media turns as unsupported fork targets", async () => {
+  const pilotHome = await mkdtemp(join(tmpdir(), "pilotdeck-fork-media-marker-"));
+  const projectRoot = join(pilotHome, "workspace");
+  const chatDir = join(pilotHome, "projects", createProjectId(projectRoot), "chats");
+  const sessionKey = "web:s_media_marker";
+  const transcriptPath = join(chatDir, `${sessionKey}.jsonl`);
+
+  await mkdir(chatDir, { recursive: true });
+
+  const lines = [
+    {
+      type: "accepted_input",
+      sessionId: sessionKey,
+      turnId: "turn-1",
+      sequence: 1,
+      createdAt: "2026-06-24T00:00:00.000Z",
+      entryId: "entry-1",
+      parentEntryId: null,
+      messages: [
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "please inspect this pdf" },
+            {
+              type: "pdf",
+              source: "base64",
+              data: "JVBERi0xLjQK",
+              mimeType: "application/pdf",
+              bytes: 9,
+              pages: 1,
+            },
+          ],
+        },
+      ],
+    },
+  ];
+
+  await writeFile(transcriptPath, `${lines.map((line) => JSON.stringify(line)).join("\n")}\n`, "utf8");
+
+  const result = await readWebSessionMessages(
+    { sessionKey, projectKey: projectRoot },
+    { projectRoot, pilotHome },
+  );
+
+  const userMessage = result.messages.find(
+    (message) => message.kind === "text" && message.entryId === "entry-1",
+  );
+  assert.ok(userMessage);
+  assert.equal((userMessage.payload as { forkUnsupportedContent?: boolean }).forkUnsupportedContent, true);
+
+  await rm(pilotHome, { recursive: true, force: true });
+});
+
+test("readWebSessionMessages reads background task transcripts by relative path", async () => {
+  const pilotHome = await mkdtemp(join(tmpdir(), "pilotdeck-background-read-"));
+  const projectRoot = join(pilotHome, "workspace");
+  const chatDir = join(pilotHome, "projects", createProjectId(projectRoot), "chats");
+  const parentSessionId = "web:s_parent_background";
+  const backgroundSessionId = "background-web-s_parent_background-agent-cron";
+  const relativeTranscriptPath = `${parentSessionId}/subagents/agent-cron.jsonl`;
+  const transcriptPath = join(chatDir, relativeTranscriptPath);
+
+  await mkdir(join(chatDir, parentSessionId, "subagents"), { recursive: true });
+  const lines = [
+    {
+      type: "accepted_input",
+      sessionId: backgroundSessionId,
+      turnId: "bg-turn-1",
+      sequence: 1,
+      createdAt: "2026-06-24T00:00:00.000Z",
+      entryId: "bg-entry-1",
+      parentEntryId: null,
+      messages: [{ role: "user", content: [{ type: "text", text: "background prompt" }] }],
+    },
+    {
+      type: "assistant_message",
+      sessionId: backgroundSessionId,
+      turnId: "bg-turn-1",
+      sequence: 2,
+      createdAt: "2026-06-24T00:00:01.000Z",
+      entryId: "bg-entry-2",
+      parentEntryId: "bg-entry-1",
+      message: { role: "assistant", content: [{ type: "text", text: "background result" }] },
+    },
+    {
+      type: "turn_result",
+      sessionId: backgroundSessionId,
+      turnId: "bg-turn-1",
+      sequence: 3,
+      createdAt: "2026-06-24T00:00:02.000Z",
+      entryId: "bg-entry-3",
+      parentEntryId: "bg-entry-2",
+      result: { stopReason: "completed", usage: {} },
+    },
+  ];
+  await writeFile(transcriptPath, `${lines.map((line) => JSON.stringify(line)).join("\n")}\n`, "utf8");
+
+  const result = await readWebSessionMessages(
+    {
+      sessionKey: backgroundSessionId,
+      projectKey: projectRoot,
+      sessionKind: "background_task",
+      parentSessionId,
+      relativeTranscriptPath,
+    },
+    { projectRoot, pilotHome },
+  );
+
+  assert.deepEqual(
+    result.messages.filter((message) => message.kind === "text").map((message) => message.text),
+    ["background prompt", "background result"],
+  );
+  assert.equal(result.session.sessionKind, "background_task");
+  assert.equal(result.session.parentSessionId, parentSessionId);
+  assert.equal(result.session.relativeTranscriptPath, relativeTranscriptPath);
+
+  await rm(pilotHome, { recursive: true, force: true });
+});
+
+test("readSubagentWebMessages resolves subagents from background task transcripts", async () => {
+  const pilotHome = await mkdtemp(join(tmpdir(), "pilotdeck-background-subagent-"));
+  const projectRoot = join(pilotHome, "workspace");
+  const chatDir = join(pilotHome, "projects", createProjectId(projectRoot), "chats");
+  const parentSessionId = "web:s_parent_background_subagent";
+  const backgroundSessionId = "background-web-s_parent_background_subagent-agent-cron";
+  const relativeTranscriptPath = `${parentSessionId}/subagents/agent-cron.jsonl`;
+  const backgroundDir = join(chatDir, parentSessionId, "subagents");
+  const subagentRelativePath = "agent-cron/subagents/sub-bg.jsonl";
+
+  await mkdir(join(backgroundDir, "agent-cron", "subagents"), { recursive: true });
+  const parentLines = [
+    {
+      type: "accepted_input",
+      sessionId: backgroundSessionId,
+      turnId: "bg-turn-1",
+      sequence: 1,
+      createdAt: "2026-06-24T00:00:00.000Z",
+      entryId: "bg-entry-1",
+      parentEntryId: null,
+      messages: [{ role: "user", content: [{ type: "text", text: "background prompt" }] }],
+    },
+    {
+      type: "subagent_started",
+      sessionId: backgroundSessionId,
+      turnId: "bg-turn-1",
+      sequence: 2,
+      createdAt: "2026-06-24T00:00:01.000Z",
+      entryId: "bg-entry-2",
+      parentEntryId: "bg-entry-1",
+      subagentId: "sub-bg",
+      subagentType: "general-purpose",
+      promptPreview: "inspect",
+      promptTruncated: false,
+      transcriptRelativePath: subagentRelativePath,
+    },
+  ];
+  const sidechainLines = [
+    {
+      type: "accepted_input",
+      sessionId: `${projectRoot}::sub::sub-bg`,
+      turnId: "sub-turn-1",
+      sequence: 1,
+      createdAt: "2026-06-24T00:00:01.100Z",
+      entryId: "sub-entry-1",
+      parentEntryId: null,
+      messages: [{ role: "user", content: [{ type: "text", text: "inspect" }] }],
+    },
+    {
+      type: "assistant_message",
+      sessionId: `${projectRoot}::sub::sub-bg`,
+      turnId: "sub-turn-1",
+      sequence: 2,
+      createdAt: "2026-06-24T00:00:01.200Z",
+      entryId: "sub-entry-2",
+      parentEntryId: "sub-entry-1",
+      message: { role: "assistant", content: [{ type: "text", text: "subagent result" }] },
+    },
+  ];
+  await writeFile(
+    join(chatDir, relativeTranscriptPath),
+    `${parentLines.map((line) => JSON.stringify(line)).join("\n")}\n`,
+    "utf8",
+  );
+  await writeFile(
+    join(backgroundDir, subagentRelativePath),
+    `${sidechainLines.map((line) => JSON.stringify(line)).join("\n")}\n`,
+    "utf8",
+  );
+
+  const result = await readSubagentWebMessages(
+    {
+      sessionKey: backgroundSessionId,
+      subagentId: "sub-bg",
+      projectKey: projectRoot,
+      sessionKind: "background_task",
+      parentSessionId,
+      relativeTranscriptPath,
+    },
+    { projectRoot, pilotHome },
+  );
+
+  assert.deepEqual(
+    result.messages.filter((message) => message.kind === "text").map((message) => message.text),
+    ["subagent result"],
+  );
+
+  await rm(pilotHome, { recursive: true, force: true });
+});
 
 test("forkWebSession rewrites copied auxiliary references to the new session", async () => {
   const pilotHome = await mkdtemp(join(tmpdir(), "pilotdeck-fork-aux-"));
@@ -420,219 +686,6 @@ test("forkWebSession rewrites copied auxiliary references to the new session", a
   await rm(pilotHome, { recursive: true, force: true });
 });
 
-
-test("readWebSessionMessages marks hidden media turns as unsupported fork targets", async () => {
-  const pilotHome = await mkdtemp(join(tmpdir(), "pilotdeck-fork-media-marker-"));
-  const projectRoot = join(pilotHome, "workspace");
-  const chatDir = join(pilotHome, "projects", createProjectId(projectRoot), "chats");
-  const sessionKey = "web:s_media_marker";
-  const transcriptPath = join(chatDir, `${sessionKey}.jsonl`);
-
-  await mkdir(chatDir, { recursive: true });
-
-  const lines = [
-    {
-      type: "accepted_input",
-      sessionId: sessionKey,
-      turnId: "turn-1",
-      sequence: 1,
-      createdAt: "2026-06-24T00:00:00.000Z",
-      entryId: "entry-1",
-      parentEntryId: null,
-      messages: [
-        {
-          role: "user",
-          content: [
-            { type: "text", text: "please inspect this pdf" },
-            {
-              type: "pdf",
-              source: "base64",
-              data: "JVBERi0xLjQK",
-              mimeType: "application/pdf",
-              bytes: 9,
-              pages: 1,
-            },
-          ],
-        },
-      ],
-    },
-  ];
-
-  await writeFile(transcriptPath, `${lines.map((line) => JSON.stringify(line)).join("\n")}\n`, "utf8");
-
-  const result = await readWebSessionMessages(
-    { sessionKey, projectKey: projectRoot },
-    { projectRoot, pilotHome },
-  );
-
-  const userMessage = result.messages.find(
-    (message) => message.kind === "text" && message.entryId === "entry-1",
-  );
-  assert.ok(userMessage);
-  assert.equal((userMessage.payload as { forkUnsupportedContent?: boolean }).forkUnsupportedContent, true);
-
-  await rm(pilotHome, { recursive: true, force: true });
-});
-
-
-test("readWebSessionMessages reads background task transcripts by relative path", async () => {
-  const pilotHome = await mkdtemp(join(tmpdir(), "pilotdeck-background-read-"));
-  const projectRoot = join(pilotHome, "workspace");
-  const chatDir = join(pilotHome, "projects", createProjectId(projectRoot), "chats");
-  const parentSessionId = "web:s_parent_background";
-  const backgroundSessionId = "background-web-s_parent_background-agent-cron";
-  const relativeTranscriptPath = `${parentSessionId}/subagents/agent-cron.jsonl`;
-  const transcriptPath = join(chatDir, relativeTranscriptPath);
-
-  await mkdir(join(chatDir, parentSessionId, "subagents"), { recursive: true });
-  const lines = [
-    {
-      type: "accepted_input",
-      sessionId: backgroundSessionId,
-      turnId: "bg-turn-1",
-      sequence: 1,
-      createdAt: "2026-06-24T00:00:00.000Z",
-      entryId: "bg-entry-1",
-      parentEntryId: null,
-      messages: [{ role: "user", content: [{ type: "text", text: "background prompt" }] }],
-    },
-    {
-      type: "assistant_message",
-      sessionId: backgroundSessionId,
-      turnId: "bg-turn-1",
-      sequence: 2,
-      createdAt: "2026-06-24T00:00:01.000Z",
-      entryId: "bg-entry-2",
-      parentEntryId: "bg-entry-1",
-      message: { role: "assistant", content: [{ type: "text", text: "background result" }] },
-    },
-    {
-      type: "turn_result",
-      sessionId: backgroundSessionId,
-      turnId: "bg-turn-1",
-      sequence: 3,
-      createdAt: "2026-06-24T00:00:02.000Z",
-      entryId: "bg-entry-3",
-      parentEntryId: "bg-entry-2",
-      result: { stopReason: "completed", usage: {} },
-    },
-  ];
-  await writeFile(transcriptPath, `${lines.map((line) => JSON.stringify(line)).join("\n")}\n`, "utf8");
-
-  const result = await readWebSessionMessages(
-    {
-      sessionKey: backgroundSessionId,
-      projectKey: projectRoot,
-      sessionKind: "background_task",
-      parentSessionId,
-      relativeTranscriptPath,
-    },
-    { projectRoot, pilotHome },
-  );
-
-  assert.deepEqual(
-    result.messages.filter((message) => message.kind === "text").map((message) => message.text),
-    ["background prompt", "background result"],
-  );
-  assert.equal(result.session.sessionKind, "background_task");
-  assert.equal(result.session.parentSessionId, parentSessionId);
-  assert.equal(result.session.relativeTranscriptPath, relativeTranscriptPath);
-
-  await rm(pilotHome, { recursive: true, force: true });
-});
-
-
-test("readSubagentWebMessages resolves subagents from background task transcripts", async () => {
-  const pilotHome = await mkdtemp(join(tmpdir(), "pilotdeck-background-subagent-"));
-  const projectRoot = join(pilotHome, "workspace");
-  const chatDir = join(pilotHome, "projects", createProjectId(projectRoot), "chats");
-  const parentSessionId = "web:s_parent_background_subagent";
-  const backgroundSessionId = "background-web-s_parent_background_subagent-agent-cron";
-  const relativeTranscriptPath = `${parentSessionId}/subagents/agent-cron.jsonl`;
-  const backgroundDir = join(chatDir, parentSessionId, "subagents");
-  const subagentRelativePath = "agent-cron/subagents/sub-bg.jsonl";
-
-  await mkdir(join(backgroundDir, "agent-cron", "subagents"), { recursive: true });
-  const parentLines = [
-    {
-      type: "accepted_input",
-      sessionId: backgroundSessionId,
-      turnId: "bg-turn-1",
-      sequence: 1,
-      createdAt: "2026-06-24T00:00:00.000Z",
-      entryId: "bg-entry-1",
-      parentEntryId: null,
-      messages: [{ role: "user", content: [{ type: "text", text: "background prompt" }] }],
-    },
-    {
-      type: "subagent_started",
-      sessionId: backgroundSessionId,
-      turnId: "bg-turn-1",
-      sequence: 2,
-      createdAt: "2026-06-24T00:00:01.000Z",
-      entryId: "bg-entry-2",
-      parentEntryId: "bg-entry-1",
-      subagentId: "sub-bg",
-      subagentType: "general-purpose",
-      promptPreview: "inspect",
-      promptTruncated: false,
-      transcriptRelativePath: subagentRelativePath,
-    },
-  ];
-  const sidechainLines = [
-    {
-      type: "accepted_input",
-      sessionId: `${projectRoot}::sub::sub-bg`,
-      turnId: "sub-turn-1",
-      sequence: 1,
-      createdAt: "2026-06-24T00:00:01.100Z",
-      entryId: "sub-entry-1",
-      parentEntryId: null,
-      messages: [{ role: "user", content: [{ type: "text", text: "inspect" }] }],
-    },
-    {
-      type: "assistant_message",
-      sessionId: `${projectRoot}::sub::sub-bg`,
-      turnId: "sub-turn-1",
-      sequence: 2,
-      createdAt: "2026-06-24T00:00:01.200Z",
-      entryId: "sub-entry-2",
-      parentEntryId: "sub-entry-1",
-      message: { role: "assistant", content: [{ type: "text", text: "subagent result" }] },
-    },
-  ];
-  await writeFile(
-    join(chatDir, relativeTranscriptPath),
-    `${parentLines.map((line) => JSON.stringify(line)).join("\n")}\n`,
-    "utf8",
-  );
-  await writeFile(
-    join(backgroundDir, subagentRelativePath),
-    `${sidechainLines.map((line) => JSON.stringify(line)).join("\n")}\n`,
-    "utf8",
-  );
-
-  const result = await readSubagentWebMessages(
-    {
-      sessionKey: backgroundSessionId,
-      subagentId: "sub-bg",
-      projectKey: projectRoot,
-      sessionKind: "background_task",
-      parentSessionId,
-      relativeTranscriptPath,
-    },
-    { projectRoot, pilotHome },
-  );
-
-  assert.deepEqual(
-    result.messages.filter((message) => message.kind === "text").map((message) => message.text),
-    ["subagent result"],
-  );
-
-  await rm(pilotHome, { recursive: true, force: true });
-});
-
-
 test("readWebSessionMessages keeps entry ids aligned after synthetic messages are hidden", async () => {
   const pilotHome = await mkdtemp(join(tmpdir(), "pilotdeck-fork-entryid-"));
   const projectRoot = join(pilotHome, "workspace");
@@ -701,7 +754,6 @@ test("readWebSessionMessages keeps entry ids aligned after synthetic messages ar
 
   await rm(pilotHome, { recursive: true, force: true });
 });
-
 
 test("readWebSessionMessages ignores pre-compact subagent refs when attaching visible tool rows", async () => {
   const pilotHome = await mkdtemp(join(tmpdir(), "pilotdeck-fork-subagent-compact-"));

--- a/tests/web/forkSession.test.ts
+++ b/tests/web/forkSession.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test } from "node:test";
 import { ForkSessionError, forkWebSession } from "../../src/web/server/forkSession.js";
+import { readSubagentWebMessages, readWebSessionMessages } from "../../src/web/server/readSessionMessages.js";
 import { readTranscript } from "../../src/session/transcript/TranscriptReader.js";
 import { createProjectId } from "../../src/pilot/paths.js";
 import { sanitizeSessionIdForPath } from "../../src/session/storage/ProjectSessionStorage.js";
@@ -415,6 +416,421 @@ test("forkWebSession rewrites copied auxiliary references to the new session", a
       }
     }
   }
+
+  await rm(pilotHome, { recursive: true, force: true });
+});
+
+
+test("readWebSessionMessages marks hidden media turns as unsupported fork targets", async () => {
+  const pilotHome = await mkdtemp(join(tmpdir(), "pilotdeck-fork-media-marker-"));
+  const projectRoot = join(pilotHome, "workspace");
+  const chatDir = join(pilotHome, "projects", createProjectId(projectRoot), "chats");
+  const sessionKey = "web:s_media_marker";
+  const transcriptPath = join(chatDir, `${sessionKey}.jsonl`);
+
+  await mkdir(chatDir, { recursive: true });
+
+  const lines = [
+    {
+      type: "accepted_input",
+      sessionId: sessionKey,
+      turnId: "turn-1",
+      sequence: 1,
+      createdAt: "2026-06-24T00:00:00.000Z",
+      entryId: "entry-1",
+      parentEntryId: null,
+      messages: [
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "please inspect this pdf" },
+            {
+              type: "pdf",
+              source: "base64",
+              data: "JVBERi0xLjQK",
+              mimeType: "application/pdf",
+              bytes: 9,
+              pages: 1,
+            },
+          ],
+        },
+      ],
+    },
+  ];
+
+  await writeFile(transcriptPath, `${lines.map((line) => JSON.stringify(line)).join("\n")}\n`, "utf8");
+
+  const result = await readWebSessionMessages(
+    { sessionKey, projectKey: projectRoot },
+    { projectRoot, pilotHome },
+  );
+
+  const userMessage = result.messages.find(
+    (message) => message.kind === "text" && message.entryId === "entry-1",
+  );
+  assert.ok(userMessage);
+  assert.equal((userMessage.payload as { forkUnsupportedContent?: boolean }).forkUnsupportedContent, true);
+
+  await rm(pilotHome, { recursive: true, force: true });
+});
+
+
+test("readWebSessionMessages reads background task transcripts by relative path", async () => {
+  const pilotHome = await mkdtemp(join(tmpdir(), "pilotdeck-background-read-"));
+  const projectRoot = join(pilotHome, "workspace");
+  const chatDir = join(pilotHome, "projects", createProjectId(projectRoot), "chats");
+  const parentSessionId = "web:s_parent_background";
+  const backgroundSessionId = "background-web-s_parent_background-agent-cron";
+  const relativeTranscriptPath = `${parentSessionId}/subagents/agent-cron.jsonl`;
+  const transcriptPath = join(chatDir, relativeTranscriptPath);
+
+  await mkdir(join(chatDir, parentSessionId, "subagents"), { recursive: true });
+  const lines = [
+    {
+      type: "accepted_input",
+      sessionId: backgroundSessionId,
+      turnId: "bg-turn-1",
+      sequence: 1,
+      createdAt: "2026-06-24T00:00:00.000Z",
+      entryId: "bg-entry-1",
+      parentEntryId: null,
+      messages: [{ role: "user", content: [{ type: "text", text: "background prompt" }] }],
+    },
+    {
+      type: "assistant_message",
+      sessionId: backgroundSessionId,
+      turnId: "bg-turn-1",
+      sequence: 2,
+      createdAt: "2026-06-24T00:00:01.000Z",
+      entryId: "bg-entry-2",
+      parentEntryId: "bg-entry-1",
+      message: { role: "assistant", content: [{ type: "text", text: "background result" }] },
+    },
+    {
+      type: "turn_result",
+      sessionId: backgroundSessionId,
+      turnId: "bg-turn-1",
+      sequence: 3,
+      createdAt: "2026-06-24T00:00:02.000Z",
+      entryId: "bg-entry-3",
+      parentEntryId: "bg-entry-2",
+      result: { stopReason: "completed", usage: {} },
+    },
+  ];
+  await writeFile(transcriptPath, `${lines.map((line) => JSON.stringify(line)).join("\n")}\n`, "utf8");
+
+  const result = await readWebSessionMessages(
+    {
+      sessionKey: backgroundSessionId,
+      projectKey: projectRoot,
+      sessionKind: "background_task",
+      parentSessionId,
+      relativeTranscriptPath,
+    },
+    { projectRoot, pilotHome },
+  );
+
+  assert.deepEqual(
+    result.messages.filter((message) => message.kind === "text").map((message) => message.text),
+    ["background prompt", "background result"],
+  );
+  assert.equal(result.session.sessionKind, "background_task");
+  assert.equal(result.session.parentSessionId, parentSessionId);
+  assert.equal(result.session.relativeTranscriptPath, relativeTranscriptPath);
+
+  await rm(pilotHome, { recursive: true, force: true });
+});
+
+
+test("readSubagentWebMessages resolves subagents from background task transcripts", async () => {
+  const pilotHome = await mkdtemp(join(tmpdir(), "pilotdeck-background-subagent-"));
+  const projectRoot = join(pilotHome, "workspace");
+  const chatDir = join(pilotHome, "projects", createProjectId(projectRoot), "chats");
+  const parentSessionId = "web:s_parent_background_subagent";
+  const backgroundSessionId = "background-web-s_parent_background_subagent-agent-cron";
+  const relativeTranscriptPath = `${parentSessionId}/subagents/agent-cron.jsonl`;
+  const backgroundDir = join(chatDir, parentSessionId, "subagents");
+  const subagentRelativePath = "agent-cron/subagents/sub-bg.jsonl";
+
+  await mkdir(join(backgroundDir, "agent-cron", "subagents"), { recursive: true });
+  const parentLines = [
+    {
+      type: "accepted_input",
+      sessionId: backgroundSessionId,
+      turnId: "bg-turn-1",
+      sequence: 1,
+      createdAt: "2026-06-24T00:00:00.000Z",
+      entryId: "bg-entry-1",
+      parentEntryId: null,
+      messages: [{ role: "user", content: [{ type: "text", text: "background prompt" }] }],
+    },
+    {
+      type: "subagent_started",
+      sessionId: backgroundSessionId,
+      turnId: "bg-turn-1",
+      sequence: 2,
+      createdAt: "2026-06-24T00:00:01.000Z",
+      entryId: "bg-entry-2",
+      parentEntryId: "bg-entry-1",
+      subagentId: "sub-bg",
+      subagentType: "general-purpose",
+      promptPreview: "inspect",
+      promptTruncated: false,
+      transcriptRelativePath: subagentRelativePath,
+    },
+  ];
+  const sidechainLines = [
+    {
+      type: "accepted_input",
+      sessionId: `${projectRoot}::sub::sub-bg`,
+      turnId: "sub-turn-1",
+      sequence: 1,
+      createdAt: "2026-06-24T00:00:01.100Z",
+      entryId: "sub-entry-1",
+      parentEntryId: null,
+      messages: [{ role: "user", content: [{ type: "text", text: "inspect" }] }],
+    },
+    {
+      type: "assistant_message",
+      sessionId: `${projectRoot}::sub::sub-bg`,
+      turnId: "sub-turn-1",
+      sequence: 2,
+      createdAt: "2026-06-24T00:00:01.200Z",
+      entryId: "sub-entry-2",
+      parentEntryId: "sub-entry-1",
+      message: { role: "assistant", content: [{ type: "text", text: "subagent result" }] },
+    },
+  ];
+  await writeFile(
+    join(chatDir, relativeTranscriptPath),
+    `${parentLines.map((line) => JSON.stringify(line)).join("\n")}\n`,
+    "utf8",
+  );
+  await writeFile(
+    join(backgroundDir, subagentRelativePath),
+    `${sidechainLines.map((line) => JSON.stringify(line)).join("\n")}\n`,
+    "utf8",
+  );
+
+  const result = await readSubagentWebMessages(
+    {
+      sessionKey: backgroundSessionId,
+      subagentId: "sub-bg",
+      projectKey: projectRoot,
+      sessionKind: "background_task",
+      parentSessionId,
+      relativeTranscriptPath,
+    },
+    { projectRoot, pilotHome },
+  );
+
+  assert.deepEqual(
+    result.messages.filter((message) => message.kind === "text").map((message) => message.text),
+    ["subagent result"],
+  );
+
+  await rm(pilotHome, { recursive: true, force: true });
+});
+
+
+test("readWebSessionMessages keeps entry ids aligned after synthetic messages are hidden", async () => {
+  const pilotHome = await mkdtemp(join(tmpdir(), "pilotdeck-fork-entryid-"));
+  const projectRoot = join(pilotHome, "workspace");
+  const chatDir = join(pilotHome, "projects", createProjectId(projectRoot), "chats");
+  const sessionKey = "web:s_entryid";
+  const transcriptPath = join(chatDir, `${sessionKey}.jsonl`);
+
+  await mkdir(chatDir, { recursive: true });
+  const lines = [
+    {
+      type: "accepted_input",
+      sessionId: sessionKey,
+      turnId: "turn-1",
+      sequence: 1,
+      createdAt: "2026-06-24T00:00:00.000Z",
+      entryId: "entry-visible-1",
+      parentEntryId: null,
+      messages: [{ role: "user", content: [{ type: "text", text: "first visible" }] }],
+    },
+    {
+      type: "durable_message",
+      sessionId: sessionKey,
+      turnId: "turn-1",
+      sequence: 2,
+      createdAt: "2026-06-24T00:00:01.000Z",
+      entryId: "entry-synthetic",
+      parentEntryId: "entry-visible-1",
+      message: {
+        role: "user",
+        metadata: { synthetic: true, purpose: "json_self_correct" },
+        content: [{ type: "text", text: "hidden synthetic" }],
+      },
+    },
+    {
+      type: "turn_result",
+      sessionId: sessionKey,
+      turnId: "turn-1",
+      sequence: 3,
+      createdAt: "2026-06-24T00:00:02.000Z",
+      entryId: "entry-result",
+      parentEntryId: "entry-synthetic",
+      result: { stopReason: "completed", usage: {} },
+    },
+    {
+      type: "accepted_input",
+      sessionId: sessionKey,
+      turnId: "turn-2",
+      sequence: 4,
+      createdAt: "2026-06-24T00:01:00.000Z",
+      entryId: "entry-visible-2",
+      parentEntryId: "entry-result",
+      messages: [{ role: "user", content: [{ type: "text", text: "second visible" }] }],
+    },
+  ];
+  await writeFile(transcriptPath, `${lines.map((line) => JSON.stringify(line)).join("\n")}\n`, "utf8");
+
+  const result = await readWebSessionMessages(
+    { sessionKey, projectKey: projectRoot },
+    { projectRoot, pilotHome, now: () => new Date("2026-06-24T01:00:00.000Z") },
+  );
+
+  assert.deepEqual(
+    result.messages.map((message) => message.entryId),
+    ["entry-visible-1", "entry-visible-2"],
+  );
+
+  await rm(pilotHome, { recursive: true, force: true });
+});
+
+
+test("readWebSessionMessages ignores pre-compact subagent refs when attaching visible tool rows", async () => {
+  const pilotHome = await mkdtemp(join(tmpdir(), "pilotdeck-fork-subagent-compact-"));
+  const projectRoot = join(pilotHome, "workspace");
+  const chatDir = join(pilotHome, "projects", createProjectId(projectRoot), "chats");
+  const sessionKey = "web:s_subagent_compact";
+  const transcriptPath = join(chatDir, `${sessionKey}.jsonl`);
+
+  await mkdir(chatDir, { recursive: true });
+  const lines = [
+    {
+      type: "accepted_input",
+      sessionId: sessionKey,
+      turnId: "turn-1",
+      sequence: 1,
+      createdAt: "2026-06-24T00:00:00.000Z",
+      entryId: "entry-old-user",
+      parentEntryId: null,
+      messages: [{ role: "user", content: [{ type: "text", text: "old task" }] }],
+    },
+    {
+      type: "assistant_message",
+      sessionId: sessionKey,
+      turnId: "turn-1",
+      sequence: 2,
+      createdAt: "2026-06-24T00:00:01.000Z",
+      entryId: "entry-old-agent",
+      parentEntryId: "entry-old-user",
+      message: {
+        role: "assistant",
+        content: [{ type: "tool_call", id: "agent-old", name: "agent", input: {} }],
+      },
+    },
+    {
+      type: "subagent_started",
+      sessionId: sessionKey,
+      turnId: "turn-1",
+      sequence: 3,
+      createdAt: "2026-06-24T00:00:02.000Z",
+      entryId: "entry-old-subagent",
+      parentEntryId: "entry-old-agent",
+      subagentId: "sub-old",
+      subagentType: "general-purpose",
+      promptPreview: "old",
+      promptTruncated: false,
+      transcriptRelativePath: `${sessionKey}/subagents/sub-old.jsonl`,
+    },
+    {
+      type: "turn_result",
+      sessionId: sessionKey,
+      turnId: "turn-1",
+      sequence: 4,
+      createdAt: "2026-06-24T00:00:03.000Z",
+      entryId: "entry-old-result",
+      parentEntryId: "entry-old-subagent",
+      result: { stopReason: "completed", usage: {} },
+    },
+    {
+      type: "control_boundary",
+      sessionId: sessionKey,
+      turnId: "compact",
+      sequence: 5,
+      createdAt: "2026-06-24T00:00:04.000Z",
+      entryId: "entry-compact",
+      parentEntryId: "entry-old-result",
+      boundary: {
+        kind: "compact",
+        subtype: "compact_boundary",
+        compactMetadata: { trigger: "manual", preTokens: 100 },
+      },
+    },
+    {
+      type: "accepted_input",
+      sessionId: sessionKey,
+      turnId: "turn-2",
+      sequence: 6,
+      createdAt: "2026-06-24T00:01:00.000Z",
+      entryId: "entry-new-user",
+      parentEntryId: "entry-compact",
+      messages: [{ role: "user", content: [{ type: "text", text: "new task" }] }],
+    },
+    {
+      type: "assistant_message",
+      sessionId: sessionKey,
+      turnId: "turn-2",
+      sequence: 7,
+      createdAt: "2026-06-24T00:01:01.000Z",
+      entryId: "entry-new-agent",
+      parentEntryId: "entry-new-user",
+      message: {
+        role: "assistant",
+        content: [{ type: "tool_call", id: "agent-new", name: "agent", input: {} }],
+      },
+    },
+    {
+      type: "subagent_started",
+      sessionId: sessionKey,
+      turnId: "turn-2",
+      sequence: 8,
+      createdAt: "2026-06-24T00:01:02.000Z",
+      entryId: "entry-new-subagent",
+      parentEntryId: "entry-new-agent",
+      subagentId: "sub-new",
+      subagentType: "general-purpose",
+      promptPreview: "new",
+      promptTruncated: false,
+      transcriptRelativePath: `${sessionKey}/subagents/sub-new.jsonl`,
+    },
+    {
+      type: "turn_result",
+      sessionId: sessionKey,
+      turnId: "turn-2",
+      sequence: 9,
+      createdAt: "2026-06-24T00:01:03.000Z",
+      entryId: "entry-new-result",
+      parentEntryId: "entry-new-subagent",
+      result: { stopReason: "completed", usage: {} },
+    },
+  ];
+  await writeFile(transcriptPath, `${lines.map((line) => JSON.stringify(line)).join("\n")}\n`, "utf8");
+
+  const result = await readWebSessionMessages(
+    { sessionKey, projectKey: projectRoot },
+    { projectRoot, pilotHome, now: () => new Date("2026-06-24T01:00:00.000Z") },
+  );
+
+  const toolUse = result.messages.find((message) => message.kind === "tool_use");
+  assert.equal(toolUse?.toolCallId, "agent-new");
+  assert.equal(toolUse?.subagentId, "sub-new");
 
   await rm(pilotHome, { recursive: true, force: true });
 });

--- a/ui/e2e/history-fork.spec.mjs
+++ b/ui/e2e/history-fork.spec.mjs
@@ -1,0 +1,32 @@
+import { test, expect } from '@playwright/test';
+
+const API_URL = process.env.PILOTDECK_API_URL || 'http://localhost:3001';
+const PROJECT_PATH = process.env.PILOTDECK_E2E_PROJECT_PATH || '/Users/da/ws/PilotDeck/PilotDeck-20260610';
+const PARENT_SESSION = process.env.PILOTDECK_E2E_PARENT_SESSION || 'web:s_df76542f-2f58-431f-8b74-94c3a33206e2';
+
+test('history fork API carries prior transcript and exposes entryId on user messages', async ({ request }) => {
+  const messagesResponse = await request.get(
+    `${API_URL}/api/sessions/${encodeURIComponent(PARENT_SESSION)}/messages?projectPath=${encodeURIComponent(PROJECT_PATH)}&limit=200`,
+  );
+  expect(messagesResponse.ok()).toBeTruthy();
+  const payload = await messagesResponse.json();
+  test.skip(!payload.messages?.length, 'No live session messages available in this environment');
+
+  const userMessage = payload.messages.find((message) => message.role === 'user' && message.entryId);
+  expect(userMessage?.entryId).toBeTruthy();
+
+  const forkResponse = await request.post(
+    `${API_URL}/api/sessions/${encodeURIComponent(PARENT_SESSION)}/fork`,
+    {
+      data: {
+        projectPath: PROJECT_PATH,
+        fromEntryId: userMessage.entryId,
+      },
+    },
+  );
+  expect(forkResponse.ok()).toBeTruthy();
+  const forkPayload = await forkResponse.json();
+  expect(forkPayload.newSessionId).toMatch(/^web[:_]s_/);
+  expect(typeof forkPayload.prefillText).toBe('string');
+  expect(forkPayload.carriedMessageCount).toBeGreaterThan(0);
+});

--- a/ui/e2e/history-fork.spec.mjs
+++ b/ui/e2e/history-fork.spec.mjs
@@ -1,10 +1,15 @@
 import { test, expect } from '@playwright/test';
 
-const API_URL = process.env.PILOTDECK_API_URL || 'http://localhost:3001';
-const PROJECT_PATH = process.env.PILOTDECK_E2E_PROJECT_PATH || '/Users/da/ws/PilotDeck/PilotDeck-20260610';
-const PARENT_SESSION = process.env.PILOTDECK_E2E_PARENT_SESSION || 'web:s_df76542f-2f58-431f-8b74-94c3a33206e2';
+const API_URL = process.env.PILOTDECK_API_URL;
+const PROJECT_PATH = process.env.PILOTDECK_E2E_PROJECT_PATH;
+const PARENT_SESSION = process.env.PILOTDECK_E2E_PARENT_SESSION;
 
 test('history fork API carries prior transcript and exposes entryId on user messages', async ({ request }) => {
+  test.skip(
+    !API_URL || !PROJECT_PATH || !PARENT_SESSION,
+    'Set PILOTDECK_API_URL, PILOTDECK_E2E_PROJECT_PATH, and PILOTDECK_E2E_PARENT_SESSION to run this environment-backed test.',
+  );
+
   const messagesResponse = await request.get(
     `${API_URL}/api/sessions/${encodeURIComponent(PARENT_SESSION)}/messages?projectPath=${encodeURIComponent(PROJECT_PATH)}&limit=200`,
   );
@@ -26,7 +31,7 @@ test('history fork API carries prior transcript and exposes entryId on user mess
   );
   expect(forkResponse.ok()).toBeTruthy();
   const forkPayload = await forkResponse.json();
-  expect(forkPayload.newSessionId).toMatch(/^web[:_]s_/);
+  expect(forkPayload.newSessionId).toMatch(/^web[:-]s_/);
   expect(typeof forkPayload.prefillText).toBe('string');
   expect(forkPayload.carriedMessageCount).toBeGreaterThan(0);
 });

--- a/ui/server/projects.js
+++ b/ui/server/projects.js
@@ -101,6 +101,8 @@ function toLegacySession(session, projectName) {
         aiTitle: session.aiTitle,
         firstPrompt: session.firstPrompt,
         tag: presentation.tag,
+        parentSessionId: session.parentSessionId,
+        forkedFromTurnId: session.forkedFromTurnId,
         __projectName: projectName,
     };
 }

--- a/ui/server/routes/messages.js
+++ b/ui/server/routes/messages.js
@@ -56,6 +56,42 @@ router.get('/:sessionId/messages', async (req, res) => {
   }
 });
 
+router.post('/:sessionId/fork', async (req, res) => {
+  try {
+    const { sessionId } = req.params;
+    const projectPath = String(req.body?.projectPath || req.body?.projectName || req.query.projectPath || REPO_ROOT);
+    const fromEntryId = String(req.body?.fromEntryId || '');
+    if (!fromEntryId) {
+      return res.status(400).json({ error: 'fromEntryId is required' });
+    }
+
+    const gateway = await getPilotDeckGateway();
+    const result = await gateway.forkSession({
+      sessionKey: sessionId,
+      projectKey: projectPath,
+      fromEntryId,
+    });
+
+    return res.json({
+      newSessionId: result.newSessionKey,
+      prefillText: result.prefillText,
+      carriedMessageCount: result.carriedMessageCount,
+    });
+  } catch (error) {
+    console.error('[messages] fork_session failed:', error);
+    const code = error && typeof error === 'object' && 'code' in error ? String(error.code) : '';
+    if (code.startsWith('fork_')) {
+      return res.status(400).json({
+        error: error instanceof Error ? error.message : 'Fork failed',
+        code,
+      });
+    }
+    return res.status(500).json({
+      error: error instanceof Error ? error.message : 'Fork failed',
+    });
+  }
+});
+
 router.get('/:sessionId/subagent/:subagentId/messages', async (req, res) => {
   try {
     const { sessionId, subagentId } = req.params;
@@ -89,6 +125,7 @@ function mapWebMessageToNormalized(message, sessionId) {
     sessionId,
     timestamp: message.createdAt,
     provider: message.provider || 'pilotdeck',
+    ...(message.entryId ? { entryId: message.entryId } : {}),
   };
   switch (message.kind) {
     case 'text':

--- a/ui/server/routes/messages.js
+++ b/ui/server/routes/messages.js
@@ -37,6 +37,15 @@ router.get('/:sessionId/messages', async (req, res) => {
       projectKey: projectPath,
       limit: limit ?? undefined,
       cursor: offset > 0 ? String(offset) : undefined,
+      ...(typeof req.query.sessionKind === 'string' && req.query.sessionKind
+        ? { sessionKind: req.query.sessionKind }
+        : {}),
+      ...(typeof req.query.parentSessionId === 'string' && req.query.parentSessionId
+        ? { parentSessionId: req.query.parentSessionId }
+        : {}),
+      ...(typeof req.query.relativeTranscriptPath === 'string' && req.query.relativeTranscriptPath
+        ? { relativeTranscriptPath: req.query.relativeTranscriptPath }
+        : {}),
     });
 
     const messages = result.messages.map((message) => mapWebMessageToNormalized(message, sessionId));
@@ -76,6 +85,7 @@ router.post('/:sessionId/fork', async (req, res) => {
       newSessionId: result.newSessionKey,
       prefillText: result.prefillText,
       carriedMessageCount: result.carriedMessageCount,
+      ...(result.mode ? { mode: result.mode } : {}),
     });
   } catch (error) {
     console.error('[messages] fork_session failed:', error);
@@ -102,6 +112,15 @@ router.get('/:sessionId/subagent/:subagentId/messages', async (req, res) => {
       sessionKey: sessionId,
       subagentId,
       projectKey: projectPath,
+      ...(typeof req.query.sessionKind === 'string' && req.query.sessionKind
+        ? { sessionKind: req.query.sessionKind }
+        : {}),
+      ...(typeof req.query.parentSessionId === 'string' && req.query.parentSessionId
+        ? { parentSessionId: req.query.parentSessionId }
+        : {}),
+      ...(typeof req.query.relativeTranscriptPath === 'string' && req.query.relativeTranscriptPath
+        ? { relativeTranscriptPath: req.query.relativeTranscriptPath }
+        : {}),
     });
 
     const messages = result.messages.map((message) =>
@@ -128,7 +147,10 @@ function mapWebMessageToNormalized(message, sessionId) {
     ...(message.entryId ? { entryId: message.entryId } : {}),
   };
   switch (message.kind) {
-    case 'text':
+    case 'text': {
+      const payload = message.payload && typeof message.payload === 'object'
+        ? message.payload
+        : {};
       return createNormalizedMessage({
         ...base,
         kind: 'text',
@@ -137,7 +159,16 @@ function mapWebMessageToNormalized(message, sessionId) {
         ...(Array.isArray(message.images) && message.images.length > 0
           ? { images: message.images.map((image) => image?.data).filter(Boolean) }
           : {}),
+        ...(payload.forkUnsupportedContent === true
+          ? {
+              forkUnsupportedContent: true,
+              forkUnsupportedReason: typeof payload.forkUnsupportedReason === 'string'
+                ? payload.forkUnsupportedReason
+                : undefined,
+            }
+          : {}),
       });
+    }
     case 'thinking':
       return createNormalizedMessage({ ...base, kind: 'thinking', content: message.text || '' });
     case 'tool_use':

--- a/ui/src/components/app-shell/AppShellV2.tsx
+++ b/ui/src/components/app-shell/AppShellV2.tsx
@@ -486,7 +486,7 @@ export default function AppShellV2() {
       }
       const target = (project.sessions ?? []).find((s) => s.id === sessId);
       if (target) {
-        handleSessionSelect(target);
+        handleSessionSelect(fallbackSession ? { ...target, ...fallbackSession } : target);
       } else if (fallbackSession) {
         handleSessionSelect(fallbackSession);
       } else {

--- a/ui/src/components/app-shell/SidebarV2.tsx
+++ b/ui/src/components/app-shell/SidebarV2.tsx
@@ -6,6 +6,7 @@ import {
   useState,
   type KeyboardEvent,
   type MouseEvent,
+  type ReactNode,
 } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
@@ -18,6 +19,7 @@ import {
   PanelLeftClose,
   Pencil,
   Plus,
+  GitBranch,
   Settings as SettingsIcon,
   Trash2,
 } from 'lucide-react';
@@ -111,6 +113,46 @@ type FlatSession = {
   session: ProjectSession;
   sessionId: string;
   lastActivity: number;
+};
+
+type SessionTreeNode = {
+  flat: FlatSession;
+  children: SessionTreeNode[];
+};
+
+const isForkChildSession = (session: ProjectSession, knownSessionIds: Set<string>): boolean =>
+  Boolean(
+    session.parentSessionId &&
+    session.sessionKind !== 'background_task' &&
+    knownSessionIds.has(session.parentSessionId),
+  );
+
+const buildSessionTree = (flatSessions: FlatSession[]): SessionTreeNode[] => {
+  const knownSessionIds = new Set(flatSessions.map((item) => item.sessionId));
+  const childrenByParent = new Map<string, FlatSession[]>();
+  const roots: FlatSession[] = [];
+
+  for (const item of flatSessions) {
+    if (isForkChildSession(item.session, knownSessionIds)) {
+      const parentId = item.session.parentSessionId as string;
+      const list = childrenByParent.get(parentId) ?? [];
+      list.push(item);
+      childrenByParent.set(parentId, list);
+    } else {
+      roots.push(item);
+    }
+  }
+
+  const toNode = (flat: FlatSession): SessionTreeNode => ({
+    flat,
+    children: (childrenByParent.get(flat.sessionId) ?? [])
+      .sort((left, right) => right.lastActivity - left.lastActivity)
+      .map(toNode),
+  });
+
+  return roots
+    .sort((left, right) => right.lastActivity - left.lastActivity)
+    .map(toNode);
 };
 
 const collectSessionsForProject = (project: Project): FlatSession[] => {
@@ -676,6 +718,121 @@ export default function SidebarV2({
     // top-level list (no folder ancestor), so the usual ml-6 indent would
     // leave a weird empty gutter on the left.
     const containerClass = options.flat ? 'space-y-0.5' : 'ml-6 space-y-0.5';
+    const sessionTree = buildSessionTree(sessions);
+    const sessionTitleById = new Map(
+      allSessions.map(({ sessionId, session }) => [sessionId, sessionDisplayTitle(session)]),
+    );
+
+    const renderSessionTreeNode = (
+      node: SessionTreeNode,
+      depth: number,
+      isForkChild: boolean,
+    ): ReactNode => {
+      const { session, sessionId, lastActivity } = node.flat;
+      const isSessionActive =
+        selectedProject?.name === project.name &&
+        selectedSession?.id === sessionId &&
+        activeTab === 'chat';
+      const isSessionRenaming = renamingSession === sessionId;
+      const isOptimisticRow =
+        typeof sessionId === 'string' && sessionId.startsWith('new-session-');
+      const indicatorStatus: SessionIndicatorStatus = isOptimisticRow
+        ? 'processing'
+        : processingSessions?.has(sessionId)
+          ? 'processing'
+          : unreadSessionIds?.has(sessionId)
+            ? 'unread'
+            : 'idle';
+      const indicatorLabel =
+        indicatorStatus === 'processing'
+          ? t('sidebar:sessions.processing', { defaultValue: 'Agent is running' })
+          : indicatorStatus === 'unread'
+            ? t('sidebar:sessions.unread', { defaultValue: 'Unread messages' })
+            : t('sidebar:sessions.idle', { defaultValue: 'No unread messages' });
+      const parentTitle = session.parentSessionId
+        ? sessionTitleById.get(session.parentSessionId)
+        : undefined;
+
+      return (
+        <div key={sessionId} className={depth > 0 ? 'ml-4 border-l border-neutral-200 pl-2 dark:border-neutral-800' : undefined}>
+          <div
+            onContextMenu={(event) =>
+              isOptimisticRow ? undefined : openSessionContextMenu(event, project, session)
+            }
+            className={cn(
+              'group/session relative w-full rounded-md transition-colors',
+              isSessionActive
+                ? 'bg-neutral-200/70 dark:bg-neutral-800'
+                : 'hover:bg-neutral-100 dark:hover:bg-neutral-800',
+            )}
+          >
+            {isSessionRenaming ? (
+              <div className="flex items-center px-2 py-1">
+                <input
+                  ref={renameInputRef}
+                  value={renameDraft}
+                  onChange={(event) => setRenameDraft(event.target.value)}
+                  onBlur={commitSessionRename}
+                  onKeyDown={(event) => handleRenameKey(event, 'session')}
+                  onClick={(event) => event.stopPropagation()}
+                  placeholder={t('sidebar:renamePlaceholder', { defaultValue: 'Rename - empty to reset' }) as string}
+                  className="w-full rounded-sm border border-neutral-300 bg-white px-1.5 py-0.5 text-[12.5px] text-neutral-900 outline-none focus:border-neutral-500 dark:border-neutral-600 dark:bg-neutral-900 dark:text-neutral-100"
+                />
+              </div>
+            ) : (
+              <button
+                type="button"
+                onClick={
+                  isOptimisticRow
+                    ? undefined
+                    : () => handleSessionClick(project, sessionId)
+                }
+                disabled={isOptimisticRow}
+                className={cn(
+                  'flex w-full items-start gap-2 px-2 py-1 text-left',
+                  isOptimisticRow && 'cursor-default',
+                )}
+              >
+                <span className="flex h-[18px] w-3 shrink-0 items-center justify-center pt-[3px]">
+                  <SessionStatusIndicator
+                    status={indicatorStatus}
+                    label={indicatorLabel}
+                  />
+                </span>
+                <div className="min-w-0 flex-1">
+                  <div
+                    className={cn(
+                      'flex min-w-0 items-center gap-1 truncate text-[12.5px] text-neutral-900 dark:text-neutral-100',
+                      isOptimisticRow && 'italic text-neutral-600 dark:text-neutral-300',
+                    )}
+                  >
+                    {isForkChild ? (
+                      <GitBranch className="h-3 w-3 shrink-0 text-neutral-400 dark:text-neutral-500" strokeWidth={2} />
+                    ) : null}
+                    <span className="truncate">{sessionDisplayTitle(session)}</span>
+                  </div>
+                  <div className="text-[11px] text-neutral-500 dark:text-neutral-400">
+                    {isOptimisticRow
+                      ? t('sidebar:sessions.sending', { defaultValue: 'Sending…' })
+                      : isForkChild
+                        ? t('sidebar:sessions.forkedFrom', {
+                            parent: parentTitle || session.parentSessionId || '',
+                            defaultValue: `forked from ${parentTitle || session.parentSessionId || 'parent'}`,
+                          })
+                        : formatRelative(lastActivity, t)}
+                  </div>
+                </div>
+              </button>
+            )}
+          </div>
+          {node.children.length > 0 ? (
+            <div className="mt-0.5 space-y-0.5">
+              {node.children.map((child) => renderSessionTreeNode(child, depth + 1, true))}
+            </div>
+          ) : null}
+        </div>
+      );
+    };
 
     return (
       <div className={containerClass}>
@@ -694,102 +851,8 @@ export default function SidebarV2({
           </button>
         ) : null}
 
-        {sessions.length > 0 ? (
-          sessions.map(({ session, sessionId, lastActivity }) => {
-            const isSessionActive =
-              selectedProject?.name === project.name &&
-              selectedSession?.id === sessionId &&
-              activeTab === 'chat';
-            const isSessionRenaming = renamingSession === sessionId;
-            // Optimistic placeholder rows are not yet backed by a real
-            // session id on the server, so clicking / renaming / deleting
-            // them is meaningless until the server's `projects_updated`
-            // swaps in the real id (typically within ~300ms).
-            const isOptimisticRow =
-              typeof sessionId === 'string' && sessionId.startsWith('new-session-');
-            // Optimistic rows always appear "processing" — the user just
-            // submitted; the agent is always running for them.
-            const indicatorStatus: SessionIndicatorStatus = isOptimisticRow
-              ? 'processing'
-              : processingSessions?.has(sessionId)
-                ? 'processing'
-                : unreadSessionIds?.has(sessionId)
-                  ? 'unread'
-                  : 'idle';
-            const indicatorLabel =
-              indicatorStatus === 'processing'
-                ? t('sidebar:sessions.processing', { defaultValue: 'Agent is running' })
-                : indicatorStatus === 'unread'
-                  ? t('sidebar:sessions.unread', { defaultValue: 'Unread messages' })
-                  : t('sidebar:sessions.idle', { defaultValue: 'No unread messages' });
-
-            return (
-              <div
-                key={sessionId}
-                onContextMenu={(event) =>
-                  isOptimisticRow ? undefined : openSessionContextMenu(event, project, session)
-                }
-                className={cn(
-                  'group/session relative w-full rounded-md transition-colors',
-                  isSessionActive
-                    ? 'bg-neutral-200/70 dark:bg-neutral-800'
-                    : 'hover:bg-neutral-100 dark:hover:bg-neutral-800',
-                )}
-              >
-                {isSessionRenaming ? (
-                  <div className="flex items-center px-2 py-1">
-                    <input
-                      ref={renameInputRef}
-                      value={renameDraft}
-                      onChange={(event) => setRenameDraft(event.target.value)}
-                      onBlur={commitSessionRename}
-                      onKeyDown={(event) => handleRenameKey(event, 'session')}
-                      onClick={(event) => event.stopPropagation()}
-                      placeholder={t('sidebar:renamePlaceholder', { defaultValue: 'Rename - empty to reset' }) as string}
-                      className="w-full rounded-sm border border-neutral-300 bg-white px-1.5 py-0.5 text-[12.5px] text-neutral-900 outline-none focus:border-neutral-500 dark:border-neutral-600 dark:bg-neutral-900 dark:text-neutral-100"
-                    />
-                  </div>
-                ) : (
-                  <button
-                    type="button"
-                    onClick={
-                      isOptimisticRow
-                        ? undefined
-                        : () => handleSessionClick(project, sessionId)
-                    }
-                    disabled={isOptimisticRow}
-                    className={cn(
-                      'flex w-full items-start gap-2 px-2 py-1 text-left',
-                      isOptimisticRow && 'cursor-default',
-                    )}
-                  >
-                    <span className="flex h-[18px] w-3 shrink-0 items-center justify-center pt-[3px]">
-                      <SessionStatusIndicator
-                        status={indicatorStatus}
-                        label={indicatorLabel}
-                      />
-                    </span>
-                    <div className="min-w-0 flex-1">
-                      <div
-                        className={cn(
-                          'truncate text-[12.5px] text-neutral-900 dark:text-neutral-100',
-                          isOptimisticRow && 'italic text-neutral-600 dark:text-neutral-300',
-                        )}
-                      >
-                        {sessionDisplayTitle(session)}
-                      </div>
-                      <div className="text-[11px] text-neutral-500 dark:text-neutral-400">
-                        {isOptimisticRow
-                          ? t('sidebar:sessions.sending', { defaultValue: 'Sending…' })
-                          : formatRelative(lastActivity, t)}
-                      </div>
-                    </div>
-                  </button>
-                )}
-
-              </div>
-            );
-          })
+        {sessionTree.length > 0 ? (
+          sessionTree.map((node) => renderSessionTreeNode(node, 0, false))
         ) : (
           <div className="px-2 py-1 text-[11px] text-neutral-500 dark:text-neutral-400">
             {t('sidebar:sessions.noSessions', { defaultValue: 'No sessions yet' })}

--- a/ui/src/components/chat-v2/ChatInterfaceV2.tsx
+++ b/ui/src/components/chat-v2/ChatInterfaceV2.tsx
@@ -1,7 +1,10 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useTasksSettings } from '../../contexts/TasksSettingsContext';
+import { useToast } from '../../contexts/ToastContext';
+import { api } from '../../utils/api';
 import type { ChatInterfaceProps, ChatRunMode, Provider } from '../chat/types/types';
+import type { ChatMessage } from '../chat/types/types';
 import {
   getSessionRequestParams,
   isBackgroundTaskSession,
@@ -71,6 +74,8 @@ function ChatInterfaceV2({
   const pendingViewSessionRef = useRef<PendingViewSession | null>(null);
   const [isAbortPending, setIsAbortPending] = useState(false);
   const [runMode, setRunMode] = useState<ChatRunMode>('agent');
+  const [isForkPending, setIsForkPending] = useState(false);
+  const { addToast } = useToast();
 
   const resetStreamingState = useCallback(() => {
     if (streamTimerRef.current) {
@@ -311,6 +316,73 @@ function ChatInterfaceV2({
     setIsAbortPending(true);
   }, [canAbortSession, handleAbortSession, isAbortPending, isLoading]);
 
+  const handleFork = useCallback(async (message: ChatMessage, _carriedPreview: number) => {
+    if (isForkPending || isLoading || isReadOnlyBackgroundSession) return;
+    const sessionId = currentSessionId || selectedSession?.id;
+    const fromEntryId = message.entryId;
+    if (!sessionId || !fromEntryId || !selectedProject) {
+      addToast('error', t('fork.missingTarget', { defaultValue: 'Cannot fork this message.' }));
+      return;
+    }
+
+    const projectPath = selectedProject.fullPath || selectedProject.path || '';
+    setIsForkPending(true);
+    try {
+      const response = await api.forkSession(sessionId, { projectPath, fromEntryId });
+      let result: { newSessionId?: string; prefillText?: string; error?: string } = {};
+      try {
+        result = await response.json();
+      } catch {
+        result = {};
+      }
+      if (!response.ok) {
+        throw new Error(result?.error || `Fork failed (${response.status})`);
+      }
+      const newSessionId = result?.newSessionId;
+      if (!newSessionId) {
+        throw new Error('Fork did not return a new session id');
+      }
+
+      if (typeof window.refreshProjects === 'function') {
+        void window.refreshProjects();
+      }
+
+      onNavigateToSession?.(newSessionId);
+      setInput(result.prefillText || message.content || '');
+      requestAnimationFrame(() => {
+        textareaRef.current?.focus();
+        scrollToBottom?.();
+      });
+      // Messages load asynchronously after the session switch; scroll again
+      // once the carried history has had a chance to render.
+      setTimeout(() => scrollToBottom?.(), 400);
+      addToast(
+        'success',
+        t('fork.ready', {
+          defaultValue: 'Fork created — edit the prompt and send when ready.',
+        }),
+      );
+    } catch (error) {
+      const messageText = error instanceof Error ? error.message : String(error);
+      addToast('error', messageText || t('fork.failed', { defaultValue: 'Fork failed.' }));
+    } finally {
+      setIsForkPending(false);
+    }
+  }, [
+    addToast,
+    currentSessionId,
+    isForkPending,
+    isLoading,
+    isReadOnlyBackgroundSession,
+    onNavigateToSession,
+    scrollToBottom,
+    selectedProject,
+    selectedSession?.id,
+    setInput,
+    t,
+    textareaRef,
+  ]);
+
   useEffect(() => {
     if (!isLoading || !canAbortSession) return;
     const handleGlobalEscape = (event: KeyboardEvent) => {
@@ -481,6 +553,8 @@ function ChatInterfaceV2({
         workingStatus={claudeStatus || pilotDeckStatus}
         runMode={runMode}
         sessionStore={sessionStore}
+        onFork={isReadOnlyBackgroundSession ? undefined : handleFork}
+        forkDisabled={isForkPending}
       />
       {composer}
     </div>

--- a/ui/src/components/chat-v2/ChatInterfaceV2.tsx
+++ b/ui/src/components/chat-v2/ChatInterfaceV2.tsx
@@ -3,17 +3,17 @@ import { useTranslation } from 'react-i18next';
 import { useTasksSettings } from '../../contexts/TasksSettingsContext';
 import { useToast } from '../../contexts/ToastContext';
 import { api } from '../../utils/api';
-import type { ChatInterfaceProps, ChatRunMode, Provider } from '../chat/types/types';
-import type { ChatMessage } from '../chat/types/types';
+import type { ChatInterfaceProps, ChatMessage, ChatRunMode, Provider } from '../chat/types/types';
 import {
   getSessionRequestParams,
-  isBackgroundTaskSession,
+  isReadOnlySession,
 } from '../../types/app';
 import { useChatProviderState } from '../chat/hooks/useChatProviderState';
 import { useChatSessionState } from '../chat/hooks/useChatSessionState';
 import { useChatRealtimeHandlers } from '../chat/hooks/useChatRealtimeHandlers';
 import { useChatComposerState } from '../chat/hooks/useChatComposerState';
 import { useSessionStore } from '../../stores/useSessionStore';
+import { safeLocalStorage } from '../chat/utils/chatStorage';
 import MessagesPaneV2 from './MessagesPaneV2';
 import ComposerV2 from './ComposerV2';
 
@@ -61,7 +61,7 @@ function ChatInterfaceV2({
   const { t } = useTranslation('chat');
   const { tasksEnabled: _tasksEnabled, isTaskMasterInstalled: _isTaskMasterInstalled } =
     useTasksSettings();
-  const isReadOnlyBackgroundSession = isBackgroundTaskSession(selectedSession);
+  const sessionIsReadOnly = isReadOnlySession(selectedSession);
   const sessionRequestParams = React.useMemo(
     () => getSessionRequestParams(selectedSession),
     [selectedSession],
@@ -317,7 +317,7 @@ function ChatInterfaceV2({
   }, [canAbortSession, handleAbortSession, isAbortPending, isLoading]);
 
   const handleFork = useCallback(async (message: ChatMessage, _carriedPreview: number) => {
-    if (isForkPending || isLoading || isReadOnlyBackgroundSession) return;
+    if (isForkPending || isLoading || sessionIsReadOnly) return;
     const sessionId = currentSessionId || selectedSession?.id;
     const fromEntryId = message.entryId;
     if (!sessionId || !fromEntryId || !selectedProject) {
@@ -329,7 +329,7 @@ function ChatInterfaceV2({
     setIsForkPending(true);
     try {
       const response = await api.forkSession(sessionId, { projectPath, fromEntryId });
-      let result: { newSessionId?: string; prefillText?: string; error?: string } = {};
+      let result: { newSessionId?: string; prefillText?: string; mode?: string; error?: string } = {};
       try {
         result = await response.json();
       } catch {
@@ -342,13 +342,25 @@ function ChatInterfaceV2({
       if (!newSessionId) {
         throw new Error('Fork did not return a new session id');
       }
+      setRunMode(result.mode === 'plan' ? 'plan' : 'agent');
 
       if (typeof window.refreshProjects === 'function') {
-        void window.refreshProjects();
+        try {
+          await window.refreshProjects();
+        } catch {
+          // Keep the fork usable even if the sidebar refresh races/fails.
+        }
+      }
+
+      const forkDraft = result.prefillText || message.content || '';
+      if (forkDraft) {
+        safeLocalStorage.setItem(`draft_input_${selectedProject.name}`, forkDraft);
+      } else {
+        safeLocalStorage.removeItem(`draft_input_${selectedProject.name}`);
       }
 
       onNavigateToSession?.(newSessionId);
-      setInput(result.prefillText || message.content || '');
+      setInput(forkDraft);
       requestAnimationFrame(() => {
         textareaRef.current?.focus();
         scrollToBottom?.();
@@ -373,7 +385,7 @@ function ChatInterfaceV2({
     currentSessionId,
     isForkPending,
     isLoading,
-    isReadOnlyBackgroundSession,
+    sessionIsReadOnly,
     onNavigateToSession,
     scrollToBottom,
     selectedProject,
@@ -425,11 +437,11 @@ function ChatInterfaceV2({
 
   // The composer is identical in welcome / normal mode — just rendered in a
   // different parent container. Pulled out so we don't drift between the two.
-  const composer = isReadOnlyBackgroundSession ? (
+  const composer = sessionIsReadOnly ? (
     <div className="mx-auto w-full max-w-[720px] px-6 pb-6 pt-3">
       <div className="rounded-xl border border-neutral-200 bg-neutral-50 px-4 py-3 text-[13px] text-neutral-600 dark:border-neutral-800 dark:bg-neutral-900 dark:text-neutral-400">
-        {t('session.readonlyBackground', {
-          defaultValue: 'This background task transcript is read-only.',
+        {t('session.readonlyTranscript', {
+          defaultValue: 'This transcript is read-only.',
         })}
       </div>
     </div>
@@ -553,7 +565,7 @@ function ChatInterfaceV2({
         workingStatus={claudeStatus || pilotDeckStatus}
         runMode={runMode}
         sessionStore={sessionStore}
-        onFork={isReadOnlyBackgroundSession ? undefined : handleFork}
+        onFork={sessionIsReadOnly ? undefined : handleFork}
         forkDisabled={isForkPending}
       />
       {composer}

--- a/ui/src/components/chat-v2/MessageRowV2.tsx
+++ b/ui/src/components/chat-v2/MessageRowV2.tsx
@@ -1,8 +1,9 @@
 import { memo, useMemo, useRef, useState, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { TFunction } from 'i18next';
-import { AlertTriangle, Check, ChevronRight, Copy, FileText, Loader2 } from 'lucide-react';
+import { AlertTriangle, Check, ChevronRight, Copy, FileText, GitBranch, Loader2 } from 'lucide-react';
 import { copyTextToClipboard } from '../../utils/clipboard';
+import { cn } from '../../lib/utils.js';
 import { useTypewriter } from './useTypewriter';
 import type { Project, SessionProvider } from '../../types/app';
 import type {
@@ -82,6 +83,9 @@ type MessageRowV2Props = {
   subagentActivityById?: Map<string, ChatMessage>;
   subagentThinkingById?: Map<string, string>;
   isSessionRunning?: boolean;
+  onFork?: (message: ChatMessage, carriedMessageCount: number) => void;
+  forkCarriedMessageCount?: number;
+  forkDisabled?: boolean;
 };
 
 // Fall back to the heavy legacy renderer for anything that isn't a vanilla
@@ -120,6 +124,9 @@ function MessageRowV2({
   subagentActivityById,
   subagentThinkingById,
   isSessionRunning,
+  onFork,
+  forkCarriedMessageCount = 0,
+  forkDisabled = false,
 }: MessageRowV2Props) {
   const { t } = useTranslation('chat');
   const delegate = useMemo(() => shouldDelegate(message), [message]);
@@ -243,7 +250,17 @@ function MessageRowV2({
       mimeType: image.mimeType,
     }));
     return withProcessRows(
-      <div className="flex w-full justify-end">
+      <div className="group/user-msg flex w-full items-end justify-end gap-1.5">
+        {onFork ? (
+          <ForkMessageButton
+            carriedMessageCount={forkCarriedMessageCount}
+            disabled={forkDisabled || isSessionRunning || !message.entryId}
+            onFork={() => {
+              if (message.entryId) onFork(message, forkCarriedMessageCount);
+            }}
+            t={t}
+          />
+        ) : null}
         <div className="min-w-0 max-w-[78%] overflow-hidden rounded-[22px] bg-neutral-100 px-4 py-2.5 text-[14px] leading-relaxed text-neutral-900 dark:bg-neutral-800 dark:text-neutral-100">
           {message.isStreaming && !formattedContent ? (
             <span className="inline-block h-4 w-2 animate-pulse bg-neutral-400 dark:bg-neutral-500" />
@@ -417,6 +434,42 @@ function CopyMarkdownButton({ content }: { content: string }) {
       title={copied ? 'Copied' : 'Copy'}
     >
       {copied ? <Check className="h-3.5 w-3.5" strokeWidth={2} /> : <Copy className="h-3.5 w-3.5" strokeWidth={2} />}
+    </button>
+  );
+}
+
+function ForkMessageButton({
+  carriedMessageCount,
+  disabled,
+  onFork,
+  t,
+}: {
+  carriedMessageCount: number;
+  disabled?: boolean;
+  onFork: () => void;
+  t: TFunction;
+}) {
+  const title = t('fork.fromHere', {
+    count: carriedMessageCount,
+    defaultValue: `Fork from here · carries ${carriedMessageCount} messages`,
+  });
+
+  return (
+    <button
+      type="button"
+      onClick={onFork}
+      disabled={disabled}
+      className={cn(
+        'mb-1 rounded-md p-1.5 text-neutral-400 opacity-0 transition-all',
+        'group-hover/user-msg:opacity-100 focus-visible:opacity-100',
+        disabled
+          ? 'cursor-not-allowed opacity-30'
+          : 'hover:bg-neutral-200/80 hover:text-neutral-700 dark:hover:bg-neutral-700 dark:hover:text-neutral-200',
+      )}
+      aria-label={title}
+      title={title}
+    >
+      <GitBranch className="h-3.5 w-3.5" strokeWidth={2} />
     </button>
   );
 }

--- a/ui/src/components/chat-v2/MessageRowV2.tsx
+++ b/ui/src/components/chat-v2/MessageRowV2.tsx
@@ -151,6 +151,11 @@ function MessageRowV2({
         : [],
     [message.attachments],
   );
+  const [userImageLightbox, setUserImageLightbox] = useState<number | null>(null);
+  const hasForkUnsupportedContent =
+    Boolean(message.forkUnsupportedContent) ||
+    messageImages.length > 0 ||
+    messageAttachments.length > 0;
 
   if (message.isAgentActivitySummary) {
     return (
@@ -240,7 +245,6 @@ function MessageRowV2({
 
   const isUser = message.type === 'user';
   const isError = message.type === 'error';
-  const [userImageLightbox, setUserImageLightbox] = useState<number | null>(null);
 
   // User: right-aligned grey bubble.
   if (isUser) {
@@ -254,9 +258,14 @@ function MessageRowV2({
         {onFork ? (
           <ForkMessageButton
             carriedMessageCount={forkCarriedMessageCount}
-            disabled={forkDisabled || isSessionRunning || !message.entryId}
+            disabled={forkDisabled || isSessionRunning || !message.entryId || hasForkUnsupportedContent}
+            disabledReason={hasForkUnsupportedContent
+              ? String(message.forkUnsupportedReason || t('fork.unsupportedAttachments', {
+                  defaultValue: 'Forking messages with attachments or media is not supported yet',
+                }))
+              : undefined}
             onFork={() => {
-              if (message.entryId) onFork(message, forkCarriedMessageCount);
+              if (message.entryId && !hasForkUnsupportedContent) onFork(message, forkCarriedMessageCount);
             }}
             t={t}
           />
@@ -441,15 +450,17 @@ function CopyMarkdownButton({ content }: { content: string }) {
 function ForkMessageButton({
   carriedMessageCount,
   disabled,
+  disabledReason,
   onFork,
   t,
 }: {
   carriedMessageCount: number;
   disabled?: boolean;
+  disabledReason?: string;
   onFork: () => void;
   t: TFunction;
 }) {
-  const title = t('fork.fromHere', {
+  const title = disabledReason ?? t('fork.fromHere', {
     count: carriedMessageCount,
     defaultValue: `Fork from here · carries ${carriedMessageCount} messages`,
   });

--- a/ui/src/components/chat-v2/MessagesPaneV2.tsx
+++ b/ui/src/components/chat-v2/MessagesPaneV2.tsx
@@ -1,7 +1,7 @@
 import { Fragment, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import type { Dispatch, ReactNode, RefObject, SetStateAction } from 'react';
 import { useTranslation } from 'react-i18next';
-import { XCircle } from 'lucide-react';
+import { XCircle, GitBranch } from 'lucide-react';
 import type {
   ChatMessage,
   ChatRunMode,
@@ -66,6 +66,9 @@ type MessagesPaneV2Props = {
   workingStatus?: ClaudeWorkStatus | PilotDeckWorkStatus | null;
   runMode?: ChatRunMode;
   sessionStore?: SessionStore;
+  onFork?: (message: ChatMessage, carriedMessageCount: number) => void;
+  forkDisabled?: boolean;
+  forkParentSessionTitle?: string | null;
 };
 
 type KeyedRenderableMessageItem = RenderableMessageItem & {
@@ -232,6 +235,23 @@ function MeasuredMessageItem({
   );
 }
 
+function countCarriedMessagesBefore(
+  items: KeyedRenderableMessageItem[],
+  renderIndex: number,
+): number {
+  return items
+    .slice(0, renderIndex)
+    .filter(({ message }) => message.type === 'user' || message.type === 'assistant' || message.isToolUse)
+    .length;
+}
+
+function isForkedChatSession(session: ProjectSession | null): boolean {
+  return Boolean(
+    session?.parentSessionId &&
+    session.sessionKind !== 'background_task',
+  );
+}
+
 export default function MessagesPaneV2({
   scrollContainerRef,
   onWheel,
@@ -266,6 +286,9 @@ export default function MessagesPaneV2({
   workingStatus,
   runMode = 'agent',
   sessionStore,
+  onFork,
+  forkDisabled = false,
+  forkParentSessionTitle = null,
 }: MessagesPaneV2Props) {
   const { t } = useTranslation('chat');
   const messageKeyMapRef = useRef<WeakMap<ChatMessage, string>>(new WeakMap());
@@ -711,6 +734,9 @@ export default function MessagesPaneV2({
       ? keyedMessageItems[item.renderIndex + 1].message
       : null;
     const isLast = !isAssistantWorking && item.renderIndex === keyedMessageItems.length - 1;
+    const forkCarriedMessageCount = item.message.type === 'user'
+      ? countCarriedMessagesBefore(keyedMessageItems, item.renderIndex)
+      : 0;
     const anchoredLiveGroups = liveProcessGroupsByAnchor.get(item.originalIndex) || [];
     const rendersLiveHeaderAfterItem = item.renderIndex === liveProcessHeaderIndex - 1;
 
@@ -758,6 +784,9 @@ export default function MessagesPaneV2({
             subagentActivityById={subagentActivityById}
             subagentThinkingById={subagentThinkingById}
             isSessionRunning={isAssistantWorking}
+            onFork={onFork}
+            forkCarriedMessageCount={forkCarriedMessageCount}
+            forkDisabled={forkDisabled}
           />
           {rendersLiveHeaderAfterItem ? (
             <LiveProcessHeader
@@ -795,6 +824,8 @@ export default function MessagesPaneV2({
     liveProcessHeaderIndex,
     liveProcessStartedAtMs,
     onFileOpen,
+    onFork,
+    forkDisabled,
     onGrantSessionToolPermission,
     onShowSettings,
     provider,
@@ -803,6 +834,7 @@ export default function MessagesPaneV2({
     showRawParameters,
     showThinking,
     subagentActivityById,
+    subagentThinkingById,
     t,
   ]);
 
@@ -860,6 +892,22 @@ export default function MessagesPaneV2({
               ))}
             </div>
           ) : null}
+        </div>
+      ) : isExistingConversationEmpty && isForkedChatSession(selectedSession) ? (
+        <div className="mx-auto flex h-full max-w-[720px] flex-col items-center justify-center gap-3 px-6 py-10 text-center">
+          <div className="flex h-10 w-10 items-center justify-center rounded-full bg-neutral-100 dark:bg-neutral-800">
+            <GitBranch className="h-5 w-5 text-neutral-500 dark:text-neutral-400" strokeWidth={2} />
+          </div>
+          <div className="text-[15px] font-medium text-neutral-900 dark:text-neutral-100">
+            {t('fork.emptyTitle', { defaultValue: 'New branch ready' })}
+          </div>
+          <div className="max-w-[520px] text-[13px] leading-5 text-neutral-500 dark:text-neutral-400">
+            {t('fork.emptyDescription', {
+              parent: forkParentSessionTitle || selectedSession?.parentSessionId || '',
+              defaultValue:
+                'This branch starts from the beginning of the original conversation. The forked prompt is waiting in the composer — edit it and send to continue here.',
+            })}
+          </div>
         </div>
       ) : isExistingConversationEmpty ? (
         <div className="mx-auto flex h-full max-w-[720px] flex-col items-center justify-center gap-2 px-6 py-10 text-center">
@@ -932,6 +980,18 @@ export default function MessagesPaneV2({
               >
                 {t('messages.loadAll', { defaultValue: 'Load all' })}
               </button>
+            </div>
+          ) : null}
+
+          {isForkedChatSession(selectedSession) ? (
+            <div className="mb-6 flex items-center gap-2 rounded-xl border border-neutral-200 bg-neutral-50 px-3 py-2 text-[12px] text-neutral-600 dark:border-neutral-800 dark:bg-neutral-900/60 dark:text-neutral-300">
+              <GitBranch className="h-3.5 w-3.5 shrink-0" strokeWidth={2} />
+              <span>
+                {t('fork.banner', {
+                  parent: forkParentSessionTitle || selectedSession?.parentSessionId || '',
+                  defaultValue: `Forked from ${forkParentSessionTitle || selectedSession?.parentSessionId || 'parent session'}`,
+                })}
+              </span>
             </div>
           ) : null}
 

--- a/ui/src/components/chat-v2/MessagesPaneV2.tsx
+++ b/ui/src/components/chat-v2/MessagesPaneV2.tsx
@@ -11,7 +11,7 @@ import type {
   PermissionGrantResult,
 } from '../chat/types/types';
 import type { SessionStore } from '../../stores/useSessionStore';
-import { isBackgroundTaskSession, type Project, type ProjectSession, type SessionProvider } from '../../types/app';
+import { getSessionRequestParams, isReadOnlySession, type Project, type ProjectSession, type SessionProvider } from '../../types/app';
 import { getIntrinsicMessageKey } from '../chat/utils/messageKeys';
 import MessageRowV2 from './MessageRowV2';
 import SubagentDetailModal from './SubagentDetailModal';
@@ -236,19 +236,19 @@ function MeasuredMessageItem({
 }
 
 function countCarriedMessagesBefore(
-  items: KeyedRenderableMessageItem[],
-  renderIndex: number,
+  messages: ChatMessage[],
+  originalIndex: number,
 ): number {
-  return items
-    .slice(0, renderIndex)
-    .filter(({ message }) => message.type === 'user' || message.type === 'assistant' || message.isToolUse)
+  return messages
+    .slice(0, originalIndex)
+    .filter((message) => message.type === 'user' || message.type === 'assistant' || message.isToolUse)
     .length;
 }
 
 function isForkedChatSession(session: ProjectSession | null): boolean {
   return Boolean(
     session?.parentSessionId &&
-    session.sessionKind !== 'background_task',
+    !isReadOnlySession(session),
   );
 }
 
@@ -305,7 +305,7 @@ export default function MessagesPaneV2({
   }, []);
 
   const sessionId = selectedSession?.id ?? null;
-  const projectPath = selectedProject?.fullPath ?? undefined;
+  const projectPath = selectedProject?.fullPath || selectedProject?.path || undefined;
 
   const getMessageKey = useCallback((message: ChatMessage, index: number) => {
     const existingKey = messageKeyMapRef.current.get(message);
@@ -354,7 +354,7 @@ export default function MessagesPaneV2({
   const hasSessionLoadError = Boolean(!isLoadingSessionMessages && sessionLoadError && chatMessages.length === 0);
   const isNewConversationEmpty = isEmpty && !selectedSession;
   const isExistingConversationEmpty = isEmpty && Boolean(selectedSession) && !hasSessionLoadError;
-  const isReadOnlyBackgroundSession = isBackgroundTaskSession(selectedSession);
+  const sessionIsReadOnly = isReadOnlySession(selectedSession);
   const liveActivities = useMemo(
     () => activityMessages.filter((message) => message.isAgentActivity),
     [activityMessages],
@@ -414,12 +414,17 @@ export default function MessagesPaneV2({
     openSubagentActivity &&
       !['completed', 'failed', 'cancelled'].includes(String(openSubagentActivity.state || '')),
   );
+  const sessionRequestParams = useMemo(
+    () => getSessionRequestParams(selectedSession),
+    [selectedSession],
+  );
   const subagentDetail = useSubagentMessages(
     openSubagentId ? sessionId : null,
     openSubagentId,
     projectPath,
     sessionStore,
     openSubagentActivity?.state,
+    sessionRequestParams,
   );
   const renderableMessages = useMemo(
     () => {
@@ -735,7 +740,7 @@ export default function MessagesPaneV2({
       : null;
     const isLast = !isAssistantWorking && item.renderIndex === keyedMessageItems.length - 1;
     const forkCarriedMessageCount = item.message.type === 'user'
-      ? countCarriedMessagesBefore(keyedMessageItems, item.renderIndex)
+      ? countCarriedMessagesBefore(renderableMessages, item.originalIndex)
       : 0;
     const anchoredLiveGroups = liveProcessGroupsByAnchor.get(item.originalIndex) || [];
     const rendersLiveHeaderAfterItem = item.renderIndex === liveProcessHeaderIndex - 1;
@@ -819,6 +824,7 @@ export default function MessagesPaneV2({
     isProcessExpanded,
     isAssistantWorking,
     keyedMessageItems,
+    renderableMessages,
     nonSubagentLiveActivities,
     liveProcessGroupsByAnchor,
     liveProcessHeaderIndex,
@@ -912,19 +918,19 @@ export default function MessagesPaneV2({
       ) : isExistingConversationEmpty ? (
         <div className="mx-auto flex h-full max-w-[720px] flex-col items-center justify-center gap-2 px-6 py-10 text-center">
           <div className="text-[15px] font-medium text-neutral-900 dark:text-neutral-100">
-            {isReadOnlyBackgroundSession
-              ? t('emptyChat.readonlyBackgroundTitle', {
-                  defaultValue: 'No displayable messages in this task transcript',
+            {sessionIsReadOnly
+              ? t('emptyChat.readonlyTranscriptTitle', {
+                  defaultValue: 'No displayable messages in this read-only transcript',
                 })
               : t('emptyChat.emptySessionTitle', {
                   defaultValue: 'No displayable messages in this conversation',
                 })}
           </div>
           <div className="max-w-[520px] text-[13px] leading-5 text-neutral-500 dark:text-neutral-400">
-            {isReadOnlyBackgroundSession
-              ? t('emptyChat.readonlyBackgroundDescription', {
+            {sessionIsReadOnly
+              ? t('emptyChat.readonlyTranscriptDescription', {
                   defaultValue:
-                    'This read-only background task transcript only contains records the chat view cannot display.',
+                    'This read-only transcript only contains records the chat view cannot display.',
                 })
               : t('emptyChat.emptySessionDescription', {
                   defaultValue:

--- a/ui/src/components/chat-v2/useSubagentMessages.ts
+++ b/ui/src/components/chat-v2/useSubagentMessages.ts
@@ -2,6 +2,10 @@ import { useEffect, useMemo, useState, useRef } from 'react';
 import type { ChatMessage } from '../chat/types/types';
 import { normalizedToChatMessages } from '../chat/hooks/useChatMessages';
 import type { NormalizedMessage, SessionStore } from '../../stores/useSessionStore';
+import type { SessionRequestParams } from '../../types/app';
+import { authenticatedFetch } from '../../utils/api';
+
+const EMPTY_NORMALIZED_MESSAGES: NormalizedMessage[] = [];
 
 interface SubagentMessagesResult {
   messages: ChatMessage[];
@@ -73,14 +77,16 @@ export function useSubagentMessages(
   projectPath?: string,
   sessionStore?: SessionStore,
   refreshKey?: string,
+  sessionRequestParams: SessionRequestParams = {},
 ): SubagentMessagesResult {
   const [snapshotMessages, setSnapshotMessages] = useState<NormalizedMessage[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const abortRef = useRef<AbortController | null>(null);
+  const { sessionKind, parentSessionId, relativeTranscriptPath } = sessionRequestParams;
   const realtimeMessages = sessionId && subagentId
-    ? sessionStore?.getSubagentDetailMessages?.(sessionId, subagentId) ?? []
-    : [];
+    ? sessionStore?.getSubagentDetailMessages?.(sessionId, subagentId) ?? EMPTY_NORMALIZED_MESSAGES
+    : EMPTY_NORMALIZED_MESSAGES;
   const useSnapshotOnly = refreshKey === 'completed' || refreshKey === 'failed';
   const messages = useMemo(() => {
     const normalized = mergeSubagentDetailMessages(snapshotMessages, realtimeMessages, useSnapshotOnly);
@@ -106,10 +112,19 @@ export function useSubagentMessages(
 
     const params = new URLSearchParams();
     if (projectPath) params.set('projectPath', projectPath);
-    const url = `/api/sessions/${encodeURIComponent(sessionId)}/subagent/${encodeURIComponent(subagentId)}/messages?${params}`;
+    if (sessionKind) params.set('sessionKind', sessionKind);
+    if (parentSessionId) params.set('parentSessionId', parentSessionId);
+    if (relativeTranscriptPath) params.set('relativeTranscriptPath', relativeTranscriptPath);
+    const query = params.toString();
+    const url = `/api/sessions/${encodeURIComponent(sessionId)}/subagent/${encodeURIComponent(subagentId)}/messages${query ? `?${query}` : ''}`;
 
-    fetch(url, { signal: controller.signal })
-      .then((res) => res.json())
+    authenticatedFetch(url, { signal: controller.signal })
+      .then((res) => {
+        if (!res.ok) {
+          throw new Error(`HTTP ${res.status}`);
+        }
+        return res.json();
+      })
       .then((data) => {
         if (controller.signal.aborted) return;
         const normalized = Array.isArray(data.messages) ? data.messages : [];
@@ -123,7 +138,7 @@ export function useSubagentMessages(
       });
 
     return () => controller.abort();
-  }, [sessionId, subagentId, projectPath, refreshKey]);
+  }, [sessionId, subagentId, projectPath, refreshKey, sessionKind, parentSessionId, relativeTranscriptPath]);
 
   return { messages, isLoading, error };
 }

--- a/ui/src/components/chat/hooks/useChatMessages.ts
+++ b/ui/src/components/chat/hooks/useChatMessages.ts
@@ -43,6 +43,7 @@ function convertSingleMessage(
         if (!content.trim() && userAttachments.length === 0 && (!userImages || userImages.length === 0)) return null;
         return {
           id: msg.id,
+          entryId: msg.entryId,
           type: 'user',
           content: unescapeWithMathProtection(decodeHtmlEntities(content)),
           timestamp: msg.timestamp,

--- a/ui/src/components/chat/hooks/useChatMessages.ts
+++ b/ui/src/components/chat/hooks/useChatMessages.ts
@@ -47,6 +47,10 @@ function convertSingleMessage(
           type: 'user',
           content: unescapeWithMathProtection(decodeHtmlEntities(content)),
           timestamp: msg.timestamp,
+          ...(msg.forkUnsupportedContent ? {
+            forkUnsupportedContent: true,
+            forkUnsupportedReason: msg.forkUnsupportedReason,
+          } : {}),
           ...(userImages && userImages.length > 0 ? { images: userImages } : {}),
           ...(userAttachments.length > 0 ? { attachments: userAttachments } : {}),
         };

--- a/ui/src/components/chat/hooks/useChatSessionState.ts
+++ b/ui/src/components/chat/hooks/useChatSessionState.ts
@@ -4,7 +4,7 @@ import { authenticatedFetch } from '../../../utils/api';
 import type { ChatMessage, ClaudeWorkStatus, PilotDeckWorkStatus } from '../types/types';
 import {
   getSessionRequestParams,
-  isBackgroundTaskSession,
+  isReadOnlySession,
   type Project,
   type ProjectSession,
   type SessionProvider,
@@ -323,7 +323,7 @@ export function useChatSessionState({
   }
 
   const activeSessionId = selSid ?? effectiveCurrentRef.current;
-  const isReadOnlyBackgroundSession = isBackgroundTaskSession(selectedSession);
+  const sessionIsReadOnly = isReadOnlySession(selectedSession);
   const sessionRequestParams = useMemo(
     () => getSessionRequestParams(selectedSession),
     [selectedSession],
@@ -597,7 +597,15 @@ export function useChatSessionState({
     }
 
     const provider = 'pilotdeck';
-    const sessionKey = `${selectedSession.id}:${selectedProject.name}:${provider}`;
+    const sessionKey = JSON.stringify([
+      selectedSession.id,
+      selectedProject.name,
+      provider,
+      sessionRequestParams.sessionKind ?? '',
+      sessionRequestParams.parentSessionId ?? '',
+      sessionRequestParams.relativeTranscriptPath ?? '',
+      sessionIsReadOnly ? 'readonly' : 'readwrite',
+    ]);
 
     // Skip if already loaded and fresh, or if stale but has live realtime
     // content (re-fetching while streaming would prune in-flight messages).
@@ -645,7 +653,7 @@ export function useChatSessionState({
     setSessionLoadError(null);
 
     // Check session status
-    if (ws && !isReadOnlyBackgroundSession) {
+    if (ws && !sessionIsReadOnly) {
       sendMessage({ type: 'check-session-status', sessionId: selectedSession.id, provider });
     }
 
@@ -691,7 +699,7 @@ export function useChatSessionState({
     selectedSession,
     sendMessage,
     ws,
-    isReadOnlyBackgroundSession,
+    sessionIsReadOnly,
     sessionRequestParams,
     sessionStore,
   ]);
@@ -839,7 +847,7 @@ export function useChatSessionState({
       setTokenBudget(null);
       return;
     }
-    if (isReadOnlyBackgroundSession) {
+    if (sessionIsReadOnly) {
       setTokenBudget(null);
       return;
     }
@@ -858,7 +866,7 @@ export function useChatSessionState({
       }
     };
     fetchInitialTokenUsage();
-  }, [isReadOnlyBackgroundSession, selectedProject, selectedSession?.id]);
+  }, [sessionIsReadOnly, selectedProject, selectedSession?.id]);
 
   const visibleMessages = useMemo(() => {
     if (chatMessages.length <= visibleMessageCount) return chatMessages;
@@ -912,13 +920,14 @@ export function useChatSessionState({
     const pendingSessionId = pendingViewSessionRef.current?.sessionId ?? null;
     const activeViewSessionId =
       selectedSession?.id || (pendingSessionId === currentSessionId ? currentSessionId : null);
+    if (sessionIsReadOnly) return;
     if (!activeViewSessionId || !processingSessions) return;
     const shouldBeProcessing = processingSessions.has(activeViewSessionId);
     if (shouldBeProcessing && !isLoading) {
       setIsLoading(true);
       setCanAbortSession(true);
     }
-  }, [currentSessionId, isLoading, pendingViewSessionRef, processingSessions, selectedSession?.id]);
+  }, [currentSessionId, isLoading, pendingViewSessionRef, processingSessions, selectedSession?.id, sessionIsReadOnly]);
 
   // "Load all" overlay
   const prevLoadingRef = useRef(false);

--- a/ui/src/components/chat/types/types.ts
+++ b/ui/src/components/chat/types/types.ts
@@ -54,6 +54,7 @@ export interface SubagentChildTool {
 
 export interface ChatMessage {
   id?: string;
+  entryId?: string;
   type: string;
   content?: string;
   timestamp: string | number | Date;

--- a/ui/src/components/main-content/view/MainContent.tsx
+++ b/ui/src/components/main-content/view/MainContent.tsx
@@ -206,6 +206,7 @@ function MainContent({
 
       const fallbackSession: ProjectSession = {
         ...existingSession,
+        isReadOnly: true,
         __projectName: lookupProjectName,
       };
 

--- a/ui/src/hooks/useProjectsState.ts
+++ b/ui/src/hooks/useProjectsState.ts
@@ -28,6 +28,34 @@ const SESSION_PAGE_SIZE = 30;
 
 const serialize = (value: unknown) => JSON.stringify(value ?? null);
 
+function preserveSelectedSessionViewState(
+  updatedSession: ProjectSession,
+  selectedSession: ProjectSession,
+): ProjectSession {
+  const viewState: Partial<ProjectSession> = {};
+  const preserveKeys: Array<keyof ProjectSession> = [
+    'sessionKind',
+    'parentSessionId',
+    'relativeTranscriptPath',
+    'transcriptKey',
+    'taskId',
+    'taskStatus',
+    'outputFile',
+    'isReadOnly',
+    '__projectName',
+  ];
+
+  for (const key of preserveKeys) {
+    if (selectedSession[key] !== undefined) {
+      (viewState as Record<string, unknown>)[key] = selectedSession[key];
+    }
+  }
+
+  return Object.keys(viewState).length > 0
+    ? { ...updatedSession, ...viewState }
+    : updatedSession;
+}
+
 export const projectsHaveChanges = (
   prevProjects: Project[],
   nextProjects: Project[],
@@ -449,7 +477,10 @@ export function useProjectsState({
       return;
     }
 
-    const normalizedUpdatedSelectedSession = updatedSelectedSession;
+    const normalizedUpdatedSelectedSession = preserveSelectedSessionViewState(
+      updatedSelectedSession,
+      selectedSession,
+    );
 
     if (serialize(normalizedUpdatedSelectedSession) !== serialize(selectedSession)) {
       setSelectedSession(normalizedUpdatedSelectedSession);

--- a/ui/src/stores/useSessionStore.ts
+++ b/ui/src/stores/useSessionStore.ts
@@ -130,6 +130,8 @@ export interface NormalizedMessage {
   // Cursor-specific ordering
   sequence?: number;
   rowid?: number;
+  /** Transcript entry id for history fork targeting. */
+  entryId?: string;
   // Streaming-only: id of slot.serverMessages tail at the moment the
   // streaming row was created. computeMerged uses this for an id-based
   // same-turn-snapshot test instead of a timestamp window.

--- a/ui/src/stores/useSessionStore.ts
+++ b/ui/src/stores/useSessionStore.ts
@@ -132,6 +132,9 @@ export interface NormalizedMessage {
   rowid?: number;
   /** Transcript entry id for history fork targeting. */
   entryId?: string;
+  /** True when the corresponding transcript entry has non-text prefill content. */
+  forkUnsupportedContent?: boolean;
+  forkUnsupportedReason?: string;
   // Streaming-only: id of slot.serverMessages tail at the moment the
   // streaming row was created. computeMerged uses this for an id-based
   // same-turn-snapshot test instead of a timestamp window.

--- a/ui/src/types/app.ts
+++ b/ui/src/types/app.ts
@@ -210,6 +210,12 @@ export function isBackgroundTaskSession(
   );
 }
 
+export function isReadOnlySession(
+  session: ProjectSession | null | undefined,
+): boolean {
+  return session?.isReadOnly === true || isBackgroundTaskSession(session);
+}
+
 export function getSessionRequestParams(
   session: ProjectSession | null | undefined,
 ): SessionRequestParams {

--- a/ui/src/utils/api.js
+++ b/ui/src/utils/api.js
@@ -154,6 +154,11 @@ export const api = {
       method: 'PUT',
       body: JSON.stringify({ summary, provider }),
     }),
+  forkSession: (sessionId, { projectPath, fromEntryId }) =>
+    authenticatedFetch(`/api/sessions/${encodeURIComponent(sessionId)}/fork`, {
+      method: 'POST',
+      body: JSON.stringify({ projectPath, fromEntryId }),
+    }),
   deleteProject: (projectName, force = false) =>
     authenticatedFetch(`/api/projects/${projectName}${force ? '?force=true' : ''}`, {
       method: 'DELETE',


### PR DESCRIPTION
## Summary
- 为对话新增 **History Fork（历史分叉）**：可从任意一条历史用户消息分叉出新会话，新会话携带分叉点之前的完整历史，并把被分叉的那条消息预填进输入框供编辑后重新发送。
- 网关层新增 `fork_session` RPC（protocol 类型 / InProcess + Remote 客户端 / ws dispatch / 本地网关实现）。
- 服务端 `forkSession` 在分叉 turn 处截断源 transcript，写入带分叉谱系 metadata 的新会话 jsonl，复制 `tool-results`/`file-history` 辅助目录，并返回预填文本与携带消息数。
- 会话持久化 `parentSessionId`/`forkedFromTurnId`，侧栏据此渲染分叉谱系树。
- 前端：用户消息 hover 出现 Fork 按钮；分叉后自动进入新会话、预填并聚焦输入框、滚动到底；分叉标题以 `⑂ <分叉点消息>` 命名增强区分度；对无携带历史的分支提供友好空态。

## Changes
- gateway: `protocol/types.ts`, `protocol/frames.ts`, `client/InProcessGateway.ts`, `client/RemoteGateway.ts`, `server/GatewayWsConnection.ts`, `cli/createLocalGateway.ts`, `cli/pilotdeck.ts`
- server: `web/server/forkSession.ts`（新增）, `web/server/readSessionMessages.ts`, `web/client/protocol.ts`, `web/client/webMessage.ts`
- session lineage: `session/transcript/TranscriptEntry.ts`, `session/storage/SessionList.ts`
- ui-server: `ui/server/routes/messages.js`（`POST /api/sessions/:id/fork`）, `ui/server/projects.js`
- ui: `ChatInterfaceV2.tsx`, `MessageRowV2.tsx`, `MessagesPaneV2.tsx`, `SidebarV2.tsx`, `useChatMessages.ts`, `types.ts`, `useSessionStore.ts`, `api.js`
- tests: `tests/web/forkSession.test.ts`, `ui/e2e/history-fork.spec.mjs`

## Test plan
- [x] 单元测试 `tests/web/forkSession.test.ts` 通过
- [x] API 端到端：从多轮会话第二个 turn 分叉，返回 `newSessionId`、`prefillText`、`carriedMessageCount`；新 transcript 携带完整历史、谱系 metadata 正确、标题为 `⑂ <消息>`
- [x] 浏览器实测（vite）：点击 Fork → 自动进入新会话、输入框预填并聚焦、携带历史渲染并滚动到底、侧栏出现带 `⑂` 的分叉条目、无 "Fork did not return a new session id" 报错
- [x] reviewer 复核

Made with [Cursor](https://cursor.com)