### PR TITLE
fix: require sqlite-capable node runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ We provide a one-line installer for macOS / Linux, plus a source-based workflow 
 curl -fsSL https://raw.githubusercontent.com/OpenBMB/PilotDeck/main/install.sh | bash
 ```
 
-The script auto-installs Node.js 22, clones the repo, installs dependencies, and builds the frontend. Once it finishes:
+The script auto-installs Node.js 22.13+ (required for the built-in SQLite runtime), clones the repo, installs dependencies, and builds the frontend. Once it finishes:
 
 ```bash
 pilotdeck            # starts the server at http://localhost:3001
@@ -316,6 +316,7 @@ pilotdeck status     # check runtime status
 git clone https://github.com/OpenBMB/PilotDeck.git
 cd PilotDeck
 
+node --version          # must be v22.13.0 or newer
 npm install              # root deps (Gateway runtime)
 cd ui && npm install     # UI deps
 cd ..

--- a/install.sh
+++ b/install.sh
@@ -11,6 +11,8 @@ INSTALL_DIR="${PILOTDECK_INSTALL_DIR:-$HOME/.pilotdeck/app}"
 CONFIG_FILE="${PILOTDECK_CONFIG_PATH:-$HOME/.pilotdeck/pilotdeck.yaml}"
 BIN_LINK="${PILOTDECK_BIN_LINK:-/usr/local/bin/pilotdeck}"
 MAX_PORT_TRIES="${PILOTDECK_MAX_PORT_TRIES:-20}"
+MIN_NODE_VERSION="22.13.0"
+NODE_INSTALL_VERSION="${PILOTDECK_NODE_VERSION:-22}"
 APT_UPDATED=0
 
 GREEN='\033[0;32m'
@@ -23,6 +25,71 @@ RESET='\033[0m'
 ok() { printf "  ${GREEN}✓${RESET} %s\n" "$1"; }
 warn() { printf "  ${YELLOW}→${RESET} %s\n" "$1"; }
 fail() { printf "  ${RED}✗${RESET} %s\n" "$1"; exit 1; }
+
+version_at_least() {
+  local version="${1#v}"
+  local minimum="${2#v}"
+  local v_major v_minor v_patch min_major min_minor min_patch
+  IFS=. read -r v_major v_minor v_patch _ <<< "$version"
+  IFS=. read -r min_major min_minor min_patch _ <<< "$minimum"
+  v_major="${v_major:-0}"
+  v_minor="${v_minor:-0}"
+  v_patch="${v_patch:-0}"
+  min_major="${min_major:-0}"
+  min_minor="${min_minor:-0}"
+  min_patch="${min_patch:-0}"
+  v_patch="${v_patch%%[^0-9]*}"
+  min_patch="${min_patch%%[^0-9]*}"
+
+  if (( v_major > min_major )); then return 0; fi
+  if (( v_major < min_major )); then return 1; fi
+  if (( v_minor > min_minor )); then return 0; fi
+  if (( v_minor < min_minor )); then return 1; fi
+  (( v_patch >= min_patch ))
+}
+
+node_supports_sqlite() {
+  node -e "import('node:sqlite').then(() => {}, () => process.exit(1))" >/dev/null 2>&1
+}
+
+install_node_runtime() {
+  if command -v fnm >/dev/null 2>&1; then
+    fnm install "$NODE_INSTALL_VERSION" </dev/null
+    fnm use "$NODE_INSTALL_VERSION"
+  elif command -v nvm >/dev/null 2>&1; then
+    nvm install "$NODE_INSTALL_VERSION" </dev/null
+    nvm use "$NODE_INSTALL_VERSION"
+  else
+    warn "Installing fnm (Fast Node Manager)..."
+    curl -fsSL https://fnm.vercel.app/install | bash
+    export PATH="$HOME/.local/share/fnm:$PATH"
+    eval "$(fnm env)"
+    fnm install "$NODE_INSTALL_VERSION" </dev/null
+    fnm use "$NODE_INSTALL_VERSION"
+  fi
+}
+
+ensure_node_runtime() {
+  local node_version
+
+  if command -v node >/dev/null 2>&1; then
+    node_version="$(node --version)"
+    if version_at_least "$node_version" "$MIN_NODE_VERSION" && node_supports_sqlite; then
+      ok "Node.js ${node_version} found"
+      return
+    fi
+    warn "Node.js ${node_version} is too old or lacks node:sqlite (need >=${MIN_NODE_VERSION}). Installing Node.js ${NODE_INSTALL_VERSION}..."
+  else
+    warn "Node.js not found. Installing via fnm..."
+  fi
+
+  install_node_runtime
+  node_version="$(node --version 2>/dev/null || true)"
+  if [[ -z "$node_version" ]] || ! version_at_least "$node_version" "$MIN_NODE_VERSION" || ! node_supports_sqlite; then
+    fail "Node.js >=${MIN_NODE_VERSION} with node:sqlite is required. Current: ${node_version:-not found}."
+  fi
+  ok "Node.js ${node_version} installed"
+}
 
 # Portable timeout: use GNU timeout if available, else fall back to a bg+kill approach.
 # Returns 124 on timeout (same convention as GNU timeout).
