### PR TITLE
Fix router text fallback for image requests

### DIFF
--- a/src/router/RouterRuntime.ts
+++ b/src/router/RouterRuntime.ts
@@ -4,7 +4,7 @@ import type {
   ModelRuntime,
   ModelProtocol,
 } from "../model/index.js";
-import { ModelRequestError } from "../model/index.js";
+import { cloneMessages, downgradeUnsupportedContent, ModelRequestError } from "../model/index.js";
 import type { InputModality } from "../model/index.js";
 import {
   DEFAULT_SUBAGENT_POLICY,
@@ -489,14 +489,20 @@ export function createRouterRuntime(
       provider: decision.provider,
       model: decision.model,
     };
-    const attempts: RouterModelRef[] = [
+    const candidateAttempts: RouterModelRef[] = [
       requestedAttempt,
       ...fallbackPlan.attempts,
     ].filter((attempt, index, all) =>
       all.findIndex((candidate) =>
         candidate.provider === attempt.provider && candidate.model === attempt.model
       ) === index
-    ).filter((attempt) => supportsMediaRequirements(attempt, requiredModalities));
+    );
+    let attempts: RouterModelRef[] = candidateAttempts
+      .filter((attempt) => supportsMediaRequirements(attempt, requiredModalities));
+    const downgradeUnsupportedMedia = attempts.length === 0 && requiredModalities.length > 0;
+    if (downgradeUnsupportedMedia) {
+      attempts = candidateAttempts;
+    }
     const zeroUsageMax = Math.max(1, config.zeroUsageRetry?.maxAttempts ?? 5);
     const zeroUsageEnabled = config.zeroUsageRetry?.enabled ?? true;
     const transientRetryEnabled = config.transientRetry?.enabled ?? true;
@@ -551,6 +557,9 @@ export function createRouterRuntime(
         resolvedFrom: attemptIndex === 0 ? decision.resolvedFrom : "fallback",
       };
       let attemptRequest = applyDecisionToRequest(attemptDecision, request);
+      if (downgradeUnsupportedMedia) {
+        attemptRequest = downgradeRequestForAttempt(attemptRequest, attempt, deps.modelRuntime);
+      }
       lastAttempt = attempt;
       lastDecision = attemptDecision;
 
@@ -977,6 +986,23 @@ function clampMaxOutputTokensToModelCap(
     // Unknown provider/model — let validateModelRequest surface the real error.
   }
   return request;
+}
+
+function downgradeRequestForAttempt(
+  request: CanonicalModelRequest,
+  attempt: RouterModelRef,
+  modelRuntime: ModelRuntime,
+): CanonicalModelRequest {
+  let multimodal: ReturnType<ModelRuntime["getMultimodal"]>;
+  try {
+    multimodal = modelRuntime.getMultimodal(attempt.provider, attempt.model);
+  } catch {
+    // Unknown provider/model should still be reported by validateModelRequest.
+    return request;
+  }
+  const messages = cloneMessages(request.messages);
+  downgradeUnsupportedContent(messages, multimodal);
+  return { ...request, messages };
 }
 
 /**

--- a/src/router/RouterRuntime.ts
+++ b/src/router/RouterRuntime.ts
@@ -497,12 +497,15 @@ export function createRouterRuntime(
         candidate.provider === attempt.provider && candidate.model === attempt.model
       ) === index
     );
-    let attempts: RouterModelRef[] = candidateAttempts
+    const nativeAttempts: RouterModelRef[] = candidateAttempts
       .filter((attempt) => supportsMediaRequirements(attempt, requiredModalities));
-    const downgradeUnsupportedMedia = attempts.length === 0 && requiredModalities.length > 0;
-    if (downgradeUnsupportedMedia) {
-      attempts = candidateAttempts;
-    }
+    const downgradedAttempts: RouterModelRef[] = requiredModalities.length > 0
+      ? candidateAttempts.filter((attempt) => !supportsMediaRequirements(attempt, requiredModalities))
+      : [];
+    const attemptPlans: AttemptPlan[] = [
+      ...nativeAttempts.map((attempt) => ({ attempt, downgradeUnsupportedMedia: false })),
+      ...downgradedAttempts.map((attempt) => ({ attempt, downgradeUnsupportedMedia: true })),
+    ];
     const zeroUsageMax = Math.max(1, config.zeroUsageRetry?.maxAttempts ?? 5);
     const zeroUsageEnabled = config.zeroUsageRetry?.enabled ?? true;
     const transientRetryEnabled = config.transientRetry?.enabled ?? true;
@@ -517,7 +520,7 @@ export function createRouterRuntime(
     let lastDecision: RouterDecision = decision;
     let lastHasYieldedContent = false;
 
-    if (attempts.length === 0) {
+    if (attemptPlans.length === 0) {
       const missing = missingForModel(requestedAttempt, requiredModalities);
       const error = createUnsupportedMediaError(
         requestedAttempt,
@@ -538,15 +541,16 @@ export function createRouterRuntime(
       return;
     }
 
-    outer: for (let attemptIndex = 0; attemptIndex < attempts.length; attemptIndex += 1) {
+    outer: for (let attemptIndex = 0; attemptIndex < attemptPlans.length; attemptIndex += 1) {
       if (ctx.abortSignal?.aborted) {
         return;
       }
-      const attempt = attempts[attemptIndex];
+      const attemptPlan = attemptPlans[attemptIndex];
+      const attempt = attemptPlan.attempt;
       if (
         attemptIndex > 0 &&
         getHealthTracker(ctx.sessionId).shouldSkip(attempt.provider) &&
-        attemptIndex < attempts.length - 1
+        attemptIndex < attemptPlans.length - 1
       ) {
         continue;
       }
@@ -557,7 +561,7 @@ export function createRouterRuntime(
         resolvedFrom: attemptIndex === 0 ? decision.resolvedFrom : "fallback",
       };
       let attemptRequest = applyDecisionToRequest(attemptDecision, request);
-      if (downgradeUnsupportedMedia) {
+      if (attemptPlan.downgradeUnsupportedMedia) {
         attemptRequest = downgradeRequestForAttempt(attemptRequest, attempt, deps.modelRuntime);
       }
       lastAttempt = attempt;
@@ -625,8 +629,8 @@ export function createRouterRuntime(
           lastError = outcome.error;
           getHealthTracker(ctx.sessionId).recordFailure(attempt.provider);
           if (!hasYieldedContent && isFallbackEligible(outcome.error)) {
-            if (attemptIndex < attempts.length - 1) {
-              const next = attempts[attemptIndex + 1];
+            if (attemptIndex < attemptPlans.length - 1) {
+              const next = attemptPlans[attemptIndex + 1].attempt;
               events.emit({
                 type: "pilotdeck_router_fallback",
                 sessionId: ctx.sessionId,
@@ -944,6 +948,11 @@ export function createRouterRuntime(
     },
   };
 }
+
+type AttemptPlan = {
+  attempt: RouterModelRef;
+  downgradeUnsupportedMedia: boolean;
+};
 
 type AttemptOutcome = {
   buffered: CanonicalModelEvent[];

--- a/tests/router/maxOutputTokens.test.ts
+++ b/tests/router/maxOutputTokens.test.ts
@@ -5,11 +5,13 @@ import type {
   CanonicalModelResponse,
   ModelCapabilities,
   ModelRuntime,
+  MultimodalConstraints,
 } from "../../src/model/index.js";
 import { createRouterRuntime } from "../../src/router/index.js";
 import type { RouterDecision } from "../../src/router/protocol/decision.js";
 
-const textOnly = { input: ["text" as const] };
+const textOnly: MultimodalConstraints = { input: ["text"] };
+const imageCapable: MultimodalConstraints = { input: ["text", "image"] };
 const baseCapabilities: ModelCapabilities = {
   supportsToolUse: true,
   supportsStreaming: true,
@@ -83,4 +85,131 @@ describe("RouterRuntime max output token caps", () => {
     assert.equal(seenRequest?.maxOutputTokens, 8_192);
     await router.shutdown();
   });
+
+  it("downgrades images to text when no configured fallback supports image input", async () => {
+    let seenRequest: CanonicalModelRequest | undefined;
+    const modelRuntime = createStreamRuntime({
+      "deepseek/deepseek-v4-pro": textOnly,
+      "fallback/text": textOnly,
+    }, (request) => {
+      seenRequest = request;
+    });
+    const router = createRouterRuntime({
+      enabled: true,
+      zeroUsageRetry: { enabled: false, maxAttempts: 0 },
+      scenarios: {
+        default: { id: "deepseek/deepseek-v4-pro", provider: "deepseek", model: "deepseek-v4-pro" },
+      },
+      fallback: {
+        default: [{ id: "fallback/text", provider: "fallback", model: "text" }],
+      },
+    }, { modelRuntime });
+    const decision: RouterDecision = {
+      provider: "deepseek",
+      model: "deepseek-v4-pro",
+      scenarioType: "default",
+      isSubagent: false,
+      orchestrating: false,
+      resolvedFrom: "scenario",
+      mutations: {},
+    };
+    const request = imageRequest();
+    let sawError = false;
+
+    for await (const event of router.execute(decision, request, { sessionId: "s", turnId: "t" })) {
+      sawError = sawError || event.type === "error";
+    }
+
+    const block = seenRequest?.messages[0]?.content[1];
+    assert.equal(seenRequest?.provider, "deepseek");
+    assert.equal(seenRequest?.model, "deepseek-v4-pro");
+    assert.equal(block?.type, "text");
+    assert.match(block?.type === "text" ? block.text : "", /omitted, model does not support image input/);
+    assert.equal(request.messages[0]?.content[1]?.type, "image");
+    assert.equal(sawError, false);
+    await router.shutdown();
+  });
+
+  it("keeps images when a configured fallback supports image input", async () => {
+    let seenRequest: CanonicalModelRequest | undefined;
+    const modelRuntime = createStreamRuntime({
+      "deepseek/deepseek-v4-pro": textOnly,
+      "vision/model": imageCapable,
+    }, (request) => {
+      seenRequest = request;
+    });
+    const router = createRouterRuntime({
+      enabled: true,
+      zeroUsageRetry: { enabled: false, maxAttempts: 0 },
+      scenarios: {
+        default: { id: "deepseek/deepseek-v4-pro", provider: "deepseek", model: "deepseek-v4-pro" },
+      },
+      fallback: {
+        default: [{ id: "vision/model", provider: "vision", model: "model" }],
+      },
+    }, { modelRuntime });
+    const decision: RouterDecision = {
+      provider: "deepseek",
+      model: "deepseek-v4-pro",
+      scenarioType: "default",
+      isSubagent: false,
+      orchestrating: false,
+      resolvedFrom: "scenario",
+      mutations: {},
+    };
+
+    for await (const _event of router.execute(decision, imageRequest(), { sessionId: "s", turnId: "t" })) {
+      // Drain the stream.
+    }
+
+    assert.equal(seenRequest?.provider, "vision");
+    assert.equal(seenRequest?.model, "model");
+    assert.equal(seenRequest?.messages[0]?.content[1]?.type, "image");
+    await router.shutdown();
+  });
 });
+
+function createStreamRuntime(
+  multimodalByModel: Record<string, MultimodalConstraints>,
+  onStream: (request: CanonicalModelRequest) => void,
+): ModelRuntime {
+  return {
+    async *stream(request) {
+      onStream(request);
+      yield { type: "message_end", finishReason: "stop" };
+    },
+    async complete(): Promise<CanonicalModelResponse> {
+      return { role: "assistant", content: [], finishReason: "stop" };
+    },
+    getCapabilities() {
+      return baseCapabilities;
+    },
+    getMultimodal(providerId, modelId) {
+      const multimodal = multimodalByModel[`${providerId}/${modelId}`];
+      if (!multimodal) {
+        throw new Error(`Unknown model ${providerId}/${modelId}`);
+      }
+      return multimodal;
+    },
+    getProviderProtocol() {
+      return "openai";
+    },
+    getProviderBaseUrl() {
+      return "https://example.test/v1";
+    },
+  };
+}
+
+function imageRequest(): CanonicalModelRequest {
+  return {
+    provider: "deepseek",
+    model: "deepseek-v4-pro",
+    messages: [{
+      role: "user",
+      content: [
+        { type: "text", text: "What is in this image?" },
+        { type: "image", source: "base64", data: "aW1hZ2U=", mimeType: "image/png", bytes: 2048 },
+      ],
+    }],
+  };
+}

--- a/tests/router/maxOutputTokens.test.ts
+++ b/tests/router/maxOutputTokens.test.ts
@@ -167,15 +167,80 @@ describe("RouterRuntime max output token caps", () => {
     assert.equal(seenRequest?.messages[0]?.content[1]?.type, "image");
     await router.shutdown();
   });
+
+  it("falls back to downgraded text after an image-capable attempt fails", async () => {
+    const seenRequests: CanonicalModelRequest[] = [];
+    const modelRuntime = createStreamRuntime({
+      "vision/model": imageCapable,
+      "fallback/text": textOnly,
+    }, (request) => {
+      seenRequests.push(request);
+    }, {
+      failModels: new Set(["vision/model"]),
+    });
+    const router = createRouterRuntime({
+      enabled: true,
+      zeroUsageRetry: { enabled: false, maxAttempts: 0 },
+      scenarios: {
+        default: { id: "vision/model", provider: "vision", model: "model" },
+      },
+      fallback: {
+        default: [{ id: "fallback/text", provider: "fallback", model: "text" }],
+      },
+    }, { modelRuntime });
+    const decision: RouterDecision = {
+      provider: "vision",
+      model: "model",
+      scenarioType: "default",
+      isSubagent: false,
+      orchestrating: false,
+      resolvedFrom: "scenario",
+      mutations: {},
+    };
+    let sawError = false;
+
+    for await (const event of router.execute(decision, imageRequest(), { sessionId: "s", turnId: "t" })) {
+      sawError = sawError || event.type === "error";
+    }
+
+    assert.equal(seenRequests.length, 2);
+    assert.equal(seenRequests[0]?.provider, "vision");
+    assert.equal(seenRequests[0]?.model, "model");
+    assert.equal(seenRequests[0]?.messages[0]?.content[1]?.type, "image");
+    assert.equal(seenRequests[1]?.provider, "fallback");
+    assert.equal(seenRequests[1]?.model, "text");
+    const fallbackBlock = seenRequests[1]?.messages[0]?.content[1];
+    assert.equal(fallbackBlock?.type, "text");
+    assert.match(
+      fallbackBlock?.type === "text" ? fallbackBlock.text : "",
+      /omitted, model does not support image input/,
+    );
+    assert.equal(sawError, false);
+    await router.shutdown();
+  });
 });
 
 function createStreamRuntime(
   multimodalByModel: Record<string, MultimodalConstraints>,
   onStream: (request: CanonicalModelRequest) => void,
+  options: { failModels?: Set<string> } = {},
 ): ModelRuntime {
   return {
     async *stream(request) {
       onStream(request);
+      if (options.failModels?.has(`${request.provider}/${request.model}`)) {
+        yield {
+          type: "error",
+          error: {
+            provider: request.provider,
+            protocol: "openai",
+            code: "server_error",
+            message: "boom",
+            retryable: true,
+          },
+        };
+        return;
+      }
       yield { type: "message_end", finishReason: "stop" };
     },
     async complete(): Promise<CanonicalModelResponse> {


### PR DESCRIPTION
## Summary
- allow the router to downgrade unsupported image inputs to text placeholders when no configured fallback model supports images
- preserve image-capable fallback behavior when a compatible vision model exists
- add router coverage for text-only and image-capable fallback chains

## Tests
- npx tsc --noEmit --module NodeNext --moduleResolution NodeNext --target ES2022 --strict --esModuleInterop --skipLibCheck --types node src/router/RouterRuntime.ts tests/router/maxOutputTokens.test.ts
- node --import tsx --test tests/router/maxOutputTokens.test.ts