### PR TITLE
Fix OpenAI-compatible tool call ID synthesis

### DIFF
--- a/src/context/DefaultContextRuntime.ts
+++ b/src/context/DefaultContextRuntime.ts
@@ -257,11 +257,15 @@ export class DefaultContextRuntime implements ContextRuntime {
     let supplementalMessages = input.supplementalMessages ?? [];
     if (this.toolResultBudget) {
       try {
-        appended = await this.toolResultBudget.applyToMessage(input.toolResultMessage);
+        appended = await this.toolResultBudget.applyToMessage(input.toolResultMessage, { turnId: input.turnId });
         supplementalMessages = await Promise.all(
           supplementalMessages.map(async ({ toolCallId, message }) => ({
             toolCallId,
-            message: await this.toolResultBudget!.applyToSupplementalMessage(message, toolCallId),
+            message: await this.toolResultBudget!.applyToSupplementalMessage(
+              message,
+              toolCallId,
+              { turnId: input.turnId },
+            ),
           })),
         );
       } catch (error) {

--- a/src/context/budget/ToolResultBudget.ts
+++ b/src/context/budget/ToolResultBudget.ts
@@ -49,6 +49,10 @@ export type ToolResultBudgetOptions = {
   state?: ToolResultBudgetState;
 };
 
+export type ToolResultBudgetApplyOptions = {
+  turnId?: string;
+};
+
 export function createToolResultBudgetState(): ToolResultBudgetState {
   return { replacements: new Map() };
 }
@@ -56,8 +60,8 @@ export function createToolResultBudgetState(): ToolResultBudgetState {
 /**
  * Replace tool_result blocks whose serialized text exceeds the budget with
  * structured `tool_result_reference` blocks. Persists the original body to
- * `{toolResultsDir}/{toolCallId}.{json|txt}` (write flag 'wx' to avoid
- * overwriting on resume).
+ * `{toolResultsDir}/{turnId}-{toolCallId}.{json|txt}` when a turn id is
+ * available (write flag 'wx' to avoid overwriting on resume).
  */
 export class ToolResultBudget {
   private readonly maxResultSizeChars: number;
@@ -76,7 +80,10 @@ export class ToolResultBudget {
     return this.state;
   }
 
-  async applyToMessage(message: CanonicalMessage): Promise<CanonicalMessage> {
+  async applyToMessage(
+    message: CanonicalMessage,
+    options: ToolResultBudgetApplyOptions = {},
+  ): Promise<CanonicalMessage> {
     if (message.role !== "user") {
       return message;
     }
@@ -88,7 +95,7 @@ export class ToolResultBudget {
         primaryContent.push(block);
         continue;
       }
-      const replaced = await this.maybeReplaceToolResult(block);
+      const replaced = await this.maybeReplaceToolResult(block, options);
       if (replaced.block !== block || replaced.mediaReferences.length > 0) {
         modified = true;
       }
@@ -101,7 +108,11 @@ export class ToolResultBudget {
     return { ...message, content: [...primaryContent, ...mediaReferences] };
   }
 
-  async applyToSupplementalMessage(message: CanonicalMessage, toolCallId: string): Promise<CanonicalMessage> {
+  async applyToSupplementalMessage(
+    message: CanonicalMessage,
+    toolCallId: string,
+    options: ToolResultBudgetApplyOptions = {},
+  ): Promise<CanonicalMessage> {
     if (message.role !== "user") {
       return message;
     }
@@ -109,7 +120,7 @@ export class ToolResultBudget {
     let modified = false;
     for (let index = 0; index < message.content.length; index += 1) {
       const block = message.content[index];
-      const replaced = await this.maybeReplaceMedia(block, index, toolCallId);
+      const replaced = await this.maybeReplaceMedia(block, index, toolCallId, options);
       if (replaced !== block) {
         modified = true;
       }
@@ -120,12 +131,13 @@ export class ToolResultBudget {
 
   private async maybeReplaceToolResult(
     block: CanonicalToolResultBlock,
+    options: ToolResultBudgetApplyOptions,
   ): Promise<{
     block: CanonicalToolResultBlock | CanonicalToolResultReferenceBlock;
     mediaReferences: CanonicalMediaReferenceBlock[];
   }> {
     if (!block.content.some(isToolResultMediaBlock)) {
-      return { block: await this.maybeReplaceTextToolResult(block), mediaReferences: [] };
+      return { block: await this.maybeReplaceTextToolResult(block, options), mediaReferences: [] };
     }
 
     const content: CanonicalToolResultContentBlock[] = [];
@@ -138,7 +150,7 @@ export class ToolResultBudget {
         continue;
       }
 
-      const replaced = await this.maybeReplaceMedia(entry, index, block.toolCallId);
+      const replaced = await this.maybeReplaceMedia(entry, index, block.toolCallId, options);
       if (replaced.type === "media_reference") {
         mediaReferences.push(replaced);
         content.push({ type: "text", text: replaced.preview });
@@ -155,9 +167,11 @@ export class ToolResultBudget {
 
   private async maybeReplaceTextToolResult(
     block: CanonicalToolResultBlock,
+    options: ToolResultBudgetApplyOptions,
   ): Promise<CanonicalToolResultBlock | CanonicalToolResultReferenceBlock> {
-    if (this.state.replacements.has(block.toolCallId)) {
-      return this.toReferenceBlock(this.state.replacements.get(block.toolCallId)!);
+    const replacementKey = scopedToolResultKey(block.toolCallId, options.turnId);
+    if (this.state.replacements.has(replacementKey)) {
+      return this.toReferenceBlock(this.state.replacements.get(replacementKey)!);
     }
 
     const flat = flattenToolResultBlockText(block);
@@ -168,7 +182,7 @@ export class ToolResultBudget {
 
     const isJson = looksLikeJson(flat);
     const ext = isJson ? "json" : "txt";
-    const path = resolve(this.toolResultsDir, `${block.toolCallId}.${ext}`);
+    const path = resolve(this.toolResultsDir, `${replacementKey}.${ext}`);
     await mkdir(dirname(path), { recursive: true, mode: 0o700 });
     try {
       await access(path);
@@ -186,7 +200,7 @@ export class ToolResultBudget {
       mimeType: isJson ? "application/json" : "text/plain",
       reason: "tool_result_too_large",
     };
-    this.state.replacements.set(block.toolCallId, record);
+    this.state.replacements.set(replacementKey, record);
     return this.toReferenceBlock(record);
   }
 
@@ -207,6 +221,7 @@ export class ToolResultBudget {
     block: CanonicalContentBlock,
     index: number,
     toolCallId: string,
+    options: ToolResultBudgetApplyOptions,
   ): Promise<CanonicalContentBlock> {
     if (block.type !== "image" && block.type !== "pdf" && block.type !== "audio") {
       return block;
@@ -220,7 +235,7 @@ export class ToolResultBudget {
     const mediaType = block.type;
     const mimeType = block.mimeType;
     const ext = extensionForMedia(mediaType, mimeType);
-    const id = `${mediaType}-${index}-${hashString(block.data).slice(0, 12)}`;
+    const id = `${scopedToolResultKey(toolCallId, options.turnId)}-${mediaType}-${index}-${hashString(block.data).slice(0, 12)}`;
     const path = resolve(this.toolResultsDir, `${id}.${ext}`);
     await mkdir(dirname(path), { recursive: true, mode: 0o700 });
     try {
@@ -311,6 +326,16 @@ function isToolResultMediaBlock(
 
 function mediaOriginalBytes(block: Extract<CanonicalContentBlock, { type: "image" | "pdf" | "audio" }>): number {
   return ("bytes" in block ? block.bytes : undefined) ?? Buffer.byteLength(block.data, "utf8");
+}
+
+function scopedToolResultKey(toolCallId: string, turnId: string | undefined): string {
+  const safeToolCallId = safePathPart(toolCallId) || "tool-call";
+  const safeTurnId = turnId === undefined ? undefined : safePathPart(turnId);
+  return safeTurnId ? `${safeTurnId}-${safeToolCallId}` : safeToolCallId;
+}
+
+function safePathPart(value: string): string {
+  return value.trim().replace(/[^A-Za-z0-9_.-]+/g, "-").replace(/^-+|-+$/g, "");
 }
 
 function extensionForMedia(mediaType: "image" | "pdf" | "audio", mimeType: string): string {

--- a/src/gateway/client/InProcessGateway.ts
+++ b/src/gateway/client/InProcessGateway.ts
@@ -1182,8 +1182,13 @@ export function mapAgentEvent(event: AgentEvent, runId: string): GatewayEvent[] 
       const PERSIST_THRESHOLD = 4096;
       let resultPath: string | undefined;
       if (totalBytes > PERSIST_THRESHOLD) {
-        const dir = resolve(tmpdir(), "pilotdeck-tool-results");
-        resultPath = resolve(dir, `${event.result.toolCallId}.txt`);
+        const dir = resolve(
+          tmpdir(),
+          "pilotdeck-tool-results",
+          safeGatewayPathPart(event.sessionId),
+          safeGatewayPathPart(event.turnId),
+        );
+        resultPath = resolve(dir, `${safeGatewayPathPart(event.result.toolCallId)}.txt`);
         void (async () => {
           try {
             await mkdir(dir, { recursive: true });
@@ -1495,6 +1500,10 @@ function previewUnknown(value: unknown): string | undefined {
   } catch {
     return String(value);
   }
+}
+
+function safeGatewayPathPart(value: string): string {
+  return value.trim().replace(/[^A-Za-z0-9_.-]+/g, "-").replace(/^-+|-+$/g, "") || "value";
 }
 
 async function buildAgentInputWithAttachments(

--- a/src/model/providers/openai/response.ts
+++ b/src/model/providers/openai/response.ts
@@ -9,12 +9,19 @@ import { ModelProviderError } from "../../protocol/errors.js";
 import { normalizeOpenAIFinishReason } from "../../response/normalizeFinishReason.js";
 import { normalizeOpenAIUsage } from "../../response/normalizeUsage.js";
 
+type OpenAIResponseToolCallIdState = {
+  baseId: string;
+  usedToolCallIds: Set<string>;
+};
+
 export function parseOpenAIResponse(raw: unknown, provider = "openai"): CanonicalModelResponse {
   const response = asRecord(raw);
   const choices = Array.isArray(response.choices) ? response.choices : [];
   const firstChoice = asRecord(choices[0]);
+  const choiceIndex = typeof firstChoice.index === "number" ? firstChoice.index : 0;
   const message = asRecord(firstChoice.message);
   const content: CanonicalContentBlock[] = [];
+  const idState = createResponseToolCallIdState(response);
 
   if (typeof message.content === "string" && message.content.length > 0) {
     content.push({ type: "text", text: message.content });
@@ -28,7 +35,9 @@ export function parseOpenAIResponse(raw: unknown, provider = "openai"): Canonica
   }
 
   if (Array.isArray(message.tool_calls)) {
-    content.push(...message.tool_calls.map((toolCall) => toCanonicalToolCall(toolCall, provider)));
+    content.push(...message.tool_calls.map((toolCall, toolIndex) =>
+      toCanonicalToolCall(toolCall, provider, idState, choiceIndex, toolIndex)
+    ));
   }
 
   return {
@@ -40,7 +49,13 @@ export function parseOpenAIResponse(raw: unknown, provider = "openai"): Canonica
   };
 }
 
-function toCanonicalToolCall(toolCall: unknown, provider: string): CanonicalToolCallBlock {
+function toCanonicalToolCall(
+  toolCall: unknown,
+  provider: string,
+  idState: OpenAIResponseToolCallIdState,
+  choiceIndex: number,
+  toolIndex: number,
+): CanonicalToolCallBlock {
   const record = asRecord(toolCall);
   const fn = asRecord(record.function);
   const rawArguments = typeof fn.arguments === "string" ? fn.arguments : "{}";
@@ -67,7 +82,7 @@ function toCanonicalToolCall(toolCall: unknown, provider: string): CanonicalTool
 
   return {
     type: "tool_call",
-    id: readNonEmptyString(record.id) ?? generateToolCallId(),
+    id: chooseResponseToolCallId(idState, readNonEmptyString(record.id), choiceIndex, toolIndex),
     name: typeof fn.name === "string" ? fn.name : "",
     input,
     raw: toolCall,
@@ -84,6 +99,47 @@ function readNonEmptyString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim().length > 0 ? value : undefined;
 }
 
-function generateToolCallId(): string {
-  return `call_${randomUUID().slice(0, 8)}`;
+function createResponseToolCallIdState(response: Record<string, unknown>): OpenAIResponseToolCallIdState {
+  return {
+    baseId: safeToolCallIdPart(readNonEmptyString(response.id) ?? `response_${randomUUID().slice(0, 12)}`),
+    usedToolCallIds: new Set(),
+  };
+}
+
+function chooseResponseToolCallId(
+  state: OpenAIResponseToolCallIdState,
+  incomingId: string | undefined,
+  choiceIndex: number,
+  toolIndex: number,
+): string {
+  const candidate = incomingId !== undefined && !state.usedToolCallIds.has(incomingId)
+    ? incomingId
+    : generateToolCallId(state, choiceIndex, toolIndex);
+  const id = nextUniqueToolCallId(candidate, state.usedToolCallIds);
+  state.usedToolCallIds.add(id);
+  return id;
+}
+
+function generateToolCallId(
+  state: OpenAIResponseToolCallIdState,
+  choiceIndex: number,
+  toolIndex: number,
+): string {
+  return `call_${state.baseId}_${choiceIndex}_${toolIndex}`;
+}
+
+function nextUniqueToolCallId(id: string, used: Set<string>): string {
+  if (!used.has(id)) {
+    return id;
+  }
+  for (let suffix = 2; ; suffix += 1) {
+    const candidate = `${id}_${suffix}`;
+    if (!used.has(candidate)) {
+      return candidate;
+    }
+  }
+}
+
+function safeToolCallIdPart(value: string): string {
+  return value.trim().replace(/[^A-Za-z0-9_-]+/g, "_").replace(/^_+|_+$/g, "") || "response";
 }

--- a/src/model/providers/openai/stream.ts
+++ b/src/model/providers/openai/stream.ts
@@ -1,4 +1,5 @@
 import { jsonrepair } from "jsonrepair";
+import { randomUUID } from "node:crypto";
 import type { CanonicalModelEvent, CanonicalToolCall } from "../../protocol/canonical.js";
 import { ModelProviderError } from "../../protocol/errors.js";
 import { normalizeOpenAIFinishReason } from "../../response/normalizeFinishReason.js";
@@ -6,9 +7,19 @@ import { normalizeOpenAIUsage } from "../../response/normalizeUsage.js";
 
 export type ThinkFsmMode = "NORMAL" | "THINKING";
 
+type OpenAIStreamToolCallState = Partial<CanonicalToolCall> & {
+  argumentsBuffer?: string;
+  choiceIndex: number;
+  toolIndex: number;
+};
+
 export type OpenAIStreamState = {
   started: boolean;
-  toolCalls: Map<number, Partial<CanonicalToolCall> & { argumentsBuffer?: string }>;
+  toolCalls: Map<string, OpenAIStreamToolCallState>;
+  usedToolCallIds: Set<string>;
+  streamSyntheticId: string;
+  streamResponseId?: string;
+  toolCallBaseId?: string;
   thinkFsm: ThinkFsmMode;
   tagBuffer: string;
   reasoningSnapshot: string;
@@ -18,6 +29,8 @@ export function createOpenAIStreamState(): OpenAIStreamState {
   return {
     started: false,
     toolCalls: new Map(),
+    usedToolCallIds: new Set(),
+    streamSyntheticId: `stream_${randomUUID().slice(0, 12)}`,
     thinkFsm: "NORMAL",
     tagBuffer: "",
     reasoningSnapshot: "",
@@ -117,6 +130,10 @@ export function normalizeOpenAIStreamEvent(
 ): CanonicalModelEvent[] {
   const chunk = asRecord(raw);
   const events: CanonicalModelEvent[] = [];
+  const responseId = readNonEmptyString(chunk.id);
+  if (responseId !== undefined && state.streamResponseId === undefined) {
+    state.streamResponseId = responseId;
+  }
 
   if (!state.started) {
     state.started = true;
@@ -129,8 +146,10 @@ export function normalizeOpenAIStreamEvent(
   }
 
   const choices = Array.isArray(chunk.choices) ? chunk.choices : [];
-  for (const choice of choices) {
+  for (let choicePosition = 0; choicePosition < choices.length; choicePosition += 1) {
+    const choice = choices[choicePosition];
     const choiceRecord = asRecord(choice);
+    const choiceIndex = typeof choiceRecord.index === "number" ? choiceRecord.index : choicePosition;
     const delta = asRecord(choiceRecord.delta);
 
     if (typeof delta.content === "string" && delta.content.length > 0) {
@@ -154,12 +173,12 @@ export function normalizeOpenAIStreamEvent(
     }
 
     if (Array.isArray(delta.tool_calls)) {
-      events.push(...toolCallEvents(delta.tool_calls, state, raw));
+      events.push(...toolCallEvents(delta.tool_calls, state, raw, choiceIndex));
     }
 
     if (choiceRecord.finish_reason) {
       const fr = normalizeOpenAIFinishReason(choiceRecord.finish_reason);
-      events.push(...finishToolCalls(state, raw, fr));
+      events.push(...finishToolCalls(state, raw, fr, choiceIndex));
       events.push({ type: "message_end", finishReason: fr, raw });
     }
   }
@@ -171,20 +190,19 @@ function toolCallEvents(
   deltas: unknown[],
   state: OpenAIStreamState,
   raw: unknown,
+  choiceIndex: number,
 ): CanonicalModelEvent[] {
   const events: CanonicalModelEvent[] = [];
 
   for (const delta of deltas) {
     const record = asRecord(delta);
-    const index = typeof record.index === "number" ? record.index : 0;
+    const toolIndex = typeof record.index === "number" ? record.index : 0;
+    const key = streamToolCallKey(choiceIndex, toolIndex);
     const fn = asRecord(record.function);
-    const hasExistingCall = state.toolCalls.has(index);
-    const current = state.toolCalls.get(index) ?? {};
+    const hasExistingCall = state.toolCalls.has(key);
+    const current = state.toolCalls.get(key) ?? { choiceIndex, toolIndex };
 
     const incomingId = readNonEmptyString(record.id);
-    if (!hasExistingCall && incomingId !== undefined) {
-      current.id = incomingId;
-    }
     // Only adopt a non-empty name. Some providers send the real name in the
     // first chunk, then `function.name: ""` in later argument-only chunks;
     // overwriting with the empty string would emit a nameless tool call and
@@ -195,8 +213,8 @@ function toolCallEvents(
     }
 
     if (!hasExistingCall) {
-      current.id = readNonEmptyString(current.id) ?? generateStreamToolCallId(index);
-      state.toolCalls.set(index, current);
+      current.id = chooseStreamToolCallId(state, incomingId, choiceIndex, toolIndex);
+      state.toolCalls.set(key, current);
       events.push({
         type: "tool_call_start",
         id: current.id,
@@ -206,16 +224,18 @@ function toolCallEvents(
     }
 
     if (typeof fn.arguments === "string") {
+      const currentId = current.id ?? chooseStreamToolCallId(state, undefined, choiceIndex, toolIndex);
+      current.id = currentId;
       current.argumentsBuffer = `${current.argumentsBuffer ?? ""}${fn.arguments}`;
       events.push({
         type: "tool_call_delta",
-        id: current.id ?? generateStreamToolCallId(index),
+        id: currentId,
         delta: fn.arguments,
         raw,
       });
     }
 
-    state.toolCalls.set(index, current);
+    state.toolCalls.set(key, current);
   }
 
   return events;
@@ -225,11 +245,15 @@ function finishToolCalls(
   state: OpenAIStreamState,
   raw: unknown,
   finishReason?: string,
+  choiceIndex?: number,
 ): CanonicalModelEvent[] {
   const events: CanonicalModelEvent[] = [];
   const isTruncation = finishReason === "length";
 
-  for (const [index, toolCall] of state.toolCalls.entries()) {
+  for (const [key, toolCall] of state.toolCalls.entries()) {
+    if (choiceIndex !== undefined && toolCall.choiceIndex !== choiceIndex) {
+      continue;
+    }
     const rawArguments = toolCall.argumentsBuffer ?? "{}";
     let input: unknown;
     let wasRepaired = false;
@@ -249,7 +273,7 @@ function finishToolCalls(
           : rawArguments;
         const code = isTruncation ? "max_output_reached" : "invalid_tool_arguments";
         console.error(
-          `[openai-stream] ${code} for tool "${toolCall.name ?? "?"}" (index=${index}, `
+          `[openai-stream] ${code} for tool "${toolCall.name ?? "?"}" (index=${key}, `
           + `buf_len=${rawArguments.length}):\n${preview}`,
         );
         throw new ModelProviderError({
@@ -270,7 +294,7 @@ function finishToolCalls(
     // as parse failures so the recovery loop retries with more tokens.
     if (wasRepaired && isTruncation) {
       console.warn(
-        `[openai-stream] discarding repaired-but-truncated tool call "${toolCall.name ?? "?"}" (index=${index})`,
+        `[openai-stream] discarding repaired-but-truncated tool call "${toolCall.name ?? "?"}" (index=${key})`,
       );
       throw new ModelProviderError({
         provider: "openai",
@@ -285,7 +309,7 @@ function finishToolCalls(
     events.push({
       type: "tool_call_end",
       toolCall: {
-        id: readNonEmptyString(toolCall.id) ?? generateStreamToolCallId(index),
+        id: toolCall.id ?? chooseStreamToolCallId(state, undefined, toolCall.choiceIndex, toolCall.toolIndex),
         name: toolCall.name ?? "",
         input,
         raw,
@@ -293,9 +317,9 @@ function finishToolCalls(
       wasRepaired,
       raw,
     });
+    state.toolCalls.delete(key);
   }
 
-  state.toolCalls.clear();
   return events;
 }
 
@@ -309,6 +333,52 @@ function readNonEmptyString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim().length > 0 ? value : undefined;
 }
 
-function generateStreamToolCallId(index: number): string {
-  return `call_${index}`;
+function streamToolCallKey(choiceIndex: number, toolIndex: number): string {
+  return `${choiceIndex}:${toolIndex}`;
+}
+
+function chooseStreamToolCallId(
+  state: OpenAIStreamState,
+  incomingId: string | undefined,
+  choiceIndex: number,
+  toolIndex: number,
+): string {
+  const candidate = incomingId !== undefined && !state.usedToolCallIds.has(incomingId)
+    ? incomingId
+    : generateStreamToolCallId(state, choiceIndex, toolIndex);
+  const id = nextUniqueToolCallId(candidate, state.usedToolCallIds);
+  state.usedToolCallIds.add(id);
+  return id;
+}
+
+function generateStreamToolCallId(
+  state: OpenAIStreamState,
+  choiceIndex: number,
+  toolIndex: number,
+): string {
+  const base = getStreamToolCallBaseId(state);
+  return `call_${base}_${choiceIndex}_${toolIndex}`;
+}
+
+function getStreamToolCallBaseId(state: OpenAIStreamState): string {
+  if (state.toolCallBaseId === undefined) {
+    state.toolCallBaseId = safeToolCallIdPart(state.streamResponseId ?? state.streamSyntheticId);
+  }
+  return state.toolCallBaseId;
+}
+
+function nextUniqueToolCallId(id: string, used: Set<string>): string {
+  if (!used.has(id)) {
+    return id;
+  }
+  for (let suffix = 2; ; suffix += 1) {
+    const candidate = `${id}_${suffix}`;
+    if (!used.has(candidate)) {
+      return candidate;
+    }
+  }
+}
+
+function safeToolCallIdPart(value: string): string {
+  return value.trim().replace(/[^A-Za-z0-9_-]+/g, "_").replace(/^_+|_+$/g, "") || "stream";
 }


### PR DESCRIPTION
## Summary
- synthesize stable non-empty IDs for blank/duplicate OpenAI-compatible tool calls in stream and non-stream responses
- keep stream tool call state isolated by choice index and tool index so parallel calls cannot cross-wire results
- scope large tool result persistence paths by session/turn/tool call id while preserving canonical toolCallId values

## Validation
- npx tsc --target ES2022 --module NodeNext --moduleResolution NodeNext --strict --esModuleInterop --skipLibCheck --types node --noEmit src/model/providers/openai/stream.ts src/model/providers/openai/response.ts src/context/budget/ToolResultBudget.ts src/context/DefaultContextRuntime.ts src/gateway/client/InProcessGateway.ts
- local uncommitted tests only, per request not included in PR: mock OpenAI-compatible empty tool id e2e and related parser/result isolation tests