### PR TITLE
Fix markdown file links and process grouping separators

### DIFF
--- a/ui/src/components/chat-v2/processGrouping.test.ts
+++ b/ui/src/components/chat-v2/processGrouping.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
+import type { NormalizedMessage } from '../../stores/useSessionStore';
 import type { ChatMessage } from '../chat/types/types';
+import { normalizedToChatMessages } from '../chat/hooks/useChatMessages';
 import {
   buildRenderableMessageItems,
   getLiveProcessGroups,
@@ -49,6 +51,41 @@ function tool(
     toolId: id,
     toolInput: JSON.stringify(input),
     toolResult,
+  };
+}
+
+function normalizedText(
+  id: string,
+  role: 'user' | 'assistant',
+  content: string,
+  offsetMs = 0,
+): NormalizedMessage {
+  return {
+    id,
+    sessionId: 'session-1',
+    provider: 'pilotdeck',
+    kind: 'text',
+    role,
+    content,
+    timestamp: timestamp(offsetMs),
+  };
+}
+
+function normalizedTool(
+  id: string,
+  toolName: string,
+  input: Record<string, unknown> = {},
+  offsetMs = 0,
+): NormalizedMessage {
+  return {
+    id,
+    sessionId: 'session-1',
+    provider: 'pilotdeck',
+    kind: 'tool_use',
+    toolName,
+    toolId: id,
+    toolInput: input,
+    timestamp: timestamp(offsetMs),
   };
 }
 
@@ -399,5 +436,52 @@ describe('processGrouping', () => {
     expect(items.map((item) => item.message.id)).toEqual(['u1', 'a1', 'a-final']);
     expect(groups).toHaveLength(2);
     expect(groups.every((group) => group.afterOriginalIndex === 1)).toBe(true);
+  });
+
+  it('keeps normalized empty assistant shells available as process separators', () => {
+    const normalized = [
+      normalizedText('u1', 'user', 'Do the work'),
+      normalizedText('a1', 'assistant', 'Starting work.', 100),
+      normalizedTool('read-1', 'Read', { file_path: '/repo/src/App.tsx' }, 200),
+      normalizedText('a-empty-1', 'assistant', '', 250),
+      normalizedTool('grep-1', 'Grep', { pattern: 'MessagesPaneV2' }, 300),
+      normalizedText('a-empty-2', 'assistant', '', 350),
+      normalizedText('a-final', 'assistant', 'Here is the result.', 400),
+    ];
+
+    const messages = normalizedToChatMessages(normalized);
+    const items = buildRenderableMessageItems(messages, { isAssistantWorking: true });
+    const groups = getLiveProcessGroups(messages, { isAssistantWorking: true });
+
+    expect(messages.map((message) => message.id)).toEqual([
+      'u1',
+      'a1',
+      'read-1',
+      'a-empty-1',
+      'grep-1',
+      'a-empty-2',
+      'a-final',
+    ]);
+    expect(items.map((item) => item.message.id)).toEqual(['u1', 'a1', 'a-final']);
+    expect(groups).toHaveLength(2);
+    expect(groups.map((group) => group.messages.map((message) => message.id))).toEqual([
+      ['read-1'],
+      ['grep-1'],
+    ]);
+  });
+
+  it('still drops unrelated normalized empty assistant messages', () => {
+    const empty = normalizedText('a-empty', 'assistant', '');
+
+    expect(normalizedToChatMessages([
+      normalizedText('u1', 'user', 'Hello'),
+      empty,
+    ]).map((message) => message.id)).toEqual(['u1']);
+
+    expect(normalizedToChatMessages([
+      normalizedText('u1', 'user', 'Hello'),
+      normalizedTool('read-1', 'Read', { file_path: '/repo/src/App.tsx' }, 100),
+      empty,
+    ]).map((message) => message.id)).toEqual(['u1', 'read-1', 'a-empty']);
   });
 });

--- a/ui/src/components/chat/hooks/useChatMessages.ts
+++ b/ui/src/components/chat/hooks/useChatMessages.ts
@@ -15,10 +15,69 @@ import { parseUserAttachmentNote } from '../utils/attachmentNotes';
 // memo(MessageRowV2) for every message in the session.
 const msgConversionCache = new WeakMap<NormalizedMessage, ChatMessage | null>();
 
