### PR TITLE
Add native Google Gemini API adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ cd ..
 **2. Configure a model provider**
 
 PilotDeck reads `~/.pilotdeck/pilotdeck.yaml`. You can create it manually, let the bootstrap script generate one, **or just open the Web UI and configure providers visually in the settings panel.**
-Supported protocols include OpenAI, Anthropic, DeepSeek, Qwen, Kimi, MiniMax and other OpenAI-compatible endpoints.
+Supported protocols include OpenAI, Anthropic, native Google Gemini, DeepSeek, Qwen, Kimi, MiniMax and other OpenAI-compatible endpoints.
 
 ```yaml
 schemaVersion: 1
@@ -336,6 +336,22 @@ model:
       protocol: openai
       url: https://api.deepseek.com/v1
       apiKey: sk-your-api-key
+```
+
+Native Gemini can be configured with `protocol: google`:
+
+```yaml
+schemaVersion: 1
+agent:
+  model: google/gemini-3.1-pro-preview
+model:
+  providers:
+    google:
+      protocol: google
+      url: https://generativelanguage.googleapis.com
+      apiKey: ${GEMINI_API_KEY}
+      models:
+        gemini-3.1-pro-preview: {}
 ```
 
 **3. Start the services**

--- a/README.zh.md
+++ b/README.zh.md
@@ -323,7 +323,7 @@ cd ..
 
 **2. 配置模型 Provider**
 PilotDeck 依赖 `~/.pilotdeck/pilotdeck.yaml` 进行配置。您可以手动创建、运行启动脚本自动生成，**或者在启动 Web UI 后直接在设置界面中进行可视化配置**。
-支持 OpenAI、Anthropic、DeepSeek、Qwen、Kimi、MiniMax 等多种协议。
+支持 OpenAI、Anthropic、原生 Google Gemini、DeepSeek、Qwen、Kimi、MiniMax 等多种协议。
 
 ```yaml
 schemaVersion: 1
@@ -335,6 +335,22 @@ model:
       protocol: openai
       url: https://api.deepseek.com/v1
       apiKey: sk-your-api-key
+```
+
+原生 Gemini 可以使用 `protocol: google`：
+
+```yaml
+schemaVersion: 1
+agent:
+  model: google/gemini-3.1-pro-preview
+model:
+  providers:
+    google:
+      protocol: google
+      url: https://generativelanguage.googleapis.com
+      apiKey: ${GEMINI_API_KEY}
+      models:
+        gemini-3.1-pro-preview: {}
 ```
 
 **3. 启动服务**

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "typescript": "^5.9.3"
   },
   "dependencies": {
+    "@google/genai": "^2.10.0",
     "@larksuiteoapi/node-sdk": "^1.65.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@types/react": "^19.2.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@google/genai':
+        specifier: ^2.10.0
+        version: 2.10.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))
       '@larksuiteoapi/node-sdk':
         specifier: ^1.65.0
         version: 1.65.0
@@ -948,6 +951,15 @@ packages:
   '@gar/promisify@1.1.3':
     resolution: {integrity: sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==}
 
