### PR TITLE
fix: include assistant tool call content

### DIFF
--- a/src/model/providers/openai/request.ts
+++ b/src/model/providers/openai/request.ts
@@ -139,7 +139,7 @@ function toOpenAIMessages(message: CanonicalMessage, messageIndex: number): Open
       role: message.role,
       content: normalContent.length > 0
         ? toOpenAIContent(normalContent)
-        : (message.role === "assistant" && thinkingBlocks.length > 0 ? "" : undefined),
+        : (message.role === "assistant" && (assistantToolCalls.length > 0 || thinkingBlocks.length > 0) ? "" : undefined),
       tool_calls: assistantToolCalls.length > 0 ? assistantToolCalls : undefined,
     };
     // DeepSeek V4 requires reasoning_content to be passed back on assistant

--- a/tests/model/providers/openai/request.test.ts
+++ b/tests/model/providers/openai/request.test.ts
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { DEFAULT_MODEL_CAPABILITIES } from "../../../../src/model/protocol/capabilities.js";
+import { DEFAULT_MULTIMODAL_CONSTRAINTS } from "../../../../src/model/protocol/multimodal.js";
+import { buildOpenAIRequest } from "../../../../src/model/providers/openai/request.js";
+import type { ModelDefinition } from "../../../../src/model/protocol/canonical.js";
+
+const model: ModelDefinition = {
+  id: "test-model",
+  capabilities: DEFAULT_MODEL_CAPABILITIES,
+  multimodal: DEFAULT_MULTIMODAL_CONSTRAINTS,
+};
+
+test("OpenAI assistant tool-call messages include empty content when no text is present", () => {
+  const body = buildOpenAIRequest({
+    provider: "openai",
+    model: "test-model",
+    stream: true,
+    messages: [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool_call",
+            id: "call_123",
+            name: "lookup",
+            input: { q: "pilotdeck" },
+          },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            toolCallId: "call_123",
+            content: [{ type: "text", text: "ok" }],
+          },
+        ],
+      },
+    ],
+  }, model);
+
+  assert.equal(body.messages[0]?.role, "assistant");
+  assert.equal(body.messages[0]?.content, "");
+  assert.equal(Array.isArray(body.messages[0]?.tool_calls), true);
+});


### PR DESCRIPTION
## Summary
- Ensure OpenAI assistant messages with tool_calls include content, defaulting to an empty string when no text is present.
- Add a focused OpenAI request serialization regression test.

Closes #263

## Tests
- npx tsc -p tsconfig.json --noEmit
- node --import tsx --test tests/model/providers/openai/request.test.ts