### PR TITLE
fix(chat): expose uploaded image paths to agent

### DIFF
--- a/src/gateway/client/InProcessGateway.ts
+++ b/src/gateway/client/InProcessGateway.ts
@@ -1506,12 +1506,15 @@ function safeGatewayPathPart(value: string): string {
   return value.trim().replace(/[^A-Za-z0-9_.-]+/g, "-").replace(/^-+|-+$/g, "") || "value";
 }
 
+const ATTACHMENT_PATH_NOTE_MARKER = "[Files attached by user and available for reading in the project:]";
+
 async function buildAgentInputWithAttachments(
   message: string,
   attachments: ChannelAttachment[] | undefined,
 ): Promise<AgentInput> {
   const attachmentBlocks = await attachmentsToContentBlocks(attachments);
-  if (attachmentBlocks.length === 0) {
+  const pathNote = buildImageAttachmentPathNote(attachments);
+  if (attachmentBlocks.length === 0 && !pathNote) {
     return { type: "text", text: message };
   }
   const blocks: CanonicalContentBlock[] = [];
@@ -1521,7 +1524,35 @@ async function buildAgentInputWithAttachments(
   for (const block of attachmentBlocks) {
     blocks.push(block);
   }
+  if (pathNote) {
+    blocks.push(pathNote);
+  }
   return { type: "blocks", content: blocks };
+}
+
+function buildImageAttachmentPathNote(
+  attachments: ChannelAttachment[] | undefined,
+): CanonicalContentBlock | undefined {
+  if (!attachments || attachments.length === 0) return undefined;
+  const seen = new Set<string>();
+  const lines: string[] = [];
+
+  for (const attachment of attachments) {
+    if (!attachment.path) continue;
+    const isImage = attachment.type === "image" || attachment.mimeType?.startsWith("image/");
+    if (!isImage || seen.has(attachment.path)) continue;
+    seen.add(attachment.path);
+
+    const fallbackName = attachment.path.split(/[\\/]/).pop() || "image";
+    const name = String(attachment.name || fallbackName).replace(/[\r\n]+/g, " ").trim() || fallbackName;
+    lines.push(`- ${name}: ${attachment.path}`);
+  }
+
+  if (lines.length === 0) return undefined;
+  return {
+    type: "text",
+    text: `\n\n${ATTACHMENT_PATH_NOTE_MARKER}\n${lines.join("\n")}`,
+  };
 }
 
 async function attachmentsToContentBlocks(

--- a/ui/server/index.js
+++ b/ui/server/index.js
@@ -2360,8 +2360,8 @@ async function moveUploadedAttachment(file, attachmentDir, index) {
 }
 
 // Mixed chat attachment upload endpoint. Images are returned as data URLs for
-// multimodal input and previews; other files are staged under the project so
-// the gateway can resolve them by path.
+// multimodal input/previews and are also staged under the project so the agent
+// can operate on the same bytes by path; other files are staged by path only.
 app.post('/api/projects/:projectName/upload-attachments', authenticateToken, async (req, res) => {
     let multerUpload;
     try {
@@ -2420,14 +2420,14 @@ app.post('/api/projects/:projectName/upload-attachments', authenticateToken, asy
 
             for (const [index, file] of req.files.entries()) {
                 if (CHAT_ATTACHMENT_IMAGE_MIMES.has(file.mimetype)) {
-                    const originalName = normalizeUploadedFilename(file.originalname);
                     const buffer = await fsPromises.readFile(file.path);
-                    await fsPromises.unlink(file.path).catch(() => { });
+                    const storedFile = await moveUploadedAttachment(file, attachmentDir, index);
                     images.push({
-                        name: originalName,
+                        name: storedFile.name,
                         data: `data:${file.mimetype};base64,${buffer.toString('base64')}`,
-                        size: file.size,
-                        mimeType: file.mimetype,
+                        path: storedFile.path,
+                        size: storedFile.size,
+                        mimeType: storedFile.mimeType,
                     });
                     continue;
                 }
@@ -2435,7 +2435,7 @@ app.post('/api/projects/:projectName/upload-attachments', authenticateToken, asy
                 files.push(await moveUploadedAttachment(file, attachmentDir, index));
             }
 
-            if (files.length === 0 && attachmentDir) {
+            if (files.length === 0 && images.length === 0 && attachmentDir) {
                 await fsPromises.rm(attachmentDir, { recursive: true, force: true }).catch(() => { });
             }
 

--- a/ui/server/pilotdeck-bridge.js
+++ b/ui/server/pilotdeck-bridge.js
@@ -253,10 +253,10 @@ export function getSessionTokenBudget(sessionKey) {
  * Convert UI-shape image attachments into Gateway-shape ChannelAttachment[].
  *
  * UI sends:
- *   { name, data: 'data:image/png;base64,XXX', size, mimeType }
+ *   { name, data: 'data:image/png;base64,XXX', path, size, mimeType }
  *
  * Gateway expects ChannelAttachment:
- *   { type: 'image', name, mimeType, content: <raw base64, no data: prefix>, bytes }
+ *   { type: 'image', name, path, mimeType, content: <raw base64, no data: prefix>, bytes }
  *
  * The bare-base64 form matches how `CanonicalImageBlock` and the
  * AttachmentResolver store the payload elsewhere in the codebase.
@@ -265,7 +265,7 @@ export function getSessionTokenBudget(sessionKey) {
  * spread it conditionally without injecting an empty array.
  *
  * @param {unknown} images
- * @returns {Array<{type:'image',name?:string,mimeType:string,content:string,bytes?:number}>|undefined}
+ * @returns {Array<{type:'image',name?:string,path?:string,mimeType:string,content:string,bytes?:number}>|undefined}
  */
 function uiImagesToAttachments(images) {
     if (!Array.isArray(images) || images.length === 0) return undefined;
@@ -284,6 +284,7 @@ function uiImagesToAttachments(images) {
         out.push({
             type: 'image',
             name: typeof img.name === 'string' ? img.name : undefined,
+            ...(typeof img.path === 'string' && img.path ? { path: img.path } : {}),
             mimeType,
             content: base64,
             ...(typeof img.size === 'number' ? { bytes: img.size } : {}),

--- a/ui/src/components/chat/types/types.ts
+++ b/ui/src/components/chat/types/types.ts
@@ -12,7 +12,9 @@ export type ChatRunMode = 'agent' | 'plan';
 export interface ChatImage {
   data: string;
   name: string;
+  path?: string;
   mimeType?: string;
+  size?: number;
 }
 
 export interface ChatAttachment {

--- a/ui/src/components/chat/utils/attachmentNotes.ts
+++ b/ui/src/components/chat/utils/attachmentNotes.ts
@@ -20,6 +20,7 @@ function inferAttachmentMimeType(name: string, filePath: string): string | undef
   if (source.endsWith('.jpg') || source.endsWith('.jpeg')) return 'image/jpeg';
   if (source.endsWith('.gif')) return 'image/gif';
   if (source.endsWith('.webp')) return 'image/webp';
+  if (source.endsWith('.svg') || source.endsWith('.svgz')) return 'image/svg+xml';
   return undefined;
 }
 

--- a/ui/src/components/chat/utils/attachmentNotes.ts
+++ b/ui/src/components/chat/utils/attachmentNotes.ts
@@ -3,7 +3,7 @@ import type { ChatAttachment } from '../types/types';
 const ATTACHMENT_NOTE_MARKER = '[Files attached by user and available for reading in the project:]';
 
 function inferAttachmentMimeType(name: string, filePath: string): string | undefined {
-  const source = `${name || filePath}`.toLowerCase();
+  const source = `${name} ${filePath}`.toLowerCase();
   if (source.endsWith('.pdf')) return 'application/pdf';
   if (source.endsWith('.doc')) return 'application/msword';
   if (source.endsWith('.docx')) return 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
@@ -21,6 +21,10 @@ function inferAttachmentMimeType(name: string, filePath: string): string | undef
   if (source.endsWith('.gif')) return 'image/gif';
   if (source.endsWith('.webp')) return 'image/webp';
   return undefined;
+}
+
+function isImageAttachmentMime(mimeType: string | undefined): boolean {
+  return Boolean(mimeType?.toLowerCase().startsWith('image/'));
 }
 
 export function parseUserAttachmentNote(content: unknown): {
@@ -46,11 +50,13 @@ export function parseUserAttachmentNote(content: unknown): {
     const name = line.slice(2, separator).trim();
     const filePath = line.slice(separator + 2).trim();
     if (!name || !filePath) continue;
+    const mimeType = inferAttachmentMimeType(name, filePath);
+    if (isImageAttachmentMime(mimeType)) continue;
 
     attachments.push({
       name,
       path: filePath,
-      mimeType: inferAttachmentMimeType(name, filePath),
+      mimeType,
     });
   }
 


### PR DESCRIPTION
## Summary
- save uploaded chat images under project .tmp/chat-attachments while preserving data URL previews
- pass image attachment paths through the web bridge into the gateway
- add readable attachment path context for the agent and hide image path notes from duplicate frontend attachment cards

## Validation
- node --check ui/server/index.js
- node --check ui/server/pilotdeck-bridge.js
- git diff --check
- npm --prefix ui run build
