### PR TITLE
fix(router): honor disabled master switch

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "skills:migrate": "tsx src/cli/pilotdeck.ts skills migrate",
     "predev": "node scripts/bootstrap-pilotdeck-config.mjs",
     "dev": "node scripts/dev-launcher.mjs",
-    "test": "npm run build && node --test --test-force-exit --test-timeout 60000 \"dist/tests/**/*.test.js\"",
+    "test": "npm run build && node --test --test-force-exit --test-timeout 60000 \"dist/tests/**/*.test.js\" \"dist/tests/**/*.spec.js\"",
     "e2e:real-agent-lifecycle-hooks": "npm run build && PILOTDECK_RUN_REAL_AGENT_LIFECYCLE_E2E=1 node dist/tests/agent/e2e/run-real-agent-lifecycle-hooks.js"
   },
   "devDependencies": {

--- a/src/cli/createLocalGateway.ts
+++ b/src/cli/createLocalGateway.ts
@@ -1232,6 +1232,9 @@ function ensureRouterConfig(
   defaultSelection: PilotAgentModelSelection,
 ): RouterConfig {
   const defaultRef = { id: defaultSelection.id, provider: defaultSelection.provider, model: defaultSelection.model };
+  if (router?.enabled === false) {
+    return { enabled: false };
+  }
   if (router) {
     // Scenarios is optional at the parse boundary (see schema.ts) — the UI
     // can persist a partial `router:` block, e.g. user toggled `enabled`
@@ -1239,6 +1242,7 @@ function ensureRouterConfig(
     // Fill `scenarios.default` from `agent.model` so RouterRuntime always
     // sees a valid map.
     return {
+      enabled: true,
       ...router,
       scenarios: router.scenarios ?? { default: defaultRef },
       fallback: router.fallback ?? { default: [defaultRef] },
@@ -1248,6 +1252,7 @@ function ensureRouterConfig(
     };
   }
   return {
+    enabled: true,
     scenarios: { default: defaultRef },
     fallback: { default: [defaultRef] },
     zeroUsageRetry: { enabled: true, maxAttempts: 2 },

--- a/src/router/RouterRuntime.ts
+++ b/src/router/RouterRuntime.ts
@@ -93,9 +93,10 @@ export function createRouterRuntime(
   config: RouterConfig,
   deps: RouterRuntimeDeps,
 ): RouterRuntime {
+  const enabled = config.enabled !== false;
   const stats = new TokenStatsCollector({
     ...config.stats,
-    enabled: config.stats?.enabled ?? false,
+    enabled: enabled && (config.stats?.enabled ?? false),
     baselineModel: config.scenarios?.default
       ? { provider: config.scenarios.default.provider, model: config.scenarios.default.model }
       : config.stats?.baselineModel,
@@ -236,6 +237,18 @@ export function createRouterRuntime(
   }
 
   async function decide(input: RouterDecisionInput): Promise<RouterDecision> {
+    if (!enabled) {
+      return {
+        provider: input.request.provider,
+        model: input.request.model,
+        scenarioType: "default",
+        isSubagent: !input.isMainAgent,
+        orchestrating: false,
+        resolvedFrom: "scenario",
+        mutations: {},
+      };
+    }
+
     const sticky = sessionStore.get(input.sessionId, !input.isMainAgent);
     const baseUsage = usageCache.get(input.sessionId);
     const inputWithUsage: RouterDecisionInput = {
@@ -444,6 +457,28 @@ export function createRouterRuntime(
     request: CanonicalModelRequest,
     ctx: RouterExecuteContext,
   ): AsyncIterable<CanonicalModelEvent> {
+    if (!enabled) {
+      const passthroughRequest: CanonicalModelRequest = {
+        ...request,
+        provider: decision.provider,
+        model: decision.model,
+      };
+      let sawErrorEvent = false;
+      for await (const item of streamAttempt(passthroughRequest, deps.modelRuntime, ctx.abortSignal)) {
+        if (item.kind === "event") {
+          if (item.event.type === "error") {
+            sawErrorEvent = true;
+          }
+          yield item.event;
+          continue;
+        }
+        if (item.outcome.error && !sawErrorEvent) {
+          yield { type: "error", error: item.outcome.error };
+        }
+      }
+      return;
+    }
+
     const startedAt = (deps.now?.() ?? new Date()).toISOString();
     const fallbackPlan = planFallback(config.fallback, decision.scenarioType);
     const baseRequest = applyDecisionToRequest(decision, request);
@@ -844,6 +879,10 @@ export function createRouterRuntime(
   }
 
   function invalidateSticky(sessionId: string): InvalidateStickyResult {
+    if (!enabled) {
+      return { orchestrating: false };
+    }
+
     const current = sessionStore.get(sessionId, false);
     const previousTier = current?.tokenSaverTier;
     const orchestrating = current?.orchestrating ?? false;
@@ -876,6 +915,7 @@ export function createRouterRuntime(
     stream,
     invalidateSticky,
     observeUsage(sessionId, usage) {
+      if (!enabled) return;
       usageCache.observe(sessionId, usage);
     },
     stats,

--- a/src/router/config/parseRouterConfig.ts
+++ b/src/router/config/parseRouterConfig.ts
@@ -62,6 +62,27 @@ export function parseRouterConfig(
     return { diagnostics };
   }
 
+  let enabled = true;
+  if (raw.enabled !== undefined) {
+    if (typeof raw.enabled === "boolean") {
+      enabled = raw.enabled;
+    } else {
+      diagnostics.push({
+        code: "ROUTER_ENABLED_INVALID",
+        severity: "fatal",
+        path: "router.enabled",
+        message: "router.enabled must be a boolean.",
+      });
+    }
+  }
+
+  if (!enabled) {
+    return {
+      config: { enabled: false },
+      diagnostics,
+    };
+  }
+
   const scenarios = parseScenarios(raw.scenarios, modelConfig, diagnostics);
   // Don't early-return on `scenarios === undefined`: that's the legitimate
   // "user only filled in tokenSaver / fallback" case. `ensureRouterConfig`
@@ -78,6 +99,7 @@ export function parseRouterConfig(
 
   return {
     config: {
+      enabled,
       ...(scenarios ? { scenarios } : {}),
       fallback,
       zeroUsageRetry,

--- a/src/router/config/schema.ts
+++ b/src/router/config/schema.ts
@@ -69,6 +69,11 @@ export type RouterCustomRouterConfig = {
 
 export type RouterConfig = {
   /**
+   * Master switch for all router behavior. When false, router-specific
+   * model refs are ignored and requests pass through to agent.model.
+   */
+  enabled?: boolean;
+  /**
    * Resolved scenario→model map.
    *
    * Optional at the *parse* boundary so a yaml that lists e.g. only

--- a/tests/router/RouterDisabled.spec.ts
+++ b/tests/router/RouterDisabled.spec.ts
@@ -1,0 +1,221 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type {
+  CanonicalMessage,
+  CanonicalModelEvent,
+  CanonicalModelRequest,
+  CanonicalModelResponse,
+  ModelCapabilities,
+  ModelConfig,
+  ModelRuntime,
+  MultimodalConstraints,
+} from "../../src/model/index.js";
+import { parseRouterConfig } from "../../src/router/config/parseRouterConfig.js";
+import { createRouterRuntime, type RouterEvent } from "../../src/router/index.js";
+
+test("disabled router config ignores invalid nested model refs", () => {
+  const result = parseRouterConfig({
+    enabled: false,
+    scenarios: { default: "missing/model" },
+    fallback: { default: ["missing/fallback"] },
+    tokenSaver: {
+      enabled: true,
+      judge: "missing/judge",
+      tiers: {
+        simple: { model: "missing/simple" },
+      },
+    },
+    autoOrchestrate: {
+      enabled: true,
+      mainAgentModel: "missing/orchestrator",
+      subagentModel: "missing/subagent",
+    },
+    stats: {
+      enabled: true,
+      baselineModel: "missing/baseline",
+    },
+  }, minimalModelConfig());
+
+  assert.deepEqual(result.diagnostics, []);
+  assert.deepEqual(result.config, { enabled: false });
+});
+
+test("disabled router passes through the request model without judge, fallback, events, or stats", async () => {
+  const runtime = fakeModelRuntime();
+  const emitted: RouterEvent[] = [];
+  const router = createRouterRuntime({
+    enabled: false,
+    scenarios: { default: ref("router", "default") },
+    fallback: { default: [ref("router", "fallback")] },
+    zeroUsageRetry: { enabled: true, maxAttempts: 3 },
+    tokenSaver: {
+      enabled: true,
+      judge: ref("router", "judge"),
+      defaultTier: "simple",
+      tiers: {
+        simple: { model: ref("router", "simple") },
+      },
+      judgeTimeoutMs: 1_000,
+    },
+    autoOrchestrate: {
+      enabled: true,
+      triggerTiers: ["simple"],
+      slimSystemPrompt: true,
+      mainAgentModel: ref("router", "orchestrator"),
+      subagentModel: ref("router", "subagent"),
+    },
+    stats: { enabled: true },
+  }, {
+    modelRuntime: runtime,
+    events: { emit: (event) => emitted.push(event) },
+  });
+
+  try {
+    const request = textRequest();
+    const decision = await router.decide({
+      request,
+      sessionId: "s-disabled",
+      isMainAgent: true,
+    });
+
+    assert.equal(decision.provider, "main");
+    assert.equal(decision.model, "agent");
+    assert.equal(decision.tokenSaverTier, undefined);
+    assert.equal(decision.orchestrating, false);
+    assert.deepEqual(decision.mutations, {});
+
+    const events = await collect(router.execute(decision, request, {
+      sessionId: "s-disabled",
+      turnId: "t-disabled",
+    }));
+
+    assert.deepEqual(runtime.completedModels, []);
+    assert.deepEqual(runtime.multimodalLookups, []);
+    assert.deepEqual(runtime.streamedModels, ["main/agent"]);
+    assert.equal(events.some((event) => event.type === "error"), false);
+    assert.deepEqual(emitted, []);
+    assert.deepEqual(router.stats.recent(), []);
+  } finally {
+    await router.shutdown();
+  }
+});
+
+test("disabled router converts thrown stream failures into canonical error events", async () => {
+  const runtime = fakeModelRuntime({ throwAfterStart: true });
+  const router = createRouterRuntime({
+    enabled: false,
+    scenarios: { default: ref("router", "default") },
+    fallback: { default: [ref("router", "fallback")] },
+  }, {
+    modelRuntime: runtime,
+  });
+
+  try {
+    const request = textRequest();
+    const decision = await router.decide({
+      request,
+      sessionId: "s-disabled-error",
+      isMainAgent: true,
+    });
+    const events = await collect(router.execute(decision, request, {
+      sessionId: "s-disabled-error",
+      turnId: "t-disabled-error",
+    }));
+
+    assert.deepEqual(events.map((event) => event.type), ["request_started", "error"]);
+    const errorEvent = events[1];
+    assert.ok(errorEvent && errorEvent.type === "error");
+    assert.equal(errorEvent.error.provider, "main");
+    assert.equal(errorEvent.error.code, "network_error");
+    assert.equal(errorEvent.error.message, "fetch failed while router disabled");
+    assert.deepEqual(runtime.streamedModels, ["main/agent"]);
+  } finally {
+    await router.shutdown();
+  }
+});
+
+function ref(provider: string, model: string) {
+  return { id: `${provider}/${model}`, provider, model };
+}
+
+function minimalModelConfig(): ModelConfig {
+  return {
+    providers: {
+      main: {
+        models: {
+          agent: {},
+        },
+      },
+    },
+  } as unknown as ModelConfig;
+}
+
+function textRequest(messages: CanonicalMessage[] = [
+  { role: "user", content: [{ type: "text", text: "hello" }] },
+]): CanonicalModelRequest {
+  return {
+    provider: "main",
+    model: "agent",
+    messages,
+    stream: true,
+  };
+}
+
+async function collect(iterable: AsyncIterable<CanonicalModelEvent>): Promise<CanonicalModelEvent[]> {
+  const events: CanonicalModelEvent[] = [];
+  for await (const event of iterable) {
+    events.push(event);
+  }
+  return events;
+}
+
+function fakeModelRuntime(options: { throwAfterStart?: boolean } = {}): ModelRuntime & {
+  completedModels: string[];
+  multimodalLookups: string[];
+  streamedModels: string[];
+} {
+  const completedModels: string[] = [];
+  const multimodalLookups: string[] = [];
+  const streamedModels: string[] = [];
+  return {
+    completedModels,
+    multimodalLookups,
+    streamedModels,
+    async *stream(request: CanonicalModelRequest): AsyncIterable<CanonicalModelEvent> {
+      streamedModels.push(`${request.provider}/${request.model}`);
+      yield { type: "request_started", provider: request.provider, model: request.model };
+      if (options.throwAfterStart) {
+        throw new Error("fetch failed while router disabled");
+      }
+      yield { type: "message_start", role: "assistant" };
+      yield { type: "text_delta", text: "ok" };
+      yield { type: "message_end", finishReason: "stop" };
+      yield { type: "usage", usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 } };
+    },
+    async complete(request: CanonicalModelRequest): Promise<CanonicalModelResponse> {
+      completedModels.push(`${request.provider}/${request.model}`);
+      throw new Error("disabled router must not call the token saver judge");
+    },
+    getCapabilities(): ModelCapabilities {
+      return {
+        supportsToolUse: true,
+        supportsStreaming: true,
+        supportsParallelToolCalls: true,
+        supportsThinking: false,
+        supportsJsonSchema: true,
+        supportsSystemPrompt: true,
+        supportsPromptCache: false,
+        maxContextTokens: 128_000,
+        maxOutputTokens: 4_096,
+      };
+    },
+    getMultimodal(providerId: string, modelId: string): MultimodalConstraints {
+      multimodalLookups.push(`${providerId}/${modelId}`);
+      throw new Error("disabled router must not inspect router model multimodal metadata");
+    },
+    getProviderBaseUrl(): string | undefined {
+      return undefined;
+    },
+  };
+}

--- a/ui/server/services/pilotdeckConfig.js
+++ b/ui/server/services/pilotdeckConfig.js
@@ -191,6 +191,7 @@ function validateModelRef(config, ref, label, errors) {
 function validateRouterModelRefs(config, errors) {
   const router = config.router;
   if (!isRecord(router)) return;
+  if (router.enabled === false) return;
 
   if (isRecord(router.scenarios)) {
     for (const [key, ref] of Object.entries(router.scenarios)) {
@@ -466,6 +467,7 @@ export function syncAgentModelWithRouter(config) {
   const modelId = agentRef.slice(slash + 1);
 
   if (!isRecord(config.router)) return config;
+  if (config.router.enabled === false) return config;
   if (!isRecord(config.router.scenarios)) return config;
   const currentDefault = config.router.scenarios.default;
   // Accept both string ("provider/model") and object ref shapes.


### PR DESCRIPTION
## Summary
- Parse and preserve router.enabled as the router master switch.
- When disabled, bypass router judge/fallback/stats/events and ignore nested router model refs.
- Skip disabled-router validation/sync in UI config handling and add a .spec.ts regression file.

## Validation
- npx tsx --test tests/router/*.ts
- npx tsc --noEmit --target ES2022 --module NodeNext --moduleResolution NodeNext --strict --esModuleInterop --skipLibCheck src/router/config/schema.ts src/router/config/parseRouterConfig.ts src/router/RouterRuntime.ts src/cli/createLocalGateway.ts tests/router/RouterDisabled.spec.ts
- node --check ui/server/services/pilotdeckConfig.js