+  '@google/genai@2.10.0':
+    resolution: {integrity: sha512-e4cFxj3tiuMtsgOT4G9c1hXyGJhg7/Buj7VVeBacRY3fRtkRZZ59Q3nuVp2xbq8BGQXLXCDB253qMhklMOeUDg==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@modelcontextprotocol/sdk': ^1.25.2
+    peerDependenciesMeta:
+      '@modelcontextprotocol/sdk':
+        optional: true
+
   '@hono/node-server@1.19.14':
     resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
     engines: {node: '>=18.14.1'}
@@ -1730,6 +1742,9 @@ packages:
   '@types/react@19.2.15':
     resolution: {integrity: sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==}
 
+  '@types/retry@0.12.0':
+    resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
+
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
@@ -2277,6 +2292,9 @@ packages:
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
+  bignumber.js@9.3.1:
+    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
+
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
@@ -2727,6 +2745,10 @@ packages:
   dagre-d3-es@7.0.14:
     resolution: {integrity: sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==}
 
+  data-uri-to-buffer@4.0.1:
+    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
+    engines: {node: '>= 12'}
+
   data-urls@7.0.0:
     resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
@@ -3148,6 +3170,10 @@ packages:
       picomatch:
         optional: true
 
+  fetch-blob@3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
+
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
@@ -3203,6 +3229,10 @@ packages:
     resolution: {integrity: sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==}
     engines: {node: '>=0.4.x'}
 
+  formdata-polyfill@4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
+
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
@@ -3256,6 +3286,14 @@ packages:
     resolution: {integrity: sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
     deprecated: This package is no longer supported.
+
+  gaxios@7.1.5:
+    resolution: {integrity: sha512-5FZy72Rh8LhtjmvDrKkI+lVhrsQrVKVsItxMoDm5mNQE+xR0WVIIs+jzPSJgBvKVsLi24fZhXJIsNI0bihDzFg==}
+    engines: {node: '>=18'}
+
+  gcp-metadata@8.1.2:
+    resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
+    engines: {node: '>=18'}
 
   generator-function@2.0.1:
     resolution: {integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==}
@@ -3314,6 +3352,14 @@ packages:
   globalthis@1.0.4:
     resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
     engines: {node: '>= 0.4'}
+
+  google-auth-library@10.9.0:
+    resolution: {integrity: sha512-xtvUqvINPhTaBm7nXqlYPcrMHJPm1lCNdSovxnKKhTm+4JsvQ+KGVYJViLoH9Yxu8w+T0Qv5HubzYT9BLrppJg==}
+    engines: {node: '>=18'}
+
+  google-logging-utils@1.1.3:
+    resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
+    engines: {node: '>=14'}
 
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
@@ -3798,6 +3844,9 @@ packages:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
     engines: {node: '>=6'}
     hasBin: true
+
+  json-bigint@1.0.0:
+    resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
 
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
@@ -4294,6 +4343,11 @@ packages:
     resolution: {integrity: sha512-c5Ko1fZJIJmzhFIkhRN76WTq+fC6tWnGy9CXA0fA+XygsWZmEwG8vmbkNqxMyoaa0Tin4djul49NzdVcJJcjeA==}
     engines: {node: ^18 || ^20 || >= 21}
 
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
+
   node-exports-info@1.6.0:
     resolution: {integrity: sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==}
     engines: {node: '>= 0.4'}
@@ -4306,6 +4360,10 @@ packages:
     peerDependenciesMeta:
       encoding:
         optional: true
+
+  node-fetch@3.3.2:
+    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   node-gyp-build@4.8.4:
     resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
@@ -4418,6 +4476,10 @@ packages:
   p-map@4.0.0:
     resolution: {integrity: sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==}
     engines: {node: '>=10'}
+
+  p-retry@4.6.2:
+    resolution: {integrity: sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==}
+    engines: {node: '>=8'}
 
   package-manager-detector@1.6.0:
     resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
@@ -4849,6 +4911,10 @@ packages:
 
   retry@0.12.0:
     resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
+    engines: {node: '>= 4'}
+
+  retry@0.13.1:
+    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
     engines: {node: '>= 4'}
 
   reusify@1.1.0:
@@ -5554,6 +5620,10 @@ packages:
     engines: {node: '>= 16'}
     hasBin: true
 
+  web-streams-polyfill@3.3.3:
+    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
+    engines: {node: '>= 8'}
+
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
@@ -6221,6 +6291,19 @@ snapshots:
 
   '@gar/promisify@1.1.3':
     optional: true
+
+  '@google/genai@2.10.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))':
+    dependencies:
+      google-auth-library: 10.9.0
+      p-retry: 4.6.2
+      protobufjs: 7.6.1
+      ws: 8.21.0
+    optionalDependencies:
+      '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   '@hono/node-server@1.19.14(hono@4.12.23)':
     dependencies:
@@ -6972,6 +7055,8 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
+  '@types/retry@0.12.0': {}
+
   '@types/trusted-types@2.0.7':
     optional: true
 
@@ -7527,6 +7612,8 @@ snapshots:
     dependencies:
       require-from-string: 2.0.2
 
+  bignumber.js@9.3.1: {}
+
   binary-extensions@2.3.0: {}
 
   bindings@1.5.0:
@@ -8030,6 +8117,8 @@ snapshots:
     dependencies:
       d3: 7.9.0
       lodash-es: 4.18.1
+
+  data-uri-to-buffer@4.0.1: {}
 
   data-urls@7.0.0:
     dependencies:
@@ -8629,6 +8718,11 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
+  fetch-blob@3.2.0:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.3.3
+
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
@@ -8694,6 +8788,10 @@ snapshots:
 
   format@0.2.2: {}
 
+  formdata-polyfill@4.0.10:
+    dependencies:
+      fetch-blob: 3.2.0
+
   forwarded@0.2.0: {}
 
   fraction.js@5.3.4: {}
@@ -8743,6 +8841,22 @@ snapshots:
       strip-ansi: 6.0.1
       wide-align: 1.1.5
     optional: true
+
+  gaxios@7.1.5:
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6
+      node-fetch: 3.3.2
+    transitivePeerDependencies:
+      - supports-color
+
+  gcp-metadata@8.1.2:
+    dependencies:
+      gaxios: 7.1.5
+      google-logging-utils: 1.1.3
+      json-bigint: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   generator-function@2.0.1: {}
 
@@ -8808,6 +8922,19 @@ snapshots:
     dependencies:
       define-properties: 1.2.1
       gopd: 1.2.0
+
+  google-auth-library@10.9.0:
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 7.1.5
+      gcp-metadata: 8.1.2
+      google-logging-utils: 1.1.3
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  google-logging-utils@1.1.3: {}
 
   gopd@1.2.0: {}
 
@@ -9387,6 +9514,10 @@ snapshots:
       - '@noble/hashes'
 
   jsesc@3.1.0: {}
+
+  json-bigint@1.0.0:
+    dependencies:
+      bignumber.js: 9.3.1
 
   json-buffer@3.0.1: {}
 
@@ -10108,6 +10239,8 @@ snapshots:
 
   node-addon-api@8.8.0: {}
 
+  node-domexception@1.0.0: {}
+
   node-exports-info@1.6.0:
     dependencies:
       array.prototype.flatmap: 1.3.3
@@ -10120,6 +10253,12 @@ snapshots:
       whatwg-url: 5.0.0
     optionalDependencies:
       encoding: 0.1.13
+
+  node-fetch@3.3.2:
+    dependencies:
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
 
   node-gyp-build@4.8.4: {}
 
@@ -10265,6 +10404,11 @@ snapshots:
     dependencies:
       aggregate-error: 3.1.0
     optional: true
+
+  p-retry@4.6.2:
+    dependencies:
+      '@types/retry': 0.12.0
+      retry: 0.13.1
 
   package-manager-detector@1.6.0: {}
 
@@ -10767,6 +10911,8 @@ snapshots:
 
   retry@0.12.0:
     optional: true
+
+  retry@0.13.1: {}
 
   reusify@1.1.0: {}
 
@@ -11677,6 +11823,8 @@ snapshots:
       minimist: 1.2.8
     transitivePeerDependencies:
       - supports-color
+
+  web-streams-polyfill@3.3.3: {}
 
   webidl-conversions@3.0.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,6 +5,7 @@ packages:
 # pnpm install. Keeping this at the workspace root makes Docker/CI installs
 # deterministic and prevents ERR_PNPM_IGNORED_BUILDS failures.
 onlyBuiltDependencies:
+  - '@google/genai'
   - bcrypt
   - better-sqlite3
   - esbuild

--- a/src/context/memory/createEdgeClawMemoryProviderFromConfig.ts
+++ b/src/context/memory/createEdgeClawMemoryProviderFromConfig.ts
@@ -18,7 +18,7 @@
 
 import { EdgeClawMemoryService, type EdgeClawMemoryLlmOptions } from "edgeclaw-memory-core";
 import { EdgeClawMemoryProvider } from "./EdgeClawMemoryProvider.js";
-import type { ModelConfig } from "../../model/protocol/canonical.js";
+import type { ModelConfig, ModelProtocol } from "../../model/protocol/canonical.js";
 import type { PilotMemoryConfig } from "../../pilot/config/types.js";
 import type { TelemetryClient } from "../../telemetry/index.js";
 
@@ -96,8 +96,15 @@ function resolveMemoryLlm(
     baseUrl: providerEntry?.url,
     apiKey: providerEntry?.apiKey,
   };
-  if (cfg.apiType !== undefined) {
-    llm.apiType = cfg.apiType;
+  const apiType = cfg.apiType ?? memoryApiTypeForProtocol(providerEntry?.protocol);
+  if (apiType !== undefined) {
+    llm.apiType = apiType as EdgeClawMemoryLlmOptions["apiType"];
   }
   return llm;
+}
+
+function memoryApiTypeForProtocol(protocol: ModelProtocol | undefined): PilotMemoryConfig["apiType"] | "openai-completions" | undefined {
+  if (protocol === "anthropic" || protocol === "google") return protocol;
+  if (protocol === "openai") return "openai-completions";
+  return undefined;
 }

--- a/src/context/memory/edgeclaw-memory-core/lib/core/skills/llm-extraction.js
+++ b/src/context/memory/edgeclaw-memory-core/lib/core/skills/llm-extraction.js
@@ -1625,6 +1625,72 @@ function extractResponsesText(payload) {
         throw new Error("Responses payload did not contain text");
     return text;
 }
+function extractAnthropicMessagesText(payload) {
+    if (!isRecord(payload) || !Array.isArray(payload.content)) {
+        throw new Error("Invalid Anthropic messages payload");
+    }
+    const text = payload.content
+        .map((part) => (isRecord(part) && typeof part.text === "string" ? part.text : ""))
+        .filter(Boolean)
+        .join("\n")
+        .trim();
+    if (!text)
+        throw new Error("Anthropic messages payload did not contain text");
+    return text;
+}
+function extractGoogleGenerateContentText(payload) {
+    if (!isRecord(payload) || !Array.isArray(payload.candidates)) {
+        throw new Error("Invalid Google generateContent payload");
+    }
+    const chunks = [];
+    for (const candidate of payload.candidates) {
+        if (!isRecord(candidate) || !isRecord(candidate.content) || !Array.isArray(candidate.content.parts))
+            continue;
+        for (const part of candidate.content.parts) {
+            if (isRecord(part) && typeof part.text === "string")
+                chunks.push(part.text);
+        }
+    }
+    const text = chunks.join("\n").trim();
+    if (!text)
+        throw new Error("Google generateContent payload did not contain text");
+    return text;
+}
+function normalizeProviderApi(value) {
+    const api = value.trim().toLowerCase();
+    return api === "gemini" ? "google" : api;
+}
+function buildGoogleGenerateContentUrl(baseUrl, model) {
+    const url = new URL(stripTrailingSlash(baseUrl));
+    const parts = url.pathname.split("/").filter(Boolean);
+    const last = parts.at(-1);
+    const apiVersion = last === "v1" || last === "v1beta" ? last : "v1beta";
+    const baseParts = last === "v1" || last === "v1beta" ? parts.slice(0, -1) : parts;
+    url.pathname = `/${[
+        ...baseParts,
+        apiVersion,
+        "models",
+        `${encodeURIComponent(normalizeGoogleModelId(model))}:generateContent`,
+    ].join("/")}`;
+    url.search = "";
+    url.hash = "";
+    return url.toString();
+}
+function normalizeGoogleModelId(model) {
+    const withoutProvider = model.trim().startsWith("google/") ? model.trim().slice("google/".length) : model.trim();
+    if (withoutProvider === "gemini-3-pro")
+        return "gemini-3-pro-preview";
+    if (withoutProvider === "gemini-3.1-pro")
+        return "gemini-3.1-pro-preview";
+    if (withoutProvider === "gemini-3-flash")
+        return "gemini-3-flash-preview";
+    if (withoutProvider === "gemini-3.1-flash" || withoutProvider === "gemini-3.1-flash-preview") {
+        return "gemini-3-flash-preview";
+    }
+    if (withoutProvider === "gemini-3.1-flash-lite")
+        return "gemini-3.1-flash-lite-preview";
+    return withoutProvider;
+}
 function looksLikeEnvVarName(value) {
     return /^[A-Z0-9_]+$/.test(value);
 }
@@ -1741,12 +1807,12 @@ export class LlmMemoryExtractor {
         const headers = new Headers(selection.headers);
         if (!headers.has("content-type"))
             headers.set("content-type", "application/json");
-        if (!headers.has("authorization"))
-            headers.set("authorization", `Bearer ${apiKey}`);
-        const apiType = selection.api.trim().toLowerCase();
+        const apiType = normalizeProviderApi(selection.api);
         let url = "";
         let body;
         if (apiType === "openai-responses" || apiType === "responses") {
+            if (!headers.has("authorization"))
+                headers.set("authorization", `Bearer ${apiKey}`);
             url = `${selection.baseUrl}/responses`;
             body = {
                 model: selection.model,
@@ -1757,7 +1823,40 @@ export class LlmMemoryExtractor {
                 ],
             };
         }
+        else if (apiType === "anthropic") {
+            if (!headers.has("x-api-key"))
+                headers.set("x-api-key", apiKey);
+            if (!headers.has("anthropic-version"))
+                headers.set("anthropic-version", "2023-06-01");
+            url = `${selection.baseUrl}/v1/messages`;
+            body = {
+                model: selection.model,
+                max_tokens: 2048,
+                temperature: 0,
+                system: input.systemPrompt,
+                messages: [
+                    { role: "user", content: input.userPrompt },
+                ],
+            };
+        }
+        else if (apiType === "google") {
+            if (!headers.has("x-goog-api-key"))
+                headers.set("x-goog-api-key", apiKey);
+            url = buildGoogleGenerateContentUrl(selection.baseUrl, selection.model);
+            body = {
+                systemInstruction: { parts: [{ text: input.systemPrompt }] },
+                contents: [
+                    { role: "user", parts: [{ text: input.userPrompt }] },
+                ],
+                generationConfig: {
+                    temperature: 0,
+                    responseMimeType: "application/json",
+                },
+            };
+        }
         else {
+            if (!headers.has("authorization"))
+                headers.set("authorization", `Bearer ${apiKey}`);
             url = `${selection.baseUrl}/chat/completions`;
             body = {
                 model: selection.model,
@@ -1875,9 +1974,13 @@ export class LlmMemoryExtractor {
                 requestLabel: input.requestLabel,
             },
         });
-        return apiType === "openai-responses" || apiType === "responses"
-            ? extractResponsesText(payload)
-            : extractChatCompletionsText(payload);
+        if (apiType === "openai-responses" || apiType === "responses")
+            return extractResponsesText(payload);
+        if (apiType === "anthropic")
+            return extractAnthropicMessagesText(payload);
+        if (apiType === "google")
+            return extractGoogleGenerateContentText(payload);
+        return extractChatCompletionsText(payload);
     }
     async callStructuredJsonWithDebug(input) {
         let rawResponse = "";

--- a/src/context/memory/edgeclaw-memory-core/lib/service.d.ts
+++ b/src/context/memory/edgeclaw-memory-core/lib/service.d.ts
@@ -5,7 +5,7 @@ type LoggerLike = {
     warn?: (...args: unknown[]) => void;
     error?: (...args: unknown[]) => void;
 };
-export type EdgeClawMemoryApiType = "openai-responses" | "responses" | "openai-completions";
+export type EdgeClawMemoryApiType = "openai-responses" | "responses" | "openai-completions" | "anthropic" | "google";
 export interface EdgeClawMemoryLlmOptions {
     provider?: string;
     model?: string;

--- a/src/context/memory/edgeclaw-memory-core/src/core/skills/llm-extraction.ts
+++ b/src/context/memory/edgeclaw-memory-core/src/core/skills/llm-extraction.ts
@@ -2096,6 +2096,69 @@ function extractResponsesText(payload: unknown): string {
   return text;
 }
 
+function extractAnthropicMessagesText(payload: unknown): string {
+  if (!isRecord(payload) || !Array.isArray(payload.content)) {
+    throw new Error("Invalid Anthropic messages payload");
+  }
+  const text = payload.content
+    .map((part) => (isRecord(part) && typeof part.text === "string" ? part.text : ""))
+    .filter(Boolean)
+    .join("\n")
+    .trim();
+  if (!text) throw new Error("Anthropic messages payload did not contain text");
+  return text;
+}
+
+function extractGoogleGenerateContentText(payload: unknown): string {
+  if (!isRecord(payload) || !Array.isArray(payload.candidates)) {
+    throw new Error("Invalid Google generateContent payload");
+  }
+  const chunks: string[] = [];
+  for (const candidate of payload.candidates) {
+    if (!isRecord(candidate) || !isRecord(candidate.content) || !Array.isArray(candidate.content.parts)) continue;
+    for (const part of candidate.content.parts) {
+      if (isRecord(part) && typeof part.text === "string") chunks.push(part.text);
+    }
+  }
+  const text = chunks.join("\n").trim();
+  if (!text) throw new Error("Google generateContent payload did not contain text");
+  return text;
+}
+
+function normalizeProviderApi(value: string): string {
+  const api = value.trim().toLowerCase();
+  return api === "gemini" ? "google" : api;
+}
+
+function buildGoogleGenerateContentUrl(baseUrl: string, model: string): string {
+  const url = new URL(stripTrailingSlash(baseUrl));
+  const parts = url.pathname.split("/").filter(Boolean);
+  const last = parts.at(-1);
+  const apiVersion = last === "v1" || last === "v1beta" ? last : "v1beta";
+  const baseParts = last === "v1" || last === "v1beta" ? parts.slice(0, -1) : parts;
+  url.pathname = `/${[
+    ...baseParts,
+    apiVersion,
+    "models",
+    `${encodeURIComponent(normalizeGoogleModelId(model))}:generateContent`,
+  ].join("/")}`;
+  url.search = "";
+  url.hash = "";
+  return url.toString();
+}
+
+function normalizeGoogleModelId(model: string): string {
+  const withoutProvider = model.trim().startsWith("google/") ? model.trim().slice("google/".length) : model.trim();
+  if (withoutProvider === "gemini-3-pro") return "gemini-3-pro-preview";
+  if (withoutProvider === "gemini-3.1-pro") return "gemini-3.1-pro-preview";
+  if (withoutProvider === "gemini-3-flash") return "gemini-3-flash-preview";
+  if (withoutProvider === "gemini-3.1-flash" || withoutProvider === "gemini-3.1-flash-preview") {
+    return "gemini-3-flash-preview";
+  }
+  if (withoutProvider === "gemini-3.1-flash-lite") return "gemini-3.1-flash-lite-preview";
+  return withoutProvider;
+}
+
 function looksLikeEnvVarName(value: string): boolean {
   return /^[A-Z0-9_]+$/.test(value);
 }
@@ -2224,12 +2287,12 @@ export class LlmMemoryExtractor {
     const apiKey = await this.resolveApiKey(selection.provider);
     const headers = new Headers(selection.headers);
     if (!headers.has("content-type")) headers.set("content-type", "application/json");
-    if (!headers.has("authorization")) headers.set("authorization", `Bearer ${apiKey}`);
-    const apiType = selection.api.trim().toLowerCase();
+    const apiType = normalizeProviderApi(selection.api);
     let url = "";
     let body: Record<string, unknown>;
 
     if (apiType === "openai-responses" || apiType === "responses") {
+      if (!headers.has("authorization")) headers.set("authorization", `Bearer ${apiKey}`);
       url = `${selection.baseUrl}/responses`;
       body = {
         model: selection.model,
@@ -2239,7 +2302,34 @@ export class LlmMemoryExtractor {
           { role: "user", content: input.userPrompt },
         ],
       };
+    } else if (apiType === "anthropic") {
+      if (!headers.has("x-api-key")) headers.set("x-api-key", apiKey);
+      if (!headers.has("anthropic-version")) headers.set("anthropic-version", "2023-06-01");
+      url = `${selection.baseUrl}/v1/messages`;
+      body = {
+        model: selection.model,
+        max_tokens: 2048,
+        temperature: 0,
+        system: input.systemPrompt,
+        messages: [
+          { role: "user", content: input.userPrompt },
+        ],
+      };
+    } else if (apiType === "google") {
+      if (!headers.has("x-goog-api-key")) headers.set("x-goog-api-key", apiKey);
+      url = buildGoogleGenerateContentUrl(selection.baseUrl, selection.model);
+      body = {
+        systemInstruction: { parts: [{ text: input.systemPrompt }] },
+        contents: [
+          { role: "user", parts: [{ text: input.userPrompt }] },
+        ],
+        generationConfig: {
+          temperature: 0,
+          responseMimeType: "application/json",
+        },
+      };
     } else {
+      if (!headers.has("authorization")) headers.set("authorization", `Bearer ${apiKey}`);
       url = `${selection.baseUrl}/chat/completions`;
       body = {
         model: selection.model,
@@ -2357,9 +2447,10 @@ export class LlmMemoryExtractor {
         requestLabel: input.requestLabel,
       },
     });
-    return apiType === "openai-responses" || apiType === "responses"
-      ? extractResponsesText(payload)
-      : extractChatCompletionsText(payload);
+    if (apiType === "openai-responses" || apiType === "responses") return extractResponsesText(payload);
+    if (apiType === "anthropic") return extractAnthropicMessagesText(payload);
+    if (apiType === "google") return extractGoogleGenerateContentText(payload);
+    return extractChatCompletionsText(payload);
   }
 
   private async callStructuredJsonWithDebug<T>(input: {

--- a/src/context/memory/edgeclaw-memory-core/src/service.ts
+++ b/src/context/memory/edgeclaw-memory-core/src/service.ts
@@ -45,7 +45,9 @@ type LoggerLike = {
 export type EdgeClawMemoryApiType =
   | "openai-responses"
   | "responses"
-  | "openai-completions";
+  | "openai-completions"
+  | "anthropic"
+  | "google";
 
 export interface EdgeClawMemoryLlmOptions {
   provider?: string;

--- a/src/model/ModelRuntime.ts
+++ b/src/model/ModelRuntime.ts
@@ -3,6 +3,7 @@ import type {
   CanonicalModelRequest,
   CanonicalModelResponse,
   ModelConfig,
+  ModelProtocol,
 } from "./protocol/canonical.js";
 import type { ModelCapabilities } from "./protocol/capabilities.js";
 import { ModelRequestError } from "./protocol/errors.js";
@@ -15,6 +16,7 @@ export interface ModelRuntime {
   complete(request: CanonicalModelRequest, options?: ModelRuntimeOptions): Promise<CanonicalModelResponse>;
   getCapabilities(providerId: string, modelId: string): ModelCapabilities;
   getMultimodal(providerId: string, modelId: string): MultimodalConstraints;
+  getProviderProtocol(providerId: string): ModelProtocol | undefined;
   getProviderBaseUrl(providerId: string): string | undefined;
 }
 
@@ -44,6 +46,7 @@ export function createModelRuntime(
     complete: (request, callOptions) => complete(request, config, { ...options, ...callOptions }),
     getCapabilities: (providerId, modelId) => getModel(providerId, modelId).capabilities,
     getMultimodal: (providerId, modelId) => getModel(providerId, modelId).multimodal,
+    getProviderProtocol: (providerId) => config.providers[providerId]?.protocol,
     getProviderBaseUrl: (providerId) => {
       const url = config.providers[providerId]?.url;
       return url ? normalizeProviderBaseUrl(url) : undefined;

--- a/src/model/catalog/providers.ts
+++ b/src/model/catalog/providers.ts
@@ -329,9 +329,9 @@ export const PROVIDER_CATALOG: ProviderCatalog = {
 
   google: {
     displayName: "Google AI (Gemini)",
-    protocol: "openai",
-    defaultUrl: "https://generativelanguage.googleapis.com/v1beta/openai",
-    apiKeyEnvVar: "GOOGLE_AI_API_KEY",
+    protocol: "google",
+    defaultUrl: "https://generativelanguage.googleapis.com",
+    apiKeyEnvVar: "GEMINI_API_KEY",
     models: {
       "gemini-2.0-flash": {
         displayName: "Gemini 2.0 Flash",
@@ -415,7 +415,7 @@ export const PROVIDER_CATALOG: ProviderCatalog = {
           supportedImageMimeTypes: ["image/jpeg", "image/png", "image/gif", "image/webp"],
           imageDetail: "auto",
         },
-        aliases: [],
+        aliases: ["gemini-3.1-pro", "gemini-3-pro"],
       },
     },
   },

--- a/src/model/config/parseModelConfig.ts
+++ b/src/model/config/parseModelConfig.ts
@@ -6,6 +6,10 @@ import {
   OPENAI_DEFAULT_CAPABILITIES,
   OPENAI_DEFAULT_MULTIMODAL,
 } from "../providers/openai/defaults.js";
+import {
+  GOOGLE_DEFAULT_CAPABILITIES,
+  GOOGLE_DEFAULT_MULTIMODAL,
+} from "../providers/google/defaults.js";
 import type {
   ModelConfig,
   ModelDefinition,
@@ -77,7 +81,9 @@ function parseProvider(providerId: string, rawProvider: unknown, env?: Credentia
   }
 
   const trimmedUrl = typeof provider.url === "string" ? provider.url.trim() : "";
-  const rawUrl = trimmedUrl.length > 0 ? trimmedUrl : catalogProvider?.defaultUrl;
+  const rawUrl = trimmedUrl.length > 0
+    ? trimmedUrl
+    : resolveDefaultProviderUrl(providerId, protocol, catalogProvider?.defaultUrl);
   if (!rawUrl) {
     throw new ModelConfigError("invalid_config_value", `Provider ${providerId} requires a url.`, { providerId });
   }
@@ -105,6 +111,17 @@ function parseProvider(providerId: string, rawProvider: unknown, env?: Credentia
     retry: parseRetryConfig(provider.retry),
     models,
   };
+}
+
+function resolveDefaultProviderUrl(
+  providerId: string,
+  protocol: ModelProtocol,
+  catalogDefaultUrl: string | undefined,
+): string | undefined {
+  if (providerId === "google" && protocol === "openai") {
+    return "https://generativelanguage.googleapis.com/v1beta/openai";
+  }
+  return catalogDefaultUrl;
 }
 
 function parseRetryConfig(raw: unknown): ProviderRetryConfig | undefined {
@@ -162,7 +179,11 @@ function parseCapabilities(
   catalogCapabilities?: ModelCapabilities,
 ): ModelCapabilities {
   const protocolDefaults =
-    protocol === "anthropic" ? ANTHROPIC_DEFAULT_CAPABILITIES : OPENAI_DEFAULT_CAPABILITIES;
+    protocol === "anthropic"
+      ? ANTHROPIC_DEFAULT_CAPABILITIES
+      : protocol === "google"
+        ? GOOGLE_DEFAULT_CAPABILITIES
+        : OPENAI_DEFAULT_CAPABILITIES;
   const defaults = catalogCapabilities ?? protocolDefaults;
 
   if (rawCapabilities === undefined) {
@@ -215,7 +236,11 @@ function parseMultimodal(
   catalogMultimodal?: MultimodalConstraints,
 ): MultimodalConstraints {
   const protocolDefaults =
-    protocol === "anthropic" ? ANTHROPIC_DEFAULT_MULTIMODAL : OPENAI_DEFAULT_MULTIMODAL;
+    protocol === "anthropic"
+      ? ANTHROPIC_DEFAULT_MULTIMODAL
+      : protocol === "google"
+        ? GOOGLE_DEFAULT_MULTIMODAL
+        : OPENAI_DEFAULT_MULTIMODAL;
   const defaults = catalogMultimodal ?? { ...DEFAULT_MULTIMODAL_CONSTRAINTS, ...protocolDefaults };
 
   if (rawMultimodal === undefined) {

--- a/src/model/config/schema.ts
+++ b/src/model/config/schema.ts
@@ -33,5 +33,5 @@ export function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 export function isModelProtocol(value: unknown): value is ModelProtocol {
-  return value === "anthropic" || value === "openai";
+  return value === "anthropic" || value === "openai" || value === "google";
 }

--- a/src/model/protocol/canonical.ts
+++ b/src/model/protocol/canonical.ts
@@ -2,7 +2,7 @@ import type { ModelCapabilities } from "./capabilities.js";
 import type { CanonicalModelError } from "./errors.js";
 import type { MultimodalConstraints } from "./multimodal.js";
 
-export type ModelProtocol = "anthropic" | "openai";
+export type ModelProtocol = "anthropic" | "openai" | "google";
 
 export type CanonicalRole = "user" | "assistant";
 

--- a/src/model/protocol/errors.ts
+++ b/src/model/protocol/errors.ts
@@ -25,7 +25,7 @@ export type SettingsFix = {
 
 export type CanonicalModelError = {
   provider: string;
-  protocol: "anthropic" | "openai";
+  protocol: "anthropic" | "openai" | "google";
   code: CanonicalModelErrorCode | (string & {});
   status?: number;
   message: string;

--- a/src/model/providers/google/client.ts
+++ b/src/model/providers/google/client.ts
@@ -1,0 +1,62 @@
+import {
+  GoogleGenAI,
+  type GenerateContentParameters,
+  type GenerateContentResponse,
+  type HttpOptions,
+} from "@google/genai";
+import type { ProviderConfig } from "../../protocol/canonical.js";
+
+export type GoogleModelClient = {
+  models: {
+    generateContent(params: GenerateContentParameters): Promise<GenerateContentResponse>;
+    generateContentStream(params: GenerateContentParameters): Promise<AsyncGenerator<GenerateContentResponse>>;
+  };
+};
+
+export type GoogleClientFactory = (provider: ProviderConfig) => GoogleModelClient;
+
+export function createGoogleClient(provider: ProviderConfig): GoogleModelClient {
+  const resolved = resolveGoogleEndpoint(provider.url);
+  const httpOptions: HttpOptions = {
+    headers: provider.headers,
+    ...(provider.timeoutMs ? { timeout: provider.timeoutMs } : {}),
+    ...(provider.extraBody ? { extraBody: provider.extraBody } : {}),
+    ...(resolved.baseUrl ? { baseUrl: resolved.baseUrl } : {}),
+  };
+
+  return new GoogleGenAI({
+    apiKey: provider.apiKey,
+    ...(resolved.apiVersion !== undefined ? { apiVersion: resolved.apiVersion } : {}),
+    httpOptions,
+  });
+}
+
+export function resolveGoogleEndpoint(rawUrl: string): { baseUrl?: string; apiVersion?: string } {
+  const trimmed = rawUrl.trim().replace(/\/+$/, "");
+  if (!trimmed) {
+    return {};
+  }
+
+  try {
+    const url = new URL(trimmed);
+    const parts = url.pathname.split("/").filter(Boolean);
+    const last = parts.at(-1);
+    if (last === "v1" || last === "v1beta") {
+      url.pathname = parts.length > 1 ? `/${parts.slice(0, -1).join("/")}/` : "/";
+      url.search = "";
+      url.hash = "";
+      return { baseUrl: url.toString(), apiVersion: last };
+    }
+
+    if (url.hostname.toLowerCase() === "generativelanguage.googleapis.com" && parts.length === 0) {
+      return {};
+    }
+
+    url.pathname = url.pathname.endsWith("/") ? url.pathname : `${url.pathname}/`;
+    url.search = "";
+    url.hash = "";
+    return { baseUrl: url.toString(), apiVersion: "" };
+  } catch {
+    return { baseUrl: trimmed, apiVersion: "" };
+  }
+}

--- a/src/model/providers/google/defaults.ts
+++ b/src/model/providers/google/defaults.ts
@@ -1,0 +1,21 @@
+import type { ModelCapabilities } from "../../protocol/capabilities.js";
+import type { MultimodalConstraints } from "../../protocol/multimodal.js";
+
+export const GOOGLE_DEFAULT_CAPABILITIES: ModelCapabilities = {
+  supportsToolUse: true,
+  supportsStreaming: true,
+  supportsParallelToolCalls: true,
+  supportsThinking: true,
+  supportsJsonSchema: true,
+  supportsSystemPrompt: true,
+  supportsPromptCache: false,
+  maxContextTokens: 1_048_576,
+  maxOutputTokens: 8_192,
+};
+
+export const GOOGLE_DEFAULT_MULTIMODAL: MultimodalConstraints = {
+  input: ["text", "image", "audio", "pdf"],
+  maxImagesPerRequest: 20,
+  supportedImageMimeTypes: ["image/jpeg", "image/png", "image/gif", "image/webp"],
+  imageDetail: "auto",
+};

--- a/src/model/providers/google/modelId.ts
+++ b/src/model/providers/google/modelId.ts
@@ -1,0 +1,22 @@
+export function normalizeGoogleModelId(id: string): string {
+  const trimmed = id.trim();
+  const withoutProvider = trimmed.startsWith("google/") ? trimmed.slice("google/".length) : trimmed;
+
+  if (withoutProvider === "gemini-3-pro") {
+    return "gemini-3-pro-preview";
+  }
+  if (withoutProvider === "gemini-3-flash") {
+    return "gemini-3-flash-preview";
+  }
+  if (withoutProvider === "gemini-3.1-pro") {
+    return "gemini-3.1-pro-preview";
+  }
+  if (withoutProvider === "gemini-3.1-flash-lite") {
+    return "gemini-3.1-flash-lite-preview";
+  }
+  if (withoutProvider === "gemini-3.1-flash" || withoutProvider === "gemini-3.1-flash-preview") {
+    return "gemini-3-flash-preview";
+  }
+
+  return withoutProvider;
+}

--- a/src/model/providers/google/request.ts
+++ b/src/model/providers/google/request.ts
@@ -1,0 +1,283 @@
+import {
+  FunctionCallingConfigMode,
+  type Content,
+  type FunctionDeclaration,
+  type FunctionResponsePart,
+  type GenerateContentConfig,
+  type GenerateContentParameters,
+  type Part,
+  type Tool,
+} from "@google/genai";
+import type {
+  CanonicalContentBlock,
+  CanonicalMessage,
+  CanonicalModelRequest,
+  CanonicalToolChoice,
+  CanonicalToolResultContentBlock,
+  CanonicalToolSchema,
+  ModelDefinition,
+} from "../../protocol/canonical.js";
+import { flattenToolResultBlockText } from "../../protocol/toolResultContent.js";
+import { normalizeGoogleModelId } from "./modelId.js";
+import { cleanSchemaForGoogle, normalizeGoogleToolSchema } from "./schema.js";
+
+export type GoogleRequestBody = GenerateContentParameters;
+
+export function buildGoogleRequest(
+  request: CanonicalModelRequest,
+  model: ModelDefinition,
+): GoogleRequestBody {
+  const tools = request.tools?.map(toGoogleFunctionDeclaration) ?? [];
+  const config: GenerateContentConfig = {
+    maxOutputTokens: request.maxOutputTokens ?? model.capabilities.maxOutputTokens,
+    temperature: request.temperature,
+    systemInstruction: request.systemPrompt ? { text: request.systemPrompt } : undefined,
+    automaticFunctionCalling: { disable: true },
+    tools: tools.length > 0 ? [{ functionDeclarations: tools } satisfies Tool] : undefined,
+    toolConfig: toGoogleToolConfig(request.toolChoice),
+    thinkingConfig: toGoogleThinkingConfig(request, model),
+  };
+
+  if (request.outputSchema) {
+    config.responseMimeType = "application/json";
+    config.responseJsonSchema = cleanSchemaForGoogle(request.outputSchema.schema);
+  }
+
+  return {
+    model: normalizeGoogleModelId(request.model),
+    contents: sanitizeGoogleContents(toGoogleContents(request.messages)),
+    config: compactObject(config) as GenerateContentConfig,
+  };
+}
+
+function toGoogleFunctionDeclaration(tool: CanonicalToolSchema): FunctionDeclaration {
+  return {
+    name: tool.name,
+    description: tool.description,
+    parametersJsonSchema: normalizeGoogleToolSchema(tool.inputSchema),
+  };
+}
+
+function toGoogleToolConfig(toolChoice: CanonicalToolChoice | undefined): GenerateContentConfig["toolConfig"] {
+  if (!toolChoice) {
+    return undefined;
+  }
+  if (toolChoice === "auto") {
+    return { functionCallingConfig: { mode: FunctionCallingConfigMode.AUTO } };
+  }
+  if (toolChoice === "none") {
+    return { functionCallingConfig: { mode: FunctionCallingConfigMode.NONE } };
+  }
+  if (toolChoice === "required") {
+    return { functionCallingConfig: { mode: FunctionCallingConfigMode.ANY } };
+  }
+  return {
+    functionCallingConfig: {
+      mode: FunctionCallingConfigMode.ANY,
+      allowedFunctionNames: [toolChoice.name],
+    },
+  };
+}
+
+function toGoogleThinkingConfig(
+  request: CanonicalModelRequest,
+  model: ModelDefinition,
+): GenerateContentConfig["thinkingConfig"] {
+  if (!request.thinking?.enabled || !model.capabilities.supportsThinking) {
+    return undefined;
+  }
+  const budget = request.thinking.budgetTokens;
+  return {
+    includeThoughts: true,
+    ...(typeof budget === "number" && Number.isFinite(budget) && budget >= 0
+      ? { thinkingBudget: budget }
+      : {}),
+  };
+}
+
+function toGoogleContents(messages: CanonicalMessage[]): Content[] {
+  const toolNamesById = collectToolCallNames(messages);
+  const contents: Content[] = [];
+
+  for (const message of messages) {
+    let currentRole: "user" | "model" | undefined;
+    let currentParts: Part[] = [];
+
+    const flush = () => {
+      if (currentRole && currentParts.length > 0) {
+        contents.push({ role: currentRole, parts: currentParts });
+      }
+      currentRole = undefined;
+      currentParts = [];
+    };
+
+    const push = (role: "user" | "model", parts: Part[]) => {
+      if (parts.length === 0) {
+        return;
+      }
+      if (currentRole !== role) {
+        flush();
+        currentRole = role;
+      }
+      currentParts.push(...parts);
+    };
+
+    for (const block of message.content) {
+      const role = googleRoleForBlock(message.role, block);
+      push(role, toGoogleParts(block, toolNamesById));
+    }
+
+    flush();
+  }
+
+  return contents;
+}
+
+function googleRoleForBlock(
+  messageRole: CanonicalMessage["role"],
+  block: CanonicalContentBlock,
+): "user" | "model" {
+  if (block.type === "tool_result" || block.type === "tool_result_reference") {
+    return "user";
+  }
+  return messageRole === "assistant" ? "model" : "user";
+}
+
+function toGoogleParts(block: CanonicalContentBlock, toolNamesById: Map<string, string>): Part[] {
+  switch (block.type) {
+    case "text":
+      return block.text.length > 0 ? [{ text: block.text }] : [];
+    case "thinking":
+      return [{
+        text: block.text,
+        thought: true,
+        ...(block.signature ? { thoughtSignature: block.signature } : {}),
+      }];
+    case "image":
+    case "pdf":
+    case "audio":
+      return [toGoogleMediaPart(block)];
+    case "tool_call":
+      return [{
+        functionCall: {
+          id: sanitizeGoogleToolCallId(block.id),
+          name: block.name,
+          args: toGoogleArgs(block.input),
+        },
+      }];
+    case "tool_result":
+      return [toGoogleFunctionResponsePart(
+        sanitizeGoogleToolCallId(block.toolCallId),
+        toolNamesById.get(sanitizeGoogleToolCallId(block.toolCallId)) ?? block.toolCallId,
+        flattenToolResultBlockText(block),
+        block.isError,
+        block.content,
+      )];
+    case "tool_result_reference":
+      return [toGoogleFunctionResponsePart(
+        sanitizeGoogleToolCallId(block.toolCallId),
+        toolNamesById.get(sanitizeGoogleToolCallId(block.toolCallId)) ?? block.toolCallId,
+        block.preview + (block.hasMore
+          ? `\n\n[Truncated: original ${block.originalBytes} bytes, file: ${block.path}]`
+          : ""),
+        false,
+        [],
+      )];
+    case "media_reference":
+      return [{ text: block.preview }];
+  }
+}
+
+function toGoogleMediaPart(
+  block: Extract<CanonicalContentBlock, { type: "image" | "pdf" | "audio" }>,
+): Part {
+  if (block.source === "url") {
+    return { fileData: { fileUri: block.data, mimeType: block.mimeType } };
+  }
+  return { inlineData: { data: block.data, mimeType: block.mimeType } };
+}
+
+function toGoogleFunctionResponsePart(
+  id: string,
+  name: string,
+  output: string,
+  isError: boolean | undefined,
+  content: CanonicalToolResultContentBlock[],
+): Part {
+  const response: Record<string, unknown> = isError
+    ? { error: output || "Tool execution failed." }
+    : { output };
+  const parts = content.flatMap(toGoogleFunctionResponseMediaPart);
+  return {
+    functionResponse: {
+      id,
+      name,
+      response,
+      ...(parts.length > 0 ? { parts } : {}),
+    },
+  };
+}
+
+function toGoogleFunctionResponseMediaPart(
+  block: CanonicalToolResultContentBlock,
+): FunctionResponsePart[] {
+  if (block.type === "text") {
+    return [];
+  }
+  if (block.source === "url") {
+    return [{ fileData: { fileUri: block.data, mimeType: block.mimeType } }];
+  }
+  return [{ inlineData: { data: block.data, mimeType: block.mimeType } }];
+}
+
+function sanitizeGoogleContents(contents: Content[]): Content[] {
+  const merged: Content[] = [];
+  for (const content of contents) {
+    if (!content.parts?.length) {
+      continue;
+    }
+    const prev = merged.length > 0 ? merged[merged.length - 1] : undefined;
+    if (prev !== undefined && prev.role === content.role) {
+      prev.parts = [...(prev.parts ?? []), ...(content.parts ?? [])];
+    } else {
+      merged.push({ ...content, parts: [...content.parts] });
+    }
+  }
+
+  if (merged[0]?.role === "model") {
+    merged.unshift({
+      role: "user",
+      parts: [{ text: "Continue the conversation from the available context." }],
+    });
+  }
+
+  return merged.length > 0 ? merged : [{ role: "user", parts: [{ text: "" }] }];
+}
+
+function collectToolCallNames(messages: CanonicalMessage[]): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const message of messages) {
+    for (const block of message.content) {
+      if (block.type === "tool_call") {
+        map.set(sanitizeGoogleToolCallId(block.id), block.name);
+      }
+    }
+  }
+  return map;
+}
+
+function sanitizeGoogleToolCallId(id: string): string {
+  return id.trim().replace(/[^A-Za-z0-9_-]+/g, "_").replace(/^_+|_+$/g, "") || "call";
+}
+
+function toGoogleArgs(input: unknown): Record<string, unknown> {
+  return input && typeof input === "object" && !Array.isArray(input)
+    ? (input as Record<string, unknown>)
+    : { value: input };
+}
+
+function compactObject<T extends object>(value: T): Partial<T> {
+  return Object.fromEntries(
+    Object.entries(value).filter(([, entry]) => entry !== undefined),
+  ) as Partial<T>;
+}

--- a/src/model/providers/google/response.ts
+++ b/src/model/providers/google/response.ts
@@ -1,0 +1,174 @@
+import type {
+  CanonicalContentBlock,
+  CanonicalFinishReason,
+  CanonicalModelResponse,
+  CanonicalThinkingBlock,
+  CanonicalToolCallBlock,
+  CanonicalUsage,
+} from "../../protocol/canonical.js";
+
+export function parseGoogleResponse(raw: unknown, provider = "google"): CanonicalModelResponse {
+  const response = asRecord(raw);
+  const candidate = firstCandidate(response);
+  const parts = contentParts(candidate);
+  const idState = createToolCallIdState(response);
+
+  return {
+    role: "assistant",
+    content: parts.flatMap((part, index) => toCanonicalContentBlock(part, provider, idState, index)),
+    usage: normalizeGoogleUsage(response.usageMetadata),
+    finishReason: normalizeGoogleFinishReason(candidate.finishReason),
+    raw,
+  };
+}
+
+export function normalizeGoogleUsage(raw: unknown): CanonicalUsage | undefined {
+  const usage = asRecord(raw);
+  const inputTokens = readNumber(usage.promptTokenCount);
+  const outputTokens = readNumber(usage.candidatesTokenCount) ?? readNumber(usage.responseTokenCount);
+  const cacheReadTokens = readNumber(usage.cachedContentTokenCount);
+  const totalTokens = readNumber(usage.totalTokenCount) ?? sumDefined(inputTokens, outputTokens, cacheReadTokens);
+  const result: CanonicalUsage = {
+    inputTokens,
+    outputTokens,
+    cacheReadTokens,
+    totalTokens,
+  };
+  return Object.values(result).some((value) => value !== undefined) ? result : undefined;
+}
+
+export function normalizeGoogleFinishReason(reason: unknown): CanonicalFinishReason {
+  switch (typeof reason === "string" ? reason.toUpperCase() : reason) {
+    case "STOP":
+      return "stop";
+    case "MAX_TOKENS":
+      return "length";
+    case "MALFORMED_FUNCTION_CALL":
+    case "UNEXPECTED_TOOL_CALL":
+      return "tool_call";
+    case "SAFETY":
+    case "RECITATION":
+    case "BLOCKLIST":
+    case "PROHIBITED_CONTENT":
+    case "SPII":
+    case "IMAGE_SAFETY":
+      return "content_filter";
+    default:
+      return "unknown";
+  }
+}
+
+function toCanonicalContentBlock(
+  part: unknown,
+  provider: string,
+  idState: GoogleToolCallIdState,
+  partIndex: number,
+): CanonicalContentBlock[] {
+  const record = asRecord(part);
+  const text = readString(record.text);
+  if (text !== undefined) {
+    if (record.thought === true) {
+      const thinking: CanonicalThinkingBlock = { type: "thinking", text };
+      const signature = readString(record.thoughtSignature);
+      if (signature) {
+        thinking.signature = signature;
+      }
+      return [thinking];
+    }
+    return text.length > 0 ? [{ type: "text", text }] : [];
+  }
+
+  const functionCall = asRecord(record.functionCall);
+  if (Object.keys(functionCall).length > 0) {
+    return [toCanonicalToolCall(functionCall, provider, idState, partIndex)];
+  }
+
+  return [];
+}
+
+function toCanonicalToolCall(
+  functionCall: Record<string, unknown>,
+  provider: string,
+  idState: GoogleToolCallIdState,
+  partIndex: number,
+): CanonicalToolCallBlock {
+  const args = functionCall.args;
+  return {
+    type: "tool_call",
+    id: chooseGoogleToolCallId(idState, readString(functionCall.id), partIndex),
+    name: readString(functionCall.name) ?? "",
+    input: args && typeof args === "object" && !Array.isArray(args) ? args : {},
+    raw: {
+      provider,
+      functionCall,
+    },
+  };
+}
+
+type GoogleToolCallIdState = {
+  baseId: string;
+  usedIds: Set<string>;
+};
+
+function createToolCallIdState(response: Record<string, unknown>): GoogleToolCallIdState {
+  return {
+    baseId: safeToolCallIdPart(readString(response.responseId) ?? "google_response"),
+    usedIds: new Set(),
+  };
+}
+
+function chooseGoogleToolCallId(
+  state: GoogleToolCallIdState,
+  incomingId: string | undefined,
+  index: number,
+): string {
+  const candidate = incomingId ? safeToolCallIdPart(incomingId) : `call_${state.baseId}_${index}`;
+  const unique = nextUniqueToolCallId(candidate, state.usedIds);
+  state.usedIds.add(unique);
+  return unique;
+}
+
+function nextUniqueToolCallId(id: string, used: Set<string>): string {
+  if (!used.has(id)) {
+    return id;
+  }
+  for (let suffix = 2; ; suffix += 1) {
+    const candidate = `${id}_${suffix}`;
+    if (!used.has(candidate)) {
+      return candidate;
+    }
+  }
+}
+
+function safeToolCallIdPart(value: string): string {
+  return value.trim().replace(/[^A-Za-z0-9_-]+/g, "_").replace(/^_+|_+$/g, "") || "google";
+}
+
+function firstCandidate(response: Record<string, unknown>): Record<string, unknown> {
+  const candidates = Array.isArray(response.candidates) ? response.candidates : [];
+  return asRecord(candidates[0]);
+}
+
+function contentParts(candidate: Record<string, unknown>): unknown[] {
+  const content = asRecord(candidate.content);
+  return Array.isArray(content.parts) ? content.parts : [];
+}
+
+function sumDefined(...values: Array<number | undefined>): number | undefined {
+  const defined = values.filter((value): value is number => value !== undefined);
+  return defined.length > 0 ? defined.reduce((sum, value) => sum + value, 0) : undefined;
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function readNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}

--- a/src/model/providers/google/schema.ts
+++ b/src/model/providers/google/schema.ts
@@ -1,0 +1,382 @@
+const GOOGLE_UNSUPPORTED_SCHEMA_KEYWORDS = new Set([
+  "patternProperties",
+  "additionalProperties",
+  "$schema",
+  "$id",
+  "$ref",
+  "$defs",
+  "definitions",
+  "examples",
+  "minLength",
+  "maxLength",
+  "minimum",
+  "maximum",
+  "multipleOf",
+  "pattern",
+  "format",
+  "minItems",
+  "maxItems",
+  "uniqueItems",
+  "minProperties",
+  "maxProperties",
+]);
+
+const META_KEYS = ["description", "title", "default"] as const;
+const VALID_GOOGLE_PARAMETER_NAME = /^[A-Za-z_][A-Za-z0-9_]{0,63}$/;
+
+type SchemaDefs = Map<string, unknown>;
+
+export function normalizeGoogleToolSchema(schema: Record<string, unknown>): Record<string, unknown> {
+  const flattened = flattenTopLevelObjectUnion(schema);
+  const cleaned = cleanSchemaForGoogle(flattened);
+  if (isRecord(cleaned)) {
+    const result: Record<string, unknown> = { ...cleaned };
+    if (result.type === undefined) {
+      result.type = "object";
+    }
+    if (!isRecord(result.properties)) {
+      result.properties = {};
+    }
+    return result;
+  }
+  return { type: "object", properties: {} };
+}
+
+export function cleanSchemaForGoogle(schema: unknown): unknown {
+  return cleanSchemaForGoogleWithDefs(schema, undefined, undefined);
+}
+
+function cleanSchemaForGoogleWithDefs(
+  schema: unknown,
+  defs: SchemaDefs | undefined,
+  refStack: Set<string> | undefined,
+): unknown {
+  if (!schema || typeof schema !== "object") {
+    return schema;
+  }
+  if (Array.isArray(schema)) {
+    return schema.map((item) => cleanSchemaForGoogleWithDefs(item, defs, refStack));
+  }
+
+  const obj = schema as Record<string, unknown>;
+  const nextDefs = extendSchemaDefs(defs, obj);
+  const refValue = typeof obj.$ref === "string" ? obj.$ref : undefined;
+  if (refValue) {
+    if (refStack?.has(refValue)) {
+      return {};
+    }
+    const resolved = tryResolveLocalRef(refValue, nextDefs);
+    if (resolved !== undefined) {
+      const nextRefStack = refStack ? new Set(refStack) : new Set<string>();
+      nextRefStack.add(refValue);
+      const cleaned = cleanSchemaForGoogleWithDefs(resolved, nextDefs, nextRefStack);
+      if (!isRecord(cleaned)) {
+        return cleaned;
+      }
+      const result: Record<string, unknown> = { ...cleaned };
+      copySchemaMeta(obj, result);
+      return result;
+    }
+    const result: Record<string, unknown> = {};
+    copySchemaMeta(obj, result);
+    return result;
+  }
+
+  const union = simplifyUnion(obj, nextDefs, refStack);
+  if (union !== undefined) {
+    return union;
+  }
+
+  const next: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(obj)) {
+    if (GOOGLE_UNSUPPORTED_SCHEMA_KEYWORDS.has(key)) {
+      continue;
+    }
+    if (key === "const") {
+      next.enum = [value];
+      continue;
+    }
+    if (key === "type") {
+      next.type = normalizeType(value);
+      continue;
+    }
+    if (key === "properties") {
+      next.properties = cleanProperties(value, nextDefs, refStack);
+      continue;
+    }
+    if (key === "items") {
+      next.items = cleanSchemaForGoogleWithDefs(value, nextDefs, refStack);
+      continue;
+    }
+    if (key === "required") {
+      continue;
+    }
+    next[key] = cleanSchemaForGoogleWithDefs(value, nextDefs, refStack);
+  }
+
+  if (next.type === "array" && next.items === undefined) {
+    next.items = {};
+  }
+
+  const required = cleanRequired(obj.required, next.properties);
+  if (required.length > 0) {
+    next.required = required;
+  }
+
+  return next;
+}
+
+function flattenTopLevelObjectUnion(schema: Record<string, unknown>): Record<string, unknown> {
+  const variantKey = Array.isArray(schema.anyOf)
+    ? "anyOf"
+    : Array.isArray(schema.oneOf)
+      ? "oneOf"
+      : null;
+  if (!variantKey) {
+    return schema;
+  }
+
+  const variants = (schema[variantKey] as unknown[])
+    .filter((variant) => isRecord(variant) && isRecord(variant.properties)) as Record<string, unknown>[];
+  if (variants.length === 0) {
+    return schema;
+  }
+
+  const mergedProperties: Record<string, unknown> = {};
+  const requiredCounts = new Map<string, number>();
+  for (const variant of variants) {
+    for (const [key, value] of Object.entries(variant.properties as Record<string, unknown>)) {
+      mergedProperties[key] = key in mergedProperties
+        ? mergePropertySchemas(mergedProperties[key], value)
+        : value;
+    }
+    const required = Array.isArray(variant.required) ? variant.required : [];
+    for (const key of required) {
+      if (typeof key === "string") {
+        requiredCounts.set(key, (requiredCounts.get(key) ?? 0) + 1);
+      }
+    }
+  }
+
+  const baseRequired = Array.isArray(schema.required)
+    ? schema.required.filter((key): key is string => typeof key === "string")
+    : undefined;
+  const required = baseRequired && baseRequired.length > 0
+    ? baseRequired
+    : Array.from(requiredCounts.entries())
+        .filter(([, count]) => count === variants.length)
+        .map(([key]) => key);
+
+  return {
+    ...schema,
+    type: "object",
+    properties: mergedProperties,
+    ...(required.length > 0 ? { required } : {}),
+  };
+}
+
+function simplifyUnion(
+  obj: Record<string, unknown>,
+  defs: SchemaDefs | undefined,
+  refStack: Set<string> | undefined,
+): unknown {
+  const variants = Array.isArray(obj.anyOf)
+    ? obj.anyOf
+    : Array.isArray(obj.oneOf)
+      ? obj.oneOf
+      : undefined;
+  if (!variants) {
+    return undefined;
+  }
+
+  const nonNullVariants = variants.filter((variant) => !isNullSchema(variant));
+  const flattened = tryFlattenLiteralUnion(nonNullVariants);
+  if (flattened) {
+    const result: Record<string, unknown> = flattened;
+    copySchemaMeta(obj, result);
+    return result;
+  }
+
+  if (nonNullVariants.length === 1) {
+    const cleaned = cleanSchemaForGoogleWithDefs(nonNullVariants[0], defs, refStack);
+    if (isRecord(cleaned)) {
+      const result: Record<string, unknown> = { ...cleaned };
+      copySchemaMeta(obj, result);
+      return result;
+    }
+    return cleaned;
+  }
+
+  return undefined;
+}
+
+function cleanProperties(
+  properties: unknown,
+  defs: SchemaDefs | undefined,
+  refStack: Set<string> | undefined,
+): Record<string, unknown> {
+  if (!isRecord(properties)) {
+    return {};
+  }
+
+  const next: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(properties)) {
+    if (!VALID_GOOGLE_PARAMETER_NAME.test(key)) {
+      continue;
+    }
+    next[key] = cleanSchemaForGoogleWithDefs(value, defs, refStack);
+  }
+  return next;
+}
+
+function cleanRequired(required: unknown, properties: unknown): string[] {
+  if (!Array.isArray(required) || !isRecord(properties)) {
+    return [];
+  }
+  return required.filter(
+    (key): key is string => typeof key === "string" && key in properties,
+  );
+}
+
+function mergePropertySchemas(existing: unknown, incoming: unknown): unknown {
+  const existingValues = extractEnumValues(existing);
+  const incomingValues = extractEnumValues(incoming);
+  if (existingValues || incomingValues) {
+    const values = Array.from(new Set([...(existingValues ?? []), ...(incomingValues ?? [])]));
+    const result: Record<string, unknown> = { enum: values };
+    const type = values.length > 0 && values.every((value) => typeof value === typeof values[0])
+      ? typeof values[0]
+      : undefined;
+    if (type) {
+      result.type = type;
+    }
+    for (const source of [existing, incoming]) {
+      if (isRecord(source)) {
+        copySchemaMeta(source, result);
+      }
+    }
+    return result;
+  }
+  return existing ?? incoming;
+}
+
+function tryFlattenLiteralUnion(variants: unknown[]): { type: string; enum: unknown[] } | undefined {
+  if (variants.length === 0) {
+    return undefined;
+  }
+  const values: unknown[] = [];
+  let commonType: string | undefined;
+  for (const variant of variants) {
+    const extracted = extractSingleEnumValue(variant);
+    if (!extracted) {
+      return undefined;
+    }
+    if (commonType === undefined) {
+      commonType = extracted.type;
+    } else if (commonType !== extracted.type) {
+      return undefined;
+    }
+    values.push(extracted.value);
+  }
+  return commonType ? { type: commonType, enum: values } : undefined;
+}
+
+function extractEnumValues(schema: unknown): unknown[] | undefined {
+  if (!isRecord(schema)) {
+    return undefined;
+  }
+  if (Array.isArray(schema.enum)) {
+    return schema.enum;
+  }
+  if ("const" in schema) {
+    return [schema.const];
+  }
+  const variants = Array.isArray(schema.anyOf)
+    ? schema.anyOf
+    : Array.isArray(schema.oneOf)
+      ? schema.oneOf
+      : undefined;
+  if (!variants) {
+    return undefined;
+  }
+  const values = variants.flatMap((variant) => extractEnumValues(variant) ?? []);
+  return values.length > 0 ? values : undefined;
+}
+
+function extractSingleEnumValue(schema: unknown): { type: string; value: unknown } | undefined {
+  if (!isRecord(schema)) {
+    return undefined;
+  }
+  const value = "const" in schema
+    ? schema.const
+    : Array.isArray(schema.enum) && schema.enum.length === 1
+      ? schema.enum[0]
+      : undefined;
+  const type = typeof schema.type === "string" ? schema.type : typeof value;
+  return value !== undefined && type !== "undefined" ? { type, value } : undefined;
+}
+
+function normalizeType(value: unknown): unknown {
+  if (!Array.isArray(value)) {
+    return value === "null" ? undefined : value;
+  }
+  const withoutNull = value.filter((entry) => entry !== "null");
+  return withoutNull.length === 1 ? withoutNull[0] : withoutNull;
+}
+
+function isNullSchema(value: unknown): boolean {
+  if (!isRecord(value)) {
+    return false;
+  }
+  if (value.type === "null" || value.const === null) {
+    return true;
+  }
+  return Array.isArray(value.enum) && value.enum.length === 1 && value.enum[0] === null;
+}
+
+function extendSchemaDefs(
+  defs: SchemaDefs | undefined,
+  schema: Record<string, unknown>,
+): SchemaDefs | undefined {
+  const entries = [
+    isRecord(schema.$defs) ? schema.$defs : undefined,
+    isRecord(schema.definitions) ? schema.definitions : undefined,
+  ].filter((entry): entry is Record<string, unknown> => entry !== undefined);
+  if (entries.length === 0) {
+    return defs;
+  }
+  const next = defs ? new Map(defs) : new Map<string, unknown>();
+  for (const entry of entries) {
+    for (const [key, value] of Object.entries(entry)) {
+      next.set(key, value);
+    }
+  }
+  return next;
+}
+
+function tryResolveLocalRef(ref: string, defs: SchemaDefs | undefined): unknown {
+  if (!defs) {
+    return undefined;
+  }
+  const match = /^#\/(?:\$defs|definitions)\/(.+)$/.exec(ref);
+  if (!match) {
+    return undefined;
+  }
+  return defs.get(decodeJsonPointerSegment(match[1] ?? ""));
+}
+
+function decodeJsonPointerSegment(segment: string): string {
+  return segment.replaceAll("~1", "/").replaceAll("~0", "~");
+}
+
+function copySchemaMeta(from: Record<string, unknown>, to: Record<string, unknown>): void {
+  for (const key of META_KEYS) {
+    if (to[key] === undefined && from[key] !== undefined) {
+      to[key] = from[key];
+    }
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/model/providers/google/schema.ts
+++ b/src/model/providers/google/schema.ts
@@ -167,8 +167,15 @@ function flattenTopLevelObjectUnion(schema: Record<string, unknown>): Record<str
         .filter(([, count]) => count === variants.length)
         .map(([key]) => key);
 
+  const {
+    anyOf: _anyOf,
+    oneOf: _oneOf,
+    required: _required,
+    ...baseSchema
+  } = schema;
+
   return {
-    ...schema,
+    ...baseSchema,
     type: "object",
     properties: mergedProperties,
     ...(required.length > 0 ? { required } : {}),

--- a/src/model/providers/google/stream.ts
+++ b/src/model/providers/google/stream.ts
@@ -1,0 +1,149 @@
+import type { CanonicalModelEvent, CanonicalToolCall } from "../../protocol/canonical.js";
+import {
+  normalizeGoogleFinishReason,
+  normalizeGoogleUsage,
+} from "./response.js";
+
+type GoogleStreamToolCallState = {
+  baseId: string;
+  usedIds: Set<string>;
+};
+
+export type GoogleStreamState = {
+  started: boolean;
+  ended: boolean;
+  toolCalls: GoogleStreamToolCallState;
+};
+
+export function createGoogleStreamState(): GoogleStreamState {
+  return {
+    started: false,
+    ended: false,
+    toolCalls: {
+      baseId: "google_stream",
+      usedIds: new Set(),
+    },
+  };
+}
+
+export function normalizeGoogleStreamEvent(
+  raw: unknown,
+  state: GoogleStreamState = createGoogleStreamState(),
+): CanonicalModelEvent[] {
+  const chunk = asRecord(raw);
+  const events: CanonicalModelEvent[] = [];
+
+  if (!state.started) {
+    state.started = true;
+    const responseId = readString(chunk.responseId);
+    if (responseId) {
+      state.toolCalls.baseId = safeToolCallIdPart(responseId);
+    }
+    events.push({ type: "message_start", role: "assistant", raw });
+  }
+
+  const usage = normalizeGoogleUsage(chunk.usageMetadata);
+  if (usage) {
+    events.push({ type: "usage", usage, raw });
+  }
+
+  for (const candidate of readCandidates(chunk)) {
+    for (const part of readParts(candidate)) {
+      events.push(...partEvents(part, state, raw));
+    }
+
+    if (candidate.finishReason) {
+      state.ended = true;
+      events.push({
+        type: "message_end",
+        finishReason: normalizeGoogleFinishReason(candidate.finishReason),
+        raw,
+      });
+    }
+  }
+
+  return events;
+}
+
+function partEvents(part: unknown, state: GoogleStreamState, raw: unknown): CanonicalModelEvent[] {
+  const record = asRecord(part);
+  const text = readString(record.text);
+  if (text !== undefined) {
+    if (record.thought === true) {
+      return [{ type: "thinking_delta", text, signature: readString(record.thoughtSignature), raw }];
+    }
+    return text.length > 0 ? [{ type: "text_delta", text, raw }] : [];
+  }
+
+  const functionCall = asRecord(record.functionCall);
+  if (Object.keys(functionCall).length > 0) {
+    const toolCall = toToolCall(functionCall, state.toolCalls, raw);
+    const args = JSON.stringify(toolCall.input ?? {});
+    return [
+      { type: "tool_call_start", id: toolCall.id, name: toolCall.name, raw },
+      ...(args.length > 0 ? [{ type: "tool_call_delta" as const, id: toolCall.id, delta: args, raw }] : []),
+      { type: "tool_call_end", toolCall, raw },
+    ];
+  }
+
+  return [];
+}
+
+function toToolCall(
+  functionCall: Record<string, unknown>,
+  state: GoogleStreamToolCallState,
+  raw: unknown,
+): CanonicalToolCall {
+  return {
+    id: chooseToolCallId(state, readString(functionCall.id)),
+    name: readString(functionCall.name) ?? "",
+    input: toToolInput(functionCall.args),
+    raw,
+  };
+}
+
+function toToolInput(args: unknown): unknown {
+  return args && typeof args === "object" && !Array.isArray(args) ? args : {};
+}
+
+function chooseToolCallId(state: GoogleStreamToolCallState, incomingId: string | undefined): string {
+  const candidate = incomingId ? safeToolCallIdPart(incomingId) : `call_${state.baseId}_${state.usedIds.size}`;
+  const unique = nextUniqueToolCallId(candidate, state.usedIds);
+  state.usedIds.add(unique);
+  return unique;
+}
+
+function nextUniqueToolCallId(id: string, used: Set<string>): string {
+  if (!used.has(id)) {
+    return id;
+  }
+  for (let suffix = 2; ; suffix += 1) {
+    const candidate = `${id}_${suffix}`;
+    if (!used.has(candidate)) {
+      return candidate;
+    }
+  }
+}
+
+function readCandidates(chunk: Record<string, unknown>): Record<string, unknown>[] {
+  return Array.isArray(chunk.candidates) ? chunk.candidates.map(asRecord) : [];
+}
+
+function readParts(candidate: Record<string, unknown>): unknown[] {
+  const content = asRecord(candidate.content);
+  return Array.isArray(content.parts) ? content.parts : [];
+}
+
+function safeToolCallIdPart(value: string): string {
+  return value.trim().replace(/[^A-Za-z0-9_-]+/g, "_").replace(/^_+|_+$/g, "") || "google";
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}

--- a/src/model/providers/openai/request.ts
+++ b/src/model/providers/openai/request.ts
@@ -7,8 +7,10 @@ import type {
   CanonicalToolChoice,
   CanonicalToolSchema,
   ModelDefinition,
+  ProviderConfig,
 } from "../../protocol/canonical.js";
 import { flattenToolResultBlockText } from "../../protocol/toolResultContent.js";
+import { cleanSchemaForGoogle, normalizeGoogleToolSchema } from "../google/schema.js";
 
 export type OpenAIRequestBody = {
   model: string;
@@ -54,7 +56,9 @@ type OpenAITool = {
 export function buildOpenAIRequest(
   request: CanonicalModelRequest,
   model: ModelDefinition,
+  provider?: ProviderConfig,
 ): OpenAIRequestBody {
+  const googleOpenAICompatible = isGoogleOpenAICompatibleProvider(provider);
   const messages = repairOpenAIToolPairing(
     request.messages.flatMap((message, messageIndex) => toOpenAIMessages(message, messageIndex)),
   );
@@ -66,7 +70,7 @@ export function buildOpenAIRequest(
     model: request.model,
     messages,
     max_tokens: request.maxOutputTokens ?? model.capabilities.maxOutputTokens,
-    tools: request.tools?.map(toOpenAITool),
+    tools: request.tools?.map((tool) => toOpenAITool(tool, googleOpenAICompatible)),
     tool_choice: toOpenAIToolChoice(request.toolChoice),
     temperature: request.temperature,
     stream: request.stream,
@@ -83,7 +87,9 @@ export function buildOpenAIRequest(
       json_schema: {
         name: request.outputSchema.name,
         description: request.outputSchema.description,
-        schema: request.outputSchema.schema,
+        schema: googleOpenAICompatible
+          ? normalizeGoogleOpenAIResponseSchema(request.outputSchema.schema)
+          : request.outputSchema.schema,
         strict: request.outputSchema.strict ?? true,
       },
     };
@@ -91,8 +97,13 @@ export function buildOpenAIRequest(
 
   if (request.thinking?.enabled) {
     (body as Record<string, unknown>).enable_thinking = true;
-    if (request.thinking.budgetTokens) {
-      (body as Record<string, unknown>).thinking_budget = request.thinking.budgetTokens;
+    const budget = request.thinking.budgetTokens;
+    if (googleOpenAICompatible) {
+      if (typeof budget === "number" && Number.isFinite(budget) && budget >= 0) {
+        (body as Record<string, unknown>).thinking_budget = budget;
+      }
+    } else if (budget) {
+      (body as Record<string, unknown>).thinking_budget = budget;
     }
   }
 
@@ -300,15 +311,43 @@ function toOpenAIContent(blocks: CanonicalContentBlock[]): string | unknown[] {
   }).filter(Boolean);
 }
 
-function toOpenAITool(tool: CanonicalToolSchema): OpenAITool {
+function toOpenAITool(tool: CanonicalToolSchema, googleOpenAICompatible: boolean): OpenAITool {
   return {
     type: "function",
     function: {
       name: tool.name,
       description: tool.description,
-      parameters: normalizeOpenAISchema(tool.inputSchema),
+      parameters: googleOpenAICompatible
+        ? normalizeGoogleToolSchema(tool.inputSchema)
+        : normalizeOpenAISchema(tool.inputSchema),
     },
   };
+}
+
+function normalizeGoogleOpenAIResponseSchema(schema: Record<string, unknown>): Record<string, unknown> {
+  const cleaned = cleanSchemaForGoogle(schema);
+  return cleaned && typeof cleaned === "object" && !Array.isArray(cleaned)
+    ? cleaned as Record<string, unknown>
+    : {};
+}
+
+function isGoogleOpenAICompatibleProvider(provider: ProviderConfig | undefined): boolean {
+  if (!provider || provider.protocol !== "openai") {
+    return false;
+  }
+  if (provider.id === "google") {
+    return true;
+  }
+
+  const rawUrl = provider.url.trim().toLowerCase();
+  try {
+    const url = new URL(rawUrl);
+    return url.hostname === "generativelanguage.googleapis.com"
+      && url.pathname.includes("/openai");
+  } catch {
+    return rawUrl.includes("generativelanguage.googleapis.com")
+      && rawUrl.includes("/openai");
+  }
 }
 
 /**

--- a/src/model/providers/registry.ts
+++ b/src/model/providers/registry.ts
@@ -8,6 +8,7 @@ export type ModelProviderAdapter = {
 
 const adapters: Record<ModelProtocol, ModelProviderAdapter> = {
   anthropic: { protocol: "anthropic", name: "Anthropic Messages API" },
+  google: { protocol: "google", name: "Google Gemini API" },
   openai: { protocol: "openai", name: "OpenAI Chat Completions API" },
 };
 

--- a/src/model/request/buildModelRequest.ts
+++ b/src/model/request/buildModelRequest.ts
@@ -1,9 +1,10 @@
 import { buildAnthropicRequest, type AnthropicRequestBody } from "../providers/anthropic/request.js";
+import { buildGoogleRequest, type GoogleRequestBody } from "../providers/google/request.js";
 import { buildOpenAIRequest, type OpenAIRequestBody } from "../providers/openai/request.js";
 import type { CanonicalModelRequest, ModelConfig } from "../protocol/canonical.js";
 import { validateModelRequest } from "./validateModelRequest.js";
 
-export type ProviderRequestBody = AnthropicRequestBody | OpenAIRequestBody;
+export type ProviderRequestBody = AnthropicRequestBody | GoogleRequestBody | OpenAIRequestBody;
 
 export function buildModelRequest(
   request: CanonicalModelRequest,
@@ -13,6 +14,10 @@ export function buildModelRequest(
 
   if (provider.protocol === "anthropic") {
     return buildAnthropicRequest(request, model);
+  }
+
+  if (provider.protocol === "google") {
+    return buildGoogleRequest(request, model);
   }
 
   return buildOpenAIRequest(request, model);

--- a/src/model/request/buildModelRequest.ts
+++ b/src/model/request/buildModelRequest.ts
@@ -20,5 +20,5 @@ export function buildModelRequest(
     return buildGoogleRequest(request, model);
   }
 
-  return buildOpenAIRequest(request, model);
+  return buildOpenAIRequest(request, model, provider);
 }

--- a/src/model/response/parseModelResponse.ts
+++ b/src/model/response/parseModelResponse.ts
@@ -1,4 +1,5 @@
 import { parseAnthropicResponse } from "../providers/anthropic/response.js";
+import { parseGoogleResponse } from "../providers/google/response.js";
 import { parseOpenAIResponse } from "../providers/openai/response.js";
 import type { CanonicalModelResponse, ModelProtocol } from "../protocol/canonical.js";
 
@@ -9,6 +10,10 @@ export function parseModelResponse(
 ): CanonicalModelResponse {
   if (protocol === "anthropic") {
     return parseAnthropicResponse(raw);
+  }
+
+  if (protocol === "google") {
+    return parseGoogleResponse(raw, providerId);
   }
 
   return parseOpenAIResponse(raw, providerId);

--- a/src/model/streaming/normalizeStreamEvent.ts
+++ b/src/model/streaming/normalizeStreamEvent.ts
@@ -1,6 +1,11 @@
 import { normalizeAnthropicStreamEvent } from "../providers/anthropic/stream.js";
 import { createAnthropicStreamState, type AnthropicStreamState } from "../providers/anthropic/stream.js";
 import {
+  createGoogleStreamState,
+  normalizeGoogleStreamEvent,
+  type GoogleStreamState,
+} from "../providers/google/stream.js";
+import {
   createOpenAIStreamState,
   normalizeOpenAIStreamEvent,
   type OpenAIStreamState,
@@ -9,13 +14,18 @@ import type { CanonicalModelEvent, ModelProtocol } from "../protocol/canonical.j
 
 export type StreamNormalizerState = {
   anthropic?: AnthropicStreamState;
+  google?: GoogleStreamState;
   openai?: OpenAIStreamState;
 };
 
 export function createStreamNormalizerState(protocol: ModelProtocol): StreamNormalizerState {
-  return protocol === "anthropic"
-    ? { anthropic: createAnthropicStreamState() }
-    : { openai: createOpenAIStreamState() };
+  if (protocol === "anthropic") {
+    return { anthropic: createAnthropicStreamState() };
+  }
+  if (protocol === "google") {
+    return { google: createGoogleStreamState() };
+  }
+  return { openai: createOpenAIStreamState() };
 }
 
 export function normalizeStreamEvent(
@@ -26,6 +36,11 @@ export function normalizeStreamEvent(
   if (protocol === "anthropic") {
     state.anthropic ??= createAnthropicStreamState();
     return normalizeAnthropicStreamEvent(raw, state.anthropic);
+  }
+
+  if (protocol === "google") {
+    state.google ??= createGoogleStreamState();
+    return normalizeGoogleStreamEvent(raw, state.google);
   }
 
   state.openai ??= createOpenAIStreamState();

--- a/src/model/streaming/streamModel.ts
+++ b/src/model/streaming/streamModel.ts
@@ -1,4 +1,7 @@
 import { normalizeModelError } from "../errors/normalizeModelError.js";
+import { createGoogleClient, type GoogleClientFactory } from "../providers/google/client.js";
+import { parseGoogleResponse } from "../providers/google/response.js";
+import type { GoogleRequestBody } from "../providers/google/request.js";
 import { buildModelRequest } from "../request/buildModelRequest.js";
 import { validateModelRequest } from "../request/validateModelRequest.js";
 import type {
@@ -11,6 +14,7 @@ import type {
 import { ModelProviderError, parseRetryAfterHeader } from "../protocol/errors.js";
 import { parseModelResponse } from "../response/parseModelResponse.js";
 import { createStreamNormalizerState, normalizeStreamEvent } from "./normalizeStreamEvent.js";
+import { createGoogleStreamState, normalizeGoogleStreamEvent } from "../providers/google/stream.js";
 import { normalizeProviderBaseUrl } from "../normalizeProviderBaseUrl.js";
 import { StreamingCheckpointManager } from "./StreamingCheckpoint.js";
 
@@ -18,6 +22,7 @@ export type ModelTransport = typeof fetch;
 
 export type ModelRuntimeOptions = {
   fetch?: ModelTransport;
+  googleClientFactory?: GoogleClientFactory;
   signal?: AbortSignal;
 };
 
@@ -35,6 +40,28 @@ export async function complete(
 
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
     throwIfAborted(options.signal);
+    if (provider.protocol === "google") {
+      try {
+        const raw = await sendGoogleCompleteRequest(
+          provider,
+          nonStreamingRequest,
+          options,
+        );
+        return parseGoogleResponse(raw, provider.id);
+      } catch (error) {
+        if (attempt < maxRetries && isRetryableRequestError(error)) {
+          const delayMs = retryBaseDelay * (attempt + 1);
+          console.warn(
+            `[PilotDeck] complete() retry: ${(error as Error).message} ` +
+            `(attempt ${attempt + 1}/${maxRetries}, delay=${delayMs}ms)`,
+          );
+          await delay(delayMs, options.signal);
+          continue;
+        }
+        throw error;
+      }
+    }
+
     const body = buildModelRequest(nonStreamingRequest, config);
     let response: Response;
     try {
@@ -89,6 +116,18 @@ export async function* streamModel(
 
   let currentRequest = streamingRequest;
   const checkpoint = new StreamingCheckpointManager();
+
+  if (provider.protocol === "google") {
+    yield* streamGoogleProviderRequest({
+      request: currentRequest,
+      provider,
+      maxRetries,
+      retryBaseDelay,
+      checkpoint,
+      options,
+    });
+    return;
+  }
 
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
     throwIfAborted(options.signal);
@@ -170,6 +209,133 @@ export async function* streamModel(
       return;
     }
   }
+}
+
+async function sendGoogleCompleteRequest(
+  provider: ProviderConfig,
+  request: CanonicalModelRequest,
+  options: ModelRuntimeOptions,
+): Promise<unknown> {
+  try {
+    const body = withGoogleAbortSignal(buildModelRequest(request, {
+      providers: { [provider.id]: provider },
+    }) as Record<string, unknown>, options.signal);
+    const client = (options.googleClientFactory ?? createGoogleClient)(provider);
+    return await client.models.generateContent(body as unknown as GoogleRequestBody);
+  } catch (error) {
+    throw toProviderError(provider, error);
+  }
+}
+
+async function* streamGoogleProviderRequest(params: {
+  request: CanonicalModelRequest & { stream: boolean };
+  provider: ProviderConfig;
+  maxRetries: number;
+  retryBaseDelay: number;
+  checkpoint: StreamingCheckpointManager;
+  options: ModelRuntimeOptions;
+}): AsyncIterable<CanonicalModelEvent> {
+  let currentRequest = params.request;
+
+  for (let attempt = 0; attempt <= params.maxRetries; attempt++) {
+    throwIfAborted(params.options.signal);
+    try {
+      const body = withGoogleAbortSignal(buildModelRequest(currentRequest, {
+        providers: { [params.provider.id]: params.provider },
+      }) as Record<string, unknown>, params.options.signal);
+      if (process.env.PILOTDECK_DUMP_REQUEST === "1") {
+        const fs = await import("node:fs");
+        const os = await import("node:os");
+        const path = await import("node:path");
+        const dumpPath = path.join(os.tmpdir(), `pilotdeck_request_${Date.now()}.json`);
+        fs.writeFileSync(dumpPath, JSON.stringify(body, null, 2));
+        console.log(`[model-debug] Request dumped to ${dumpPath} (model=${currentRequest.model})`);
+      }
+
+      const client = (params.options.googleClientFactory ?? createGoogleClient)(params.provider);
+      const stream = await client.models.generateContentStream(body as unknown as GoogleRequestBody);
+      const state = createGoogleStreamState();
+      let sawTerminalEvent = false;
+
+      for await (const chunk of stream) {
+        throwIfAborted(params.options.signal);
+        for (const event of normalizeGoogleStreamEvent(chunk, state)) {
+          if (event.type === "message_end" || event.type === "error") {
+            sawTerminalEvent = true;
+          }
+          params.checkpoint.onEvent(event);
+          yield event;
+        }
+      }
+
+      if (!sawTerminalEvent && !state.ended) {
+        yield { type: "message_end", finishReason: "unknown", raw: undefined };
+      }
+      return;
+    } catch (error) {
+      const providerError = toProviderError(params.provider, error);
+      if (
+        attempt < params.maxRetries &&
+        isRetryableGoogleStreamError(providerError, error) &&
+        params.checkpoint.hasSubstantialContent()
+      ) {
+        currentRequest = buildContinuationRequest(currentRequest, params.checkpoint.get().partialText);
+        params.checkpoint.reset();
+        await delay(params.retryBaseDelay * (attempt + 1), params.options.signal);
+        continue;
+      }
+
+      if (isRetryableGoogleStreamError(providerError, error) && attempt < params.maxRetries) {
+        await delay(params.retryBaseDelay * (attempt + 1), params.options.signal);
+        continue;
+      }
+
+      yield { type: "error", error: providerError.error };
+      return;
+    }
+  }
+}
+
+function isRetryableGoogleStreamError(providerError: ModelProviderError, raw: unknown): boolean {
+  return providerError.error.retryable || isRetryableStreamError(raw);
+}
+
+function withGoogleAbortSignal(body: Record<string, unknown>, signal: AbortSignal | undefined): Record<string, unknown> {
+  if (!signal) {
+    return body;
+  }
+  const config = body.config && typeof body.config === "object"
+    ? { ...(body.config as Record<string, unknown>), abortSignal: signal }
+    : { abortSignal: signal };
+  return { ...body, config };
+}
+
+function toProviderError(provider: ProviderConfig, error: unknown): ModelProviderError {
+  if (error instanceof ModelProviderError) {
+    return error;
+  }
+  return new ModelProviderError(
+    normalizeModelError(provider.id, provider.protocol, error, extractStatus(error)),
+  );
+}
+
+function extractStatus(error: unknown): number | undefined {
+  if (!error || typeof error !== "object") {
+    return undefined;
+  }
+  const record = error as Record<string, unknown>;
+  const status = record.status ?? record.statusCode ?? record.code;
+  if (typeof status === "number" && Number.isInteger(status)) {
+    return status;
+  }
+  const response = record.response;
+  if (response && typeof response === "object") {
+    const responseStatus = (response as Record<string, unknown>).status;
+    if (typeof responseStatus === "number" && Number.isInteger(responseStatus)) {
+      return responseStatus;
+    }
+  }
+  return undefined;
 }
 
 function isRetryableRequestError(error: unknown): boolean {

--- a/src/model/streaming/streamModel.ts
+++ b/src/model/streaming/streamModel.ts
@@ -223,6 +223,7 @@ async function sendGoogleCompleteRequest(
     const client = (options.googleClientFactory ?? createGoogleClient)(provider);
     return await client.models.generateContent(body as unknown as GoogleRequestBody);
   } catch (error) {
+    throwIfGoogleAbort(error, options.signal);
     throw toProviderError(provider, error);
   }
 }
@@ -273,6 +274,7 @@ async function* streamGoogleProviderRequest(params: {
       }
       return;
     } catch (error) {
+      throwIfGoogleAbort(error, params.options.signal);
       const providerError = toProviderError(params.provider, error);
       if (
         attempt < params.maxRetries &&
@@ -293,6 +295,15 @@ async function* streamGoogleProviderRequest(params: {
       yield { type: "error", error: providerError.error };
       return;
     }
+  }
+}
+
+function throwIfGoogleAbort(error: unknown, signal: AbortSignal | undefined): void {
+  if (signal?.aborted) {
+    throw createAbortError(signal.reason);
+  }
+  if (isAbortError(error)) {
+    throw error;
   }
 }
 

--- a/src/pilot/config/parseMemoryConfig.ts
+++ b/src/pilot/config/parseMemoryConfig.ts
@@ -189,12 +189,18 @@ function readMemoryApiType(value: unknown): PilotMemoryApiType | undefined {
   if (value === undefined) {
     return undefined;
   }
-  if (value === "openai-responses" || value === "responses" || value === "openai-completions") {
+  if (
+    value === "openai-responses"
+    || value === "responses"
+    || value === "openai-completions"
+    || value === "anthropic"
+    || value === "google"
+  ) {
     return value;
   }
   throw new PilotConfigError(
     "CONFIG_MEMORY_VALUE_INVALID",
-    "memory.apiType must be openai-responses, responses, or openai-completions.",
+    "memory.apiType must be openai-responses, responses, openai-completions, anthropic, or google.",
   );
 }
 

--- a/src/pilot/config/types.ts
+++ b/src/pilot/config/types.ts
@@ -83,7 +83,12 @@ export type PilotAgentConfig = {
  */
 export type PilotRouterConfig = RouterConfig;
 
-export type PilotMemoryApiType = "openai-responses" | "responses" | "openai-completions";
+export type PilotMemoryApiType =
+  | "openai-responses"
+  | "responses"
+  | "openai-completions"
+  | "anthropic"
+  | "google";
 export type PilotMemoryReasoningMode = "answer_first" | "accuracy_first";
 
 export type PilotMemoryScheduleConfig = {

--- a/src/router/RouterRuntime.ts
+++ b/src/router/RouterRuntime.ts
@@ -2,6 +2,7 @@ import type {
   CanonicalModelEvent,
   CanonicalModelRequest,
   ModelRuntime,
+  ModelProtocol,
 } from "../model/index.js";
 import { ModelRequestError } from "../model/index.js";
 import type { InputModality } from "../model/index.js";
@@ -511,7 +512,12 @@ export function createRouterRuntime(
 
     if (attempts.length === 0) {
       const missing = missingForModel(requestedAttempt, requiredModalities);
-      const error = createUnsupportedMediaError(requestedAttempt, requiredModalities, missing);
+      const error = createUnsupportedMediaError(
+        requestedAttempt,
+        requiredModalities,
+        missing,
+        protocolForProvider(deps.modelRuntime, requestedAttempt.provider),
+      );
       events.emit({
         type: "pilotdeck_router_execute_failed",
         sessionId: ctx.sessionId,
@@ -993,9 +999,10 @@ async function* streamAttempt(
       throw error;
     }
     const fromError = (error as { error?: import("../model/index.js").CanonicalModelError })?.error;
-    providerError = fromError ?? canonicalizeModelRequestError(error, request) ?? {
+    const protocol = protocolForProvider(modelRuntime, request.provider);
+    providerError = fromError ?? canonicalizeModelRequestError(error, request, protocol) ?? {
       provider: request.provider,
-      protocol: "anthropic",
+      protocol,
       code: classifyNetworkErrorCode(error),
       message: error instanceof Error ? error.message : String(error),
       retryable: isNetworkTransient(error),
@@ -1016,6 +1023,7 @@ async function* streamAttempt(
 function canonicalizeModelRequestError(
   error: unknown,
   request: CanonicalModelRequest,
+  protocol: ModelProtocol,
 ): import("../model/index.js").CanonicalModelError | undefined {
   if (!(error instanceof ModelRequestError)) {
     return undefined;
@@ -1023,12 +1031,20 @@ function canonicalizeModelRequestError(
 
   return {
     provider: request.provider,
-    protocol: "anthropic",
+    protocol,
     code: error.code,
     message: error.message,
     retryable: false,
     raw: error.details,
   };
+}
+
+function protocolForProvider(modelRuntime: ModelRuntime, providerId: string): ModelProtocol {
+  try {
+    return modelRuntime.getProviderProtocol(providerId) ?? "openai";
+  } catch {
+    return "openai";
+  }
 }
 
 function abortableDelay(ms: number, signal?: AbortSignal): Promise<void> {
@@ -1103,12 +1119,13 @@ function createUnsupportedMediaError(
   attempt: RouterModelRef,
   required: readonly InputModality[],
   missing: readonly InputModality[],
+  protocol: ModelProtocol,
 ): import("../model/index.js").CanonicalModelError {
   const missingText = (missing.length > 0 ? missing : required).join(", ");
   const requiredText = required.join(", ");
   return {
     provider: attempt.provider,
-    protocol: "openai",
+    protocol,
     code: "unsupported_modality",
     message:
       `Router could not find a configured fallback model for ${attempt.provider}/${attempt.model} ` +

--- a/tests/model/google/request.test.ts
+++ b/tests/model/google/request.test.ts
@@ -1,0 +1,198 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { buildModelRequest } from "../../../src/model/request/buildModelRequest.js";
+import { parseModelConfig } from "../../../src/model/config/parseModelConfig.js";
+import { normalizeGoogleModelId } from "../../../src/model/providers/google/modelId.js";
+import { normalizeGoogleToolSchema } from "../../../src/model/providers/google/schema.js";
+import type { CanonicalModelRequest } from "../../../src/model/protocol/canonical.js";
+
+describe("Google model request adaptation", () => {
+  it("accepts native google protocol configs and defaults Gemini model capabilities", () => {
+    const config = parseModelConfig({
+      providers: {
+        google: {
+          protocol: "google",
+          url: "https://generativelanguage.googleapis.com",
+          apiKey: "${GEMINI_API_KEY}",
+          models: {
+            "gemini-3-pro": {},
+          },
+        },
+      },
+    }, { env: { GEMINI_API_KEY: " test-key\n" } });
+
+    assert.equal(config.providers.google?.protocol, "google");
+    assert.equal(config.providers.google?.apiKey, "test-key");
+    assert.equal(config.providers.google?.models["gemini-3-pro"]?.capabilities.supportsToolUse, true);
+  });
+
+  it("keeps Google OpenAI-compatible configs on the legacy default URL", () => {
+    const config = parseModelConfig({
+      providers: {
+        google: {
+          protocol: "openai",
+          apiKey: "key",
+          models: {
+            "gemini-2.5-flash": {},
+          },
+        },
+      },
+    });
+
+    assert.equal(config.providers.google?.protocol, "openai");
+    assert.equal(
+      config.providers.google?.url,
+      "https://generativelanguage.googleapis.com/v1beta/openai",
+    );
+  });
+
+  it("normalizes common Gemini aliases to preview ids", () => {
+    assert.equal(normalizeGoogleModelId("gemini-3-pro"), "gemini-3-pro-preview");
+    assert.equal(normalizeGoogleModelId("gemini-3.1-pro"), "gemini-3.1-pro-preview");
+    assert.equal(normalizeGoogleModelId("gemini-3.1-flash"), "gemini-3-flash-preview");
+    assert.equal(normalizeGoogleModelId("google/gemini-2.5-flash"), "gemini-2.5-flash");
+  });
+
+  it("cleans tool JSON Schema for Gemini function declarations", () => {
+    const cleaned = normalizeGoogleToolSchema({
+      type: "object",
+      additionalProperties: false,
+      required: ["pattern", "-A", "mode", "refValue"],
+      properties: {
+        pattern: { type: "string", minLength: 1, pattern: "x+" },
+        "-A": { type: "integer", minimum: 0 },
+        mode: {
+          anyOf: [
+            { const: "content", type: "string" },
+            { const: "count", type: "string" },
+          ],
+        },
+        refValue: { $ref: "#/$defs/RefValue", description: "Resolved reference." },
+      },
+      $defs: {
+        RefValue: { type: "string", format: "uri" },
+      },
+    });
+
+    assert.equal(cleaned.type, "object");
+    assert.deepEqual(cleaned.required, ["pattern", "mode", "refValue"]);
+    assert.equal("additionalProperties" in cleaned, false);
+    const properties = cleaned.properties as Record<string, unknown>;
+    assert.equal("-A" in properties, false);
+    assert.deepEqual(properties.pattern, { type: "string" });
+    assert.deepEqual(properties.mode, { type: "string", enum: ["content", "count"] });
+    assert.deepEqual(properties.refValue, {
+      type: "string",
+      description: "Resolved reference.",
+    });
+  });
+
+  it("flattens top-level object unions before sending tools", () => {
+    const cleaned = normalizeGoogleToolSchema({
+      anyOf: [
+        {
+          type: "object",
+          required: ["action"],
+          properties: {
+            action: { const: "read", type: "string" },
+            path: { type: "string" },
+          },
+        },
+        {
+          type: "object",
+          required: ["action"],
+          properties: {
+            action: { const: "write", type: "string" },
+            content: { type: "string" },
+          },
+        },
+      ],
+      additionalProperties: false,
+    });
+
+    assert.equal(cleaned.type, "object");
+    assert.deepEqual(cleaned.required, ["action"]);
+    const properties = cleaned.properties as Record<string, unknown>;
+    assert.deepEqual(properties.action, { type: "string", enum: ["read", "write"] });
+    assert.deepEqual(properties.path, { type: "string" });
+    assert.deepEqual(properties.content, { type: "string" });
+    assert.equal("additionalProperties" in cleaned, false);
+  });
+
+  it("builds native Gemini requests with cleaned tools, thinking, and history order", () => {
+    const config = parseModelConfig({
+      providers: {
+        google: {
+          protocol: "google",
+          url: "https://generativelanguage.googleapis.com",
+          apiKey: "key",
+          models: {
+            "gemini-3-pro": {
+              capabilities: { supportsThinking: true },
+            },
+          },
+        },
+      },
+    });
+
+    const request: CanonicalModelRequest = {
+      provider: "google",
+      model: "gemini-3-pro",
+      systemPrompt: "Be terse.",
+      thinking: { enabled: true, budgetTokens: -1 } as never,
+      messages: [
+        {
+          role: "assistant",
+          content: [
+            { type: "text", text: "Earlier answer." },
+            { type: "tool_call", id: "call 1", name: "lookup", input: { query: "x" } },
+          ],
+        },
+        {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              toolCallId: "call 1",
+              content: [{ type: "text", text: "result" }],
+            },
+            { type: "text", text: "Continue." },
+          ],
+        },
+      ],
+      tools: [{
+        name: "lookup",
+        inputSchema: {
+          type: "object",
+          properties: {
+            query: { type: "string", minLength: 1 },
+            "-A": { type: "integer" },
+          },
+          required: ["query", "-A"],
+          additionalProperties: false,
+        },
+      }],
+    };
+
+    const body = buildModelRequest(request, config) as Record<string, unknown>;
+    assert.equal(body.model, "gemini-3-pro-preview");
+
+    const contents = body.contents as Array<{ role: string; parts: Array<Record<string, unknown>> }>;
+    assert.equal(contents[0]?.role, "user");
+    assert.equal(contents[1]?.role, "model");
+    assert.equal(contents[2]?.role, "user");
+    assert.deepEqual(contents[2]?.parts[0]?.functionResponse, {
+      id: "call_1",
+      name: "lookup",
+      response: { output: "result" },
+    });
+
+    const configBody = body.config as Record<string, unknown>;
+    assert.deepEqual(configBody.thinkingConfig, { includeThoughts: true });
+    assert.deepEqual(configBody.systemInstruction, { text: "Be terse." });
+    const tools = configBody.tools as Array<{ functionDeclarations: Array<Record<string, unknown>> }>;
+    const schema = tools[0]?.functionDeclarations[0]?.parametersJsonSchema as Record<string, unknown>;
+    assert.deepEqual(schema.required, ["query"]);
+    assert.equal("-A" in (schema.properties as Record<string, unknown>), false);
+  });
+});

--- a/tests/model/google/runtime.test.ts
+++ b/tests/model/google/runtime.test.ts
@@ -1,0 +1,206 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import type { GenerateContentParameters, GenerateContentResponse } from "@google/genai";
+import { complete, streamModel } from "../../../src/model/streaming/streamModel.js";
+import { parseGoogleResponse } from "../../../src/model/providers/google/response.js";
+import { normalizeGoogleStreamEvent } from "../../../src/model/providers/google/stream.js";
+import type { CanonicalModelRequest, ModelConfig } from "../../../src/model/protocol/canonical.js";
+
+const modelConfig: ModelConfig = {
+  providers: {
+    google: {
+      id: "google",
+      protocol: "google",
+      url: "https://generativelanguage.googleapis.com",
+      apiKey: "test-key",
+      headers: {},
+      models: {
+        "gemini-2.5-flash": {
+          id: "gemini-2.5-flash",
+          capabilities: {
+            supportsToolUse: true,
+            supportsStreaming: true,
+            supportsParallelToolCalls: true,
+            supportsThinking: true,
+            supportsJsonSchema: true,
+            supportsSystemPrompt: true,
+            supportsPromptCache: false,
+            maxContextTokens: 1_048_576,
+            maxOutputTokens: 8_192,
+          },
+          multimodal: {
+            input: ["text", "image", "audio", "pdf"],
+          },
+        },
+      },
+    },
+  },
+};
+
+const baseRequest: CanonicalModelRequest = {
+  provider: "google",
+  model: "gemini-2.5-flash",
+  messages: [{ role: "user", content: [{ type: "text", text: "Hello" }] }],
+  stream: false,
+};
+
+describe("Google response adaptation", () => {
+  it("parses text, thinking, function calls, usage, and finish reason", () => {
+    const parsed = parseGoogleResponse({
+      responseId: "resp 1",
+      candidates: [{
+        finishReason: "MALFORMED_FUNCTION_CALL",
+        content: {
+          parts: [
+            { text: "thinking", thought: true, thoughtSignature: "sig" },
+            { text: "visible" },
+            { functionCall: { name: "lookup", args: { query: "x" } } },
+          ],
+        },
+      }],
+      usageMetadata: {
+        promptTokenCount: 10,
+        candidatesTokenCount: 4,
+        cachedContentTokenCount: 2,
+        totalTokenCount: 16,
+      },
+    });
+
+    assert.deepEqual(parsed.content, [
+      { type: "thinking", text: "thinking", signature: "sig" },
+      { type: "text", text: "visible" },
+      {
+        type: "tool_call",
+        id: "call_resp_1_2",
+        name: "lookup",
+        input: { query: "x" },
+        raw: {
+          provider: "google",
+          functionCall: { name: "lookup", args: { query: "x" } },
+        },
+      },
+    ]);
+    assert.deepEqual(parsed.usage, {
+      inputTokens: 10,
+      outputTokens: 4,
+      cacheReadTokens: 2,
+      totalTokens: 16,
+    });
+    assert.equal(parsed.finishReason, "tool_call");
+  });
+
+  it("normalizes Google stream chunks into canonical events", () => {
+    const events = normalizeGoogleStreamEvent({
+      responseId: "stream 1",
+      candidates: [{
+        finishReason: "STOP",
+        content: {
+          parts: [
+            { text: "hi " },
+            { functionCall: { id: "tool 1", name: "lookup", args: { query: "x" } } },
+          ],
+        },
+      }],
+      usageMetadata: { promptTokenCount: 1, candidatesTokenCount: 2, totalTokenCount: 3 },
+    });
+
+    assert.deepEqual(events.map((event) => event.type), [
+      "message_start",
+      "usage",
+      "text_delta",
+      "tool_call_start",
+      "tool_call_delta",
+      "tool_call_end",
+      "message_end",
+    ]);
+    assert.equal(events[3]?.type, "tool_call_start");
+    assert.equal("id" in events[3] ? events[3].id : undefined, "tool_1");
+    assert.equal("name" in events[3] ? events[3].name : undefined, "lookup");
+    assert.equal(events.at(-1)?.type, "message_end");
+  });
+});
+
+describe("Google runtime SDK integration", () => {
+  it("uses a Google client for non-streaming completion", async () => {
+    let seen: GenerateContentParameters | undefined;
+    const response = await complete(baseRequest, modelConfig, {
+      googleClientFactory: () => ({
+        models: {
+          generateContent: async (params) => {
+            seen = params;
+            return {
+              candidates: [{
+                finishReason: "STOP",
+                content: { parts: [{ text: "Hello back" }] },
+              }],
+            } as GenerateContentResponse;
+          },
+          generateContentStream: async () => emptyGoogleStream(),
+        },
+      }),
+    });
+
+    assert.equal(seen?.model, "gemini-2.5-flash");
+    assert.equal(response.finishReason, "stop");
+    assert.deepEqual(response.content, [{ type: "text", text: "Hello back" }]);
+  });
+
+  it("uses a Google client for streaming completion", async () => {
+    const events = [];
+    for await (const event of streamModel({ ...baseRequest, stream: true }, modelConfig, {
+      googleClientFactory: () => ({
+        models: {
+          generateContent: async () => ({}) as GenerateContentResponse,
+          generateContentStream: async () => googleStream([
+            {
+              candidates: [{ content: { parts: [{ text: "hel" }] } }],
+            },
+            {
+              candidates: [{ finishReason: "STOP", content: { parts: [{ text: "lo" }] } }],
+              usageMetadata: { promptTokenCount: 2, candidatesTokenCount: 1, totalTokenCount: 3 },
+            },
+          ]),
+        },
+      }),
+    })) {
+      events.push(event);
+    }
+
+    assert.deepEqual(events.map((event) => event.type), [
+      "request_started",
+      "message_start",
+      "text_delta",
+      "usage",
+      "text_delta",
+      "message_end",
+    ]);
+  });
+
+  it("normalizes Google SDK errors through provider error handling", async () => {
+    await assert.rejects(
+      () => complete(baseRequest, modelConfig, {
+        googleClientFactory: () => ({
+          models: {
+            generateContent: async () => {
+              throw Object.assign(new Error("API key not valid."), { status: 401 });
+            },
+            generateContentStream: async () => emptyGoogleStream(),
+          },
+        }),
+      }),
+      (error: unknown) => {
+        assert.equal((error as { error?: { code?: string } }).error?.code, "auth_error");
+        assert.equal((error as { error?: { protocol?: string } }).error?.protocol, "google");
+        return true;
+      },
+    );
+  });
+});
+
+async function* googleStream(chunks: unknown[]): AsyncGenerator<GenerateContentResponse> {
+  for (const chunk of chunks) {
+    yield chunk as GenerateContentResponse;
+  }
+}
+
+async function* emptyGoogleStream(): AsyncGenerator<GenerateContentResponse> {}

--- a/ui/server/routes/config.js
+++ b/ui/server/routes/config.js
@@ -58,6 +58,38 @@ function broadcastConfigEvent(payload) {
   process.emit('pilotdeck:config-broadcast', payload);
 }
 
+function normalizeGoogleProbeModel(model) {
+  const text = String(model || '').trim();
+  const withoutProvider = text.startsWith('google/') ? text.slice('google/'.length) : text;
+  if (withoutProvider === 'gemini-3-pro') return 'gemini-3-pro-preview';
+  if (withoutProvider === 'gemini-3.1-pro') return 'gemini-3.1-pro-preview';
+  if (withoutProvider === 'gemini-3-flash') return 'gemini-3-flash-preview';
+  if (withoutProvider === 'gemini-3.1-flash' || withoutProvider === 'gemini-3.1-flash-preview') {
+    return 'gemini-3-flash-preview';
+  }
+  if (withoutProvider === 'gemini-3.1-flash-lite') return 'gemini-3.1-flash-lite-preview';
+  return withoutProvider;
+}
+
+function buildGoogleGenerateContentUrl(baseUrl, model) {
+  const normalizedBaseUrl = String(baseUrl || 'https://generativelanguage.googleapis.com').trim().replace(/\/+$/, '')
+    || 'https://generativelanguage.googleapis.com';
+  const url = new URL(normalizedBaseUrl);
+  const parts = url.pathname.split('/').filter(Boolean);
+  const last = parts.at(-1);
+  const apiVersion = last === 'v1' || last === 'v1beta' ? last : 'v1beta';
+  const baseParts = last === 'v1' || last === 'v1beta' ? parts.slice(0, -1) : parts;
+  url.pathname = `/${[
+    ...baseParts,
+    apiVersion,
+    'models',
+    `${encodeURIComponent(normalizeGoogleProbeModel(model))}:generateContent`,
+  ].join('/')}`;
+  url.search = '';
+  url.hash = '';
+  return url.toString();
+}
+
 router.get('/', (_req, res) => {
   try {
     const record = readPilotDeckConfigFile();
@@ -214,10 +246,11 @@ router.post('/test-connection', async (req, res) => {
     return res.status(400).json({ ok: false, error: 'baseUrl, apiKey, and model are required' });
   }
 
-  // Accept V2 protocols ('openai' | 'anthropic') as well as the legacy
+  // Accept V2 protocols ('openai' | 'anthropic' | 'google') as well as the legacy
   // onboarding values ('openai-chat' | 'anthropic') for compatibility.
   const normalizedType = String(providerType || '').toLowerCase();
   const isAnthropic = normalizedType === 'anthropic';
+  const isGoogle = normalizedType === 'google';
   const normalizedBaseUrl = String(baseUrl).trim().replace(/\/+$/, '');
   const timeout = 10_000;
   const controller = new AbortController();
@@ -227,7 +260,21 @@ router.post('/test-connection', async (req, res) => {
     let url;
     let fetchOptions;
 
-    if (isAnthropic) {
+    if (isGoogle) {
+      url = buildGoogleGenerateContentUrl(normalizedBaseUrl, model);
+      fetchOptions = {
+        method: 'POST',
+        headers: {
+          'x-goog-api-key': apiKey,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          contents: [{ role: 'user', parts: [{ text: 'Hi' }] }],
+          generationConfig: { maxOutputTokens: 1 },
+        }),
+        signal: controller.signal,
+      };
+    } else if (isAnthropic) {
       url = `${normalizedBaseUrl}/v1/messages`;
       fetchOptions = {
         method: 'POST',
@@ -263,6 +310,14 @@ router.post('/test-connection', async (req, res) => {
     const response = await fetch(url, fetchOptions);
     clearTimeout(timer);
     const responseText = await response.text();
+    const expectedShape = isAnthropic
+      ? 'Anthropic message'
+      : isGoogle
+        ? 'Google Gemini generateContent response'
+        : 'OpenAI chat completion';
+    const baseUrlHint = isGoogle
+      ? 'For native Google Gemini, the base URL is usually https://generativelanguage.googleapis.com.'
+      : 'For OpenAI-compatible endpoints, the base URL usually ends with /v1.';
 
     if (response.ok) {
       let body;
@@ -271,17 +326,19 @@ router.post('/test-connection', async (req, res) => {
       } catch {
         return res.json({
           ok: false,
-          error: `Expected a JSON completion response but received non-JSON content from ${url}. For OpenAI-compatible endpoints, the base URL usually ends with /v1.`,
+          error: `Expected a JSON ${expectedShape} but received non-JSON content from ${url}. ${baseUrlHint}`,
         });
       }
 
       const hasCompletionShape = isAnthropic
         ? Array.isArray(body?.content) || body?.type === 'message'
+        : isGoogle
+          ? Array.isArray(body?.candidates)
         : Array.isArray(body?.choices);
       if (!hasCompletionShape) {
         return res.json({
           ok: false,
-          error: `Endpoint returned HTTP ${response.status}, but the response was not a valid ${isAnthropic ? 'Anthropic message' : 'OpenAI chat completion'}. Check the base URL path.`,
+          error: `Endpoint returned HTTP ${response.status}, but the response was not a valid ${expectedShape}. Check the base URL path.`,
         });
       }
 

--- a/ui/server/services/pilotdeckConfig.js
+++ b/ui/server/services/pilotdeckConfig.js
@@ -298,9 +298,7 @@ export function preserveMaskedSecrets(nextValue, previousValue) {
 // ─── Runtime env derivation ──────────────────────────────────────────────────
 
 function providerProtocolToMemoryApi(protocol) {
-  // Memory embeddings/chat still route through OpenAI-compatible env vars.
-  // Native Google chat providers are valid for the main agent config, but
-  // memory.apiType currently remains an OpenAI-compatible selector.
+  if (protocol === 'anthropic' || protocol === 'google') return protocol;
   return 'openai-completions';
 }
 
@@ -336,6 +334,10 @@ export function buildRuntimeEnv(config) {
     env.OPENAI_MODEL = main.model;
     env.ANTHROPIC_API_KEY = main.provider.apiKey || '';
     env.ANTHROPIC_MODEL = main.model;
+    env.GEMINI_API_KEY = main.provider.apiKey || '';
+    env.GOOGLE_API_KEY = main.provider.apiKey || '';
+    env.GOOGLE_GENERATIVE_AI_API_KEY = main.provider.apiKey || '';
+    env.GEMINI_MODEL = main.model;
   }
 
   // Reasoning models (DeepSeek-R1, MiniMax-M2.7, etc.) need a generous

--- a/ui/server/services/pilotdeckConfig.js
+++ b/ui/server/services/pilotdeckConfig.js
@@ -173,8 +173,8 @@ function validateProvider(id, provider, errors) {
   }
   const protocol = normalizeString(provider.protocol).toLowerCase();
   if (!protocol) errors.push(`model.providers.${id}.protocol is required`);
-  else if (protocol !== 'openai' && protocol !== 'anthropic') {
-    errors.push(`model.providers.${id}.protocol must be "openai" or "anthropic"`);
+  else if (protocol !== 'openai' && protocol !== 'anthropic' && protocol !== 'google') {
+    errors.push(`model.providers.${id}.protocol must be "openai", "anthropic", or "google"`);
   }
   if (!normalizeString(provider.url)) errors.push(`model.providers.${id}.url is required`);
   if (!normalizeString(provider.apiKey)) errors.push(`model.providers.${id}.apiKey is required`);
@@ -298,9 +298,9 @@ export function preserveMaskedSecrets(nextValue, previousValue) {
 // ─── Runtime env derivation ──────────────────────────────────────────────────
 
 function providerProtocolToMemoryApi(protocol) {
-  // V2 catalog only uses 'openai' (Chat Completions) and 'anthropic'.
-  // The /responses style is only relevant when a user manually sets
-  // memory.apiType, which they can do alongside protocol="openai".
+  // Memory embeddings/chat still route through OpenAI-compatible env vars.
+  // Native Google chat providers are valid for the main agent config, but
+  // memory.apiType currently remains an OpenAI-compatible selector.
   return 'openai-completions';
 }
 

--- a/ui/src/components/onboarding/view/subcomponents/LlmConfigurationStep.tsx
+++ b/ui/src/components/onboarding/view/subcomponents/LlmConfigurationStep.tsx
@@ -1,7 +1,12 @@
 import { useCallback, useEffect, useState } from 'react';
 import { Check, ChevronDown, Loader2, Plus } from 'lucide-react';
 import { authenticatedFetch } from '../../../../utils/api';
-import { CATALOG_PROVIDERS, findCatalogProviderByUrl, type CatalogProvider } from '../../../../shared/catalogProviders';
+import {
+  CATALOG_PROVIDERS,
+  findCatalogProviderByUrl,
+  type CatalogProvider,
+  type CatalogProviderProtocol,
+} from '../../../../shared/catalogProviders';
 
 type LlmConfigurationStepProps = {
   onSaved: () => void | Promise<void>;
@@ -54,7 +59,7 @@ export default function LlmConfigurationStep({ onSaved }: LlmConfigurationStepPr
 
   // Inputs that are only relevant when the user picks the "+" (custom) tile.
   const [customProviderId, setCustomProviderId] = useState('');
-  const [customProtocol, setCustomProtocol] = useState<'openai' | 'anthropic'>('openai');
+  const [customProtocol, setCustomProtocol] = useState<CatalogProviderProtocol>('openai');
 
   const isCustomMode = selectedProvider?.id === CUSTOM_PROVIDER_ID;
   const selectedModels = selectedProvider?.models ?? [];
@@ -85,7 +90,7 @@ export default function LlmConfigurationStep({ onSaved }: LlmConfigurationStepPr
 
   const effectiveUrl = customUrl.trim() || selectedProvider?.defaultUrl || '';
   const effectiveModelId = customModelId.trim() || selectedModelId;
-  const effectiveProtocol: 'openai' | 'anthropic' = isCustomMode
+  const effectiveProtocol: CatalogProviderProtocol = isCustomMode
     ? customProtocol
     : (selectedProvider?.protocol ?? 'openai');
   const effectiveProviderId = isCustomMode ? customProviderId.trim() : (selectedProvider?.id ?? '');
@@ -271,7 +276,7 @@ export default function LlmConfigurationStep({ onSaved }: LlmConfigurationStepPr
             <Plus className="h-4 w-4" />
             <div>
               <div className="font-medium">Custom</div>
-              <div className="mt-0.5 text-[11px] opacity-60">Any OpenAI / Anthropic endpoint</div>
+              <div className="mt-0.5 text-[11px] opacity-60">OpenAI / Anthropic / Google</div>
             </div>
             {isCustomMode && (
               <Check className="absolute right-2 top-2 h-4 w-4 text-foreground" strokeWidth={2.5} />
@@ -309,11 +314,12 @@ export default function LlmConfigurationStep({ onSaved }: LlmConfigurationStepPr
                     <select
                       id="custom-protocol"
                       value={customProtocol}
-                      onChange={(e) => { setCustomProtocol(e.target.value as 'openai' | 'anthropic'); setTestStatus('idle'); setTestMessage(''); }}
+                      onChange={(e) => { setCustomProtocol(e.target.value as CatalogProviderProtocol); setTestStatus('idle'); setTestMessage(''); }}
                       className="w-full appearance-none rounded-lg border border-border bg-background px-3 py-2.5 pr-8 text-sm text-foreground focus:border-foreground/40 focus:outline-none"
                     >
                       <option value="openai">openai</option>
                       <option value="anthropic">anthropic</option>
+                      <option value="google">google</option>
                     </select>
                     <ChevronDown className="pointer-events-none absolute right-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
                   </div>
@@ -335,6 +341,11 @@ export default function LlmConfigurationStep({ onSaved }: LlmConfigurationStepPr
                 {customProtocol === 'openai' && (
                   <p className="mt-1 text-[11px] text-muted-foreground">
                     OpenAI-compatible base URLs should include the API version path, for example ending in <span className="font-mono">/v1</span>.
+                  </p>
+                )}
+                {customProtocol === 'google' && (
+                  <p className="mt-1 text-[11px] text-muted-foreground">
+                    Native Google Gemini uses <span className="font-mono">https://generativelanguage.googleapis.com</span> unless you need a custom endpoint.
                   </p>
                 )}
                 </div>
@@ -434,6 +445,11 @@ export default function LlmConfigurationStep({ onSaved }: LlmConfigurationStepPr
                   {(selectedProvider?.protocol ?? customProtocol) === 'openai' && (
                     <p className="mt-1 text-[11px] text-muted-foreground">
                       OpenAI-compatible base URLs should include the API version path, for example ending in <span className="font-mono">/v1</span>.
+                    </p>
+                  )}
+                  {(selectedProvider?.protocol ?? customProtocol) === 'google' && (
+                    <p className="mt-1 text-[11px] text-muted-foreground">
+                      Native Google Gemini uses <span className="font-mono">https://generativelanguage.googleapis.com</span>.
                     </p>
                   )}
                 </div>

--- a/ui/src/components/settings/view/tabs/PilotDeckConfigTab.tsx
+++ b/ui/src/components/settings/view/tabs/PilotDeckConfigTab.tsx
@@ -48,6 +48,7 @@ import {
   CATALOG_PROVIDERS,
   findCatalogProviderById,
   type CatalogProvider,
+  type CatalogProviderProtocol,
   type CatalogModel,
 } from '../../../../shared/catalogProviders';
 import type { SettingsProject } from '../../types/types';
@@ -58,7 +59,7 @@ import { isCronConfigEnabled, patch } from './pilotDeckConfigForm';
 // pre-/post-translation in the backend — disk shape === UI shape.
 
 type V2Provider = {
-  protocol?: 'openai' | 'anthropic';
+  protocol?: CatalogProviderProtocol;
   url?: string;
   apiKey?: string;
   timeoutMs?: number;
@@ -801,10 +802,11 @@ function ProviderCard({
           <span className="mb-1 block">{t('pilotDeckConfig.panels.models.protocol')}</span>
           <Select
             value={protocol}
-            onChange={(v) => update({ protocol: v as 'openai' | 'anthropic' })}
+            onChange={(v) => update({ protocol: v as CatalogProviderProtocol })}
             options={[
               { value: 'openai',    label: t('pilotDeckConfig.panels.models.protocolOptions.openai') },
               { value: 'anthropic', label: t('pilotDeckConfig.panels.models.protocolOptions.anthropic') },
+              { value: 'google',    label: t('pilotDeckConfig.panels.models.protocolOptions.google') },
             ]}
           />
         </label>

--- a/ui/src/i18n/locales/en/settings.json
+++ b/ui/src/i18n/locales/en/settings.json
@@ -690,10 +690,11 @@
         "protocol": "Protocol",
         "protocolOptions": {
           "openai": "openai (chat-completions)",
-          "anthropic": "anthropic (messages API)"
+          "anthropic": "anthropic (messages API)",
+          "google": "google (Gemini API)"
         },
         "baseUrl": "Base URL",
-        "baseUrlHint": "For OpenAI-compatible providers, include the /v1 suffix, for example https://api.example.com/v1.",
+        "baseUrlHint": "For native Google Gemini, use https://generativelanguage.googleapis.com. For OpenAI-compatible providers, include the /v1 suffix.",
         "defaultsTo": "Defaults to",
         "fromCatalog": "from catalog.",
         "effective": "Effective:",

--- a/ui/src/i18n/locales/zh-CN/settings.json
+++ b/ui/src/i18n/locales/zh-CN/settings.json
@@ -690,10 +690,11 @@
         "protocol": "协议",
         "protocolOptions": {
           "openai": "openai（聊天补全）",
-          "anthropic": "anthropic（消息 API）"
+          "anthropic": "anthropic（消息 API）",
+          "google": "google（Gemini API）"
         },
         "baseUrl": "接口地址",
-        "baseUrlHint": "OpenAI 兼容接口请填到 /v1，例如 https://api.example.com/v1。",
+        "baseUrlHint": "原生 Google Gemini 使用 https://generativelanguage.googleapis.com。OpenAI 兼容接口请填到 /v1。",
         "defaultsTo": "默认使用目录中的",
         "fromCatalog": "。",
         "effective": "实际地址：",

--- a/ui/src/shared/catalogProviders.ts
+++ b/ui/src/shared/catalogProviders.ts
@@ -17,10 +17,12 @@ export type CatalogModel = {
   maxContextTokens?: number;
 };
 
+export type CatalogProviderProtocol = 'anthropic' | 'openai' | 'google';
+
 export type CatalogProvider = {
   id: string;
   displayName: string;
-  protocol: 'anthropic' | 'openai';
+  protocol: CatalogProviderProtocol;
   defaultUrl: string;
   models: CatalogModel[];
 };
@@ -67,12 +69,13 @@ export const CATALOG_PROVIDERS: CatalogProvider[] = [
   },
   {
     id: 'google',
-    displayName: 'Google AI',
-    protocol: 'openai',
-    defaultUrl: 'https://generativelanguage.googleapis.com/v1beta/openai',
+    displayName: 'Google AI (Gemini)',
+    protocol: 'google',
+    defaultUrl: 'https://generativelanguage.googleapis.com',
     models: [
-      { id: 'gemini-2.5-pro', displayName: 'Gemini 2.5 Pro', supportsImage: true, maxContextTokens: 1048576 },
+      { id: 'gemini-3.1-pro-preview', displayName: 'Gemini 3.1 Pro Preview', supportsImage: true, maxContextTokens: 1048576 },
       { id: 'gemini-2.5-flash', displayName: 'Gemini 2.5 Flash', supportsImage: true, maxContextTokens: 1048576 },
+      { id: 'gemini-2.5-pro', displayName: 'Gemini 2.5 Pro', supportsImage: true, maxContextTokens: 1048576 },
       { id: 'gemini-2.0-flash', displayName: 'Gemini 2.0 Flash', supportsImage: true, maxContextTokens: 1048576 },
     ],
   },


### PR DESCRIPTION
## Summary

- add native `protocol: google` support backed by `@google/genai`
- normalize Gemini requests, streams, responses, tool schemas, thinking config, model IDs, and provider errors
- expose native Google configuration in onboarding and Settings while preserving legacy Google OpenAI-compatible configs
- propagate provider protocol into router errors and memory extraction so Google/Anthropic do not fall back to OpenAI-compatible wire format
- document native Gemini provider configuration

## Verification

- `npx tsc --noEmit --pretty false`
- `npx tsx --test tests/model/google/*.test.ts`
- `npm --prefix ui run build`
- `npm test`

Note: per maintainer request, no additional memory protocol test file is included in the latest commit.