### PR TITLE
fix: unwrap google provider error payloads

### DIFF
--- a/src/model/errors/normalizeModelError.ts
+++ b/src/model/errors/normalizeModelError.ts
@@ -26,7 +26,7 @@ export function normalizeModelError(
   status?: number,
 ): CanonicalModelError {
   const raw = error;
-  const record = isRecord(error) ? error : undefined;
+  const record = firstErrorRecord(error);
   const nestedError = record && isRecord(record.error) ? record.error : undefined;
   const source = nestedError ?? record;
 
@@ -67,6 +67,16 @@ export function normalizeModelError(
     result.retryAfterMs = retryAfterMs;
   }
   return result;
+}
+
+function firstErrorRecord(error: unknown): Record<string, unknown> | undefined {
+  if (isRecord(error)) {
+    return error;
+  }
+  if (!Array.isArray(error)) {
+    return undefined;
+  }
+  return error.find(isRecord);
 }
 
 /**

--- a/tests/model/errors.test.ts
+++ b/tests/model/errors.test.ts
@@ -1,0 +1,25 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { normalizeModelError } from "../../src/model/errors/normalizeModelError.js";
+
+describe("normalizeModelError", () => {
+  it("unwraps Google OpenAI-compatible array errors", () => {
+    const error = normalizeModelError("google", "openai", [{
+      error: {
+        code: 429,
+        message:
+          "You exceeded your current quota, please check your plan and billing details. " +
+          "Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_requests, " +
+          "limit: 20, model: gemini-2.5-flash. Please retry in 47.805054227s.",
+        status: "RESOURCE_EXHAUSTED",
+      },
+    }], 429);
+
+    assert.equal(error.code, "billing");
+    assert.equal(error.status, 429);
+    assert.equal(error.retryable, false);
+    assert.equal(error.retryAfterMs, 47805);
+    assert.match(error.message, /exceeded your current quota/i);
+    assert.match(error.userHint ?? "", /quota depleted/i);
+  });
+});


### PR DESCRIPTION
## Summary
- unwrap array-shaped Google OpenAI-compatible error payloads before normalization
- preserve quota/billing messages and retry-after parsing instead of collapsing to a generic provider error
- add regression coverage for the Google quota error shape

## Tests
- node --import tsx --test tests/model/errors.test.ts tests/model/google/request.test.ts tests/model/google/runtime.test.ts
- npm run build