@@ -394,38 +461,7 @@ esac
 echo ""
 
 echo "Checking Node.js..."
-if command -v node >/dev/null 2>&1; then
-  NODE_VERSION="$(node --version)"
-  NODE_MAJOR="$(echo "$NODE_VERSION" | sed 's/v//' | cut -d. -f1)"
-  if [[ "$NODE_MAJOR" -ge 22 ]]; then
-    ok "Node.js ${NODE_VERSION} found"
-  else
-    warn "Node.js ${NODE_VERSION} is too old (need >=22). Installing Node.js 22..."
-    if command -v fnm >/dev/null 2>&1; then
-      fnm install 22
-      fnm use 22
-    elif command -v nvm >/dev/null 2>&1; then
-      nvm install 22 </dev/null
-      nvm use 22
-    else
-      warn "Installing fnm (Fast Node Manager)..."
-      curl -fsSL https://fnm.vercel.app/install | bash
-      export PATH="$HOME/.local/share/fnm:$PATH"
-      eval "$(fnm env)"
-      fnm install 22 </dev/null
-      fnm use 22
-    fi
-    ok "Node.js $(node --version) installed"
-  fi
-else
-  warn "Node.js not found. Installing via fnm..."
-  curl -fsSL https://fnm.vercel.app/install | bash
-  export PATH="$HOME/.local/share/fnm:$PATH"
-  eval "$(fnm env)"
-  fnm install 22 </dev/null
-  fnm use 22
-  ok "Node.js $(node --version) installed"
-fi
+ensure_node_runtime
 echo ""
 
 echo "Checking git..."
@@ -550,9 +586,44 @@ done
 INSTALL_DIR="$(cd "$(dirname "$SOURCE")/.." && pwd)"
 CONFIG_FILE="${PILOTDECK_CONFIG_PATH:-$HOME/.pilotdeck/pilotdeck.yaml}"
 MAX_PORT_TRIES="${PILOTDECK_MAX_PORT_TRIES:-20}"
+MIN_NODE_VERSION="22.13.0"
 
 fail() { printf "pilotdeck: %s\n" "$1" >&2; exit 1; }
 warn() { printf "pilotdeck: %s\n" "$1" >&2; }
