### PR TITLE
fix(agent): normalize tool call ids

### DIFF
--- a/src/agent/loop/ensureToolResultPairing.ts
+++ b/src/agent/loop/ensureToolResultPairing.ts
@@ -7,11 +7,20 @@ export function ensureToolResultPairing(
   now: () => Date = () => new Date(),
   message = "Tool execution did not produce a result.",
 ): PilotDeckToolResult[] {
-  const resultsByCallId = new Map(results.map((result) => [result.toolCallId, result]));
+  const resultsByCallId = new Map<string, PilotDeckToolResult[]>();
+  for (const result of results) {
+    const queue = resultsByCallId.get(result.toolCallId);
+    if (queue) {
+      queue.push(result);
+    } else {
+      resultsByCallId.set(result.toolCallId, [result]);
+    }
+  }
+
   const paired: PilotDeckToolResult[] = [];
 
   for (const call of calls) {
-    paired.push(resultsByCallId.get(call.id) ?? createMissingToolResult(call, now, message));
+    paired.push(resultsByCallId.get(call.id)?.shift() ?? createMissingToolResult(call, now, message));
   }
 
   return paired;

--- a/src/model/providers/openai/stream.ts
+++ b/src/model/providers/openai/stream.ts
@@ -178,10 +178,12 @@ function toolCallEvents(
     const record = asRecord(delta);
     const index = typeof record.index === "number" ? record.index : 0;
     const fn = asRecord(record.function);
+    const hasExistingCall = state.toolCalls.has(index);
     const current = state.toolCalls.get(index) ?? {};
 
-    if (typeof record.id === "string") {
-      current.id = record.id;
+    const incomingId = readNonEmptyString(record.id);
+    if (!hasExistingCall && incomingId !== undefined) {
+      current.id = incomingId;
     }
     // Only adopt a non-empty name. Some providers send the real name in the
     // first chunk, then `function.name: ""` in later argument-only chunks;
@@ -192,7 +194,7 @@ function toolCallEvents(
       current.name = name;
     }
 
-    if (!state.toolCalls.has(index)) {
+    if (!hasExistingCall) {
       current.id = readNonEmptyString(current.id) ?? generateStreamToolCallId(index);
       state.toolCalls.set(index, current);
       events.push({

--- a/src/model/streaming/assembleModelMessage.ts
+++ b/src/model/streaming/assembleModelMessage.ts
@@ -112,6 +112,8 @@ export function assembleAssistantMessage(state: ModelMessageAssemblerState): Ass
     }
   }
 
+  normalizeToolCallIds(state);
+
   return {
     message: {
       role: "assistant",
@@ -123,6 +125,35 @@ export function assembleAssistantMessage(state: ModelMessageAssemblerState): Ass
     error: state.error,
     hasRepairedToolCalls: state.hasRepairedToolCalls,
   };
+}
+
+function normalizeToolCallIds(state: ModelMessageAssemblerState): void {
+  if (state.toolCalls.length === 0) return;
+
+  const used = new Set<string>();
+  const normalizedToolCalls = state.toolCalls.map((toolCall, index) => {
+    const id = nextToolCallId(toolCall.id, index, used);
+    used.add(id);
+    return id === toolCall.id ? toolCall : { ...toolCall, id };
+  });
+
+  let toolCallIndex = 0;
+  state.content = state.content.map((block) => {
+    if (block.type !== "tool_call") return block;
+    const normalized = normalizedToolCalls[toolCallIndex++];
+    return normalized ? { ...block, id: normalized.id } : block;
+  });
+  state.toolCalls = normalizedToolCalls;
+}
+
+function nextToolCallId(rawId: string | undefined, index: number, used: Set<string>): string {
+  const base = rawId && rawId.trim().length > 0 ? rawId.trim() : `call_${index}`;
+  if (!used.has(base)) return base;
+
+  for (let suffix = 2; ; suffix += 1) {
+    const candidate = `${base}_${suffix}`;
+    if (!used.has(candidate)) return candidate;
+  }
 }
 
 const TEXT_TOOL_CALL_MARKERS = [


### PR DESCRIPTION
## Summary
- normalize empty or duplicate tool call ids before tool scheduling/transcript persistence
- prevent OpenAI-compatible stream chunks with empty ids from overwriting generated fallback ids
- pair duplicate-id tool results by queue order instead of overwriting by map key

## Validation
- npm run build

Note: regression tests are intentionally not included per request.