+type ConvertSingleMessageOptions = {
+  preserveEmptyAssistantShell?: boolean;
+};
+
+function normalizeAssistantText(content: string): string {
+  let text = decodeHtmlEntities(content);
+  text = unescapeWithMathProtection(text);
+  return formatUsageLimitText(text);
+}
+
+function isEmptyAssistantTextMessage(msg: NormalizedMessage): boolean {
+  if (msg.kind !== 'text' || msg.role !== 'assistant') {
+    return false;
+  }
+  return normalizeAssistantText(msg.content || '').trim().length === 0;
+}
+
+function isNonRenderableTransportMessage(msg: NormalizedMessage): boolean {
+  return (
+    msg.kind === 'tool_result' ||
+    msg.kind === 'stream_end' ||
+    msg.kind === 'complete' ||
+    msg.kind === 'status' ||
+    msg.kind === 'permission_request' ||
+    msg.kind === 'permission_cancelled' ||
+    msg.kind === 'session_created'
+  );
+}
+
+function findNeighborRenderableMessage(
+  messages: NormalizedMessage[],
+  index: number,
+  direction: -1 | 1,
+): NormalizedMessage | null {
+  for (let i = index + direction; i >= 0 && i < messages.length; i += direction) {
+    const msg = messages[i];
+    if (!msg || isNonRenderableTransportMessage(msg)) {
+      continue;
+    }
+    return msg;
+  }
+  return null;
+}
+
+function shouldPreserveEmptyAssistantShell(
+  messages: NormalizedMessage[],
+  index: number,
+): boolean {
+  const msg = messages[index];
+  if (!msg || !isEmptyAssistantTextMessage(msg)) {
+    return false;
+  }
+
+  const previous = findNeighborRenderableMessage(messages, index, -1);
+  const next = findNeighborRenderableMessage(messages, index, 1);
+  return previous?.kind === 'tool_use' || next?.kind === 'tool_use';
+}
+
 function convertSingleMessage(
   msg: NormalizedMessage,
   toolResultMap: Map<string, NormalizedMessage>,
   subagentLinks?: Map<string, { subagentId: string; subagentType: string }>,
+  options: ConvertSingleMessageOptions = {},
 ): ChatMessage | null {
   switch (msg.kind) {
     case 'text': {
@@ -55,10 +114,8 @@ function convertSingleMessage(
           ...(userAttachments.length > 0 ? { attachments: userAttachments } : {}),
         };
       } else {
-        let text = decodeHtmlEntities(content);
-        text = unescapeWithMathProtection(text);
-        text = formatUsageLimitText(text);
-        if (!text.trim()) return null;
+        const text = normalizeAssistantText(content);
+        if (!text.trim() && !options.preserveEmptyAssistantShell) return null;
         return {
           id: msg.id,
           type: 'assistant',
@@ -295,7 +352,8 @@ function convertNormalizedMessages(
   }
   const toolResultMap = new Map<string, NormalizedMessage>();
 
-  for (const msg of messages) {
+  for (let index = 0; index < messages.length; index += 1) {
+    const msg = messages[index];
     // tool_use messages depend on toolResultMap + subagentLinks (external state) so skip cache
     if (msg.kind === 'tool_use') {
       if (msg.toolId && !msg.toolResult) {
@@ -309,15 +367,20 @@ function convertNormalizedMessages(
       continue;
     }
 
+    const preserveEmptyAssistantShell = shouldPreserveEmptyAssistantShell(messages, index);
+    const skipCache = isEmptyAssistantTextMessage(msg);
+
     // All other message types: use WeakMap cache for stable references
-    if (msgConversionCache.has(msg)) {
+    if (!skipCache && msgConversionCache.has(msg)) {
       const cached = msgConversionCache.get(msg);
       if (cached) converted.push(cached);
       continue;
     }
 
-    const result = convertSingleMessage(msg, toolResultMap);
-    msgConversionCache.set(msg, result);
+    const result = convertSingleMessage(msg, toolResultMap, undefined, { preserveEmptyAssistantShell });
+    if (!skipCache) {
+      msgConversionCache.set(msg, result);
+    }
     if (result) converted.push(result);
   }
 

--- a/ui/src/components/chat/utils/resolveMarkdownFileHref.test.ts
+++ b/ui/src/components/chat/utils/resolveMarkdownFileHref.test.ts
@@ -11,11 +11,15 @@ describe('resolveMarkdownFileHref', () => {
         { origin: ORIGIN },
       ),
     ).toBe('大模型调研报告.md');
+    expect(
+      resolveMarkdownFileHref('/session/%E5%A4%A7%E6%A8%A1%E5%9E%8B%E8%B0%83%E7%A0%94%E6%8A%A5%E5%91%8A.md'),
+    ).toBe('大模型调研报告.md');
   });
 
   it('resolves relative markdown paths', () => {
     expect(resolveMarkdownFileHref('docs/report.md')).toBe('docs/report.md');
     expect(resolveMarkdownFileHref('./notes.md')).toBe('notes.md');
+    expect(resolveMarkdownFileHref('/docs/report.md')).toBe('docs/report.md');
   });
 
   it('ignores external URLs and non-file session paths', () => {

--- a/ui/src/components/chat/utils/resolveMarkdownFileHref.ts
+++ b/ui/src/components/chat/utils/resolveMarkdownFileHref.ts
@@ -30,6 +30,28 @@ const resolveRelativeToFile = (href: string, baseFilePath: string): string => {
   return resolved.join('/');
 };
 
+const resolveProjectPathFromPathname = (pathname: string): string | null => {
+  const normalizedPathname = pathname.replace(/\\/g, '/');
+
+  // Assistant sometimes emits /session/<filename.md> even though /session is
+  // reserved for conversation ids.
+  const sessionPrefix = '/session/';
+  if (normalizedPathname.startsWith(sessionPrefix)) {
+    const filePath = normalizedPathname.slice(sessionPrefix.length);
+    if (looksLikeProjectFilePath(filePath)) return filePath;
+  }
+
+  // Optional deep-link shape: /p/:project/f/:encoded/path
+  const projectFileMatch = normalizedPathname.match(/^\/p\/[^/]+\/f\/(.+)$/);
+  if (projectFileMatch) {
+    const filePath = decodePath(projectFileMatch[1]);
+    if (looksLikeProjectFilePath(filePath)) return filePath;
+  }
+
+  const rootRelativePath = normalizedPathname.replace(/^\/+/, '');
+  return looksLikeProjectFilePath(rootRelativePath) ? rootRelativePath : null;
+};
+
 /**
  * Returns a project-relative file path when `href` points at a local workspace
  * file. Handles common assistant-generated shapes such as
@@ -45,8 +67,14 @@ export function resolveMarkdownFileHref(
   const trimmed = href.trim();
   if (!trimmed || trimmed.startsWith('#')) return null;
 
-  // Relative / root-relative paths (no protocol).
-  if (!/^([a-z][a-z0-9+.-]*:|\/\/)/i.test(trimmed)) {
+  const hasProtocol = /^([a-z][a-z0-9+.-]*:|\/\/)/i.test(trimmed);
+
+  if (trimmed.startsWith('/')) {
+    return resolveProjectPathFromPathname(decodePath(trimmed));
+  }
+
+  // Relative paths (no protocol).
+  if (!hasProtocol) {
     const decoded = decodePath(trimmed);
     const normalized = decoded.replace(/^\.\//, '').replace(/^\/+/, '');
     const candidate = options?.baseFilePath && !decoded.startsWith('/')
@@ -62,23 +90,7 @@ export function resolveMarkdownFileHref(
     if (origin && url.origin !== origin) return null;
 
     const pathname = decodePath(url.pathname);
-
-    // Assistant sometimes emits /session/<filename.md> even though /session is
-    // reserved for conversation ids.
-    const sessionPrefix = '/session/';
-    if (pathname.startsWith(sessionPrefix)) {
-      const filePath = pathname.slice(sessionPrefix.length);
-      if (looksLikeProjectFilePath(filePath)) return filePath;
-    }
-
-    // Optional deep-link shape: /p/:project/f/:encoded/path
-    const projectFileMatch = pathname.match(/^\/p\/[^/]+\/f\/(.+)$/);
-    if (projectFileMatch) {
-      const filePath = decodePath(projectFileMatch[1]);
-      if (looksLikeProjectFilePath(filePath)) return filePath;
-    }
-
-    return null;
+    return resolveProjectPathFromPathname(pathname);
   } catch {
     return null;
   }


### PR DESCRIPTION
## Summary
- Fix root-relative /session/<file.md> markdown links so misrouted file URLs resolve to the project file instead of session/<file.md>
- Preserve normalized empty assistant shells next to tool-use messages so live process grouping can use them as separators
- Add regression coverage for root-relative file links and normalized process separators

## Tests
- npm --prefix ui test -- processGrouping.test.ts resolveMarkdownFileHref.test.ts MessagesPaneV2.render.test.tsx
- npm exec -- eslint src/components/chat-v2/processGrouping.test.ts src/components/chat/hooks/useChatMessages.ts src/components/chat/utils/resolveMarkdownFileHref.test.ts src/components/chat/utils/resolveMarkdownFileHref.ts
- git diff --check