### PR TITLE
Fix IM permission prompts

### DIFF
--- a/src/adapters/channel/bluebubbles/BlueBubblesChannel.ts
+++ b/src/adapters/channel/bluebubbles/BlueBubblesChannel.ts
@@ -5,6 +5,7 @@ import type { ChannelAdapter, ChannelHandle, ChannelLogger, ChannelStartDeps } f
 import { BlueBubblesSessionMapper } from "./BlueBubblesSessionMapper.js";
 import { renderBlueBubblesEvent } from "./bluebubbles-render.js";
 import { ImElicitationHelper } from "../protocol/ImElicitationHelper.js";
+import { ImPermissionHelper } from "../protocol/ImPermissionHelper.js";
 
 const POLL_MS = 2500;
 const MESSAGE_LIMIT = 50;
@@ -43,6 +44,7 @@ export class BlueBubblesChannel implements ChannelAdapter {
   private seenGuids = new Set<string>();
   private activeChats = new Set<string>();
   private readonly elicitation = new ImElicitationHelper();
+  private readonly permissions = new ImPermissionHelper();
   private running = false;
 
   constructor(options: BlueBubblesChannelOptions = {}) {
@@ -149,6 +151,16 @@ export class BlueBubblesChannel implements ChannelAdapter {
       return;
     }
 
+    if (this.permissions.hasPending(chatGuid) && this.gateway) {
+      try {
+        const confirmation = await this.permissions.answer(chatGuid, text, this.gateway);
+        if (confirmation) await this.sendReply(chatGuid, confirmation);
+      } catch (e) {
+        this.logger?.error?.(`bluebubbles: permission answer error: ${e}`);
+      }
+      return;
+    }
+
     if (this.activeChats.has(chatGuid)) {
       this.logger?.info?.(`bluebubbles: chat ${chatGuid} already active, skipping`);
       return;
@@ -184,6 +196,11 @@ export class BlueBubblesChannel implements ChannelAdapter {
           await this.sendReply(chatGuid, questionText);
           continue;
         }
+        if (event.type === "permission_request") {
+          const questionText = this.permissions.capture(chatGuid, sessionKey, event);
+          await this.sendReply(chatGuid, questionText);
+          continue;
+        }
         const fragment = renderBlueBubblesEvent(event);
         if (fragment != null) replyText += fragment;
       }
@@ -193,6 +210,7 @@ export class BlueBubblesChannel implements ChannelAdapter {
     }
 
     this.elicitation.clear(chatGuid);
+    this.permissions.clear(chatGuid);
 
     const finalText = replyText.trim();
     if (finalText) {

--- a/src/adapters/channel/dingtalk/DingTalkChannel.ts
+++ b/src/adapters/channel/dingtalk/DingTalkChannel.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import type { Gateway, GatewayChannelKey } from "../../../gateway/index.js";
 import type { ChannelAdapter, ChannelHandle, ChannelLogger, ChannelStartDeps } from "../protocol/ChannelAdapter.js";
 import { ImElicitationHelper } from "../protocol/ImElicitationHelper.js";
+import { ImPermissionHelper } from "../protocol/ImPermissionHelper.js";
 import { DingTalkSessionMapper } from "./DingTalkSessionMapper.js";
 import { renderDingTalkEvent } from "./dingtalk-render.js";
 
@@ -36,6 +37,7 @@ export class DingTalkChannel implements ChannelAdapter {
   private client: any = null;
   private activeChats = new Set<string>();
   private readonly elicitation = new ImElicitationHelper();
+  private readonly permissions = new ImPermissionHelper();
   private sessionWebhooks = new Map<string, string>();
   private seenIds = new Set<string>();
 
@@ -134,6 +136,16 @@ export class DingTalkChannel implements ChannelAdapter {
       return;
     }
 
+    if (this.permissions.hasPending(chatId) && this.gateway) {
+      try {
+        const confirmation = await this.permissions.answer(chatId, text.trim(), this.gateway);
+        if (confirmation) await this.sendReply(chatId, confirmation);
+      } catch (e) {
+        this.logger?.error?.(`dingtalk: permission answer error: ${e}`);
+      }
+      return;
+    }
+
     if (this.activeChats.has(chatId)) {
       this.logger?.info?.(`dingtalk: chat ${chatId} already active, skipping`);
       return;
@@ -195,6 +207,11 @@ export class DingTalkChannel implements ChannelAdapter {
           await this.sendReply(chatId, questionText);
           continue;
         }
+        if (event.type === "permission_request") {
+          const questionText = this.permissions.capture(chatId, sessionKey, event);
+          await this.sendReply(chatId, questionText);
+          continue;
+        }
         const fragment = renderDingTalkEvent(event);
         if (fragment != null) replyText += fragment;
       }
@@ -204,6 +221,7 @@ export class DingTalkChannel implements ChannelAdapter {
     }
 
     this.elicitation.clear(chatId);
+    this.permissions.clear(chatId);
     const finalText = replyText.trim();
     if (finalText) {
       await this.sendReply(chatId, finalText);

--- a/src/adapters/channel/discord/DiscordChannel.ts
+++ b/src/adapters/channel/discord/DiscordChannel.ts
@@ -1,6 +1,7 @@
 import type { Gateway, GatewayChannelKey } from "../../../gateway/index.js";
 import type { ChannelAdapter, ChannelHandle, ChannelLogger, ChannelStartDeps } from "../protocol/ChannelAdapter.js";
 import { ImElicitationHelper } from "../protocol/ImElicitationHelper.js";
+import { ImPermissionHelper } from "../protocol/ImPermissionHelper.js";
 import { DiscordSessionMapper } from "./DiscordSessionMapper.js";
 import { renderDiscordEvent } from "./discord-render.js";
 
@@ -31,6 +32,7 @@ export class DiscordChannel implements ChannelAdapter {
   private botUserId: string | null = null;
   private activeChats = new Set<string>();
   private readonly elicitation = new ImElicitationHelper();
+  private readonly permissions = new ImPermissionHelper();
 
   constructor(options: DiscordChannelOptions = {}) {
     this.mapper = options.mapper ?? new DiscordSessionMapper();
@@ -117,6 +119,16 @@ export class DiscordChannel implements ChannelAdapter {
       return;
     }
 
+    if (this.permissions.hasPending(chatId) && this.gateway) {
+      try {
+        const confirmation = await this.permissions.answer(chatId, text, this.gateway);
+        if (confirmation) await this.sendReply(chatId, confirmation);
+      } catch (e) {
+        this.logger?.error?.(`discord: permission answer error: ${e}`);
+      }
+      return;
+    }
+
     if (this.activeChats.has(chatId)) {
       this.logger?.info?.(`discord: chat ${chatId} already active, skipping`);
       return;
@@ -154,6 +166,11 @@ export class DiscordChannel implements ChannelAdapter {
           await this.sendReply(chatId, questionText);
           continue;
         }
+        if (event.type === "permission_request") {
+          const questionText = this.permissions.capture(chatId, sessionKey, event);
+          await this.sendReply(chatId, questionText);
+          continue;
+        }
         const fragment = renderDiscordEvent(event);
         if (fragment != null) replyText += fragment;
       }
@@ -163,6 +180,7 @@ export class DiscordChannel implements ChannelAdapter {
     }
 
     this.elicitation.clear(chatId);
+    this.permissions.clear(chatId);
     const finalText = replyText.trim();
     if (finalText) {
       await this.sendReply(chatId, finalText);

--- a/src/adapters/channel/email/EmailChannel.ts
+++ b/src/adapters/channel/email/EmailChannel.ts
@@ -3,6 +3,7 @@ import type { ChannelAdapter, ChannelHandle, ChannelLogger, ChannelStartDeps } f
 import { EmailSessionMapper } from "./EmailSessionMapper.js";
 import { renderEmailEvent } from "./email-render.js";
 import { ImElicitationHelper } from "../protocol/ImElicitationHelper.js";
+import { ImPermissionHelper } from "../protocol/ImPermissionHelper.js";
 
 let ImapFlow: any;
 let nodemailer: any;
@@ -42,6 +43,7 @@ export class EmailChannel implements ChannelAdapter {
   private defaultSubject = "Message";
   private activeChats = new Set<string>();
   private readonly elicitation = new ImElicitationHelper();
+  private readonly permissions = new ImPermissionHelper();
   private stopped = false;
 
   constructor(options: EmailChannelOptions = {}) {
@@ -218,6 +220,16 @@ export class EmailChannel implements ChannelAdapter {
       return;
     }
 
+    if (this.permissions.hasPending(chatId) && this.gateway) {
+      try {
+        const confirmation = await this.permissions.answer(chatId, text, this.gateway);
+        if (confirmation) await this.sendReply(chatId, confirmation);
+      } catch (e) {
+        this.logger?.error?.(`email: permission answer error: ${e}`);
+      }
+      return;
+    }
+
     if (this.activeChats.has(chatId)) {
       this.logger?.info?.(`email: chat ${chatId} already active, skipping`);
       return;
@@ -253,6 +265,11 @@ export class EmailChannel implements ChannelAdapter {
           await this.sendReply(chatId, questionText);
           continue;
         }
+        if (event.type === "permission_request") {
+          const questionText = this.permissions.capture(chatId, sessionKey, event);
+          await this.sendReply(chatId, questionText);
+          continue;
+        }
         const fragment = renderEmailEvent(event);
         if (fragment != null) replyText += fragment;
       }
@@ -262,6 +279,7 @@ export class EmailChannel implements ChannelAdapter {
     }
 
     this.elicitation.clear(chatId);
+    this.permissions.clear(chatId);
 
     const finalText = replyText.trim();
     if (finalText) {

--- a/src/adapters/channel/feishu/FeishuChannel.ts
+++ b/src/adapters/channel/feishu/FeishuChannel.ts
@@ -4,6 +4,7 @@ import type { Gateway } from "../../../gateway/index.js";
 import type { ChannelAdapter, ChannelHandle, ChannelLogger, ChannelStartDeps } from "../protocol/ChannelAdapter.js";
 import { executeChannelCommand, resolveCommand } from "../protocol/ChannelCommandRegistry.js";
 import { ImElicitationHelper } from "../protocol/ImElicitationHelper.js";
+import { ImPermissionHelper } from "../protocol/ImPermissionHelper.js";
 import {
   ImLiveReplyController,
   type ImLiveReplyControllerOptions,
@@ -99,6 +100,7 @@ export class FeishuChannel implements ChannelAdapter {
   private readonly seenEvents = new Set<string>();
   private readonly activeChats = new Set<string>();
   private readonly elicitation = new ImElicitationHelper();
+  private readonly permissions = new ImPermissionHelper();
 
   private wsClient: any = null;
 
@@ -265,6 +267,16 @@ export class FeishuChannel implements ChannelAdapter {
       return;
     }
 
+    if (this.permissions.hasPending(chatId)) {
+      try {
+        const confirmation = await this.permissions.answer(chatId, text, this.gateway);
+        if (confirmation) await this.send({ chatId, text: confirmation });
+      } catch (e) {
+        this.logger?.error?.(`feishu: permission answer error: ${e}`);
+      }
+      return;
+    }
+
     const mapped = this.mapper.resolve({ chatId, text });
 
     if (mapped.command === "new" && !mapped.message) {
@@ -341,6 +353,12 @@ export class FeishuChannel implements ChannelAdapter {
             await this.send({ chatId, text: questionText });
             continue;
           }
+          if (event.type === "permission_request") {
+            const questionText = this.permissions.capture(chatId, mapped.sessionKey, event);
+            await liveReply.pauseActivity();
+            await this.send({ chatId, text: questionText });
+            continue;
+          }
           if (event.type === "error" && event.code === "agent_aborted") {
             await liveReply.markAborted();
             continue;
@@ -364,6 +382,7 @@ export class FeishuChannel implements ChannelAdapter {
       }
 
       this.elicitation.clear(chatId);
+      this.permissions.clear(chatId);
       await liveReply.flushFinal();
     } finally {
       if (reactionId && messageId) {

--- a/src/adapters/channel/homeassistant/HomeAssistantChannel.ts
+++ b/src/adapters/channel/homeassistant/HomeAssistantChannel.ts
@@ -3,6 +3,7 @@ import type { ChannelAdapter, ChannelHandle, ChannelLogger, ChannelStartDeps } f
 import { HomeAssistantSessionMapper } from "./HomeAssistantSessionMapper.js";
 import { renderHomeAssistantEvent } from "./homeassistant-render.js";
 import { ImElicitationHelper } from "../protocol/ImElicitationHelper.js";
+import { ImPermissionHelper } from "../protocol/ImPermissionHelper.js";
 
 let WebSocketImpl: any;
 try {
@@ -49,6 +50,7 @@ export class HomeAssistantChannel implements ChannelAdapter {
   private authSettle: ((ok: boolean) => void) | null = null;
   private activeChats = new Set<string>();
   private readonly elicitation = new ImElicitationHelper();
+  private readonly permissions = new ImPermissionHelper();
 
   constructor(options: HomeAssistantChannelOptions = {}) {
     this.mapper = options.mapper ?? new HomeAssistantSessionMapper();
@@ -232,6 +234,16 @@ export class HomeAssistantChannel implements ChannelAdapter {
       return;
     }
 
+    if (this.permissions.hasPending(chatId) && this.gateway) {
+      try {
+        const confirmation = await this.permissions.answer(chatId, text, this.gateway);
+        if (confirmation) await this.sendReply(chatId, confirmation);
+      } catch (e) {
+        this.logger?.error?.(`homeassistant: permission answer error: ${e}`);
+      }
+      return;
+    }
+
     if (this.activeChats.has(chatId)) {
       this.logger?.info?.(`homeassistant: chat ${chatId} already active, skipping`);
       return;
@@ -267,6 +279,11 @@ export class HomeAssistantChannel implements ChannelAdapter {
           await this.sendReply(chatId, questionText);
           continue;
         }
+        if (event.type === "permission_request") {
+          const questionText = this.permissions.capture(chatId, sessionKey, event);
+          await this.sendReply(chatId, questionText);
+          continue;
+        }
         const fragment = renderHomeAssistantEvent(event);
         if (fragment != null) replyText += fragment;
       }
@@ -276,6 +293,7 @@ export class HomeAssistantChannel implements ChannelAdapter {
     }
 
     this.elicitation.clear(chatId);
+    this.permissions.clear(chatId);
 
     const finalText = replyText.trim();
     if (finalText) {

--- a/src/adapters/channel/matrix/MatrixChannel.ts
+++ b/src/adapters/channel/matrix/MatrixChannel.ts
@@ -4,6 +4,7 @@ import type { ChannelAdapter, ChannelHandle, ChannelLogger, ChannelStartDeps } f
 import { MatrixSessionMapper } from "./MatrixSessionMapper.js";
 import { renderMatrixEvent } from "./matrix-render.js";
 import { ImElicitationHelper } from "../protocol/ImElicitationHelper.js";
+import { ImPermissionHelper } from "../protocol/ImPermissionHelper.js";
 
 let MatrixSdk: any;
 try {
@@ -38,6 +39,7 @@ export class MatrixChannel implements ChannelAdapter {
   private userId: string | null = null;
   private activeChats = new Set<string>();
   private readonly elicitation = new ImElicitationHelper();
+  private readonly permissions = new ImPermissionHelper();
 
   constructor(options: MatrixChannelOptions = {}) {
     this.mapper = options.mapper ?? new MatrixSessionMapper();
@@ -135,6 +137,16 @@ export class MatrixChannel implements ChannelAdapter {
       return;
     }
 
+    if (this.permissions.hasPending(roomId) && this.gateway) {
+      try {
+        const confirmation = await this.permissions.answer(roomId, text, this.gateway);
+        if (confirmation) await this.sendReply(roomId, confirmation);
+      } catch (e) {
+        this.logger?.error?.(`matrix: permission answer error: ${e}`);
+      }
+      return;
+    }
+
     if (this.activeChats.has(roomId)) {
       this.logger?.info?.(`matrix: room ${roomId} already active, skipping`);
       return;
@@ -170,6 +182,11 @@ export class MatrixChannel implements ChannelAdapter {
           await this.sendReply(roomId, questionText);
           continue;
         }
+        if (event.type === "permission_request") {
+          const questionText = this.permissions.capture(roomId, sessionKey, event);
+          await this.sendReply(roomId, questionText);
+          continue;
+        }
         const fragment = renderMatrixEvent(event);
         if (fragment != null) replyText += fragment;
       }
@@ -179,6 +196,7 @@ export class MatrixChannel implements ChannelAdapter {
     }
 
     this.elicitation.clear(roomId);
+    this.permissions.clear(roomId);
 
     const finalText = replyText.trim();
     if (finalText) {

--- a/src/adapters/channel/mattermost/MattermostChannel.ts
+++ b/src/adapters/channel/mattermost/MattermostChannel.ts
@@ -3,6 +3,7 @@ import type { ChannelAdapter, ChannelHandle, ChannelLogger, ChannelStartDeps } f
 import { MattermostSessionMapper } from "./MattermostSessionMapper.js";
 import { renderMattermostEvent } from "./mattermost-render.js";
 import { ImElicitationHelper } from "../protocol/ImElicitationHelper.js";
+import { ImPermissionHelper } from "../protocol/ImPermissionHelper.js";
 
 let WebSocketImpl: any;
 try {
@@ -40,6 +41,7 @@ export class MattermostChannel implements ChannelAdapter {
   private closed = false;
   private activeChats = new Set<string>();
   private readonly elicitation = new ImElicitationHelper();
+  private readonly permissions = new ImPermissionHelper();
 
   constructor(options: MattermostChannelOptions = {}) {
     this.mapper = options.mapper ?? new MattermostSessionMapper();
@@ -170,6 +172,16 @@ export class MattermostChannel implements ChannelAdapter {
       return;
     }
 
+    if (this.permissions.hasPending(chatId) && this.gateway) {
+      try {
+        const confirmation = await this.permissions.answer(chatId, text, this.gateway);
+        if (confirmation) await this.sendReply({ channelId, rootId }, confirmation);
+      } catch (e) {
+        this.logger?.error?.(`mattermost: permission answer error: ${e}`);
+      }
+      return;
+    }
+
     if (this.activeChats.has(chatId)) {
       this.logger?.info?.(`mattermost: chat ${chatId} already active, skipping`);
       return;
@@ -212,6 +224,12 @@ export class MattermostChannel implements ChannelAdapter {
           await this.sendReply(ctx, questionText);
           continue;
         }
+        if (event.type === "permission_request") {
+          const chatId = ctx.rootId ? `${ctx.channelId}:${ctx.rootId}` : ctx.channelId;
+          const questionText = this.permissions.capture(chatId, sessionKey, event);
+          await this.sendReply(ctx, questionText);
+          continue;
+        }
         const fragment = renderMattermostEvent(event);
         if (fragment != null) replyText += fragment;
       }
@@ -222,6 +240,7 @@ export class MattermostChannel implements ChannelAdapter {
 
     const chatId = ctx.rootId ? `${ctx.channelId}:${ctx.rootId}` : ctx.channelId;
     this.elicitation.clear(chatId);
+    this.permissions.clear(chatId);
 
     const finalText = replyText.trim();
     if (finalText) {

--- a/src/adapters/channel/protocol/ImLiveReplyController.ts
+++ b/src/adapters/channel/protocol/ImLiveReplyController.ts
@@ -215,6 +215,17 @@ export class ImLiveReplyController<Handle = ImLiveReplyHandle> {
     await this.stopNativeActivity();
   }
 
+  async resumeActivity(kind: ImLiveReplyActivityKind = "thinking"): Promise<void> {
+    if (this.closed) return;
+    this.clearActivityTimers();
+    const segment = this.currentSegment;
+    segment.activityKind = kind;
+    segment.activityStartedAt = Date.now();
+    segment.activityArmed = true;
+    segment.activityUpdates = 0;
+    await this.flushActivity({ force: true });
+  }
+
   async clear(): Promise<void> {
     this.clearTextTimer();
     this.clearTurnTimer();

--- a/src/adapters/channel/protocol/ImPermissionHelper.ts
+++ b/src/adapters/channel/protocol/ImPermissionHelper.ts
@@ -1,0 +1,81 @@
+import type { Gateway, GatewayEvent } from "../../../gateway/index.js";
+
+type PendingPermission = {
+  sessionKey: string;
+  requestId: string;
+  toolName: string;
+  payload: unknown;
+};
+
+export class ImPermissionHelper {
+  private readonly pending = new Map<string, PendingPermission>();
+
+  capture(chatId: string, sessionKey: string, event: GatewayEvent & { type: "permission_request" }): string {
+    this.pending.set(chatId, {
+      sessionKey,
+      requestId: event.requestId,
+      toolName: event.toolName,
+      payload: event.payload,
+    });
+
+    const lines = [
+      `工具 ${event.toolName} 需要权限才能继续执行。`,
+      "",
+      "请求内容：",
+      formatPayload(event.payload),
+      "",
+      "回复 1 允许一次，回复 2 允许本会话，回复 0 拒绝。",
+    ];
+    return lines.join("\n");
+  }
+
+  hasPending(chatId: string): boolean {
+    return this.pending.has(chatId);
+  }
+
+  async answer(chatId: string, text: string, gateway: Gateway): Promise<string | undefined> {
+    const entry = this.pending.get(chatId);
+    if (!entry) return undefined;
+
+    const trimmed = text.trim();
+    if (trimmed !== "0" && trimmed !== "1" && trimmed !== "2") {
+      return "请回复 1 允许一次，回复 2 允许本会话，回复 0 拒绝。";
+    }
+
+    this.pending.delete(chatId);
+    if (trimmed === "0") {
+      await gateway.permissionDecide({
+        sessionKey: entry.sessionKey,
+        requestId: entry.requestId,
+        decision: "deny",
+        reason: "User denied permission from IM channel.",
+      });
+      return "已拒绝，继续处理。";
+    }
+
+    await gateway.permissionDecide({
+      sessionKey: entry.sessionKey,
+      requestId: entry.requestId,
+      decision: "allow",
+      remember: trimmed === "2",
+    });
+    return trimmed === "2" ? "已允许本会话，继续执行。" : "已允许一次，继续执行。";
+  }
+
+  clear(chatId: string): void {
+    this.pending.delete(chatId);
+  }
+}
+
+function formatPayload(payload: unknown): string {
+  let text: string;
+  try {
+    text = JSON.stringify(payload, null, 2) ?? String(payload);
+  } catch {
+    text = String(payload);
+  }
+
+  const trimmed = text.trim();
+  if (trimmed.length <= 800) return trimmed || "(空)";
+  return `${trimmed.slice(0, 800)}...`;
+}

--- a/src/adapters/channel/qq/QQChannel.ts
+++ b/src/adapters/channel/qq/QQChannel.ts
@@ -2,6 +2,7 @@ import type { Gateway, GatewayChannelKey } from "../../../gateway/index.js";
 import type { ChannelAdapter, ChannelHandle, ChannelLogger, ChannelStartDeps } from "../protocol/ChannelAdapter.js";
 import { QQBotGateway, type QQBotCredentials, type QQGroupMessageEvent, type QQC2CMessageEvent } from "./qqbot-gateway.js";
 import { ImElicitationHelper } from "../protocol/ImElicitationHelper.js";
+import { ImPermissionHelper } from "../protocol/ImPermissionHelper.js";
 import { QQSessionMapper } from "./QQSessionMapper.js";
 import { renderQQEvent } from "./qq-render.js";
 
@@ -31,6 +32,7 @@ export class QQChannel implements ChannelAdapter {
   private botGateway?: QQBotGateway;
   private activeChats = new Set<string>();
   private readonly elicitation = new ImElicitationHelper();
+  private readonly permissions = new ImPermissionHelper();
 
   constructor(options: QQChannelOptions = {}) {
     this.credentials = {
@@ -133,6 +135,16 @@ export class QQChannel implements ChannelAdapter {
       return;
     }
 
+    if (this.permissions.hasPending(chatKey) && this.gateway) {
+      try {
+        const confirmation = await this.permissions.answer(chatKey, text, this.gateway);
+        if (confirmation) await this.sendReply(groupOpenId, confirmation);
+      } catch (e) {
+        this.logger?.error?.(`qq: permission answer error: ${e}`);
+      }
+      return;
+    }
+
     if (this.activeChats.has(chatKey)) {
       this.logger?.info?.(`qq: chat ${chatKey} already active, skipping`);
       return;
@@ -149,7 +161,7 @@ export class QQChannel implements ChannelAdapter {
 
     this.activeChats.add(chatKey);
     try {
-      await this.processMessage(groupOpenId, mapped.sessionKey, mapped.message, event.id);
+      await this.processMessage(chatKey, groupOpenId, mapped.sessionKey, mapped.message, event.id);
     } finally {
       this.activeChats.delete(chatKey);
     }
@@ -170,6 +182,16 @@ export class QQChannel implements ChannelAdapter {
         if (confirmation) await this.sendC2CReply(userOpenId, confirmation);
       } catch (e) {
         this.logger?.error?.(`qq: elicitation answer error (c2c): ${e}`);
+      }
+      return;
+    }
+
+    if (this.permissions.hasPending(chatKey) && this.gateway) {
+      try {
+        const confirmation = await this.permissions.answer(chatKey, rawText, this.gateway);
+        if (confirmation) await this.sendC2CReply(userOpenId, confirmation);
+      } catch (e) {
+        this.logger?.error?.(`qq: permission answer error (c2c): ${e}`);
       }
       return;
     }
@@ -209,6 +231,11 @@ export class QQChannel implements ChannelAdapter {
           await this.sendC2CReplyChunked(userOpenId, questionText, msgId);
           continue;
         }
+        if (event.type === "permission_request") {
+          const questionText = this.permissions.capture(chatKey, sessionKey, event);
+          await this.sendC2CReplyChunked(userOpenId, questionText, msgId);
+          continue;
+        }
         const fragment = renderQQEvent(event);
         if (fragment != null) replyText += fragment;
       }
@@ -218,6 +245,7 @@ export class QQChannel implements ChannelAdapter {
     }
 
     this.elicitation.clear(chatKey);
+    this.permissions.clear(chatKey);
     const finalText = replyText.trim();
     if (finalText) {
       await this.sendC2CReplyChunked(userOpenId, finalText, msgId);
@@ -255,6 +283,7 @@ export class QQChannel implements ChannelAdapter {
   }
 
   private async processMessage(
+    chatKey: string,
     groupOpenId: string,
     sessionKey: string,
     message: string,
@@ -270,7 +299,12 @@ export class QQChannel implements ChannelAdapter {
         message,
       })) {
         if (event.type === "elicitation_request") {
-          const questionText = this.elicitation.capture(groupOpenId, sessionKey, event);
+          const questionText = this.elicitation.capture(chatKey, sessionKey, event);
+          await this.sendReplyChunked(groupOpenId, questionText, msgId);
+          continue;
+        }
+        if (event.type === "permission_request") {
+          const questionText = this.permissions.capture(chatKey, sessionKey, event);
           await this.sendReplyChunked(groupOpenId, questionText, msgId);
           continue;
         }
@@ -282,7 +316,8 @@ export class QQChannel implements ChannelAdapter {
       replyText = "处理消息时发生错误，请重试。";
     }
 
-    this.elicitation.clear(groupOpenId);
+    this.elicitation.clear(chatKey);
+    this.permissions.clear(chatKey);
     const finalText = replyText.trim();
     if (finalText) {
       await this.sendReplyChunked(groupOpenId, finalText, msgId);

--- a/src/adapters/channel/signal/SignalChannel.ts
+++ b/src/adapters/channel/signal/SignalChannel.ts
@@ -3,6 +3,7 @@ import type { ChannelAdapter, ChannelHandle, ChannelLogger, ChannelStartDeps } f
 import { SignalSessionMapper } from "./SignalSessionMapper.js";
 import { renderSignalEvent } from "./signal-render.js";
 import { ImElicitationHelper } from "../protocol/ImElicitationHelper.js";
+import { ImPermissionHelper } from "../protocol/ImPermissionHelper.js";
 
 const MAX_MESSAGE_LENGTH = 2000;
 const DEFAULT_REST_URL = "http://127.0.0.1:8080";
@@ -72,6 +73,7 @@ export class SignalChannel implements ChannelAdapter {
   private running = false;
   private activeChats = new Set<string>();
   private readonly elicitation = new ImElicitationHelper();
+  private readonly permissions = new ImPermissionHelper();
   private recipientByChat = new Map<string, string>();
 
   constructor(options: SignalChannelOptions = {}) {
@@ -184,6 +186,16 @@ export class SignalChannel implements ChannelAdapter {
       return;
     }
 
+    if (this.permissions.hasPending(sessionChatId) && this.gateway) {
+      try {
+        const confirmation = await this.permissions.answer(sessionChatId, text, this.gateway);
+        if (confirmation) await this.sendReply(sessionChatId, confirmation);
+      } catch (e) {
+        this.logger?.error?.(`signal: permission answer error: ${e}`);
+      }
+      return;
+    }
+
     if (this.activeChats.has(sessionChatId)) {
       this.logger?.info?.(`signal: chat ${sessionChatId} already active, skipping`);
       return;
@@ -219,6 +231,11 @@ export class SignalChannel implements ChannelAdapter {
           await this.sendReply(chatId, questionText);
           continue;
         }
+        if (event.type === "permission_request") {
+          const questionText = this.permissions.capture(chatId, sessionKey, event);
+          await this.sendReply(chatId, questionText);
+          continue;
+        }
         const fragment = renderSignalEvent(event);
         if (fragment != null) replyText += fragment;
       }
@@ -228,6 +245,7 @@ export class SignalChannel implements ChannelAdapter {
     }
 
     this.elicitation.clear(chatId);
+    this.permissions.clear(chatId);
 
     const finalText = replyText.trim();
     if (finalText) {

--- a/src/adapters/channel/signal/SignalChannel.ts
+++ b/src/adapters/channel/signal/SignalChannel.ts
@@ -145,7 +145,9 @@ export class SignalChannel implements ChannelAdapter {
           const lines = carry.split(/\r?\n/);
           carry = lines.pop() ?? "";
           for (const line of lines) {
-            await this.parseLine(line);
+            void this.parseLine(line).catch((e) => {
+              this.logger?.error?.(`signal: parseLine error: ${e}`);
+            });
           }
         }
       } catch (e) {

--- a/src/adapters/channel/slack/SlackChannel.ts
+++ b/src/adapters/channel/slack/SlackChannel.ts
@@ -1,6 +1,7 @@
 import type { Gateway, GatewayChannelKey } from "../../../gateway/index.js";
 import type { ChannelAdapter, ChannelHandle, ChannelLogger, ChannelStartDeps } from "../protocol/ChannelAdapter.js";
 import { ImElicitationHelper } from "../protocol/ImElicitationHelper.js";
+import { ImPermissionHelper } from "../protocol/ImPermissionHelper.js";
 import { SlackSessionMapper } from "./SlackSessionMapper.js";
 import { renderSlackEvent } from "./slack-render.js";
 
@@ -33,6 +34,7 @@ export class SlackChannel implements ChannelAdapter {
   private botUserId: string | null = null;
   private activeChats = new Set<string>();
   private readonly elicitation = new ImElicitationHelper();
+  private readonly permissions = new ImPermissionHelper();
 
   constructor(options: SlackChannelOptions = {}) {
     this.mapper = options.mapper ?? new SlackSessionMapper();
@@ -128,6 +130,16 @@ export class SlackChannel implements ChannelAdapter {
       return;
     }
 
+    if (this.permissions.hasPending(chatId) && this.gateway) {
+      try {
+        const confirmation = await this.permissions.answer(chatId, text, this.gateway);
+        if (confirmation) await this.sendReply({ channelId, threadTs }, confirmation);
+      } catch (e) {
+        this.logger?.error?.(`slack: permission answer error: ${e}`);
+      }
+      return;
+    }
+
     if (this.activeChats.has(chatId)) {
       this.logger?.info?.(`slack: chat ${chatId} already active, skipping`);
       return;
@@ -170,6 +182,11 @@ export class SlackChannel implements ChannelAdapter {
           await this.sendReply(ctx, questionText);
           continue;
         }
+        if (event.type === "permission_request") {
+          const questionText = this.permissions.capture(chatId, sessionKey, event);
+          await this.sendReply(ctx, questionText);
+          continue;
+        }
         const fragment = renderSlackEvent(event);
         if (fragment != null) replyText += fragment;
       }
@@ -179,6 +196,7 @@ export class SlackChannel implements ChannelAdapter {
     }
 
     this.elicitation.clear(chatId);
+    this.permissions.clear(chatId);
     const finalText = replyText.trim();
     if (finalText) {
       await this.sendReply(ctx, finalText);

--- a/src/adapters/channel/sms/SmsChannel.ts
+++ b/src/adapters/channel/sms/SmsChannel.ts
@@ -5,6 +5,7 @@ import type { ChannelAdapter, ChannelHandle, ChannelLogger, ChannelStartDeps } f
 import { SmsSessionMapper } from "./SmsSessionMapper.js";
 import { renderSmsEvent } from "./sms-render.js";
 import { ImElicitationHelper } from "../protocol/ImElicitationHelper.js";
+import { ImPermissionHelper } from "../protocol/ImPermissionHelper.js";
 
 let twilioFactory: any;
 try {
@@ -44,6 +45,7 @@ export class SmsChannel implements ChannelAdapter {
   private path = DEFAULT_PATH;
   private activeChats = new Set<string>();
   private readonly elicitation = new ImElicitationHelper();
+  private readonly permissions = new ImPermissionHelper();
 
   constructor(options: SmsChannelOptions = {}) {
     this.mapper = options.mapper ?? new SmsSessionMapper();
@@ -206,6 +208,16 @@ export class SmsChannel implements ChannelAdapter {
       return;
     }
 
+    if (this.permissions.hasPending(chatId) && this.gateway) {
+      try {
+        const confirmation = await this.permissions.answer(chatId, text, this.gateway);
+        if (confirmation) await this.sendReply(chatId, confirmation);
+      } catch (e) {
+        this.logger?.error?.(`sms: permission answer error: ${e}`);
+      }
+      return;
+    }
+
     if (this.activeChats.has(chatId)) {
       this.logger?.info?.(`sms: chat ${chatId} already active, skipping`);
       return;
@@ -241,6 +253,11 @@ export class SmsChannel implements ChannelAdapter {
           await this.sendReply(chatId, questionText);
           continue;
         }
+        if (event.type === "permission_request") {
+          const questionText = this.permissions.capture(chatId, sessionKey, event);
+          await this.sendReply(chatId, questionText);
+          continue;
+        }
         const fragment = renderSmsEvent(event);
         if (fragment != null) replyText += fragment;
       }
@@ -250,6 +267,7 @@ export class SmsChannel implements ChannelAdapter {
     }
 
     this.elicitation.clear(chatId);
+    this.permissions.clear(chatId);
 
     const finalText = replyText.trim();
     if (finalText) {

--- a/src/adapters/channel/telegram/TelegramChannel.ts
+++ b/src/adapters/channel/telegram/TelegramChannel.ts
@@ -1,6 +1,7 @@
 import type { Gateway, GatewayChannelKey } from "../../../gateway/index.js";
 import type { ChannelAdapter, ChannelHandle, ChannelLogger, ChannelStartDeps } from "../protocol/ChannelAdapter.js";
 import { ImElicitationHelper } from "../protocol/ImElicitationHelper.js";
+import { ImPermissionHelper } from "../protocol/ImPermissionHelper.js";
 import { TelegramSessionMapper } from "./TelegramSessionMapper.js";
 import { renderTelegramEvent } from "./telegram-render.js";
 
@@ -32,6 +33,7 @@ export class TelegramChannel implements ChannelAdapter {
   private bot: any = null;
   private activeChats = new Set<string>();
   private readonly elicitation = new ImElicitationHelper();
+  private readonly permissions = new ImPermissionHelper();
 
   constructor(options: TelegramChannelOptions = {}) {
     this.mapper = options.mapper ?? new TelegramSessionMapper();
@@ -101,6 +103,16 @@ export class TelegramChannel implements ChannelAdapter {
       return;
     }
 
+    if (this.permissions.hasPending(chatId) && this.gateway) {
+      try {
+        const confirmation = await this.permissions.answer(chatId, msg.text, this.gateway);
+        if (confirmation) await this.sendReply(chatId, confirmation);
+      } catch (e) {
+        this.logger?.error?.(`telegram: permission answer error: ${e}`);
+      }
+      return;
+    }
+
     if (this.activeChats.has(chatId)) {
       this.logger?.info?.(`telegram: chat ${chatId} already active, skipping`);
       return;
@@ -138,6 +150,11 @@ export class TelegramChannel implements ChannelAdapter {
           await this.sendReply(chatId, questionText);
           continue;
         }
+        if (event.type === "permission_request") {
+          const questionText = this.permissions.capture(chatId, sessionKey, event);
+          await this.sendReply(chatId, questionText);
+          continue;
+        }
         const fragment = renderTelegramEvent(event);
         if (fragment != null) replyText += fragment;
       }
@@ -147,6 +164,7 @@ export class TelegramChannel implements ChannelAdapter {
     }
 
     this.elicitation.clear(chatId);
+    this.permissions.clear(chatId);
     const finalText = replyText.trim();
     if (finalText) {
       await this.sendReply(chatId, finalText);

--- a/src/adapters/channel/wecom-callback/WeComCallbackChannel.ts
+++ b/src/adapters/channel/wecom-callback/WeComCallbackChannel.ts
@@ -6,6 +6,7 @@ import type { ChannelAdapter, ChannelHandle, ChannelLogger, ChannelStartDeps } f
 import { WeComCallbackSessionMapper } from "./WeComCallbackSessionMapper.js";
 import { renderWeComCallbackEvent } from "./wecom-callback-render.js";
 import { ImElicitationHelper } from "../protocol/ImElicitationHelper.js";
+import { ImPermissionHelper } from "../protocol/ImPermissionHelper.js";
 
 const QYAPI = "https://qyapi.weixin.qq.com/cgi-bin";
 const DEFAULT_PORT = 8780;
@@ -90,6 +91,7 @@ export class WeComCallbackChannel implements ChannelAdapter {
   private accessTokenExpires = 0;
   private activeChats = new Set<string>();
   private readonly elicitation = new ImElicitationHelper();
+  private readonly permissions = new ImPermissionHelper();
 
   constructor(options: WeComCallbackChannelOptions = {}) {
     this.mapper = options.mapper ?? new WeComCallbackSessionMapper();
@@ -215,6 +217,16 @@ export class WeComCallbackChannel implements ChannelAdapter {
       return;
     }
 
+    if (this.permissions.hasPending(chatId) && this.gateway) {
+      try {
+        const confirmation = await this.permissions.answer(chatId, text, this.gateway);
+        if (confirmation) await this.sendReply(chatId, confirmation);
+      } catch (e) {
+        this.logger?.error?.(`wecom_callback: permission answer error: ${e}`);
+      }
+      return;
+    }
+
     if (this.activeChats.has(chatId)) {
       this.logger?.info?.(`wecom_callback: chat ${chatId} already active, skipping`);
       return;
@@ -250,6 +262,11 @@ export class WeComCallbackChannel implements ChannelAdapter {
           await this.sendReply(chatId, questionText);
           continue;
         }
+        if (event.type === "permission_request") {
+          const questionText = this.permissions.capture(chatId, sessionKey, event);
+          await this.sendReply(chatId, questionText);
+          continue;
+        }
         const fragment = renderWeComCallbackEvent(event);
         if (fragment != null) replyText += fragment;
       }
@@ -259,6 +276,7 @@ export class WeComCallbackChannel implements ChannelAdapter {
     }
 
     this.elicitation.clear(chatId);
+    this.permissions.clear(chatId);
 
     const finalText = replyText.trim();
     if (finalText) {

--- a/src/adapters/channel/wecom/WeComChannel.ts
+++ b/src/adapters/channel/wecom/WeComChannel.ts
@@ -4,6 +4,7 @@ import type { ChannelAdapter, ChannelHandle, ChannelLogger, ChannelStartDeps } f
 import { WeComSessionMapper } from "./WeComSessionMapper.js";
 import { renderWeComEvent } from "./wecom-render.js";
 import { ImElicitationHelper } from "../protocol/ImElicitationHelper.js";
+import { ImPermissionHelper } from "../protocol/ImPermissionHelper.js";
 
 let WebSocketCtor: any = null;
 try {
@@ -49,6 +50,7 @@ export class WeComChannel implements ChannelAdapter {
   private listenStopped = false;
   private activeChats = new Set<string>();
   private readonly elicitation = new ImElicitationHelper();
+  private readonly permissions = new ImPermissionHelper();
 
   constructor(options: WeComChannelOptions = {}) {
     this.mapper = options.mapper ?? new WeComSessionMapper();
@@ -231,6 +233,16 @@ export class WeComChannel implements ChannelAdapter {
       return;
     }
 
+    if (this.permissions.hasPending(chatId) && this.gateway) {
+      try {
+        const confirmation = await this.permissions.answer(chatId, text, this.gateway);
+        if (confirmation) await this.sendReply(chatId, confirmation);
+      } catch (e) {
+        this.logger?.error?.(`wecom: permission answer error: ${e}`);
+      }
+      return;
+    }
+
     if (this.activeChats.has(chatId)) {
       this.logger?.info?.(`wecom: chat ${chatId} already active, skipping`);
       return;
@@ -291,6 +303,11 @@ export class WeComChannel implements ChannelAdapter {
           await this.sendReply(chatId, questionText);
           continue;
         }
+        if (event.type === "permission_request") {
+          const questionText = this.permissions.capture(chatId, sessionKey, event);
+          await this.sendReply(chatId, questionText);
+          continue;
+        }
         const fragment = renderWeComEvent(event);
         if (fragment != null) replyText += fragment;
       }
@@ -300,6 +317,7 @@ export class WeComChannel implements ChannelAdapter {
     }
 
     this.elicitation.clear(chatId);
+    this.permissions.clear(chatId);
 
     const finalText = replyText.trim();
     if (finalText) {

--- a/src/adapters/channel/weixin/WeixinChannel.ts
+++ b/src/adapters/channel/weixin/WeixinChannel.ts
@@ -7,6 +7,7 @@ import type { Gateway, GatewayChannelKey } from "../../../gateway/index.js";
 import type { ChannelAdapter, ChannelHandle, ChannelLogger, ChannelStartDeps } from "../protocol/ChannelAdapter.js";
 import { executeChannelCommand } from "../protocol/ChannelCommandRegistry.js";
 import { ImElicitationHelper } from "../protocol/ImElicitationHelper.js";
+import { ImPermissionHelper } from "../protocol/ImPermissionHelper.js";
 import {
   ImLiveReplyController,
   type ImLiveReplyControllerOptions,
@@ -56,6 +57,7 @@ export class WeixinChannel implements ChannelAdapter {
   private pollPromise: Promise<void> | null = null;
   private activeChats = new Set<string>();
   private readonly elicitation = new ImElicitationHelper();
+  private readonly permissions = new ImPermissionHelper();
   private contextTokens = new Map<string, string>();
   private consecutivePollErrors = 0;
 
@@ -210,6 +212,16 @@ export class WeixinChannel implements ChannelAdapter {
       return;
     }
 
+    if (this.permissions.hasPending(fromUser) && this.gateway) {
+      try {
+        const confirmation = await this.permissions.answer(fromUser, text, this.gateway);
+        if (confirmation) await this.sendReply(fromUser, confirmation);
+      } catch (e) {
+        this.logger?.error?.(`weixin: permission answer error: ${e}`);
+      }
+      return;
+    }
+
     const mapped = this.mapper.resolve({ chatId: fromUser, text });
     if (mapped.command === "new" && !mapped.message) {
       await this.sendReply(fromUser, "已创建新会话。");
@@ -296,6 +308,12 @@ export class WeixinChannel implements ChannelAdapter {
           await this.sendReply(userId, questionText);
           continue;
         }
+        if (event.type === "permission_request") {
+          const questionText = this.permissions.capture(userId, sessionKey, event);
+          await liveReply.pauseActivity();
+          await this.sendReply(userId, questionText);
+          continue;
+        }
         if (event.type === "error" && event.code === "agent_aborted") {
           await liveReply.markAborted();
           continue;
@@ -319,6 +337,7 @@ export class WeixinChannel implements ChannelAdapter {
     }
 
     this.elicitation.clear(userId);
+    this.permissions.clear(userId);
     await liveReply.flushFinal();
   }
 

--- a/src/adapters/channel/weixin/WeixinChannel.ts
+++ b/src/adapters/channel/weixin/WeixinChannel.ts
@@ -59,6 +59,7 @@ export class WeixinChannel implements ChannelAdapter {
   private loopAbort = new AbortController();
   private pollPromise: Promise<void> | null = null;
   private activeChats = new Set<string>();
+  private activeLiveReplies = new Map<string, ImLiveReplyController<void>>();
   private readonly elicitation = new ImElicitationHelper();
   private readonly permissions = new ImPermissionHelper();
   private contextTokens = new Map<string, string>();
@@ -217,8 +218,12 @@ export class WeixinChannel implements ChannelAdapter {
 
     if (this.permissions.hasPending(fromUser) && this.gateway) {
       try {
+        const trimmed = text.trim();
         const confirmation = await this.permissions.answer(fromUser, text, this.gateway);
         if (confirmation) await this.sendReply(fromUser, confirmation);
+        if (trimmed === "1" || trimmed === "2") {
+          await this.activeLiveReplies.get(fromUser)?.resumeActivity("tool");
+        }
       } catch (e) {
         this.logger?.error?.(`weixin: permission answer error: ${e}`);
       }
@@ -280,6 +285,7 @@ export class WeixinChannel implements ChannelAdapter {
         this.logger?.warn?.(`weixin: live reply ${phase} failed: ${formatWeixinError(error)}`);
       },
     });
+    this.activeLiveReplies.set(userId, liveReply);
     let activeRunId: string | undefined;
     let watchdogSettled = false;
     const watchdog = turnTimeoutMs > 0
@@ -343,6 +349,7 @@ export class WeixinChannel implements ChannelAdapter {
     } finally {
       watchdogSettled = true;
       if (watchdog) clearTimeout(watchdog);
+      this.activeLiveReplies.delete(userId);
     }
 
     this.elicitation.clear(userId);

--- a/src/adapters/channel/weixin/WeixinChannel.ts
+++ b/src/adapters/channel/weixin/WeixinChannel.ts
@@ -17,6 +17,9 @@ import { WeixinSessionMapper } from "./WeixinSessionMapper.js";
 
 const CREDENTIALS_PATH = join(homedir(), ".pilotdeck", "weixin-credentials.json");
 const POLL_RETRY_DELAY_MS = 3000;
+const WEIXIN_ACTIVITY_DELAY_MS = 300;
+const WEIXIN_ACTIVITY_UPDATE_THROTTLE_MS = 3000;
+const WEIXIN_ACTIVITY_MAX_UPDATES = 120;
 let ilinkFetchCompatibilityInstalled = false;
 
 export type WeixinChannelOptions = {
@@ -264,14 +267,19 @@ export class WeixinChannel implements ChannelAdapter {
   ): Promise<void> {
     if (!this.gateway) return;
 
+    const turnTimeoutMs = this.liveReplyOptions?.turnTimeoutMs ?? 600_000;
     const liveReply = new ImLiveReplyController<void>({
       ...this.liveReplyOptions,
+      activityDelayMs: this.liveReplyOptions?.activityDelayMs ?? WEIXIN_ACTIVITY_DELAY_MS,
+      activityUpdateThrottleMs:
+        this.liveReplyOptions?.activityUpdateThrottleMs ?? WEIXIN_ACTIVITY_UPDATE_THROTTLE_MS,
+      activityMaxUpdates: this.liveReplyOptions?.activityMaxUpdates ?? WEIXIN_ACTIVITY_MAX_UPDATES,
+      activityTtlMs: this.liveReplyOptions?.activityTtlMs ?? turnTimeoutMs,
       transport: this.createLiveReplyTransport(userId),
       onTransportError: (error, phase) => {
         this.logger?.warn?.(`weixin: live reply ${phase} failed: ${formatWeixinError(error)}`);
       },
     });
-    const turnTimeoutMs = this.liveReplyOptions?.turnTimeoutMs ?? 600_000;
     let activeRunId: string | undefined;
     let watchdogSettled = false;
     const watchdog = turnTimeoutMs > 0
@@ -291,6 +299,7 @@ export class WeixinChannel implements ChannelAdapter {
     watchdog?.unref?.();
 
     try {
+      void this.sendTypingIfPossible(userId);
       for await (const event of this.gateway.submitTurn({
         sessionKey,
         channelKey: "weixin",

--- a/src/adapters/channel/whatsapp/WhatsAppChannel.ts
+++ b/src/adapters/channel/whatsapp/WhatsAppChannel.ts
@@ -2,6 +2,7 @@ import { spawn, type ChildProcess } from "node:child_process";
 import type { Gateway, GatewayChannelKey } from "../../../gateway/index.js";
 import type { ChannelAdapter, ChannelHandle, ChannelLogger, ChannelStartDeps } from "../protocol/ChannelAdapter.js";
 import { ImElicitationHelper } from "../protocol/ImElicitationHelper.js";
+import { ImPermissionHelper } from "../protocol/ImPermissionHelper.js";
 import { WhatsAppSessionMapper } from "./WhatsAppSessionMapper.js";
 import { renderWhatsAppEvent } from "./whatsapp-render.js";
 
@@ -40,6 +41,7 @@ export class WhatsAppChannel implements ChannelAdapter {
   private seenIds = new Set<string>();
   private activeChats = new Set<string>();
   private readonly elicitation = new ImElicitationHelper();
+  private readonly permissions = new ImPermissionHelper();
   private running = false;
 
   constructor(options: WhatsAppChannelOptions = {}) {
@@ -199,6 +201,16 @@ export class WhatsAppChannel implements ChannelAdapter {
       return;
     }
 
+    if (this.permissions.hasPending(msg.chatId) && this.gateway) {
+      try {
+        const confirmation = await this.permissions.answer(msg.chatId, msg.text, this.gateway);
+        if (confirmation) await this.sendReply(msg.chatId, confirmation);
+      } catch (e) {
+        this.logger?.error?.(`whatsapp: permission answer error: ${e}`);
+      }
+      return;
+    }
+
     if (this.activeChats.has(msg.chatId)) {
       this.logger?.info?.(`whatsapp: chat ${msg.chatId} already active, skipping`);
       return;
@@ -234,6 +246,11 @@ export class WhatsAppChannel implements ChannelAdapter {
           await this.sendReply(chatId, questionText);
           continue;
         }
+        if (event.type === "permission_request") {
+          const questionText = this.permissions.capture(chatId, sessionKey, event);
+          await this.sendReply(chatId, questionText);
+          continue;
+        }
         const fragment = renderWhatsAppEvent(event);
         if (fragment != null) replyText += fragment;
       }
@@ -243,6 +260,7 @@ export class WhatsAppChannel implements ChannelAdapter {
     }
 
     this.elicitation.clear(chatId);
+    this.permissions.clear(chatId);
     const finalText = replyText.trim();
     if (finalText) {
       await this.sendReply(chatId, finalText);

--- a/src/gateway/permission/createGatewayPermissionHook.ts
+++ b/src/gateway/permission/createGatewayPermissionHook.ts
@@ -61,8 +61,16 @@ export function createGatewayPermissionHook(
 ): CallbackHookHandler {
   return async ({ hookInput, signal }) => {
     const toolName = typeof hookInput.toolName === "string" ? hookInput.toolName : "UnknownTool";
-    const toolCallId = typeof hookInput.toolCallId === "string" ? hookInput.toolCallId : "";
-    const payload = "input" in hookInput ? hookInput.input : hookInput;
+    const toolCallId = typeof hookInput.toolCallId === "string"
+      ? hookInput.toolCallId
+      : typeof hookInput.toolUseId === "string"
+        ? hookInput.toolUseId
+        : "";
+    const payload = "toolInput" in hookInput
+      ? hookInput.toolInput
+      : "input" in hookInput
+        ? hookInput.input
+        : {};
     const requestId = options.uuid ? options.uuid() : randomUUID();
 
     const delivered = options.emit({

--- a/src/gateway/permission/createGatewayPermissionHook.ts
+++ b/src/gateway/permission/createGatewayPermissionHook.ts
@@ -118,15 +118,21 @@ export function createGatewayPermissionHook(
       // Mutate the live array shared with PermissionContext.rules.allow
       // so the next tool.checkPermissions() / decide() in this same turn
       // walks the allow branch instead of asking again.
-      const alreadyAllowed = options.permissionRules.some(
-        (rule) => rule.behavior === "allow" && rule.toolName === toolName,
-      );
-      if (!alreadyAllowed) {
-        options.permissionRules.push({
-          source: "session",
-          behavior: "allow",
-          toolName,
-        });
+      const rules = extractSessionAllowRules(hookInput.permissionSuggestions, toolName);
+      const rulesToRemember = rules.length > 0
+        ? rules
+        : [{ source: "session" as const, behavior: "allow" as const, toolName }];
+
+      for (const rule of rulesToRemember) {
+        const alreadyAllowed = options.permissionRules.some(
+          (existing) =>
+            existing.behavior === "allow"
+            && existing.toolName === rule.toolName
+            && existing.pattern === rule.pattern,
+        );
+        if (!alreadyAllowed) {
+          options.permissionRules.push(rule);
+        }
       }
     }
 
@@ -141,4 +147,30 @@ export function createGatewayPermissionHook(
       },
     } satisfies PilotDeckHookSyncOutput;
   };
+}
+
+function extractSessionAllowRules(value: unknown, fallbackToolName: string): PermissionRule[] {
+  if (!Array.isArray(value)) return [];
+  const allowSession = value.find((option) =>
+    isRecord(option) && option.id === "allow_session" && Array.isArray(option.rules)
+  );
+  if (!isRecord(allowSession) || !Array.isArray(allowSession.rules)) return [];
+
+  return allowSession.rules.flatMap((candidate) => {
+    if (!isRecord(candidate)) return [];
+    const toolName = typeof candidate.toolName === "string" && candidate.toolName
+      ? candidate.toolName
+      : fallbackToolName;
+    if (!toolName) return [];
+    return [{
+      source: "session" as const,
+      behavior: "allow" as const,
+      toolName,
+      ...(typeof candidate.pattern === "string" && candidate.pattern ? { pattern: candidate.pattern } : {}),
+    }];
+  });
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/src/permission/decision/PermissionRuntime.ts
+++ b/src/permission/decision/PermissionRuntime.ts
@@ -23,9 +23,10 @@ export class PermissionRuntime {
       permissionContext.rules.allow.filter((rule) => rule.source === "session"),
       tool.name,
       input,
+      permissionContext,
     );
 
-    const denyRule = findMatchingRule(permissionContext.rules.deny, tool.name, input);
+    const denyRule = findMatchingRule(permissionContext.rules.deny, tool.name, input, permissionContext);
     if (denyRule) {
       if (sessionAllowRule && denyRule.source === "user") {
         return this.allowSessionRule(tool, input, context, toolCallId, sessionAllowRule);
@@ -33,7 +34,7 @@ export class PermissionRuntime {
       return denyFromRule(denyRule);
     }
 
-    const askRule = findMatchingRule(permissionContext.rules.ask, tool.name, input);
+    const askRule = findMatchingRule(permissionContext.rules.ask, tool.name, input, permissionContext);
     if (askRule) {
       return finalizeAsk(askFromRule(tool, input, toolCallId, askRule), permissionContext);
     }
@@ -49,7 +50,7 @@ export class PermissionRuntime {
     // tool.checkPermissions returns ask → runtime surfaces another
     // permission prompt → next call repeats → infinite prompts.
     // Deny rules (checked above) still win over allow rules.
-    const allowRule = findMatchingRule(permissionContext.rules.allow, tool.name, input);
+    const allowRule = findMatchingRule(permissionContext.rules.allow, tool.name, input, permissionContext);
     if (allowRule) {
       // Plan mode deny takes precedence over user allow rules for
       // non-readonly tools (except plan-directory markdown writes). Without this guard,
@@ -220,8 +221,13 @@ function decideByMode(
   });
 }
 
-function findMatchingRule(rules: PermissionRule[], toolName: string, input: unknown): PermissionRule | undefined {
-  return rules.find((rule) => matchPermissionRule(rule, toolName, input));
+function findMatchingRule(
+  rules: PermissionRule[],
+  toolName: string,
+  input: unknown,
+  context: PermissionContext,
+): PermissionRule | undefined {
+  return rules.find((rule) => matchPermissionRule(rule, toolName, input, context));
 }
 
 function allow(reason: PermissionDecisionReason): PermissionDecision {

--- a/src/permission/policy/matchPermissionRule.ts
+++ b/src/permission/policy/matchPermissionRule.ts
@@ -1,23 +1,46 @@
-import type { PermissionRule } from "../protocol/types.js";
+import path from "node:path";
+import type { PermissionContext, PermissionRule } from "../protocol/types.js";
 
-export function matchPermissionRule(rule: PermissionRule, toolName: string, input?: unknown): boolean {
-  if (rule.toolName === toolName) {
-    return rule.pattern ? matchRulePattern(rule, input) : true;
-  }
+const FILE_WRITE_TOOLS = new Set(["write_file", "edit_file"]);
 
-  if (!rule.toolName.includes("*")) {
+export function matchPermissionRule(
+  rule: PermissionRule,
+  toolName: string,
+  input?: unknown,
+  context?: PermissionContext,
+): boolean {
+  if (!matchesToolName(rule.toolName, toolName)) {
     return false;
   }
 
-  return wildcardToRegExp(rule.toolName).test(toolName) && (!rule.pattern || matchRulePattern(rule, input));
+  if (FILE_WRITE_TOOLS.has(toolName) && !rule.pattern) {
+    return isFileInputInsideWorkspace(input, context);
+  }
+
+  return rule.pattern ? matchRulePattern(rule, toolName, input, context) : true;
 }
 
-function matchRulePattern(rule: PermissionRule, input: unknown): boolean {
+function matchesToolName(ruleToolName: string, toolName: string): boolean {
+  if (ruleToolName === toolName) return true;
+  return ruleToolName.includes("*") && wildcardToRegExp(ruleToolName).test(toolName);
+}
+
+function matchRulePattern(
+  rule: PermissionRule,
+  toolName: string,
+  input: unknown,
+  context: PermissionContext | undefined,
+): boolean {
   if (!rule.pattern) return true;
-  if (rule.toolName !== "bash") return true;
+  if (toolName === "bash") return matchBashPattern(rule.pattern, input);
+  if (FILE_WRITE_TOOLS.has(toolName)) return matchFilePathPattern(rule.pattern, input, context);
+  return true;
+}
+
+function matchBashPattern(pattern: string, input: unknown): boolean {
   const command = readCommand(input);
   if (!command) return false;
-  const normalizedPattern = rule.pattern.replace(/:\*$/, "*");
+  const normalizedPattern = pattern.replace(/:\*$/, "*");
   return wildcardToRegExp(normalizedPattern).test(command);
 }
 
@@ -27,6 +50,41 @@ function readCommand(input: unknown): string {
     return typeof command === "string" ? command.trim() : "";
   }
   return "";
+}
+
+function matchFilePathPattern(pattern: string, input: unknown, context: PermissionContext | undefined): boolean {
+  const filePath = resolveInputFilePath(input, context);
+  return filePath ? wildcardToRegExp(normalizePathForPattern(pattern)).test(normalizePathForPattern(filePath)) : false;
+}
+
+function isFileInputInsideWorkspace(input: unknown, context: PermissionContext | undefined): boolean {
+  const filePath = resolveInputFilePath(input, context);
+  if (!filePath || !context) return false;
+  return [context.cwd, ...context.additionalWorkingDirectories]
+    .map((root) => path.resolve(root))
+    .some((root) => isPathWithinRoot(filePath, root));
+}
+
+function resolveInputFilePath(input: unknown, context: PermissionContext | undefined): string | undefined {
+  const filePath = readFilePath(input);
+  if (!filePath || filePath.includes("\0") || !context) return undefined;
+  return path.resolve(path.isAbsolute(filePath) ? filePath : path.join(context.cwd, filePath));
+}
+
+function readFilePath(input: unknown): string {
+  if (typeof input !== "object" || input === null) return "";
+  const record = input as { file_path?: unknown; filePath?: unknown };
+  const filePath = record.file_path ?? record.filePath;
+  return typeof filePath === "string" ? filePath.trim() : "";
+}
+
+function isPathWithinRoot(candidate: string, root: string): boolean {
+  const relative = path.relative(root, candidate);
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+function normalizePathForPattern(value: string): string {
+  return value.replace(/\\/g, "/");
 }
 
 function wildcardToRegExp(pattern: string): RegExp {

--- a/src/tool/builtin/editFile.ts
+++ b/src/tool/builtin/editFile.ts
@@ -3,6 +3,7 @@ import type { PilotDeckToolDefinition } from "../protocol/types.js";
 import { PilotDeckToolRuntimeError } from "../protocol/errors.js";
 import { isNotebookPath } from "./filesystem/fileTypeSafety.js";
 import { resolvePilotDeckWorkspacePath } from "./filesystem/pathSafety.js";
+import { checkFilesystemWritePermission } from "./filesystem/writePermissions.js";
 import { readTextFile } from "./filesystem/readTextFile.js";
 import { writeTextFile } from "./filesystem/writeTextFile.js";
 import {
@@ -54,6 +55,8 @@ export function createEditFileTool(): PilotDeckToolDefinition<EditFileInput> {
     isReadOnly: () => false,
     isConcurrencySafe: () => false,
     isDestructive: () => false,
+    checkPermissions: async (input, context) =>
+      checkFilesystemWritePermission("edit_file", input.file_path, context),
     validateInput: async (input, context) => {
       const resolved = resolvePilotDeckWorkspacePath(input.file_path, context, {
         forWrite: true,

--- a/src/tool/builtin/editFile.ts
+++ b/src/tool/builtin/editFile.ts
@@ -25,7 +25,7 @@ export function createEditFileTool(): PilotDeckToolDefinition<EditFileInput> {
     name: "edit_file",
     aliases: ["Edit"],
     description:
-      "Edit a workspace text file by replacing an exact string match.\n\nUsage:\n- You must read the target file with read_file before editing it. This tool will reject the input if the file has not been read in this session.\n- old_string must exactly match the file content character-by-character, including indentation. Copy old_string directly from read_file output without adding or removing spaces.\n- Use this tool for targeted changes to an existing file.\n- old_string must appear in the target file.\n- If old_string is not unique, either provide a more specific old_string or set replace_all to update every occurrence.\n- Use replace_all when renaming or replacing repeated text across the same file.\n- If the file is outside the workspace or does not exist, the tool returns a controlled error.",
+      "Edit a workspace text file, or an outside-workspace text file after explicit host permission, by replacing an exact string match.\n\nUsage:\n- You must read the target file with read_file before editing it. This tool will reject the input if the file has not been read in this session.\n- old_string must exactly match the file content character-by-character, including indentation. Copy old_string directly from read_file output without adding or removing spaces.\n- Use this tool for targeted changes to an existing file.\n- old_string must appear in the target file.\n- If old_string is not unique, either provide a more specific old_string or set replace_all to update every occurrence.\n- Use replace_all when renaming or replacing repeated text across the same file.\n- Paths outside the workspace require explicit user permission before execution.",
     kind: "filesystem",
     inputSchema: {
       type: "object",
@@ -34,7 +34,7 @@ export function createEditFileTool(): PilotDeckToolDefinition<EditFileInput> {
       properties: {
         file_path: {
           type: "string",
-          description: "Relative or absolute path of the file to edit. The path must resolve inside the workspace.",
+          description: "Relative or absolute path of the file to edit. Paths outside the workspace require explicit user permission.",
         },
         old_string: {
           type: "string",
@@ -55,7 +55,10 @@ export function createEditFileTool(): PilotDeckToolDefinition<EditFileInput> {
     isConcurrencySafe: () => false,
     isDestructive: () => false,
     validateInput: async (input, context) => {
-      const resolved = resolvePilotDeckWorkspacePath(input.file_path, context, { forWrite: true });
+      const resolved = resolvePilotDeckWorkspacePath(input.file_path, context, {
+        forWrite: true,
+        allowOutsideWorkspace: true,
+      });
       if (!resolved.ok) {
         return {
           ok: false,
@@ -143,7 +146,10 @@ export function createEditFileTool(): PilotDeckToolDefinition<EditFileInput> {
       };
     },
     execute: async (input, context) => {
-      const resolved = resolvePilotDeckWorkspacePath(input.file_path, context, { forWrite: true });
+      const resolved = resolvePilotDeckWorkspacePath(input.file_path, context, {
+        forWrite: true,
+        allowOutsideWorkspace: context.currentPermissionDecision?.type === "allow",
+      });
       if (!resolved.ok) {
         throw new PilotDeckToolRuntimeError(resolved.error.code, resolved.error.message, resolved.error.details);
       }

--- a/src/tool/builtin/filesystem/pathSafety.ts
+++ b/src/tool/builtin/filesystem/pathSafety.ts
@@ -13,7 +13,7 @@ const DEFAULT_WRITE_DENY_DIRECTORIES = new Set([".git", "node_modules", "dist"])
 export function resolvePilotDeckWorkspacePath(
   inputPath: string,
   context: PilotDeckToolRuntimeContext,
-  options?: { forWrite?: boolean; mustExist?: boolean },
+  options?: { forWrite?: boolean; mustExist?: boolean; allowOutsideWorkspace?: boolean },
 ): PilotDeckPathSafetyResult {
   if (!inputPath || inputPath.includes("\0")) {
     return {
@@ -41,6 +41,17 @@ export function resolvePilotDeckWorkspacePath(
   const root = roots.find((candidate) => isPathWithinRoot(absolutePath, candidate));
 
   if (!root) {
+    if (options?.allowOutsideWorkspace) {
+      const relativePath = path.relative(context.cwd, absolutePath) || ".";
+      if (options?.forWrite && isWriteDenied(relativePath)) {
+        return {
+          ok: false,
+          error: toolError("path_not_allowed", `Writing to ${relativePath} is not allowed by default.`),
+        };
+      }
+      return { ok: true, absolutePath, relativePath, root: context.cwd };
+    }
+
     return {
       ok: false,
       error: toolError("path_not_allowed", `Path ${inputPath} is outside the PilotDeck workspace.`),

--- a/src/tool/builtin/filesystem/writePermissions.ts
+++ b/src/tool/builtin/filesystem/writePermissions.ts
@@ -1,0 +1,67 @@
+import path from "node:path";
+import type { PermissionResult, PermissionRule } from "../../../permission/index.js";
+import type { PilotDeckToolRuntimeContext } from "../../protocol/types.js";
+import { resolvePilotDeckWorkspacePath } from "./pathSafety.js";
+
+export function checkFilesystemWritePermission(
+  toolName: "write_file" | "edit_file",
+  inputPath: string,
+  context: PilotDeckToolRuntimeContext,
+): PermissionResult {
+  const workspaceResolved = resolvePilotDeckWorkspacePath(inputPath, context, { forWrite: true });
+  if (workspaceResolved.ok) {
+    return { type: "passthrough" };
+  }
+
+  const outsideResolved = resolvePilotDeckWorkspacePath(inputPath, context, {
+    forWrite: true,
+    allowOutsideWorkspace: true,
+  });
+  if (!outsideResolved.ok) {
+    return {
+      type: "deny",
+      reason: { type: "safety", message: outsideResolved.error.message },
+      message: outsideResolved.error.message,
+    };
+  }
+
+  const rule = buildRecursiveFileWriteRule(toolName, outsideResolved.absolutePath);
+  const reason = {
+    type: "tool" as const,
+    toolName,
+    message: `${toolName} targets a path outside the workspace.`,
+  };
+  return {
+    type: "ask",
+    reason,
+    request: {
+      toolCallId: "",
+      toolName,
+      inputSummary: JSON.stringify({ file_path: outsideResolved.absolutePath }),
+      reason,
+      options: [
+        { id: "allow_once", label: "Allow once" },
+        { id: "allow_session", label: "Allow this folder for this session", rules: [rule] },
+        { id: "deny", label: "Deny" },
+        { id: "cancel", label: "Cancel" },
+      ],
+      metadata: {
+        externalPath: outsideResolved.absolutePath,
+        allowedDirectory: path.dirname(outsideResolved.absolutePath),
+        pattern: rule.pattern,
+      },
+    },
+  };
+}
+
+function buildRecursiveFileWriteRule(
+  toolName: "write_file" | "edit_file",
+  absolutePath: string,
+): PermissionRule {
+  return {
+    source: "session",
+    behavior: "allow",
+    toolName,
+    pattern: path.join(path.dirname(absolutePath), "*"),
+  };
+}

--- a/src/tool/builtin/writeFile.ts
+++ b/src/tool/builtin/writeFile.ts
@@ -2,6 +2,7 @@ import { stat } from "node:fs/promises";
 import type { PilotDeckToolDefinition } from "../protocol/types.js";
 import { PilotDeckToolRuntimeError } from "../protocol/errors.js";
 import { resolvePilotDeckWorkspacePath } from "./filesystem/pathSafety.js";
+import { checkFilesystemWritePermission } from "./filesystem/writePermissions.js";
 import { writeTextFile } from "./filesystem/writeTextFile.js";
 import {
   buildStructuredPatch,
@@ -104,6 +105,8 @@ export function createWriteFileTool(): PilotDeckToolDefinition<WriteFileInput, W
     isReadOnly: () => false,
     isConcurrencySafe: () => false,
     isDestructive: () => true,
+    checkPermissions: async (input, context) =>
+      checkFilesystemWritePermission("write_file", input.file_path, context),
     validateInput: async (input, context) => {
       const resolved = resolvePilotDeckWorkspacePath(input.file_path, context, {
         forWrite: true,

--- a/src/tool/builtin/writeFile.ts
+++ b/src/tool/builtin/writeFile.ts
@@ -37,7 +37,7 @@ export function createWriteFileTool(): PilotDeckToolDefinition<WriteFileInput, W
     name: "write_file",
     aliases: ["Write"],
     description:
-      "Writes a UTF-8 text file inside the workspace.\n\nUsage:\n- The file_path parameter may be relative to the current workspace or an absolute path, but it must resolve inside the workspace.\n- This tool will overwrite the existing file if there is one at the provided path.\n- You must read an existing file with read_file before writing to it. This tool will fail if you did not read the file first.\n- If the target file changed after the last read, this tool will fail and you must read it again before writing.\n- Prefer the edit_file tool for modifying existing files. Only use this tool to create new files or for complete rewrites.\n- The returned filePath is always the resolved absolute path.\n- Do not create documentation files (*.md) or README files unless explicitly requested by the User.\n- Only use emojis if the user explicitly requests it. Avoid writing emojis to files unless asked.",
+      "Writes a UTF-8 text file inside the workspace, or outside the workspace after explicit host permission.\n\nUsage:\n- The file_path parameter may be relative to the current workspace or an absolute path. Paths outside the workspace require explicit user permission before execution.\n- This tool will overwrite the existing file if there is one at the provided path.\n- You must read an existing file with read_file before writing to it. This tool will fail if you did not read the file first.\n- If the target file changed after the last read, this tool will fail and you must read it again before writing.\n- Prefer the edit_file tool for modifying existing files. Only use this tool to create new files or for complete rewrites.\n- The returned filePath is always the resolved absolute path.\n- Do not create documentation files (*.md) or README files unless explicitly requested by the User.\n- Only use emojis if the user explicitly requests it. Avoid writing emojis to files unless asked.",
     kind: "filesystem",
     inputSchema: {
       type: "object",
@@ -47,7 +47,7 @@ export function createWriteFileTool(): PilotDeckToolDefinition<WriteFileInput, W
         file_path: {
           type: "string",
           description:
-            "The path to the file to write. It may be relative to the current workspace or absolute, but it must resolve inside the workspace.",
+            "The path to the file to write. It may be relative to the current workspace or absolute. Paths outside the workspace require explicit user permission.",
         },
         content: {
           type: "string",
@@ -105,7 +105,10 @@ export function createWriteFileTool(): PilotDeckToolDefinition<WriteFileInput, W
     isConcurrencySafe: () => false,
     isDestructive: () => true,
     validateInput: async (input, context) => {
-      const resolved = resolvePilotDeckWorkspacePath(input.file_path, context, { forWrite: true });
+      const resolved = resolvePilotDeckWorkspacePath(input.file_path, context, {
+        forWrite: true,
+        allowOutsideWorkspace: true,
+      });
       if (!resolved.ok) {
         return {
           ok: false,
@@ -138,7 +141,10 @@ export function createWriteFileTool(): PilotDeckToolDefinition<WriteFileInput, W
       return { ok: true, input };
     },
     execute: async (input, context) => {
-      const resolved = resolvePilotDeckWorkspacePath(input.file_path, context, { forWrite: true });
+      const resolved = resolvePilotDeckWorkspacePath(input.file_path, context, {
+        forWrite: true,
+        allowOutsideWorkspace: context.currentPermissionDecision?.type === "allow",
+      });
       if (!resolved.ok) {
         throw new PilotDeckToolRuntimeError(resolved.error.code, resolved.error.message, resolved.error.details);
       }

--- a/src/tool/execution/ToolRuntime.ts
+++ b/src/tool/execution/ToolRuntime.ts
@@ -214,7 +214,11 @@ export class ToolRuntime {
     }
 
     executeInput = decision.updatedInput ?? executeInput;
-    const baseContext: PilotDeckToolRuntimeContext = { ...context, currentToolCallId: call.id };
+    const baseContext: PilotDeckToolRuntimeContext = {
+      ...context,
+      currentToolCallId: call.id,
+      currentPermissionDecision: decision,
+    };
     const executeContext: PilotDeckToolRuntimeContext = baseContext.progress
       ? {
           ...baseContext,

--- a/src/tool/protocol/types.ts
+++ b/src/tool/protocol/types.ts
@@ -7,6 +7,7 @@ import type {
 } from "../../model/index.js";
 import type {
   PermissionContext,
+  PermissionDecision,
   PermissionMode,
   PermissionResult,
 } from "../../permission/index.js";
@@ -187,6 +188,12 @@ export type PilotDeckToolRuntimeContext = {
   permissionMode: PermissionMode;
   permissionContext: PermissionContext;
   auditRecorder?: PilotDeckToolAuditRecorder;
+  /**
+   * The final allow decision for the current tool call, populated by
+   * ToolRuntime after permission checks pass and before tool execution.
+   * Direct tool invocations leave this unset.
+   */
+  currentPermissionDecision?: Extract<PermissionDecision, { type: "allow" }>;
   now?: () => Date;
   env?: NodeJS.ProcessEnv;
   maxResultBytes?: number;

--- a/ui/src/components/chat/utils/chatPermissions.ts
+++ b/ui/src/components/chat/utils/chatPermissions.ts
@@ -9,9 +9,11 @@ import {
 
 export function buildPilotDeckToolPermissionEntry(toolName?: string, toolInput?: unknown) {
   if (!toolName) return null;
+  const fileWriteToolName = normalizeFileWriteToolName(toolName);
+  if (fileWriteToolName) return buildFileWritePermissionEntry(fileWriteToolName, toolInput);
   if (toolName !== 'Bash' && toolName !== 'bash') return toolName;
 
-  const parsed = safeJsonParse(toolInput);
+  const parsed = parseToolInputRecord(toolInput);
   const command = typeof parsed?.command === 'string' ? parsed.command.trim() : '';
   if (!command) return 'bash';
 
@@ -22,6 +24,43 @@ export function buildPilotDeckToolPermissionEntry(toolName?: string, toolInput?:
     return `bash:${tokens[0]} ${tokens[1]}:*`;
   }
   return `bash:${tokens[0]}:*`;
+}
+
+function normalizeFileWriteToolName(toolName: string) {
+  if (toolName === 'write_file' || toolName === 'Write') return 'write_file';
+  if (toolName === 'edit_file' || toolName === 'Edit') return 'edit_file';
+  return null;
+}
+
+function buildFileWritePermissionEntry(toolName: 'write_file' | 'edit_file', toolInput: unknown) {
+  const parsed = parseToolInputRecord(toolInput);
+  const filePath = typeof parsed?.file_path === 'string' ? parsed.file_path.trim() : '';
+  if (!isAbsoluteFilePath(filePath)) return null;
+  const parent = dirnameForPermission(filePath);
+  if (!parent) return null;
+  return `${toolName}:${parent.endsWith('/') || parent.endsWith('\\') ? `${parent}*` : `${parent}/*`}`;
+}
+
+function parseToolInputRecord(toolInput: unknown): Record<string, unknown> | null {
+  if (toolInput && typeof toolInput === 'object' && !Array.isArray(toolInput)) {
+    return toolInput as Record<string, unknown>;
+  }
+  return safeJsonParse(toolInput);
+}
+
+function isAbsoluteFilePath(filePath: string) {
+  return filePath.startsWith('/') || /^[A-Za-z]:[\\/]/.test(filePath);
+}
+
+function dirnameForPermission(filePath: string) {
+  const normalized = filePath.replace(/\\/g, '/').replace(/\/+$/, '') || '/';
+  const driveMatch = /^([A-Za-z]:)(\/.*)?$/.exec(normalized);
+  const value = driveMatch ? `${driveMatch[1]}${driveMatch[2] ?? '/'}` : normalized;
+  const index = value.lastIndexOf('/');
+  if (index < 0) return '';
+  if (index === 0) return '/';
+  if (/^[A-Za-z]:\/[^/]*$/.test(value)) return `${value.slice(0, 2)}/`;
+  return value.slice(0, index);
 }
 
 export function formatToolInputForDisplay(input: unknown) {


### PR DESCRIPTION
## Summary
- add a shared IM permission helper for pending permission_request events
- wire permission decisions into existing IM-style channels so user replies unblock the turn
- align QQ group pending keys while adding permission handling

## Validation
- npx tsc --noEmit --target ES2022 --module NodeNext --moduleResolution NodeNext --strict --esModuleInterop --skipLibCheck <changed channel files>

No test files are included in this PR.