### PR TITLE
fix: pass noProxy during startup

### DIFF
--- a/src/cli/pilotdeck.ts
+++ b/src/cli/pilotdeck.ts
@@ -34,7 +34,7 @@ async function main(argv = process.argv.slice(2)): Promise<void> {
     // Apply proxy from config (env-based proxy from top-level installGlobalProxy
     // takes precedence; this fills in when only pilotdeck.yaml has a proxy).
     if (snapshot.config.proxy?.url) {
-      await installGlobalProxy(snapshot.config.proxy.url);
+      await installGlobalProxy(snapshot.config.proxy.url, snapshot.config.proxy.noProxy);
     }
 
     let alwaysOn: AlwaysOnManager | undefined;

--- a/ui/server/services/pilotdeckConfig.js
+++ b/ui/server/services/pilotdeckConfig.js
@@ -325,6 +325,11 @@ export function buildRuntimeEnv(config) {
     env.HTTPS_PROXY = proxyUrl;
     env.https_proxy = proxyUrl;
   }
+  const noProxy = typeof normalized.proxy?.noProxy === 'string' ? normalized.proxy.noProxy.trim() : '';
+  if (noProxy) {
+    env.NO_PROXY = noProxy;
+    env.no_proxy = noProxy;
+  }
 
   if (main) {
     env.PILOTDECK_API_BASE_URL = main.provider.url || '';


### PR DESCRIPTION
## Summary
- Pass proxy.noProxy into CLI cold-start proxy installation.
- Export NO_PROXY and no_proxy in the UI runtime environment.

Closes #253

## Tests
- npx tsc -p tsconfig.json --noEmit