+
+version_at_least() {
+  local version="${1#v}"
+  local minimum="${2#v}"
+  local v_major v_minor v_patch min_major min_minor min_patch
+  IFS=. read -r v_major v_minor v_patch _ <<< "$version"
+  IFS=. read -r min_major min_minor min_patch _ <<< "$minimum"
+  v_major="${v_major:-0}"
+  v_minor="${v_minor:-0}"
+  v_patch="${v_patch:-0}"
+  min_major="${min_major:-0}"
+  min_minor="${min_minor:-0}"
+  min_patch="${min_patch:-0}"
+  v_patch="${v_patch%%[^0-9]*}"
+  min_patch="${min_patch%%[^0-9]*}"
+
+  if (( v_major > min_major )); then return 0; fi
+  if (( v_major < min_major )); then return 1; fi
+  if (( v_minor > min_minor )); then return 0; fi
+  if (( v_minor < min_minor )); then return 1; fi
+  (( v_patch >= min_patch ))
+}
+
+ensure_node_runtime() {
+  command -v node >/dev/null 2>&1 || fail "Node.js >=${MIN_NODE_VERSION} is required; re-run install.sh to install it."
+  local node_version
+  node_version="$(node --version)"
+  if ! version_at_least "$node_version" "$MIN_NODE_VERSION"; then
+    fail "Node.js >=${MIN_NODE_VERSION} is required because PilotDeck uses node:sqlite. Current: ${node_version}. Re-run install.sh or switch Node with fnm/nvm."
+  fi
+  if ! node -e "import('node:sqlite').then(() => {}, () => process.exit(1))" >/dev/null 2>&1; then
+    fail "Current Node.js (${node_version}) does not provide node:sqlite. Re-run install.sh or switch to Node.js 22.13+."
+  fi
+}
 
 is_port_free() {
   local port="$1"
@@ -649,6 +720,8 @@ if [[ "$COMMAND" == "status" ]]; then
   printf "Next start:   http://localhost:%s\n" "$NEXT_SERVER_PORT"
   exit 0
 fi
+
+ensure_node_runtime
 
 SERVER_BASE="${SERVER_PORT:-3001}"
 GATEWAY_BASE="${PILOTDECK_GATEWAY_PORT:-18789}"

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
+  "engines": {
+    "node": ">=22.13.0"
+  },
   "workspaces": [
     "ui"
   ],
@@ -10,13 +13,14 @@
     "pilotdeck": "./dist/src/cli/pilotdeck.js"
   },
   "scripts": {
+    "check:runtime": "node scripts/check-node-runtime.mjs",
     "install:browser": "npx @playwright/mcp install-browser chrome-for-testing",
-    "prebuild": "node scripts/bootstrap-pilotdeck-config.mjs && cd src/context/memory/edgeclaw-memory-core && npm run build",
+    "prebuild": "npm run check:runtime && node scripts/bootstrap-pilotdeck-config.mjs && cd src/context/memory/edgeclaw-memory-core && npm run build",
     "build": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\" && tsc -p tsconfig.json && node -e \"require('fs').cpSync('src/extension/plugins/builtin','dist/src/extension/plugins/builtin',{recursive:true})\"",
-    "server": "tsx src/cli/pilotdeck.ts server",
-    "server:built": "node dist/src/cli/pilotdeck.js server",
+    "server": "npm run check:runtime && tsx src/cli/pilotdeck.ts server",
+    "server:built": "npm run check:runtime && node dist/src/cli/pilotdeck.js server",
     "skills:migrate": "tsx src/cli/pilotdeck.ts skills migrate",
-    "predev": "node scripts/bootstrap-pilotdeck-config.mjs",
+    "predev": "npm run check:runtime && node scripts/bootstrap-pilotdeck-config.mjs",
     "dev": "node scripts/dev-launcher.mjs",
     "test": "npm run build && node --test --test-force-exit --test-timeout 60000 \"dist/tests/**/*.test.js\" \"dist/tests/**/*.spec.js\"",
     "e2e:real-agent-lifecycle-hooks": "npm run build && PILOTDECK_RUN_REAL_AGENT_LIFECYCLE_E2E=1 node dist/tests/agent/e2e/run-real-agent-lifecycle-hooks.js"

--- a/scripts/check-node-runtime.mjs
+++ b/scripts/check-node-runtime.mjs
@@ -1,0 +1,48 @@
+const minimumNodeVersion = [22, 13, 0];
+const minimumNodeVersionLabel = "22.13.0";
+
+function parseNodeVersion(version) {
+  return version
+    .replace(/^v/, "")
+    .split(".")
+    .map((part) => Number.parseInt(part, 10) || 0);
+}
+
+function isAtLeastMinimum(version) {
+  const current = parseNodeVersion(version);
+  for (let index = 0; index < minimumNodeVersion.length; index += 1) {
+    if ((current[index] ?? 0) > minimumNodeVersion[index]) return true;
+    if ((current[index] ?? 0) < minimumNodeVersion[index]) return false;
+  }
+  return true;
+}
+
+function fail(message) {
+  console.error(`[pilotdeck] ${message}`);
+  process.exit(1);
+}
+
+const emitWarning = process.emitWarning.bind(process);
+process.emitWarning = (warning, typeOrOptions, ...args) => {
+  const warningType = typeof typeOrOptions === "string" ? typeOrOptions : typeOrOptions?.type;
+  const warningText = typeof warning === "string" ? warning : warning?.message;
+  if (warningType === "ExperimentalWarning" && warningText?.includes("SQLite")) {
+    return;
+  }
+  emitWarning(warning, typeOrOptions, ...args);
+};
+
+const nodeVersion = process.versions.node;
+if (!isAtLeastMinimum(nodeVersion)) {
+  fail(
+    `Node.js >=${minimumNodeVersionLabel} is required because PilotDeck uses node:sqlite. Current: v${nodeVersion}.`,
+  );
+}
+
+try {
+  await import("node:sqlite");
+} catch {
+  fail(
+    `Current Node.js (v${nodeVersion}) does not provide node:sqlite. Switch to Node.js ${minimumNodeVersionLabel}+ and reinstall dependencies.`,
+  );
+}

--- a/src/context/memory/edgeclaw-memory-core/package-lock.json
+++ b/src/context/memory/edgeclaw-memory-core/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "edgeclaw-memory-core",
       "version": "0.0.0",
+      "engines": {
+        "node": ">=22.13.0"
+      },
       "devDependencies": {
         "@types/node": "^22.14.1",
         "typescript": "^5.9.3"

--- a/src/context/memory/edgeclaw-memory-core/package.json
+++ b/src/context/memory/edgeclaw-memory-core/package.json
@@ -3,6 +3,9 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
+  "engines": {
+    "node": ">=22.13.0"
+  },
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "exports": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -5,14 +5,18 @@
   "description": "PilotDeck Web UI — talks to src/gateway via ui/server/pilotdeck-bridge.js.",
   "type": "module",
   "main": "server/index.js",
+  "engines": {
+    "node": ">=22.13.0"
+  },
   "scripts": {
-    "predev": "node ../scripts/bootstrap-pilotdeck-config.mjs",
+    "check:runtime": "node ../scripts/check-node-runtime.mjs",
+    "predev": "npm run check:runtime && node ../scripts/bootstrap-pilotdeck-config.mjs",
     "dev": "node ../scripts/dev-launcher.mjs",
     "dev:concurrent": "concurrently --kill-others-on-fail --names gateway,server,client \"npm:dev:gateway\" \"npm:dev:server\" \"npm:dev:client\"",
     "dev:gateway": "npm --prefix .. run server",
-    "dev:server": "node --import tsx server/index.js",
+    "dev:server": "npm run check:runtime && node --import tsx server/index.js",
     "dev:client": "vite",
-    "server": "node --import tsx server/index.js",
+    "server": "npm run check:runtime && node --import tsx server/index.js",
     "gateway": "npm --prefix .. run server",
     "client": "vite",
     "build": "vite build",


### PR DESCRIPTION
## Summary
- require Node.js 22.13+ for PilotDeck runtime paths that use node:sqlite
- add runtime checks to installer, generated CLI wrapper, root scripts, and UI server scripts
- document the Node.js minimum version for install/source workflows

## Tests
- npm run check:runtime
- bash -n install.sh
- node --check scripts/check-node-runtime.mjs
- npm --prefix src/context/memory/edgeclaw-memory-core run build