### PR TITLE
Add ask run mode

### DIFF
--- a/src/agent/loop/AgentLoop.ts
+++ b/src/agent/loop/AgentLoop.ts
@@ -11,11 +11,13 @@ import {
   type CanonicalMessage,
   type CanonicalModelError,
   type CanonicalModelRequest,
+  type CanonicalToolSchema,
   type CanonicalUsage,
   materializeMediaReferences,
   type PartialTextToolCallInfo,
 } from "../../model/index.js";
 import type {
+  PilotDeckToolDefinition,
   PilotDeckReadFileStateMap,
   PilotDeckSubagentForkApi,
   PilotDeckToolErrorResult,
@@ -44,6 +46,12 @@ import { LargeFileRepair, type LargeFileRepairDecision } from "./LargeFileRepair
 import { resolveOutputTokenRetryBump } from "./outputTokenRetry.js";
 import { projectToolResults } from "./projectToolResults.js";
 import { requiresPromptCapability } from "../../tool/userInteractionConstraints.js";
+import type { AgentRunMode } from "../protocol/input.js";
+import {
+  ASK_MODE_DESCRIPTION_SUFFIX,
+  isAskModeAllowedTool,
+} from "../../tool/askModeConstraints.js";
+import { buildAskModeAgentToolSchema } from "../../tool/builtin/agent.js";
 
 const TOOL_EVENT_PUMP_INTERVAL_MS = 500;
 const SUBAGENT_STATUS_HEARTBEAT_MS = 2_000;
@@ -68,6 +76,7 @@ export type AgentLoopInput = {
   turnId: string;
   messages: CanonicalMessage[];
   maxTurns?: number;
+  runMode?: AgentRunMode;
   permissionMode?: PermissionMode;
   /** The user's actual permission preference before plan-mode override. */
   basePermissionMode?: PermissionMode;
@@ -110,6 +119,7 @@ export class AgentLoop {
   }
 
   async *run(input: AgentLoopInput): AsyncGenerator<AgentEvent, AgentLoopRunResult, unknown> {
+    this.applyRunModeOverride(input.runMode);
     this.applyPermissionOverrides(input.permissionMode, input.permissionRules, input.basePermissionMode);
     const startedAt = this.now().toISOString();
     let messages = [...input.messages];
@@ -1193,14 +1203,18 @@ export class AgentLoop {
             .filter((tool) => requiresPromptCapability(tool, {}))
             .map((tool) => tool.name),
         );
-    let tools = this.dependencies.tools.registry.toCanonicalSchemas()
+    let toolDefinitions = this.dependencies.tools.registry.list()
       .filter((tool) => !promptBlockedToolNames.has(tool.name));
     if (input.allowPlanModeTools !== true) {
-      tools = tools.filter(
+      toolDefinitions = toolDefinitions.filter(
         (tool) => tool.name !== "enter_plan_mode" && tool.name !== "exit_plan_mode",
       );
     }
     const requestMessages = normalizeMessagesForModelRequest(messages);
+    let tools = toolDefinitions.map(toolToCanonicalSchema);
+    if (this.config.runMode === "ask") {
+      tools = filterAskModeTools(toolDefinitions);
+    }
     const prepared = await contextRuntime.prepareForModel({
       sessionId: input.sessionId,
       turnId: input.turnId,
@@ -1278,6 +1292,7 @@ export class AgentLoop {
       abortSignal: input.abortSignal,
       subagentTimeoutMs: this.config.subagentTimeoutMs,
       toolAliases: this.config.toolAliases,
+      runMode: this.config.runMode ?? "agent",
       permissionMode: this.config.permissionMode,
       permissionContext,
       auditRecorder: this.dependencies.auditRecorder,
@@ -1667,12 +1682,42 @@ export class AgentLoop {
     mergeUserRules(this.config.permissionContext.rules.ask, permissionRules.ask);
   }
 
+  private applyRunModeOverride(runMode?: AgentRunMode): void {
+    if (runMode) {
+      this.config.runMode = runMode;
+    } else {
+      this.config.runMode ??= "agent";
+    }
+  }
+
   private readonly now = (): Date => this.dependencies.now?.() ?? new Date();
 }
 
 function mergeUserRules(target: PermissionRule[], userRules: PermissionRule[] | undefined): void {
   const nonUserRules = target.filter((rule) => rule.source !== "user");
   target.splice(0, target.length, ...nonUserRules, ...(userRules ?? []));
+}
+
+function filterAskModeTools(tools: PilotDeckToolDefinition[]): CanonicalToolSchema[] {
+  const agentOverride = buildAskModeAgentToolSchema();
+  return tools
+    .filter(isAskModeAllowedTool)
+    .map((tool) => {
+      if (tool.name === "agent") {
+        return { ...toolToCanonicalSchema(tool), description: agentOverride.description, inputSchema: agentOverride.inputSchema };
+      }
+      const suffix = ASK_MODE_DESCRIPTION_SUFFIX[tool.name];
+      const schema = toolToCanonicalSchema(tool);
+      return suffix ? { ...schema, description: schema.description + suffix } : schema;
+    });
+}
+
+function toolToCanonicalSchema(tool: PilotDeckToolDefinition): CanonicalToolSchema {
+  return {
+    name: tool.name,
+    description: tool.description,
+    inputSchema: tool.inputSchema,
+  };
 }
 
 function findLifecycleBlock(result: LifecycleDispatchResult): { reason: string; stopReason?: string } | undefined {

--- a/src/agent/protocol/input.ts
+++ b/src/agent/protocol/input.ts
@@ -1,6 +1,8 @@
 import type { CanonicalContentBlock } from "../../model/index.js";
 import type { PermissionMode, PermissionRuleSet } from "../../permission/index.js";
 
+export type AgentRunMode = "agent" | "plan" | "ask";
+
 export type AgentInput =
   | { type: "text"; text: string; isMeta?: boolean }
   | { type: "blocks"; content: CanonicalContentBlock[]; isMeta?: boolean };
@@ -9,6 +11,7 @@ export type AgentSubmitOptions = {
   turnId?: string;
   maxTurns?: number;
   metadata?: Record<string, unknown>;
+  runMode?: AgentRunMode;
   permissionMode?: PermissionMode;
   /** The user's actual permission preference before plan-mode override. */
   basePermissionMode?: PermissionMode;

--- a/src/agent/runtime/AgentRuntimeConfig.ts
+++ b/src/agent/runtime/AgentRuntimeConfig.ts
@@ -1,5 +1,6 @@
 import type { CanonicalThinkingConfig, CanonicalToolChoice, MultimodalConstraints } from "../../model/index.js";
 import type { PermissionContext, PermissionMode } from "../../permission/index.js";
+import type { AgentRunMode } from "../protocol/input.js";
 
 export type AgentRuntimeConfig = {
   provider: string;
@@ -16,6 +17,7 @@ export type AgentRuntimeConfig = {
   toolAliases?: Record<string, string>;
   maxContextMessages?: number;
   stopOnStructuredOutput?: boolean;
+  runMode?: AgentRunMode;
   permissionMode: PermissionMode;
   /** Who last set the current mode: "user" (UI/CLI) or "tool" (enter_plan_mode). */
   permissionModeOrigin?: "user" | "tool";

--- a/src/agent/session/AgentSession.ts
+++ b/src/agent/session/AgentSession.ts
@@ -77,6 +77,7 @@ export class AgentSession {
       messages: this.state.messages,
       input,
       maxTurns: submitOptions.maxTurns,
+      runMode: submitOptions.runMode,
       permissionMode: submitOptions.permissionMode,
       basePermissionMode: submitOptions.basePermissionMode,
       allowPlanModeTools: submitOptions.allowPlanModeTools,

--- a/src/agent/sub/SubAgentSession.ts
+++ b/src/agent/sub/SubAgentSession.ts
@@ -192,7 +192,8 @@ export class SubAgentSession {
     const allowedSet = new Set(this.options.definition.allowedTools);
     const wildcard = allowedSet.has("*");
     const forceReadOnly = this.options.definition.isReadOnly
-      || this.options.parentConfig.permissionMode === "plan";
+      || this.options.parentConfig.permissionMode === "plan"
+      || this.options.parentConfig.runMode === "ask";
     for (const tool of this.options.parentDependencies.tools.registry.list()) {
       if (tool.name === "enter_plan_mode" || tool.name === "exit_plan_mode") {
         continue; // Subagents must not participate in the plan-mode workflow.
@@ -206,8 +207,8 @@ export class SubAgentSession {
       if (tool.name === "ask_user_question") {
         continue; // Subagents have no elicitation channel.
       }
-      if (forceReadOnly && tool.isDestructive?.({} as never) === true) {
-        continue; // S9 — read-only subagents reject destructive tools outright
+      if (forceReadOnly && !tool.isReadOnly({} as never)) {
+        continue; // S9 — read-only subagents reject side-effecting tools outright.
       }
       if (!wildcard && !allowedSet.has(tool.name)) continue;
       scoped.register(tool as PilotDeckToolDefinition);

--- a/src/agent/turn/TurnRunner.ts
+++ b/src/agent/turn/TurnRunner.ts
@@ -1,6 +1,7 @@
 import { agentError, normalizeAgentError } from "../protocol/errors.js";
 import type { AgentEvent } from "../protocol/events.js";
 import type { AgentInput } from "../protocol/input.js";
+import type { AgentRunMode } from "../protocol/input.js";
 import type { AgentTurnResult } from "../protocol/result.js";
 import type { AgentLoop, AgentLoopSeedState } from "../loop/AgentLoop.js";
 import type { AgentTranscriptWriter } from "../../session/transcript/TranscriptWriter.js";
@@ -16,6 +17,7 @@ export type TurnRunnerOptions = {
   messages: CanonicalMessage[];
   input: AgentInput;
   maxTurns?: number;
+  runMode?: AgentRunMode;
   permissionMode?: PermissionMode;
   /** The user's actual permission preference before plan-mode override. */
   basePermissionMode?: PermissionMode;
@@ -114,6 +116,7 @@ export class TurnRunner {
         turnId: options.turnId,
         messages,
         maxTurns: options.maxTurns,
+        runMode: options.runMode,
         permissionMode: options.permissionMode,
         basePermissionMode: options.basePermissionMode,
         allowPlanModeTools: options.allowPlanModeTools,
@@ -167,6 +170,9 @@ function acceptedInputMetadata(options: TurnRunnerOptions): Record<string, unkno
   const metadata: Record<string, unknown> = {};
   if (options.permissionMode) {
     metadata.permissionMode = options.permissionMode;
+  }
+  if (options.runMode) {
+    metadata.runMode = options.runMode;
   }
   if (options.basePermissionMode) {
     metadata.basePermissionMode = options.basePermissionMode;

--- a/src/gateway/client/InProcessGateway.ts
+++ b/src/gateway/client/InProcessGateway.ts
@@ -357,6 +357,8 @@ export class InProcessGateway implements Gateway {
         }
         const permissionSettings = readPermissionSettings();
         const inputMode = normalizeGatewayModeForLegacyInput((input as { mode?: unknown }).mode);
+        const runMode = normalizeGatewayRunMode((input as { runMode?: unknown }).runMode)
+          ?? (inputMode === "plan" ? "plan" : "agent");
         const permissionMode = inputMode ?? (permissionSettings.skipPermissions ? "bypassPermissions" : undefined);
         const basePermissionMode = normalizeGatewayModeForLegacyInput((input as { basePermissionMode?: unknown }).basePermissionMode);
         const allowPlanModeTools = input.allowPlanModeTools ?? inputMode === "plan";
@@ -388,6 +390,7 @@ export class InProcessGateway implements Gateway {
           {
             turnId: runId,
             maxTurns: input.maxTurns,
+            runMode,
             permissionMode,
             basePermissionMode,
             allowPlanModeTools,
@@ -810,6 +813,16 @@ export function normalizeGatewayModeForLegacyInput(value: unknown): GatewaySubmi
     return value;
   }
   return "default";
+}
+
+export function normalizeGatewayRunMode(value: unknown): GatewaySubmitTurnInput["runMode"] | undefined {
+  if (value === undefined || value === null || value === "") {
+    return undefined;
+  }
+  if (value === "agent" || value === "plan" || value === "ask") {
+    return value;
+  }
+  return "agent";
 }
 
 function emitSessionTelemetry(
@@ -1464,6 +1477,7 @@ function normalizePlanCommandInput(input: GatewaySubmitTurnInput): GatewaySubmit
   return {
     ...input,
     message: parsed.message,
+    runMode: "plan",
     mode: "plan",
     basePermissionMode: input.basePermissionMode ?? input.mode ?? "default",
     allowPlanModeTools: true,

--- a/src/gateway/protocol/types.ts
+++ b/src/gateway/protocol/types.ts
@@ -1,4 +1,5 @@
 import type { AgentTurnResult } from "../../agent/index.js";
+import type { AgentRunMode } from "../../agent/protocol/input.js";
 import type {
   CronCreateInput,
   CronCreateResult,
@@ -78,6 +79,7 @@ export type GatewaySubmitTurnInput = {
   /** Override the agent session's working directory for this session. */
   workspaceCwd?: string;
   attachments?: ChannelAttachment[];
+  runMode?: AgentRunMode;
   mode?: GatewayMode;
   /** The user's actual permission preference before plan-mode override. */
   basePermissionMode?: GatewayMode;

--- a/src/tool/askModeConstraints.ts
+++ b/src/tool/askModeConstraints.ts
@@ -1,0 +1,88 @@
+/**
+ * Ask mode is a read-only run mode. Permission mode can still be
+ * `default` or `bypassPermissions`, but it must not grant write access.
+ */
+
+import type { PilotDeckToolDefinition } from "./protocol/types.js";
+import { isReadOnlyShellCommand } from "./builtin/bash/permissions.js";
+
+export const ASK_MODE_ALLOWED_TOOLS = new Set([
+  "read_file",
+  "grep",
+  "glob",
+  "web_search",
+  "web_fetch",
+  "ask_user_question",
+  "read_skill",
+  "structured_output",
+  "agent",
+  "bash",
+]);
+
+export const ASK_MODE_DESCRIPTION_SUFFIX: Record<string, string> = {
+  bash: "\n\n[ASK MODE] READ-ONLY commands only. Write/modify/delete commands will be rejected.",
+  agent: "\n\n[ASK MODE] Subagents inherit ask mode and the same permission setting. They can read and search, but cannot modify files.",
+};
+
+const ASK_MODE_VIOLATION_HEADER = "[ASK_MODE_VIOLATION]";
+
+export function isAskModeAllowedTool(tool: PilotDeckToolDefinition): boolean {
+  if (tool.kind === "mcp") {
+    return tool.isReadOnly({} as never);
+  }
+  return ASK_MODE_ALLOWED_TOOLS.has(tool.name);
+}
+
+export function buildAskModeViolationMessage(toolName: string): string {
+  return [
+    `${ASK_MODE_VIOLATION_HEADER} Tool "${toolName}" is BLOCKED in ask mode.`,
+    "",
+    "Ask mode is read-only. Tools may inspect files, search, ask questions, fetch/read external content, or launch read-only subagents, but they cannot modify files or create side effects.",
+    "",
+    "Do NOT retry this tool. It will fail again while ask mode is active.",
+  ].join("\n");
+}
+
+export function buildAskModeBashViolationMessage(command: string): string {
+  const truncated = command.length > 120 ? command.slice(0, 120) + "…" : command;
+  return [
+    `${ASK_MODE_VIOLATION_HEADER} bash command "${truncated}" is BLOCKED because it is not read-only.`,
+    "",
+    "In ask mode, bash is restricted to read-only commands only (pwd, ls, cat, head, wc, git status, git diff, git log, git show, find without write actions, etc.).",
+  ].join("\n");
+}
+
+export function getAskModeViolation(
+  tool: PilotDeckToolDefinition,
+  input: unknown,
+): string | undefined {
+  if (!isAskModeAllowedTool(tool)) {
+    return buildAskModeViolationMessage(tool.name);
+  }
+
+  if (tool.name === "bash") {
+    const command = readStringProperty(input, "command");
+    if (!command || !isReadOnlyShellCommand(command)) {
+      return buildAskModeBashViolationMessage(command ?? "");
+    }
+    return undefined;
+  }
+
+  if (!tool.isReadOnly(input) && tool.name !== "agent") {
+    return buildAskModeViolationMessage(tool.name);
+  }
+
+  return undefined;
+}
+
+function readStringProperty(input: unknown, key: string): string | undefined {
+  if (!input || typeof input !== "object") {
+    return undefined;
+  }
+  const value = (input as Record<string, unknown>)[key];
+  return typeof value === "string" ? value : undefined;
+}
+
+export function isAskModeViolationText(text: unknown): boolean {
+  return typeof text === "string" && text.includes(ASK_MODE_VIOLATION_HEADER);
+}

--- a/src/tool/builtin/agent.ts
+++ b/src/tool/builtin/agent.ts
@@ -169,7 +169,7 @@ export function createAgentTool(
       // Full fork path (C2): preferred when AgentLoop wired the fork API.
       if (context.subagent) {
         let requestedType = explicit ?? "general-purpose";
-        if (context.permissionContext?.mode === "plan" && requestedType === "general-purpose") {
+        if ((context.permissionContext?.mode === "plan" || context.runMode === "ask") && requestedType === "general-purpose") {
           requestedType = "explore";
         }
         return runFullFork({
@@ -181,7 +181,7 @@ export function createAgentTool(
         });
       }
       let requestedType = explicit ?? "general-purpose";
-      if (context.permissionContext?.mode === "plan" && requestedType === "general-purpose") {
+      if ((context.permissionContext?.mode === "plan" || context.runMode === "ask") && requestedType === "general-purpose") {
         requestedType = "explore";
       }
 
@@ -233,6 +233,64 @@ function buildAgentToolDescription(): string {
     "- Inside the AgentLoop, this runs a real forked subagent with its own scoped tool loop.",
     "- In stand-alone runtimes and some tests, it falls back to a single model call that preserves the same high-level subagent intent.",
   ].join("\n");
+}
+
+const ASK_MODE_SUBAGENT_TYPES = ["explore", "plan", "verify"] as const;
+
+export function buildAskModeAgentToolSchema(): {
+  description: string;
+  inputSchema: Record<string, unknown>;
+} {
+  const typeLines = ASK_MODE_SUBAGENT_TYPES
+    .map((id) => {
+      const definition = SUBAGENT_DEFINITIONS[id];
+      return `- ${id}: ${definition.description} Tools: ${definition.allowedTools.join(", ")}.`;
+    })
+    .join("\n");
+
+  const description = [
+    "Launch a read-only subagent for investigation, planning, or verification.",
+    "",
+    "In ask mode, subagents inherit ask mode and the same permission setting. Only read-only subagent types are available; 'general-purpose' is treated as 'explore'.",
+    "",
+    "Provide:",
+    "- `description`: a short 3-5 word label for the task.",
+    "- `prompt`: the full directive for the subagent. Include goal, context, constraints, and what good output looks like. The subagent can only read and search; it cannot modify files.",
+    "- `subagent_type` (optional): 'explore', 'plan', or 'verify'. Defaults to 'explore'.",
+    "",
+    "Available subagent types:",
+    typeLines,
+    "",
+    "The subagent returns one structured report with these sections: `Scope`, `Result`, `Key files`, `Files changed`, and `Issues`.",
+  ].join("\n");
+
+  const inputSchema: Record<string, unknown> = {
+    type: "object",
+    required: ["description", "prompt"],
+    additionalProperties: false,
+    properties: {
+      description: {
+        type: "string",
+        description: "Short 3-5 word task summary used to label the subagent run.",
+      },
+      prompt: {
+        type: "string",
+        description:
+          "Detailed directive for the subagent. Include the goal, relevant context, constraints, and desired output. The subagent can only read and search; it cannot modify files.",
+      },
+      subagent_type: {
+        type: "string",
+        description:
+          "Subagent preset. In ask mode only 'explore', 'plan', and 'verify' are available. Defaults to 'explore'.",
+      },
+      subagentType: {
+        type: "string",
+        description: "Deprecated legacy alias for subagent_type. Prefer subagent_type.",
+      },
+    },
+  };
+
+  return { description, inputSchema };
 }
 
 function normalizeRequestedSubagentType(value: string | undefined): string | undefined {

--- a/src/tool/execution/ToolRuntime.ts
+++ b/src/tool/execution/ToolRuntime.ts
@@ -8,6 +8,7 @@ import {
   buildPlanModeBashViolationMessage,
   buildPlanModeViolationMessage,
 } from "../planModeConstraints.js";
+import { getAskModeViolation } from "../askModeConstraints.js";
 import { isReadOnlyShellCommand } from "../builtin/bash/permissions.js";
 import {
   applyResultSizeLimit,
@@ -67,6 +68,20 @@ export class ToolRuntime {
         tool.name,
         "plan_mode_violation",
         planModeViolation,
+        startedAt,
+        context,
+      );
+    }
+
+    const askModeViolation = context.runMode === "ask"
+      ? getAskModeViolation(tool, call.input)
+      : undefined;
+    if (askModeViolation) {
+      return this.errorResult(
+        call.id,
+        tool.name,
+        "ask_mode_violation",
+        askModeViolation,
         startedAt,
         context,
       );

--- a/src/tool/index.ts
+++ b/src/tool/index.ts
@@ -206,3 +206,12 @@ export {
   buildPlanModeBashViolationMessage,
   isPlanModeViolationText,
 } from "./planModeConstraints.js";
+export {
+  ASK_MODE_ALLOWED_TOOLS,
+  ASK_MODE_DESCRIPTION_SUFFIX,
+  buildAskModeViolationMessage,
+  buildAskModeBashViolationMessage,
+  getAskModeViolation,
+  isAskModeAllowedTool,
+  isAskModeViolationText,
+} from "./askModeConstraints.js";

--- a/src/tool/protocol/errors.ts
+++ b/src/tool/protocol/errors.ts
@@ -13,7 +13,8 @@ export type PilotDeckToolErrorCode =
   | "file_conflict"
   | "unsupported_tool"
   | "setup_required"
-  | "plan_mode_violation";
+  | "plan_mode_violation"
+  | "ask_mode_violation";
 
 export type PilotDeckToolError = {
   code: PilotDeckToolErrorCode;

--- a/src/tool/protocol/types.ts
+++ b/src/tool/protocol/types.ts
@@ -11,6 +11,7 @@ import type {
   PermissionMode,
   PermissionResult,
 } from "../../permission/index.js";
+import type { AgentRunMode } from "../../agent/protocol/input.js";
 import type { PilotDeckToolAuditRecorder } from "../audit/ToolAuditRecorder.js";
 import type { PilotDeckElicitationChannel } from "../elicitation/PilotDeckElicitationChannel.js";
 import type { PilotDeckToolInputSchema, PilotDeckToolValidationResult } from "./schema.js";
@@ -202,6 +203,7 @@ export type PilotDeckToolRuntimeContext = {
   now?: () => Date;
   env?: NodeJS.ProcessEnv;
   maxResultBytes?: number;
+  runMode?: AgentRunMode;
   /**
    * Optional streaming progress sink. Tools that produce incremental output
    * (e.g. `bash` stdout/stderr chunks) can call this to emit progress events

--- a/src/web/client/index.ts
+++ b/src/web/client/index.ts
@@ -18,6 +18,7 @@ export {
   type WebGatewayFrame,
   type WebGatewayMethod,
   type WebGatewayMode,
+  type WebAgentRunMode,
   type WebHelloOk,
   type WebListProjectsResult,
   type WebListSessionsInput,

--- a/src/web/client/protocol.ts
+++ b/src/web/client/protocol.ts
@@ -16,6 +16,11 @@ export type WebGatewayMode =
   | "plan"
   | "bypassPermissions";
 
+export type WebAgentRunMode =
+  | "agent"
+  | "plan"
+  | "ask";
+
 export type WebGatewayChannelKey =
   | "cli"
   | "tui"
@@ -132,6 +137,7 @@ export type WebSubmitTurnInput = {
   message: string;
   projectKey?: string;
   attachments?: WebChannelAttachment[];
+  runMode?: WebAgentRunMode;
   mode?: WebGatewayMode;
   basePermissionMode?: WebGatewayMode;
   /** Allow model-visible plan mode tools. Defaults to true only for explicit plan-mode turns. */
@@ -275,6 +281,7 @@ export type WebForkSessionResult = {
   newSessionKey: string;
   prefillText: string;
   carriedMessageCount: number;
+  runMode?: WebAgentRunMode;
   mode?: WebGatewayMode;
 };
 

--- a/src/web/server/forkSession.ts
+++ b/src/web/server/forkSession.ts
@@ -22,7 +22,7 @@ import type {
   AgentSessionMetadataTranscriptEntry,
   AgentTranscriptEntry,
 } from "../../session/transcript/TranscriptEntry.js";
-import type { WebGatewayMode, WebForkSessionInput, WebForkSessionResult } from "../client/protocol.js";
+import type { WebAgentRunMode, WebGatewayMode, WebForkSessionInput, WebForkSessionResult } from "../client/protocol.js";
 
 export type ForkWebSessionOptions = {
   projectRoot: string;
@@ -55,6 +55,11 @@ function hasUnsupportedPrefillContent(entry: AgentAcceptedInputTranscriptEntry):
 
 function getForkMode(entry: AgentAcceptedInputTranscriptEntry): WebGatewayMode | undefined {
   return entry.metadata?.permissionMode === "plan" ? "plan" : undefined;
+}
+
+function getForkRunMode(entry: AgentAcceptedInputTranscriptEntry): WebAgentRunMode | undefined {
+  const value = entry.metadata?.runMode;
+  return value === "agent" || value === "plan" || value === "ask" ? value : undefined;
 }
 
 function buildForkTitle(
@@ -463,6 +468,7 @@ export async function forkWebSession(
     );
   }
   const forkMode = getForkMode(forkAcceptedInput);
+  const forkRunMode = getForkRunMode(forkAcceptedInput);
   const preservedSourceEntries = entries.filter((entry) => shouldPreserveSourceEntry(entry, forkPoint));
   const forkInputText = extractAcceptedInputText(forkAcceptedInput);
   const prefillText = forkPoint.preserveTarget ? "" : forkInputText;
@@ -526,6 +532,7 @@ export async function forkWebSession(
     newSessionKey,
     prefillText,
     carriedMessageCount,
+    ...(forkRunMode ? { runMode: forkRunMode } : {}),
     ...(forkMode ? { mode: forkMode } : {}),
   };
 }

--- a/tests/model/catalogOutputTokens.test.ts
+++ b/tests/model/catalogOutputTokens.test.ts
@@ -30,11 +30,11 @@ describe("provider catalog output token caps", () => {
     assert.equal(dashscope?.defaultUrl, "https://dashscope.aliyuncs.com/compatible-mode/v1");
     assert.equal(dashscope?.apiKeyEnvVar, "DASHSCOPE_API_KEY");
     assert.equal(dashscope?.models["qwen3.7-plus"]?.capabilities.supportsToolUse, true);
-    assert.equal(dashscope?.models["qwen3.7-plus"]?.multimodal.input.includes("image"), true);
-    assert.equal(dashscope?.models["qwen3.6-flash"]?.multimodal.input.includes("image"), false);
+    assert.equal(dashscope?.models["qwen3.7-plus"]?.multimodal?.input.includes("image"), true);
+    assert.equal(dashscope?.models["qwen3.6-flash"]?.multimodal?.input.includes("image"), false);
     assert.equal(dashscope?.models["qwen-max"]?.capabilities.maxOutputTokens, 2_000);
     assert.equal(dashscope?.models["qwen-plus"]?.capabilities.maxContextTokens, 131_072);
-    assert.equal(dashscope?.models["qwen-turbo"]?.aliases.includes("qwen-turbo-latest"), true);
+    assert.equal(dashscope?.models["qwen-turbo"]?.aliases?.includes("qwen-turbo-latest"), true);
 
     const zhipu = PROVIDER_CATALOG.zhipu;
     assert.equal(zhipu?.protocol, "openai");
@@ -44,7 +44,7 @@ describe("provider catalog output token caps", () => {
     assert.equal(zhipu?.models["glm-4.6"]?.capabilities.maxOutputTokens, 131_072);
     assert.equal(zhipu?.models["glm-4.7"]?.capabilities.maxContextTokens, 200_000);
     assert.equal(zhipu?.models["glm-4-plus"]?.capabilities.maxOutputTokens, 8_192);
-    assert.equal(zhipu?.models["glm-4-flash-250414"]?.aliases.includes("GLM-4-Flash-250414"), true);
+    assert.equal(zhipu?.models["glm-4-flash-250414"]?.aliases?.includes("GLM-4-Flash-250414"), true);
   });
 
   it("infers DashScope and Zhipu protocol and URLs from the catalog", () => {

--- a/ui/server/pilotdeck-bridge.js
+++ b/ui/server/pilotdeck-bridge.js
@@ -317,6 +317,12 @@ function normalizePermissionMode(value) {
     return 'default';
 }
 
+function normalizeRunMode(value) {
+    if (value === undefined || value === null || value === '') return undefined;
+    if (value === 'agent' || value === 'plan' || value === 'ask') return value;
+    return 'agent';
+}
+
 function resolvePermissionMode(options) {
     const explicit = normalizePermissionMode(options?.permissionMode || options?.mode);
     // A literal "default" from the chat composer is the implicit
@@ -893,7 +899,8 @@ export async function runChatViaGateway(
     ];
     const resolvedMode = resolvePermissionMode(options);
     const basePermissionMode = normalizePermissionMode(options?.basePermissionMode);
-    console.log(`[pilotdeck-bridge] submitTurn mode=${resolvedMode} (options.permissionMode=${options?.permissionMode}, options.mode=${options?.mode})`);
+    const runMode = normalizeRunMode(options?.runMode) || (resolvedMode === 'plan' ? 'plan' : 'agent');
+    console.log(`[pilotdeck-bridge] submitTurn runMode=${runMode} mode=${resolvedMode} (options.permissionMode=${options?.permissionMode}, options.mode=${options?.mode})`);
 
     try {
         const stream = gw.submitTurn({
@@ -901,6 +908,7 @@ export async function runChatViaGateway(
             channelKey,
             projectKey,
             message: command ?? '',
+            runMode,
             mode: resolvedMode,
             runId,
             ...(basePermissionMode ? { basePermissionMode } : {}),

--- a/ui/src/components/chat-v2/ChatInterfaceV2.tsx
+++ b/ui/src/components/chat-v2/ChatInterfaceV2.tsx
@@ -96,7 +96,11 @@ function ChatInterfaceV2({
   } = useChatProviderState({ selectedSession });
 
   const cycleRunMode = useCallback(() => {
-    setRunMode((currentMode) => (currentMode === 'plan' ? 'agent' : 'plan'));
+    setRunMode((currentMode) => {
+      if (currentMode === 'agent') return 'plan';
+      if (currentMode === 'plan') return 'ask';
+      return 'agent';
+    });
   }, []);
 
   const selectPermissionMode = useCallback((mode: typeof permissionMode) => {
@@ -211,6 +215,7 @@ function ChatInterfaceV2({
     selectedSession,
     currentSessionId,
     model,
+    runMode,
     permissionMode: effectivePermissionMode,
     basePermissionMode: permissionMode,
     cycleRunMode,
@@ -333,7 +338,7 @@ function ChatInterfaceV2({
     setIsForkPending(true);
     try {
       const response = await api.forkSession(sessionId, { projectPath, fromEntryId });
-      let result: { newSessionId?: string; prefillText?: string; mode?: string; error?: string } = {};
+      let result: { newSessionId?: string; prefillText?: string; runMode?: string; mode?: string; error?: string } = {};
       try {
         result = await response.json();
       } catch {
@@ -346,7 +351,7 @@ function ChatInterfaceV2({
       if (!newSessionId) {
         throw new Error('Fork did not return a new session id');
       }
-      setRunMode(result.mode === 'plan' ? 'plan' : 'agent');
+      setRunMode(result.runMode === 'ask' ? 'ask' : result.mode === 'plan' || result.runMode === 'plan' ? 'plan' : 'agent');
 
       if (typeof window.refreshProjects === 'function') {
         try {

--- a/ui/src/components/chat-v2/ComposerV2.tsx
+++ b/ui/src/components/chat-v2/ComposerV2.tsx
@@ -16,6 +16,7 @@ import {
   Check,
   ChevronDown,
   CircleGauge,
+  CircleHelp,
   Hand,
   ListChecks,
   Loader2,
@@ -174,6 +175,12 @@ const RUN_MODE_OPTIONS: RunModeOption[] = [
     Icon: ListChecks,
     labelKey: 'input.runModes.plan',
     defaultLabel: 'Plan',
+  },
+  {
+    mode: 'ask',
+    Icon: CircleHelp,
+    labelKey: 'input.runModes.ask',
+    defaultLabel: 'Ask',
   },
 ];
 
@@ -481,6 +488,8 @@ export default function ComposerV2({
                           'inline-flex h-7 max-w-[108px] items-center justify-center gap-1.5 rounded-md px-2 text-[12px] font-medium transition sm:max-w-[140px]',
                           runMode === 'plan'
                             ? 'text-blue-600 hover:bg-blue-50 dark:text-blue-300 dark:hover:bg-blue-950/30'
+                            : runMode === 'ask'
+                              ? 'text-emerald-600 hover:bg-emerald-50 dark:text-emerald-300 dark:hover:bg-emerald-950/30'
                             : 'text-neutral-600 hover:bg-neutral-100 dark:text-neutral-300 dark:hover:bg-neutral-800',
                         )}
                         title={t('input.runModes.change', {
@@ -508,6 +517,7 @@ export default function ComposerV2({
                             const Icon = option.Icon;
                             const isSelected = runMode === option.mode;
                             const isPlan = option.mode === 'plan';
+                            const isAsk = option.mode === 'ask';
                             const optionDisabled = isPlan && !planModeAvailable;
                             const label = t(option.labelKey, {
                               defaultValue: option.defaultLabel,
@@ -516,6 +526,10 @@ export default function ComposerV2({
                               ? (t('input.runModes.planDescription', {
                                   defaultValue: 'Generate a plan first, then execute after confirmation',
                                 }) as string)
+                              : isAsk
+                                ? (t('input.runModes.askDescription', {
+                                    defaultValue: 'Read-only analysis with optional subagents',
+                                  }) as string)
                               : (t('input.runModes.agentDescription', {
                                   defaultValue: 'Directly process and execute the task',
                                 }) as string);
@@ -546,6 +560,8 @@ export default function ComposerV2({
                                     'h-4 w-4 shrink-0',
                                     isPlan
                                       ? 'text-blue-600 dark:text-blue-300'
+                                      : isAsk
+                                        ? 'text-emerald-600 dark:text-emerald-300'
                                       : 'text-neutral-500 dark:text-neutral-400',
                                   )}
                                   strokeWidth={1.9}
@@ -556,6 +572,8 @@ export default function ComposerV2({
                                       'block truncate text-[13px] font-medium',
                                       isPlan
                                         ? 'text-blue-700 dark:text-blue-300'
+                                        : isAsk
+                                          ? 'text-emerald-700 dark:text-emerald-300'
                                         : 'text-neutral-900 dark:text-neutral-100',
                                     )}
                                   >

--- a/ui/src/components/chat/hooks/useChatComposerState.ts
+++ b/ui/src/components/chat/hooks/useChatComposerState.ts
@@ -45,6 +45,7 @@ interface UseChatComposerStateArgs {
   model: string;
   permissionMode: PermissionMode | string;
   basePermissionMode?: PermissionMode | string;
+  runMode?: string;
   cycleRunMode: () => void;
   isLoading: boolean;
   canAbortSession: boolean;
@@ -142,6 +143,7 @@ export function useChatComposerState({
   model,
   permissionMode,
   basePermissionMode,
+  runMode,
   cycleRunMode,
   isLoading,
   canAbortSession,
@@ -791,6 +793,7 @@ export function useChatComposerState({
         sessionId: effectiveSessionId,
         temporarySessionId: sessionToActivate,
         toolsSettings,
+        runMode,
         permissionMode,
         basePermissionMode,
         model,
@@ -824,6 +827,7 @@ export function useChatComposerState({
       onSessionActivityBump,
       onSessionProcessing,
       pendingViewSessionRef,
+      runMode,
       permissionMode,
       basePermissionMode,
       resetCommandMenuState,

--- a/ui/src/components/chat/types/types.ts
+++ b/ui/src/components/chat/types/types.ts
@@ -7,7 +7,7 @@ import type {
 export type Provider = SessionProvider;
 
 export type PermissionMode = 'default' | 'bypassPermissions' | 'plan';
-export type ChatRunMode = 'agent' | 'plan';
+export type ChatRunMode = 'agent' | 'plan' | 'ask';
 
 export interface ChatImage {
   data: string;

--- a/ui/src/components/chat/utils/sessionLauncher.ts
+++ b/ui/src/components/chat/utils/sessionLauncher.ts
@@ -1,5 +1,5 @@
 import type { Project, ProjectSession } from '../../../types/app';
-import type { ChatAttachment, PilotDeckSettings, PermissionMode } from '../types/types';
+import type { ChatAttachment, ChatRunMode, PilotDeckSettings, PermissionMode } from '../types/types';
 import { getPilotDeckSettings, safeLocalStorage } from './chatStorage';
 
 type StartSessionOptions = {
@@ -11,6 +11,7 @@ type StartSessionOptions = {
   temporarySessionId?: string;
   permissionMode?: PermissionMode | string;
   basePermissionMode?: PermissionMode | string;
+  runMode?: ChatRunMode | string;
   model?: string;
   sessionSummary?: string | null;
   toolsSettings?: PilotDeckSettings;
@@ -85,6 +86,7 @@ export function startSessionCommand({
   temporarySessionId,
   permissionMode = 'default',
   basePermissionMode,
+  runMode,
   model,
   sessionSummary,
   toolsSettings = getPilotDeckSettings(),
@@ -106,6 +108,7 @@ export function startSessionCommand({
       projectPath: resolvedProjectPath,
       cwd: resolvedProjectPath,
       toolsSettings,
+      ...(runMode ? { runMode } : {}),
       permissionMode,
       ...(basePermissionMode ? { basePermissionMode } : {}),
       ...(model ? { model } : {}),

--- a/ui/src/i18n/locales/en/chat.json
+++ b/ui/src/i18n/locales/en/chat.json
@@ -263,9 +263,11 @@
     "runModes": {
       "agent": "Agent",
       "plan": "Plan",
+      "ask": "Ask",
       "change": "Select run mode",
       "agentDescription": "Directly process and execute the task",
-      "planDescription": "Generate a plan first, then execute after confirmation"
+      "planDescription": "Generate a plan first, then execute after confirmation",
+      "askDescription": "Read-only analysis with optional subagents"
     }
   },
   "commandMenu": {

--- a/ui/src/i18n/locales/zh-CN/chat.json
+++ b/ui/src/i18n/locales/zh-CN/chat.json
@@ -246,9 +246,11 @@
     "runModes": {
       "agent": "智能体",
       "plan": "计划",
+      "ask": "询问",
       "change": "选择运行模式",
       "agentDescription": "直接处理并执行任务",
-      "planDescription": "先产出计划，确认后再执行"
+      "planDescription": "先产出计划，确认后再执行",
+      "askDescription": "只读分析，可使用只读子智能体"
     }
   },
   "commandMenu": {


### PR DESCRIPTION
## Summary
- Add `runMode: "ask"` as a read-only capability ceiling separate from permission mode.
- Keep `default` / `bypassPermissions` selectable in Ask mode while preventing writes even under bypass.
- Keep subagents enabled in Ask mode and downgrade general-purpose requests to read-only exploration.

## Validation
- `npm test`
- `npm --prefix ui run build`
- `git diff --check`

## Notes
- Includes a small follow-up fix for strict optional catalog test fields introduced by the latest upstream main.