### PR TITLE
Fix glob handling for absolute and Windows paths

### DIFF
--- a/src/tool/builtin/filesystem/ripgrep.ts
+++ b/src/tool/builtin/filesystem/ripgrep.ts
@@ -4,7 +4,6 @@ import path from "node:path";
 import { PilotDeckToolRuntimeError } from "../../protocol/errors.js";
 
 const require = createRequire(import.meta.url);
-const { rgPath } = require("@vscode/ripgrep") as { rgPath: string };
 
 const DEFAULT_TIMEOUT_MS = 20_000;
 const DEFAULT_KILL_GRACE_MS = 1_000;
@@ -19,15 +18,19 @@ export type RipgrepRunInput = {
   toolName: "glob" | "grep";
 };
 
+let cachedRipgrepPath: string | undefined;
+
 export async function runRipgrep(input: RipgrepRunInput): Promise<string> {
   const env = input.env ?? process.env;
   const args = [...input.args];
+  const ripgrepPath = resolveBundledRipgrepPath(input.toolName);
 
   return await new Promise<string>((resolve, reject) => {
-    const child = spawn(rgPath, args, {
+    const child = spawn(ripgrepPath, args, {
       cwd: input.cwd,
       env,
       stdio: ["ignore", "pipe", "pipe"],
+      windowsHide: true,
     });
 
     let stdout = "";
@@ -68,12 +71,7 @@ export async function runRipgrep(input: RipgrepRunInput): Promise<string> {
       if (settled) return;
       settled = true;
       if (isEnoent(error)) {
-        reject(
-          new PilotDeckToolRuntimeError(
-            "unsupported_tool",
-            `${input.toolName} requires ripgrep (\`rg\`) to be installed and available on PATH.`,
-          ),
-        );
+        reject(createBundledRipgrepUnavailableError(input.toolName, error));
         return;
       }
       reject(
@@ -117,6 +115,34 @@ export async function runRipgrep(input: RipgrepRunInput): Promise<string> {
       );
     });
   });
+}
+
+function resolveBundledRipgrepPath(toolName: RipgrepRunInput["toolName"]): string {
+  if (cachedRipgrepPath) {
+    return cachedRipgrepPath;
+  }
+
+  try {
+    const resolved = require("@vscode/ripgrep") as { rgPath?: unknown };
+    if (typeof resolved.rgPath !== "string" || resolved.rgPath.length === 0) {
+      throw new Error("@vscode/ripgrep did not expose a valid rgPath.");
+    }
+    cachedRipgrepPath = resolved.rgPath;
+    return cachedRipgrepPath;
+  } catch (error) {
+    throw createBundledRipgrepUnavailableError(toolName, error);
+  }
+}
+
+function createBundledRipgrepUnavailableError(
+  toolName: RipgrepRunInput["toolName"],
+  cause: unknown,
+): PilotDeckToolRuntimeError {
+  return new PilotDeckToolRuntimeError(
+    "unsupported_tool",
+    `${toolName} requires the bundled ripgrep binary from @vscode/ripgrep, but it is not available for ${process.platform}-${process.arch}. Reinstall dependencies with optional dependencies enabled.`,
+    { cause: cause instanceof Error ? cause.message : String(cause) },
+  );
 }
 
 export function splitRipgrepLines(stdout: string): string[] {

--- a/src/tool/builtin/filesystem/ripgrepFiles.ts
+++ b/src/tool/builtin/filesystem/ripgrepFiles.ts
@@ -21,10 +21,22 @@ export type RipgrepFilesResult = {
   truncated: boolean;
 };
 
+export function normalizeRipgrepGlobPattern(pattern: string): string {
+  return pattern.replace(/\\/g, "/");
+}
+
 export async function ripgrepFiles(input: RipgrepFilesInput): Promise<RipgrepFilesResult> {
   const stdout = await runRipgrep({
     cwd: input.cwd,
-    args: ["--files", "--hidden", "--no-ignore", "--glob", input.pattern, "."],
+    args: [
+      "--files",
+      "--hidden",
+      "--no-ignore",
+      "--glob",
+      normalizeRipgrepGlobPattern(input.pattern),
+      "--sort=modified",
+      ".",
+    ],
     env: input.env,
     signal: input.signal,
     toolName: "glob",
@@ -32,8 +44,7 @@ export async function ripgrepFiles(input: RipgrepFilesInput): Promise<RipgrepFil
   const limit = input.limit ?? DEFAULT_LIMIT;
   const files = splitRipgrepLines(stdout)
     .map(normalizeRelativePath)
-    .filter((line) => !isIgnoredPath(line))
-    .sort();
+    .filter((line) => !isIgnoredPath(line));
   const selected = files.slice(0, limit);
   return {
     files: selected,

--- a/src/tool/builtin/filesystem/ripgrepFiles.ts
+++ b/src/tool/builtin/filesystem/ripgrepFiles.ts
@@ -1,3 +1,5 @@
+import { statSync } from "node:fs";
+import path from "node:path";
 import {
   isIgnoredPath,
   normalizeRelativePath,
@@ -6,6 +8,7 @@ import {
 } from "./ripgrep.js";
 
 const DEFAULT_LIMIT = 1_000;
+const GLOB_ESCAPE_CHARS = new Set(["*", "?", "[", "]", "{", "}", "\\"]);
 
 export type RipgrepFilesInput = {
   cwd: string;
@@ -21,8 +24,20 @@ export type RipgrepFilesResult = {
   truncated: boolean;
 };
 
-export function normalizeRipgrepGlobPattern(pattern: string): string {
-  return pattern.replace(/\\/g, "/");
+export function normalizeRipgrepGlobPattern(pattern: string, cwd?: string): string {
+  let normalized = "";
+  for (let index = 0; index < pattern.length; index += 1) {
+    const char = pattern[index];
+    if (char !== "\\") {
+      normalized += char;
+      continue;
+    }
+
+    normalized += shouldTreatBackslashAsPathSeparator(pattern, index, normalized, cwd)
+      ? "/"
+      : "\\";
+  }
+  return normalized;
 }
 
 export async function ripgrepFiles(input: RipgrepFilesInput): Promise<RipgrepFilesResult> {
@@ -33,7 +48,7 @@ export async function ripgrepFiles(input: RipgrepFilesInput): Promise<RipgrepFil
       "--hidden",
       "--no-ignore",
       "--glob",
-      normalizeRipgrepGlobPattern(input.pattern),
+      normalizeRipgrepGlobPattern(input.pattern, input.cwd),
       "--sort=modified",
       ".",
     ],
@@ -51,4 +66,66 @@ export async function ripgrepFiles(input: RipgrepFilesInput): Promise<RipgrepFil
     count: files.length,
     truncated: selected.length < files.length,
   };
+}
+
+function shouldTreatBackslashAsPathSeparator(
+  pattern: string,
+  index: number,
+  normalizedPrefix: string,
+  cwd: string | undefined,
+): boolean {
+  const next = pattern[index + 1];
+  if (!next) {
+    return false;
+  }
+
+  if (!GLOB_ESCAPE_CHARS.has(next)) {
+    return true;
+  }
+
+  if (startsGlobstarPathSegment(pattern, index + 1)) {
+    return true;
+  }
+
+  if (hasUnescapedGlobSpecialChars(lastPathSegment(normalizedPrefix))) {
+    return true;
+  }
+
+  return cwd !== undefined && staticPrefixIsDirectory(normalizedPrefix, cwd);
+}
+
+function startsGlobstarPathSegment(pattern: string, index: number): boolean {
+  return pattern.startsWith("**", index)
+    && (index + 2 === pattern.length || pattern[index + 2] === "\\" || pattern[index + 2] === "/");
+}
+
+function lastPathSegment(pattern: string): string {
+  const lastSeparator = pattern.lastIndexOf("/");
+  return lastSeparator === -1 ? pattern : pattern.slice(lastSeparator + 1);
+}
+
+function staticPrefixIsDirectory(prefix: string, cwd: string): boolean {
+  if (prefix.length === 0 || hasUnescapedGlobSpecialChars(prefix)) {
+    return false;
+  }
+
+  try {
+    return statSync(path.resolve(cwd, prefix)).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function hasUnescapedGlobSpecialChars(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const char = value[index];
+    if (char === "\\") {
+      index += 1;
+      continue;
+    }
+    if (char === "*" || char === "?" || char === "[" || char === "{") {
+      return true;
+    }
+  }
+  return false;
 }

--- a/src/tool/builtin/glob.ts
+++ b/src/tool/builtin/glob.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import type { PilotDeckToolDefinition } from "../protocol/types.js";
 import { PilotDeckToolRuntimeError } from "../protocol/errors.js";
 import { resolvePilotDeckWorkspacePath } from "./filesystem/pathSafety.js";
@@ -8,6 +9,41 @@ export type GlobInput = {
   path?: string;
   limit?: number;
 };
+
+export function extractGlobBaseDirectory(pattern: string): {
+  baseDir: string;
+  relativePattern: string;
+} {
+  const match = pattern.match(/[*?[{]/);
+  if (!match || match.index === undefined) {
+    return {
+      baseDir: path.dirname(pattern),
+      relativePattern: path.basename(pattern),
+    };
+  }
+
+  const staticPrefix = pattern.slice(0, match.index);
+  const lastSepIndex = Math.max(
+    staticPrefix.lastIndexOf("/"),
+    staticPrefix.lastIndexOf(path.sep),
+  );
+
+  if (lastSepIndex === -1) {
+    return { baseDir: "", relativePattern: pattern };
+  }
+
+  let baseDir = staticPrefix.slice(0, lastSepIndex);
+  const relativePattern = pattern.slice(lastSepIndex + 1);
+
+  if (baseDir === "" && lastSepIndex === 0) {
+    baseDir = "/";
+  }
+  if (process.platform === "win32" && /^[A-Za-z]:$/.test(baseDir)) {
+    baseDir = `${baseDir}${path.sep}`;
+  }
+
+  return { baseDir, relativePattern };
+}
 
 export function createGlobTool(): PilotDeckToolDefinition<GlobInput> {
   return {
@@ -23,7 +59,9 @@ export function createGlobTool(): PilotDeckToolDefinition<GlobInput> {
       properties: {
         pattern: {
           type: "string",
-          description: "The glob pattern to match files against.",
+          description:
+            "The glob pattern to match files against. May be workspace-relative, path-relative, "
+            + "or an absolute glob that resolves inside the workspace.",
         },
         path: {
           type: "string",
@@ -41,19 +79,38 @@ export function createGlobTool(): PilotDeckToolDefinition<GlobInput> {
     isReadOnly: () => true,
     isConcurrencySafe: () => true,
     execute: async (input, context) => {
-      const resolved = resolvePilotDeckWorkspacePath(input.path ?? ".", context, { mustExist: true });
-      if (!resolved.ok) {
-        throw new PilotDeckToolRuntimeError(resolved.error.code, resolved.error.message, resolved.error.details);
+      let searchPath = input.path ?? ".";
+      let searchPattern = input.pattern;
+
+      if (path.isAbsolute(input.pattern)) {
+        const extracted = extractGlobBaseDirectory(input.pattern);
+        if (extracted.baseDir) {
+          searchPath = extracted.baseDir;
+          searchPattern = extracted.relativePattern;
+        }
+      }
+
+      const resolvedSearchPath = resolvePilotDeckWorkspacePath(
+        searchPath,
+        context,
+        { mustExist: true },
+      );
+      if (!resolvedSearchPath.ok) {
+        throw new PilotDeckToolRuntimeError(
+          resolvedSearchPath.error.code,
+          resolvedSearchPath.error.message,
+          resolvedSearchPath.error.details,
+        );
       }
 
       const result = await ripgrepFiles({
-        cwd: resolved.absolutePath,
-        pattern: input.pattern,
+        cwd: resolvedSearchPath.absolutePath,
+        pattern: searchPattern,
         limit: input.limit,
         env: context.env,
         signal: context.abortSignal,
       });
-      const workspacePrefix = resolved.relativePath === "." ? "" : `${resolved.relativePath}/`;
+      const workspacePrefix = resolvedSearchPath.relativePath === "." ? "" : `${resolvedSearchPath.relativePath}/`;
       const workspaceFiles = result.files.map((file) => `${workspacePrefix}${file}`);
 
       return {

--- a/src/tool/index.ts
+++ b/src/tool/index.ts
@@ -67,7 +67,7 @@ export {
 } from "./builtin/agent.js";
 export { createReadFileTool, type ReadFileInput } from "./builtin/readFile.js";
 export { createReadSkillTool, type ReadSkillDeps, type ReadSkillInput } from "./builtin/readSkill.js";
-export { createGlobTool, type GlobInput } from "./builtin/glob.js";
+export { createGlobTool, extractGlobBaseDirectory, type GlobInput } from "./builtin/glob.js";
 export { createGrepTool, type GrepInput } from "./builtin/grep.js";
 export { createEditFileTool, type EditFileInput } from "./builtin/editFile.js";
 export {

--- a/tests/tool/builtin/glob.spec.ts
+++ b/tests/tool/builtin/glob.spec.ts
@@ -1,0 +1,152 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, writeFile, utimes } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { createDefaultPermissionContext } from "../../../src/permission/index.js";
+import { createGlobTool, extractGlobBaseDirectory } from "../../../src/tool/index.js";
+import { normalizeRipgrepGlobPattern } from "../../../src/tool/builtin/filesystem/ripgrepFiles.js";
+import { PilotDeckToolRuntimeError } from "../../../src/tool/protocol/errors.js";
+import type {
+  PilotDeckToolExecutionOutput,
+  PilotDeckToolRuntimeContext,
+} from "../../../src/tool/protocol/types.js";
+
+type GlobData = {
+  files: string[];
+  count: number;
+  truncated: boolean;
+};
+
+test("extractGlobBaseDirectory splits absolute glob patterns for ripgrep", () => {
+  assert.deepEqual(
+    extractGlobBaseDirectory("/tmp_workspace/04_Search_Retrieval_task_2_conflicting_handling/laws/**/*"),
+    {
+      baseDir: "/tmp_workspace/04_Search_Retrieval_task_2_conflicting_handling/laws",
+      relativePattern: "**/*",
+    },
+  );
+  assert.deepEqual(extractGlobBaseDirectory("/workspace/src/tool/builtin/glob.ts"), {
+    baseDir: "/workspace/src/tool/builtin",
+    relativePattern: "glob.ts",
+  });
+});
+
+test("normalizeRipgrepGlobPattern converts Windows path separators for ripgrep glob matching", () => {
+  assert.equal(normalizeRipgrepGlobPattern("laws\\**\\*"), "laws/**/*");
+  assert.equal(normalizeRipgrepGlobPattern("**\\*.ts"), "**/*.ts");
+});
+
+test("glob accepts absolute patterns that resolve inside the workspace", async () => {
+  const root = await makeWorkspace();
+  await mkdir(path.join(root, "laws", "nested"), { recursive: true });
+  await writeFile(path.join(root, "laws", "law1.docx"), "law 1");
+  await writeFile(path.join(root, "laws", "nested", "law2.pdf"), "law 2");
+
+  const result = await runGlob(root, {
+    pattern: path.join(root, "laws", "**", "*"),
+  });
+
+  assert.deepEqual(result.files, ["laws/law1.docx", "laws/nested/law2.pdf"]);
+  assert.equal(result.count, 2);
+  assert.equal(result.truncated, false);
+});
+
+test("glob accepts absolute literal file patterns inside the workspace", async () => {
+  const root = await makeWorkspace();
+  await mkdir(path.join(root, "src", "tool"), { recursive: true });
+  await writeFile(path.join(root, "src", "tool", "glob.ts"), "export {};");
+
+  const result = await runGlob(root, {
+    pattern: path.join(root, "src", "tool", "glob.ts"),
+  });
+
+  assert.deepEqual(result.files, ["src/tool/glob.ts"]);
+});
+
+test("glob accepts Windows-style glob separators before calling ripgrep", async () => {
+  const root = await makeWorkspace();
+  await mkdir(path.join(root, "laws", "nested"), { recursive: true });
+  await writeFile(path.join(root, "laws", "nested", "law2.pdf"), "law 2");
+
+  const result = await runGlob(root, { pattern: "laws\\**\\*" });
+
+  assert.deepEqual(result.files, ["laws/nested/law2.pdf"]);
+  assert.equal(result.count, 1);
+  assert.equal(result.truncated, false);
+});
+
+test("glob does not require system ripgrep on PATH", async () => {
+  const root = await makeWorkspace();
+  await writeFile(path.join(root, "a.txt"), "a");
+
+  const result = await runGlob(root, { pattern: "*.txt" }, { env: { PATH: "" } });
+
+  assert.deepEqual(result.files, ["a.txt"]);
+  assert.equal(result.count, 1);
+  assert.equal(result.truncated, false);
+});
+
+test("glob rejects absolute patterns outside the workspace in default permission mode", async () => {
+  const root = await makeWorkspace();
+  const outside = await makeWorkspace();
+
+  await assert.rejects(
+    () => runGlob(root, { pattern: path.join(outside, "**", "*") }),
+    (error) => error instanceof PilotDeckToolRuntimeError && error.code === "path_not_allowed",
+  );
+});
+
+test("glob returns modified-time ordered results", async () => {
+  const root = await makeWorkspace();
+  await writeFile(path.join(root, "newer.txt"), "newer");
+  await writeFile(path.join(root, "older.txt"), "older");
+  await utimes(
+    path.join(root, "older.txt"),
+    new Date("2020-01-01T00:00:00.000Z"),
+    new Date("2020-01-01T00:00:00.000Z"),
+  );
+  await utimes(
+    path.join(root, "newer.txt"),
+    new Date("2022-01-01T00:00:00.000Z"),
+    new Date("2022-01-01T00:00:00.000Z"),
+  );
+
+  const result = await runGlob(root, { pattern: "*.txt" });
+
+  assert.deepEqual(result.files, ["older.txt", "newer.txt"]);
+});
+
+async function makeWorkspace(): Promise<string> {
+  return await mkdtemp(path.join(tmpdir(), "pilotdeck-glob-test-"));
+}
+
+async function runGlob(
+  cwd: string,
+  input: { pattern: string; path?: string; limit?: number },
+  options?: { env?: NodeJS.ProcessEnv },
+): Promise<GlobData> {
+  const tool = createGlobTool();
+  const output = await tool.execute(
+    input,
+    createContext(cwd, options),
+  ) as PilotDeckToolExecutionOutput<GlobData>;
+  assert.ok(output.data);
+  return output.data;
+}
+
+function createContext(
+  cwd: string,
+  options?: { env?: NodeJS.ProcessEnv },
+): PilotDeckToolRuntimeContext {
+  return {
+    sessionId: "session-1",
+    turnId: "turn-1",
+    cwd,
+    permissionMode: "default",
+    permissionContext: createDefaultPermissionContext({ cwd }),
+    env: options?.env,
+    now: () => new Date("2026-06-26T00:00:00.000Z"),
+  };
+}

--- a/tests/tool/builtin/glob.spec.ts
+++ b/tests/tool/builtin/glob.spec.ts
@@ -36,6 +36,8 @@ test("extractGlobBaseDirectory splits absolute glob patterns for ripgrep", () =>
 test("normalizeRipgrepGlobPattern converts Windows path separators for ripgrep glob matching", () => {
   assert.equal(normalizeRipgrepGlobPattern("laws\\**\\*"), "laws/**/*");
   assert.equal(normalizeRipgrepGlobPattern("**\\*.ts"), "**/*.ts");
+  assert.equal(normalizeRipgrepGlobPattern("literal\\[1\\].txt"), "literal\\[1\\].txt");
+  assert.equal(normalizeRipgrepGlobPattern("literal\\*.txt"), "literal\\*.txt");
 });
 
 test("glob accepts absolute patterns that resolve inside the workspace", async () => {
@@ -75,6 +77,19 @@ test("glob accepts Windows-style glob separators before calling ripgrep", async 
   assert.deepEqual(result.files, ["laws/nested/law2.pdf"]);
   assert.equal(result.count, 1);
   assert.equal(result.truncated, false);
+});
+
+test("glob preserves ripgrep escapes while normalizing path separators", async () => {
+  const root = await makeWorkspace();
+  await mkdir(path.join(root, "src"), { recursive: true });
+  await writeFile(path.join(root, "src", "tool.ts"), "export {};");
+  await writeFile(path.join(root, "literal[1].txt"), "literal");
+
+  const windowsPathResult = await runGlob(root, { pattern: "src\\*.ts" });
+  const escapedGlobResult = await runGlob(root, { pattern: "literal\\[1\\].txt" });
+
+  assert.deepEqual(windowsPathResult.files, ["src/tool.ts"]);
+  assert.deepEqual(escapedGlobResult.files, ["literal[1].txt"]);
 });
 
 test("glob does not require system ripgrep on PATH", async () => {


### PR DESCRIPTION
## Summary
- support absolute glob and literal file patterns that resolve inside the PilotDeck workspace
- normalize Windows-style glob separators before passing patterns to ripgrep
- lazy-load bundled @vscode/ripgrep and report a clearer error when the platform binary is unavailable

## Tests
- node --import tsx --test tests/tool/builtin/glob.spec.ts
- npx tsc --noEmit --module NodeNext --moduleResolution NodeNext --target ES2022 --strict --esModuleInterop --skipLibCheck tests/tool/builtin/glob.spec.ts src/tool/builtin/glob.ts src/tool/builtin/filesystem/ripgrepFiles.ts src/tool/builtin/filesystem/ripgrep.ts src/tool/index.ts
- git diff --check