### PR TITLE
feat: support OpenAI Responses API

### DIFF
--- a/src/context/memory/createEdgeClawMemoryProviderFromConfig.ts
+++ b/src/context/memory/createEdgeClawMemoryProviderFromConfig.ts
@@ -105,6 +105,7 @@ function resolveMemoryLlm(
 
 function memoryApiTypeForProtocol(protocol: ModelProtocol | undefined): PilotMemoryConfig["apiType"] | "openai-completions" | undefined {
   if (protocol === "anthropic" || protocol === "google") return protocol;
+  if (protocol === "openai-responses") return "openai-responses";
   if (protocol === "openai") return "openai-completions";
   return undefined;
 }

--- a/src/model/catalog/providers.ts
+++ b/src/model/catalog/providers.ts
@@ -250,6 +250,138 @@ export const PROVIDER_CATALOG: ProviderCatalog = {
     },
   },
 
+  // ── OpenAI Responses API ──────────────────────────────────────────────
+
+  "openai-responses": {
+    displayName: "OpenAI (Responses API)",
+    protocol: "openai-responses",
+    defaultUrl: "https://api.openai.com/v1",
+    apiKeyEnvVar: "OPENAI_API_KEY",
+    models: {
+      "gpt-4o": {
+        displayName: "GPT-4o",
+        capabilities: {
+          supportsToolUse: true,
+          supportsStreaming: true,
+          supportsParallelToolCalls: true,
+          supportsThinking: false,
+          supportsJsonSchema: true,
+          supportsSystemPrompt: true,
+          supportsPromptCache: false,
+          maxContextTokens: 128000,
+          maxOutputTokens: 16384,
+        },
+        multimodal: {
+          input: ["text", "image"],
+          maxImagesPerRequest: 20,
+          supportedImageMimeTypes: ["image/jpeg", "image/png", "image/gif", "image/webp"],
+          imageDetail: "auto",
+        },
+        aliases: ["gpt-4o-2024-11-20"],
+      },
+      "gpt-4o-mini": {
+        displayName: "GPT-4o Mini",
+        capabilities: {
+          supportsToolUse: true,
+          supportsStreaming: true,
+          supportsParallelToolCalls: true,
+          supportsThinking: false,
+          supportsJsonSchema: true,
+          supportsSystemPrompt: true,
+          supportsPromptCache: false,
+          maxContextTokens: 128000,
+          maxOutputTokens: 16384,
+        },
+        multimodal: {
+          input: ["text", "image"],
+          maxImagesPerRequest: 20,
+          supportedImageMimeTypes: ["image/jpeg", "image/png", "image/gif", "image/webp"],
+          imageDetail: "auto",
+        },
+        aliases: [],
+      },
+      "gpt-4.1": {
+        displayName: "GPT-4.1",
+        capabilities: {
+          supportsToolUse: true,
+          supportsStreaming: true,
+          supportsParallelToolCalls: true,
+          supportsThinking: false,
+          supportsJsonSchema: true,
+          supportsSystemPrompt: true,
+          supportsPromptCache: false,
+          maxContextTokens: 1047576,
+          maxOutputTokens: 32768,
+        },
+        multimodal: {
+          input: ["text", "image"],
+          maxImagesPerRequest: 20,
+          supportedImageMimeTypes: ["image/jpeg", "image/png", "image/gif", "image/webp"],
+          imageDetail: "auto",
+        },
+        aliases: [],
+      },
+      "gpt-4.1-mini": {
+        displayName: "GPT-4.1 Mini",
+        capabilities: {
+          supportsToolUse: true,
+          supportsStreaming: true,
+          supportsParallelToolCalls: true,
+          supportsThinking: false,
+          supportsJsonSchema: true,
+          supportsSystemPrompt: true,
+          supportsPromptCache: false,
+          maxContextTokens: 1047576,
+          maxOutputTokens: 32768,
+        },
+        multimodal: {
+          input: ["text", "image"],
+          maxImagesPerRequest: 20,
+          supportedImageMimeTypes: ["image/jpeg", "image/png", "image/gif", "image/webp"],
+          imageDetail: "auto",
+        },
+        aliases: [],
+      },
+      "o3": {
+        displayName: "o3",
+        capabilities: {
+          supportsToolUse: true,
+          supportsStreaming: true,
+          supportsParallelToolCalls: false,
+          supportsThinking: true,
+          supportsJsonSchema: true,
+          supportsSystemPrompt: true,
+          supportsPromptCache: false,
+          maxContextTokens: 200000,
+          maxOutputTokens: 100000,
+        },
+        multimodal: {
+          input: ["text", "image"],
+          maxImagesPerRequest: 20,
+          supportedImageMimeTypes: ["image/jpeg", "image/png", "image/gif", "image/webp"],
+          imageDetail: "auto",
+        },
+        aliases: [],
+      },
+      "o3-mini": {
+        displayName: "o3 Mini",
+        capabilities: {
+          supportsToolUse: true,
+          supportsStreaming: true,
+          supportsParallelToolCalls: false,
+          supportsThinking: true,
+          supportsJsonSchema: true,
+          supportsSystemPrompt: true,
+          supportsPromptCache: false,
+          maxContextTokens: 200000,
+          maxOutputTokens: 100000,
+        },
+        multimodal: { input: ["text"] },
+        aliases: [],
+      },
+    },
+  },
+
   // ── Alibaba Cloud Model Studio / DashScope ────────────────────────────
 
   dashscope: {

--- a/src/model/config/schema.ts
+++ b/src/model/config/schema.ts
@@ -33,5 +33,5 @@ export function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 export function isModelProtocol(value: unknown): value is ModelProtocol {
-  return value === "anthropic" || value === "openai" || value === "google";
+  return value === "anthropic" || value === "openai" || value === "openai-responses" || value === "google";
 }

--- a/src/model/protocol/canonical.ts
+++ b/src/model/protocol/canonical.ts
@@ -2,7 +2,7 @@ import type { ModelCapabilities } from "./capabilities.js";
 import type { CanonicalModelError } from "./errors.js";
 import type { MultimodalConstraints } from "./multimodal.js";
 
-export type ModelProtocol = "anthropic" | "openai" | "google";
+export type ModelProtocol = "anthropic" | "openai" | "openai-responses" | "google";
 
 export type CanonicalRole = "user" | "assistant";
 

--- a/src/model/protocol/errors.ts
+++ b/src/model/protocol/errors.ts
@@ -25,7 +25,7 @@ export type SettingsFix = {
 
 export type CanonicalModelError = {
   provider: string;
-  protocol: "anthropic" | "openai" | "google";
+  protocol: "anthropic" | "openai" | "openai-responses" | "google";
   code: CanonicalModelErrorCode | (string & {});
   status?: number;
   message: string;

--- a/src/model/providers/openai-responses/request.ts
+++ b/src/model/providers/openai-responses/request.ts
@@ -1,0 +1,216 @@
+import type {
+  CanonicalContentBlock,
+  CanonicalMessage,
+  CanonicalToolChoice,
+  CanonicalToolSchema,
+  ModelDefinition,
+  ProviderConfig,
+  CanonicalModelRequest,
+} from "../../protocol/canonical.js";
+import { flattenToolResultBlockText } from "../../protocol/toolResultContent.js";
+import { normalizeOpenAISchema } from "../openai/request.js";
+
+export type OpenAIResponsesRequestBody = {
+  model: string;
+  input: OpenAIResponsesInputItem[];
+  instructions?: string;
+  max_output_tokens: number;
+  stream?: boolean;
+  temperature?: number;
+  metadata?: Record<string, unknown>;
+  tools?: OpenAIResponsesTool[];
+  tool_choice?: unknown;
+  text?: {
+    format: {
+      type: "json_schema";
+      name: string;
+      description?: string;
+      schema: Record<string, unknown>;
+      strict?: boolean;
+    };
+  };
+  store?: boolean;
+};
+
+type OpenAIResponsesInputItem =
+  | {
+      role: "user" | "assistant";
+      content: Array<Record<string, unknown>>;
+    }
+  | {
+      type: "function_call";
+      call_id: string;
+      name: string;
+      arguments: string;
+    }
+  | {
+      type: "function_call_output";
+      call_id: string;
+      output: string;
+    };
+
+type OpenAIResponsesTool = {
+  type: "function";
+  name: string;
+  description?: string;
+  parameters: Record<string, unknown>;
+  strict: true;
+};
+
+export function buildOpenAIResponsesRequest(
+  request: CanonicalModelRequest,
+  model: ModelDefinition,
+  _provider?: ProviderConfig,
+): OpenAIResponsesRequestBody {
+  const body: OpenAIResponsesRequestBody = {
+    model: request.model,
+    input: request.messages.flatMap(toResponsesInputItems),
+    instructions: request.systemPrompt,
+    max_output_tokens: request.maxOutputTokens ?? model.capabilities.maxOutputTokens,
+    tools: request.tools?.map(toResponsesTool),
+    tool_choice: toResponsesToolChoice(request.toolChoice),
+    temperature: request.temperature,
+    stream: request.stream,
+    metadata: request.metadata
+      ? Object.fromEntries(
+          Object.entries(request.metadata).map(([key, value]) => [key, String(value)]),
+        )
+      : undefined,
+    store: false,
+  };
+
+  if (request.outputSchema) {
+    body.text = {
+      format: {
+        type: "json_schema",
+        name: request.outputSchema.name,
+        description: request.outputSchema.description,
+        schema: request.outputSchema.schema,
+        strict: request.outputSchema.strict ?? true,
+      },
+    };
+  }
+
+  return body;
+}
+
+function toResponsesInputItems(message: CanonicalMessage): OpenAIResponsesInputItem[] {
+  const items: OpenAIResponsesInputItem[] = [];
+  const normalContent: CanonicalContentBlock[] = [];
+
+  const flushContent = () => {
+    if (normalContent.length === 0) return;
+    const content = normalContent.flatMap((block) => toResponsesContentPart(block, message.role));
+    if (content.length > 0) {
+      items.push({ role: message.role, content });
+    }
+    normalContent.length = 0;
+  };
+
+  for (const block of message.content) {
+    if (block.type === "tool_call") {
+      flushContent();
+      items.push({
+        type: "function_call",
+        call_id: block.id,
+        name: block.name,
+        arguments: JSON.stringify(block.input ?? {}),
+      });
+      continue;
+    }
+
+    if (block.type === "tool_result") {
+      flushContent();
+      items.push({
+        type: "function_call_output",
+        call_id: block.toolCallId,
+        output: flattenToolResultBlockText(block),
+      });
+      const visualContent = block.content.filter((part) => part.type === "image" || part.type === "pdf");
+      if (visualContent.length > 0) {
+        items.push({
+          role: "user",
+          content: [
+            { type: "input_text", text: "[Visual content from tool result]" },
+            ...visualContent.flatMap((part) => toResponsesContentPart(part, "user")),
+          ],
+        });
+      }
+      continue;
+    }
+
+    if (block.type === "tool_result_reference") {
+      flushContent();
+      items.push({
+        type: "function_call_output",
+        call_id: block.toolCallId,
+        output: block.preview + (block.hasMore
+          ? `\n\n[Truncated: original ${block.originalBytes} bytes, file: ${block.path}]`
+          : ""),
+      });
+      continue;
+    }
+
+    normalContent.push(block);
+  }
+
+  flushContent();
+  return items;
+}
+
+function toResponsesContentPart(
+  block: CanonicalContentBlock,
+  role: "user" | "assistant",
+): Record<string, unknown>[] {
+  const textType = role === "assistant" ? "output_text" : "input_text";
+  switch (block.type) {
+    case "text":
+      return [{ type: textType, text: block.text }];
+    case "thinking":
+      return [{ type: "output_text", text: block.text }];
+    case "image":
+      return [{
+        type: "input_image",
+        image_url: block.source === "url" ? block.data : `data:${block.mimeType};base64,${block.data}`,
+        detail: block.detail,
+      }];
+    case "pdf":
+      return [{
+        type: "input_file",
+        filename: "document.pdf",
+        file_data: `data:${block.mimeType};base64,${block.data}`,
+      }];
+    case "audio":
+      return block.source === "url"
+        ? [{ type: textType, text: `[Audio URL: ${block.data}]` }]
+        : [{ type: textType, text: "[Audio content omitted]" }];
+    case "media_reference":
+      return [{ type: textType, text: block.preview }];
+    case "tool_call":
+    case "tool_result":
+    case "tool_result_reference":
+      return [];
+  }
+}
+
+function toResponsesTool(tool: CanonicalToolSchema): OpenAIResponsesTool {
+  return {
+    type: "function",
+    name: tool.name,
+    description: tool.description,
+    parameters: normalizeOpenAISchema(tool.inputSchema),
+    strict: true,
+  };
+}
+
+function toResponsesToolChoice(toolChoice: CanonicalToolChoice | undefined): unknown {
+  if (!toolChoice) {
+    return undefined;
+  }
+
+  if (toolChoice === "auto" || toolChoice === "none" || toolChoice === "required") {
+    return toolChoice;
+  }
+
+  return { type: "function", name: toolChoice.name };
+}

--- a/src/model/providers/openai-responses/request.ts
+++ b/src/model/providers/openai-responses/request.ts
@@ -8,7 +8,7 @@ import type {
   CanonicalModelRequest,
 } from "../../protocol/canonical.js";
 import { flattenToolResultBlockText } from "../../protocol/toolResultContent.js";
-import { normalizeOpenAISchema } from "../openai/request.js";
+import { normalizeOpenAISchema } from "../openai/schema.js";
 
 export type OpenAIResponsesRequestBody = {
   model: string;
@@ -100,7 +100,7 @@ function toResponsesInputItems(message: CanonicalMessage): OpenAIResponsesInputI
 
   const flushContent = () => {
     if (normalContent.length === 0) return;
-    const content = normalContent.flatMap((block) => toResponsesContentPart(block, message.role));
+    const content = normalContent.flatMap((block) => toResponsesContentPart(block));
     if (content.length > 0) {
       items.push({ role: message.role, content });
     }
@@ -132,7 +132,7 @@ function toResponsesInputItems(message: CanonicalMessage): OpenAIResponsesInputI
           role: "user",
           content: [
             { type: "input_text", text: "[Visual content from tool result]" },
-            ...visualContent.flatMap((part) => toResponsesContentPart(part, "user")),
+            ...visualContent.flatMap((part) => toResponsesContentPart(part)),
           ],
         });
       }
@@ -158,16 +158,12 @@ function toResponsesInputItems(message: CanonicalMessage): OpenAIResponsesInputI
   return items;
 }
 
-function toResponsesContentPart(
-  block: CanonicalContentBlock,
-  role: "user" | "assistant",
-): Record<string, unknown>[] {
-  const textType = role === "assistant" ? "output_text" : "input_text";
+function toResponsesContentPart(block: CanonicalContentBlock): Record<string, unknown>[] {
   switch (block.type) {
     case "text":
-      return [{ type: textType, text: block.text }];
+      return [{ type: "input_text", text: block.text }];
     case "thinking":
-      return [{ type: "output_text", text: block.text }];
+      return [{ type: "input_text", text: block.text }];
     case "image":
       return [{
         type: "input_image",
@@ -182,10 +178,10 @@ function toResponsesContentPart(
       }];
     case "audio":
       return block.source === "url"
-        ? [{ type: textType, text: `[Audio URL: ${block.data}]` }]
-        : [{ type: textType, text: "[Audio content omitted]" }];
+        ? [{ type: "input_text", text: `[Audio URL: ${block.data}]` }]
+        : [{ type: "input_text", text: "[Audio content omitted]" }];
     case "media_reference":
-      return [{ type: textType, text: block.preview }];
+      return [{ type: "input_text", text: block.preview }];
     case "tool_call":
     case "tool_result":
     case "tool_result_reference":

--- a/src/model/providers/openai-responses/response.ts
+++ b/src/model/providers/openai-responses/response.ts
@@ -1,0 +1,186 @@
+import { jsonrepair } from "jsonrepair";
+import { randomUUID } from "node:crypto";
+import type {
+  CanonicalContentBlock,
+  CanonicalModelResponse,
+  CanonicalToolCallBlock,
+} from "../../protocol/canonical.js";
+import { ModelProviderError } from "../../protocol/errors.js";
+import { normalizeOpenAIUsage } from "../../response/normalizeUsage.js";
+
+type ToolCallIdState = {
+  baseId: string;
+  usedToolCallIds: Set<string>;
+};
+
+export function parseOpenAIResponsesResponse(
+  raw: unknown,
+  provider = "openai-responses",
+): CanonicalModelResponse {
+  const response = asRecord(raw);
+  const content: CanonicalContentBlock[] = [];
+  const idState = createToolCallIdState(response);
+
+  if (typeof response.output_text === "string" && response.output_text.length > 0) {
+    content.push({ type: "text", text: response.output_text });
+  }
+
+  const output = Array.isArray(response.output) ? response.output : [];
+  for (let index = 0; index < output.length; index += 1) {
+    const item = asRecord(output[index]);
+    if (item.type === "message") {
+      content.push(...textBlocksFromMessageItem(item));
+    } else if (item.type === "function_call") {
+      content.push(toCanonicalToolCall(item, provider, idState, index));
+    } else if (item.type === "reasoning") {
+      const reasoning = reasoningText(item);
+      if (reasoning.length > 0) {
+        content.push({ type: "thinking", text: reasoning });
+      }
+    }
+  }
+
+  return {
+    role: "assistant",
+    content: dedupeInitialOutputText(content, response.output_text),
+    usage: normalizeOpenAIUsage(response.usage),
+    finishReason: normalizeResponsesFinishReason(response, output),
+    raw,
+  };
+}
+
+function textBlocksFromMessageItem(item: Record<string, unknown>): CanonicalContentBlock[] {
+  const content = Array.isArray(item.content) ? item.content : [];
+  const blocks: CanonicalContentBlock[] = [];
+  for (const part of content) {
+    const record = asRecord(part);
+    const text = readTextPart(record);
+    if (text) {
+      blocks.push({ type: "text", text });
+    }
+  }
+  return blocks;
+}
+
+function readTextPart(part: Record<string, unknown>): string | undefined {
+  if (typeof part.text === "string" && part.text.length > 0) {
+    return part.text;
+  }
+  if (typeof part.output_text === "string" && part.output_text.length > 0) {
+    return part.output_text;
+  }
+  return undefined;
+}
+
+function reasoningText(item: Record<string, unknown>): string {
+  const summary = Array.isArray(item.summary) ? item.summary : [];
+  return summary
+    .map((part) => readTextPart(asRecord(part)))
+    .filter((text): text is string => Boolean(text))
+    .join("\n");
+}
+
+function toCanonicalToolCall(
+  item: Record<string, unknown>,
+  provider: string,
+  idState: ToolCallIdState,
+  index: number,
+): CanonicalToolCallBlock {
+  const rawArguments = typeof item.arguments === "string" ? item.arguments : "{}";
+  let input: unknown;
+  try {
+    input = JSON.parse(rawArguments);
+  } catch {
+    try {
+      input = JSON.parse(jsonrepair(rawArguments));
+      console.warn(`[openai-responses] repaired invalid JSON for tool call (len=${rawArguments.length})`);
+    } catch {
+      throw new ModelProviderError({
+        provider,
+        protocol: "openai-responses",
+        code: "invalid_tool_arguments",
+        message: "OpenAI Responses tool call arguments are not valid JSON.",
+        retryable: true,
+        raw: item,
+      });
+    }
+  }
+
+  return {
+    type: "tool_call",
+    id: chooseToolCallId(idState, readNonEmptyString(item.call_id) ?? readNonEmptyString(item.id), index),
+    name: typeof item.name === "string" ? item.name : "",
+    input,
+    raw: item,
+  };
+}
+
+function normalizeResponsesFinishReason(response: Record<string, unknown>, output: unknown[]) {
+  if (output.some((item) => asRecord(item).type === "function_call")) return "tool_call";
+  if (response.status === "completed") return "stop";
+  if (response.status === "incomplete") return "length";
+  if (response.status === "failed") return "error";
+  if (response.status === "cancelled") return "error";
+  if (response.status === "queued" || response.status === "in_progress") return "unknown";
+  return "unknown";
+}
+
+function dedupeInitialOutputText(
+  content: CanonicalContentBlock[],
+  outputText: unknown,
+): CanonicalContentBlock[] {
+  if (typeof outputText !== "string" || outputText.length === 0) {
+    return content;
+  }
+  const [first, ...rest] = content;
+  if (first?.type !== "text") {
+    return content;
+  }
+  const restText = rest
+    .filter((block): block is Extract<CanonicalContentBlock, { type: "text" }> => block.type === "text")
+    .map((block) => block.text)
+    .join("\n");
+  return restText === outputText ? rest : content;
+}
+
+function createToolCallIdState(response: Record<string, unknown>): ToolCallIdState {
+  return {
+    baseId: safeToolCallIdPart(readNonEmptyString(response.id) ?? `response_${randomUUID().slice(0, 12)}`),
+    usedToolCallIds: new Set(),
+  };
+}
+
+function chooseToolCallId(state: ToolCallIdState, incomingId: string | undefined, index: number): string {
+  const candidate = incomingId !== undefined && !state.usedToolCallIds.has(incomingId)
+    ? incomingId
+    : `call_${state.baseId}_${index}`;
+  const id = nextUniqueToolCallId(candidate, state.usedToolCallIds);
+  state.usedToolCallIds.add(id);
+  return id;
+}
+
+function nextUniqueToolCallId(id: string, used: Set<string>): string {
+  if (!used.has(id)) {
+    return id;
+  }
+  for (let suffix = 2; ; suffix += 1) {
+    const candidate = `${id}_${suffix}`;
+    if (!used.has(candidate)) {
+      return candidate;
+    }
+  }
+}
+
+function readNonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value : undefined;
+}
+
+function safeToolCallIdPart(value: string): string {
+  return value.trim().replace(/[^A-Za-z0-9_-]+/g, "_").replace(/^_+|_+$/g, "") || "response";
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}

--- a/src/model/providers/openai-responses/stream.ts
+++ b/src/model/providers/openai-responses/stream.ts
@@ -1,0 +1,307 @@
+import { jsonrepair } from "jsonrepair";
+import { randomUUID } from "node:crypto";
+import type { CanonicalModelEvent, CanonicalToolCall } from "../../protocol/canonical.js";
+import { ModelProviderError } from "../../protocol/errors.js";
+import { normalizeOpenAIUsage } from "../../response/normalizeUsage.js";
+
+type ToolCallState = Partial<CanonicalToolCall> & {
+  argumentsBuffer?: string;
+  itemId?: string;
+  outputIndex?: number;
+};
+
+export type OpenAIResponsesStreamState = {
+  started: boolean;
+  streamSyntheticId: string;
+  responseId?: string;
+  toolCalls: Map<string, ToolCallState>;
+  completedToolCallKeys: Set<string>;
+  usedToolCallIds: Set<string>;
+  sawToolCall: boolean;
+};
+
+export function createOpenAIResponsesStreamState(): OpenAIResponsesStreamState {
+  return {
+    started: false,
+    streamSyntheticId: `stream_${randomUUID().slice(0, 12)}`,
+    toolCalls: new Map(),
+    completedToolCallKeys: new Set(),
+    usedToolCallIds: new Set(),
+    sawToolCall: false,
+  };
+}
+
+export function normalizeOpenAIResponsesStreamEvent(
+  raw: unknown,
+  state: OpenAIResponsesStreamState = createOpenAIResponsesStreamState(),
+): CanonicalModelEvent[] {
+  const event = asRecord(raw);
+  const type = typeof event.type === "string" ? event.type : "";
+  const events: CanonicalModelEvent[] = [];
+  const response = asRecord(event.response);
+  const responseId = readNonEmptyString(response.id) ?? readNonEmptyString(event.response_id);
+  if (responseId && !state.responseId) {
+    state.responseId = responseId;
+  }
+
+  if ((type === "response.created" || type === "response.in_progress") && !state.started) {
+    state.started = true;
+    events.push({ type: "message_start", role: "assistant", raw });
+  }
+
+  if (type === "response.output_text.delta" && typeof event.delta === "string" && event.delta.length > 0) {
+    ensureStarted(events, state, raw);
+    events.push({ type: "text_delta", text: event.delta, raw });
+  }
+
+  if (isReasoningDelta(type) && typeof event.delta === "string" && event.delta.length > 0) {
+    ensureStarted(events, state, raw);
+    events.push({ type: "thinking_delta", text: event.delta, raw });
+  }
+
+  if (type === "response.output_item.added") {
+    events.push(...handleOutputItemAdded(event, state, raw));
+  }
+
+  if (type === "response.function_call_arguments.delta" && typeof event.delta === "string") {
+    ensureStarted(events, state, raw);
+    const toolCall = ensureToolCall(event, state);
+    toolCall.argumentsBuffer = `${toolCall.argumentsBuffer ?? ""}${event.delta}`;
+    events.push({ type: "tool_call_delta", id: toolCall.id ?? "", delta: event.delta, raw });
+  }
+
+  if (type === "response.function_call_arguments.done") {
+    ensureStarted(events, state, raw);
+    if (isCompletedToolCall(event, state)) {
+      return events;
+    }
+    const toolCall = ensureToolCall(event, state);
+    if (typeof event.arguments === "string") {
+      toolCall.argumentsBuffer = event.arguments;
+    }
+    events.push(finishToolCall(toolCall, raw));
+    completeToolCall(event, state);
+  }
+
+  if (type === "response.output_item.done") {
+    const item = asRecord(event.item);
+    if (item.type === "function_call") {
+      ensureStarted(events, state, raw);
+      if (isCompletedToolCall({ ...event, item }, state)) {
+        return events;
+      }
+      const toolCall = ensureToolCall({ ...event, item }, state);
+      if (typeof item.arguments === "string") {
+        toolCall.argumentsBuffer = item.arguments;
+      }
+      events.push(finishToolCall(toolCall, raw));
+      completeToolCall({ ...event, item }, state);
+    }
+  }
+
+  if (type === "response.completed") {
+    ensureStarted(events, state, raw);
+    const usage = normalizeOpenAIUsage(response.usage);
+    if (usage) {
+      events.push({ type: "usage", usage, raw });
+    }
+    for (const [key, toolCall] of state.toolCalls.entries()) {
+      events.push(finishToolCall(toolCall, raw));
+      state.toolCalls.delete(key);
+    }
+    events.push({ type: "message_end", finishReason: state.sawToolCall ? "tool_call" : "stop", raw });
+  }
+
+  if (type === "response.incomplete") {
+    ensureStarted(events, state, raw);
+    events.push({ type: "message_end", finishReason: "length", raw });
+  }
+
+  if (type === "response.failed" || type === "error") {
+    const responseError = asRecord(response.error);
+    const eventError = asRecord(event.error);
+    const error = Object.keys(responseError).length > 0 ? responseError : eventError;
+    events.push({
+      type: "error",
+      error: {
+        provider: "openai-responses",
+        protocol: "openai-responses",
+        code: readNonEmptyString(error.code) ?? "provider_error",
+        message: readNonEmptyString(error.message) ?? "OpenAI Responses request failed.",
+        retryable: false,
+        raw,
+      },
+    });
+  }
+
+  return events;
+}
+
+function handleOutputItemAdded(
+  event: Record<string, unknown>,
+  state: OpenAIResponsesStreamState,
+  raw: unknown,
+): CanonicalModelEvent[] {
+  const item = asRecord(event.item);
+  if (item.type !== "function_call") {
+    return [];
+  }
+
+  const events: CanonicalModelEvent[] = [];
+  ensureStarted(events, state, raw);
+  const key = toolCallKey(event, item);
+  const existing = state.toolCalls.get(key);
+  if (existing) {
+    return events;
+  }
+  const toolCall: ToolCallState = {
+    id: chooseToolCallId(state, readNonEmptyString(item.call_id) ?? readNonEmptyString(item.id)),
+    name: readNonEmptyString(item.name) ?? "",
+    itemId: readNonEmptyString(item.id),
+    outputIndex: readNumber(event.output_index),
+    argumentsBuffer: typeof item.arguments === "string" ? item.arguments : "",
+  };
+  state.sawToolCall = true;
+  state.toolCalls.set(key, toolCall);
+  events.push({
+    type: "tool_call_start",
+    id: toolCall.id ?? "call_missing",
+    name: toolCall.name ?? "",
+    raw,
+  });
+  return events;
+}
+
+function ensureToolCall(event: Record<string, unknown>, state: OpenAIResponsesStreamState): ToolCallState {
+  const item = asRecord(event.item);
+  const key = toolCallKey(event, item);
+  let toolCall = state.toolCalls.get(key);
+  if (!toolCall) {
+    toolCall = {
+      id: chooseToolCallId(state, readNonEmptyString(event.call_id) ?? readNonEmptyString(item.call_id)),
+      name: readNonEmptyString(item.name) ?? "",
+      itemId: readNonEmptyString(item.id) ?? readNonEmptyString(event.item_id),
+      outputIndex: readNumber(event.output_index),
+      argumentsBuffer: "",
+    };
+    state.sawToolCall = true;
+    state.toolCalls.set(key, toolCall);
+  }
+  return toolCall;
+}
+
+function finishToolCall(toolCall: ToolCallState, raw: unknown): CanonicalModelEvent {
+  const rawArguments = toolCall.argumentsBuffer ?? "{}";
+  let input: unknown;
+  let wasRepaired = false;
+  try {
+    input = JSON.parse(rawArguments || "{}");
+  } catch {
+    try {
+      input = JSON.parse(jsonrepair(rawArguments));
+      wasRepaired = true;
+      console.warn(
+        `[openai-responses-stream] repaired invalid JSON for tool "${toolCall.name ?? "?"}" `
+        + `(buf_len=${rawArguments.length})`,
+      );
+    } catch {
+      throw new ModelProviderError({
+        provider: "openai-responses",
+        protocol: "openai-responses",
+        code: "invalid_tool_arguments",
+        message: "OpenAI Responses stream tool call arguments are not valid JSON.",
+        retryable: true,
+        raw,
+      });
+    }
+  }
+
+  return {
+    type: "tool_call_end",
+    toolCall: {
+      id: toolCall.id ?? "call_missing",
+      name: toolCall.name ?? "",
+      input,
+      raw,
+    },
+    wasRepaired,
+    raw,
+  };
+}
+
+function completeToolCall(event: Record<string, unknown>, state: OpenAIResponsesStreamState): void {
+  const item = asRecord(event.item);
+  const key = toolCallKey(event, item);
+  state.completedToolCallKeys.add(key);
+  state.toolCalls.delete(key);
+}
+
+function isCompletedToolCall(event: Record<string, unknown>, state: OpenAIResponsesStreamState): boolean {
+  const item = asRecord(event.item);
+  return state.completedToolCallKeys.has(toolCallKey(event, item));
+}
+
+function toolCallKey(event: Record<string, unknown>, item: Record<string, unknown>): string {
+  return readNonEmptyString(event.item_id)
+    ?? readNonEmptyString(item.id)
+    ?? readNonEmptyString(event.call_id)
+    ?? readNonEmptyString(item.call_id)
+    ?? `index:${readNumber(event.output_index) ?? 0}`;
+}
+
+function ensureStarted(
+  events: CanonicalModelEvent[],
+  state: OpenAIResponsesStreamState,
+  raw: unknown,
+): void {
+  if (state.started) {
+    return;
+  }
+  state.started = true;
+  events.push({ type: "message_start", role: "assistant", raw });
+}
+
+function isReasoningDelta(type: string): boolean {
+  return type === "response.reasoning_summary_text.delta"
+    || type === "response.reasoning_text.delta"
+    || type === "response.reasoning.delta";
+}
+
+function chooseToolCallId(state: OpenAIResponsesStreamState, incomingId: string | undefined): string {
+  const candidate = incomingId !== undefined && !state.usedToolCallIds.has(incomingId)
+    ? incomingId
+    : `call_${safeToolCallIdPart(state.responseId ?? state.streamSyntheticId)}_${state.usedToolCallIds.size}`;
+  const id = nextUniqueToolCallId(candidate, state.usedToolCallIds);
+  state.usedToolCallIds.add(id);
+  return id;
+}
+
+function nextUniqueToolCallId(id: string, used: Set<string>): string {
+  if (!used.has(id)) {
+    return id;
+  }
+  for (let suffix = 2; ; suffix += 1) {
+    const candidate = `${id}_${suffix}`;
+    if (!used.has(candidate)) {
+      return candidate;
+    }
+  }
+}
+
+function readNonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value : undefined;
+}
+
+function readNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function safeToolCallIdPart(value: string): string {
+  return value.trim().replace(/[^A-Za-z0-9_-]+/g, "_").replace(/^_+|_+$/g, "") || "response";
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}

--- a/src/model/providers/openai-responses/stream.ts
+++ b/src/model/providers/openai-responses/stream.ts
@@ -118,6 +118,9 @@ export function normalizeOpenAIResponsesStreamEvent(
   }
 
   if (type === "response.failed" || type === "error") {
+    if (type === "response.failed") {
+      ensureStarted(events, state, raw);
+    }
     const responseError = asRecord(response.error);
     const eventError = asRecord(event.error);
     const error = Object.keys(responseError).length > 0 ? responseError : eventError;
@@ -132,6 +135,9 @@ export function normalizeOpenAIResponsesStreamEvent(
         raw,
       },
     });
+    if (type === "response.failed") {
+      events.push({ type: "message_end", finishReason: "error", raw });
+    }
   }
 
   return events;

--- a/src/model/providers/openai/request.ts
+++ b/src/model/providers/openai/request.ts
@@ -355,7 +355,7 @@ function isGoogleOpenAICompatibleProvider(provider: ProviderConfig | undefined):
  * allows `array` (including union types like `type: ["string", "array"]`).
  * Normalize tool input schemas defensively to avoid provider-side 400s.
  */
-function normalizeOpenAISchema(schema: Record<string, unknown>): Record<string, unknown> {
+export function normalizeOpenAISchema(schema: Record<string, unknown>): Record<string, unknown> {
   return normalizeOpenAISchemaNode(schema) as Record<string, unknown>;
 }
 

--- a/src/model/providers/openai/request.ts
+++ b/src/model/providers/openai/request.ts
@@ -11,6 +11,7 @@ import type {
 } from "../../protocol/canonical.js";
 import { flattenToolResultBlockText } from "../../protocol/toolResultContent.js";
 import { cleanSchemaForGoogle, normalizeGoogleToolSchema } from "../google/schema.js";
+import { normalizeOpenAISchema } from "./schema.js";
 
 export type OpenAIRequestBody = {
   model: string;
@@ -348,38 +349,6 @@ function isGoogleOpenAICompatibleProvider(provider: ProviderConfig | undefined):
     return rawUrl.includes("generativelanguage.googleapis.com")
       && rawUrl.includes("/openai");
   }
-}
-
-/**
- * Azure/OpenAI-compatible endpoints can require `items` whenever a schema node
- * allows `array` (including union types like `type: ["string", "array"]`).
- * Normalize tool input schemas defensively to avoid provider-side 400s.
- */
-export function normalizeOpenAISchema(schema: Record<string, unknown>): Record<string, unknown> {
-  return normalizeOpenAISchemaNode(schema) as Record<string, unknown>;
-}
-
-function normalizeOpenAISchemaNode(node: unknown): unknown {
-  if (Array.isArray(node)) {
-    return node.map(normalizeOpenAISchemaNode);
-  }
-  if (!isRecord(node)) {
-    return node;
-  }
-
-  const normalized: Record<string, unknown> = {};
-  for (const [key, value] of Object.entries(node)) {
-    normalized[key] = normalizeOpenAISchemaNode(value);
-  }
-
-  const typeField = normalized.type;
-  const allowsArray = typeField === "array"
-    || (Array.isArray(typeField) && typeField.includes("array"));
-  if (allowsArray && !("items" in normalized)) {
-    normalized.items = {};
-  }
-
-  return normalized;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/model/providers/openai/schema.ts
+++ b/src/model/providers/openai/schema.ts
@@ -1,0 +1,35 @@
+/**
+ * Azure/OpenAI-compatible endpoints can require `items` whenever a schema node
+ * allows `array` (including union types like `type: ["string", "array"]`).
+ * Normalize tool input schemas defensively to avoid provider-side 400s.
+ */
+export function normalizeOpenAISchema(schema: Record<string, unknown>): Record<string, unknown> {
+  return normalizeOpenAISchemaNode(schema) as Record<string, unknown>;
+}
+
+function normalizeOpenAISchemaNode(node: unknown): unknown {
+  if (Array.isArray(node)) {
+    return node.map(normalizeOpenAISchemaNode);
+  }
+  if (!isRecord(node)) {
+    return node;
+  }
+
+  const normalized: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(node)) {
+    normalized[key] = normalizeOpenAISchemaNode(value);
+  }
+
+  const typeField = normalized.type;
+  const allowsArray = typeField === "array"
+    || (Array.isArray(typeField) && typeField.includes("array"));
+  if (allowsArray && !("items" in normalized)) {
+    normalized.items = {};
+  }
+
+  return normalized;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/src/model/providers/registry.ts
+++ b/src/model/providers/registry.ts
@@ -10,6 +10,7 @@ const adapters: Record<ModelProtocol, ModelProviderAdapter> = {
   anthropic: { protocol: "anthropic", name: "Anthropic Messages API" },
   google: { protocol: "google", name: "Google Gemini API" },
   openai: { protocol: "openai", name: "OpenAI Chat Completions API" },
+  "openai-responses": { protocol: "openai-responses", name: "OpenAI Responses API" },
 };
 
 export const ModelProviderRegistry = {

--- a/src/model/request/buildModelRequest.ts
+++ b/src/model/request/buildModelRequest.ts
@@ -1,10 +1,18 @@
 import { buildAnthropicRequest, type AnthropicRequestBody } from "../providers/anthropic/request.js";
 import { buildGoogleRequest, type GoogleRequestBody } from "../providers/google/request.js";
 import { buildOpenAIRequest, type OpenAIRequestBody } from "../providers/openai/request.js";
+import {
+  buildOpenAIResponsesRequest,
+  type OpenAIResponsesRequestBody,
+} from "../providers/openai-responses/request.js";
 import type { CanonicalModelRequest, ModelConfig } from "../protocol/canonical.js";
 import { validateModelRequest } from "./validateModelRequest.js";
 
-export type ProviderRequestBody = AnthropicRequestBody | GoogleRequestBody | OpenAIRequestBody;
+export type ProviderRequestBody =
+  | AnthropicRequestBody
+  | GoogleRequestBody
+  | OpenAIRequestBody
+  | OpenAIResponsesRequestBody;
 
 export function buildModelRequest(
   request: CanonicalModelRequest,
@@ -18,6 +26,10 @@ export function buildModelRequest(
 
   if (provider.protocol === "google") {
     return buildGoogleRequest(request, model);
+  }
+
+  if (provider.protocol === "openai-responses") {
+    return buildOpenAIResponsesRequest(request, model, provider);
   }
 
   return buildOpenAIRequest(request, model, provider);

--- a/src/model/response/parseModelResponse.ts
+++ b/src/model/response/parseModelResponse.ts
@@ -1,6 +1,7 @@
 import { parseAnthropicResponse } from "../providers/anthropic/response.js";
 import { parseGoogleResponse } from "../providers/google/response.js";
 import { parseOpenAIResponse } from "../providers/openai/response.js";
+import { parseOpenAIResponsesResponse } from "../providers/openai-responses/response.js";
 import type { CanonicalModelResponse, ModelProtocol } from "../protocol/canonical.js";
 
 export function parseModelResponse(
@@ -14,6 +15,10 @@ export function parseModelResponse(
 
   if (protocol === "google") {
     return parseGoogleResponse(raw, providerId);
+  }
+
+  if (protocol === "openai-responses") {
+    return parseOpenAIResponsesResponse(raw, providerId);
   }
 
   return parseOpenAIResponse(raw, providerId);

--- a/src/model/streaming/normalizeStreamEvent.ts
+++ b/src/model/streaming/normalizeStreamEvent.ts
@@ -10,12 +10,18 @@ import {
   normalizeOpenAIStreamEvent,
   type OpenAIStreamState,
 } from "../providers/openai/stream.js";
+import {
+  createOpenAIResponsesStreamState,
+  normalizeOpenAIResponsesStreamEvent,
+  type OpenAIResponsesStreamState,
+} from "../providers/openai-responses/stream.js";
 import type { CanonicalModelEvent, ModelProtocol } from "../protocol/canonical.js";
 
 export type StreamNormalizerState = {
   anthropic?: AnthropicStreamState;
   google?: GoogleStreamState;
   openai?: OpenAIStreamState;
+  openaiResponses?: OpenAIResponsesStreamState;
 };
 
 export function createStreamNormalizerState(protocol: ModelProtocol): StreamNormalizerState {
@@ -24,6 +30,9 @@ export function createStreamNormalizerState(protocol: ModelProtocol): StreamNorm
   }
   if (protocol === "google") {
     return { google: createGoogleStreamState() };
+  }
+  if (protocol === "openai-responses") {
+    return { openaiResponses: createOpenAIResponsesStreamState() };
   }
   return { openai: createOpenAIStreamState() };
 }
@@ -41,6 +50,11 @@ export function normalizeStreamEvent(
   if (protocol === "google") {
     state.google ??= createGoogleStreamState();
     return normalizeGoogleStreamEvent(raw, state.google);
+  }
+
+  if (protocol === "openai-responses") {
+    state.openaiResponses ??= createOpenAIResponsesStreamState();
+    return normalizeOpenAIResponsesStreamEvent(raw, state.openaiResponses);
   }
 
   state.openai ??= createOpenAIStreamState();

--- a/src/model/streaming/streamModel.ts
+++ b/src/model/streaming/streamModel.ts
@@ -505,6 +505,10 @@ function buildEndpoint(provider: ProviderConfig, _stream: boolean): string {
     return joinUrl(provider.url, "v1/messages");
   }
 
+  if (provider.protocol === "openai-responses") {
+    return joinUrl(provider.url, "responses");
+  }
+
   return joinUrl(provider.url, "chat/completions");
 }
 

--- a/ui/server/routes/config.js
+++ b/ui/server/routes/config.js
@@ -246,11 +246,12 @@ router.post('/test-connection', async (req, res) => {
     return res.status(400).json({ ok: false, error: 'baseUrl, apiKey, and model are required' });
   }
 
-  // Accept V2 protocols ('openai' | 'anthropic' | 'google') as well as the legacy
-  // onboarding values ('openai-chat' | 'anthropic') for compatibility.
+  // Accept V2 protocols ('openai' | 'openai-responses' | 'anthropic' | 'google')
+  // as well as legacy onboarding values for compatibility.
   const normalizedType = String(providerType || '').toLowerCase();
   const isAnthropic = normalizedType === 'anthropic';
   const isGoogle = normalizedType === 'google';
+  const isOpenAIResponses = normalizedType === 'openai-responses' || normalizedType === 'responses';
   const normalizedBaseUrl = String(baseUrl).trim().replace(/\/+$/, '');
   const timeout = 10_000;
   const controller = new AbortController();
@@ -290,6 +291,22 @@ router.post('/test-connection', async (req, res) => {
         }),
         signal: controller.signal,
       };
+    } else if (isOpenAIResponses) {
+      url = `${normalizedBaseUrl}/responses`;
+      fetchOptions = {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          model,
+          max_output_tokens: 16,
+          input: 'Hi',
+          store: false,
+        }),
+        signal: controller.signal,
+      };
     } else {
       url = `${normalizedBaseUrl}/chat/completions`;
       fetchOptions = {
@@ -314,10 +331,12 @@ router.post('/test-connection', async (req, res) => {
       ? 'Anthropic message'
       : isGoogle
         ? 'Google Gemini generateContent response'
-        : 'OpenAI chat completion';
+        : isOpenAIResponses
+          ? 'OpenAI Responses response'
+          : 'OpenAI chat completion';
     const baseUrlHint = isGoogle
       ? 'For native Google Gemini, the base URL is usually https://generativelanguage.googleapis.com.'
-      : 'For OpenAI-compatible endpoints, the base URL usually ends with /v1.';
+      : 'For OpenAI-compatible and Responses API endpoints, the base URL usually ends with /v1.';
 
     if (response.ok) {
       let body;
@@ -334,7 +353,9 @@ router.post('/test-connection', async (req, res) => {
         ? Array.isArray(body?.content) || body?.type === 'message'
         : isGoogle
           ? Array.isArray(body?.candidates)
-        : Array.isArray(body?.choices);
+          : isOpenAIResponses
+            ? body?.object === 'response' || Array.isArray(body?.output) || typeof body?.output_text === 'string'
+            : Array.isArray(body?.choices);
       if (!hasCompletionShape) {
         return res.json({
           ok: false,

--- a/ui/server/services/pilotdeckConfig.js
+++ b/ui/server/services/pilotdeckConfig.js
@@ -173,8 +173,8 @@ function validateProvider(id, provider, errors) {
   }
   const protocol = normalizeString(provider.protocol).toLowerCase();
   if (!protocol) errors.push(`model.providers.${id}.protocol is required`);
-  else if (protocol !== 'openai' && protocol !== 'anthropic' && protocol !== 'google') {
-    errors.push(`model.providers.${id}.protocol must be "openai", "anthropic", or "google"`);
+  else if (protocol !== 'openai' && protocol !== 'openai-responses' && protocol !== 'anthropic' && protocol !== 'google') {
+    errors.push(`model.providers.${id}.protocol must be "openai", "openai-responses", "anthropic", or "google"`);
   }
   if (!normalizeString(provider.url)) errors.push(`model.providers.${id}.url is required`);
   if (!normalizeString(provider.apiKey)) errors.push(`model.providers.${id}.apiKey is required`);
@@ -299,6 +299,7 @@ export function preserveMaskedSecrets(nextValue, previousValue) {
 
 function providerProtocolToMemoryApi(protocol) {
   if (protocol === 'anthropic' || protocol === 'google') return protocol;
+  if (protocol === 'openai-responses') return 'openai-responses';
   return 'openai-completions';
 }
 

--- a/ui/src/components/onboarding/view/subcomponents/LlmConfigurationStep.tsx
+++ b/ui/src/components/onboarding/view/subcomponents/LlmConfigurationStep.tsx
@@ -318,6 +318,7 @@ export default function LlmConfigurationStep({ onSaved }: LlmConfigurationStepPr
                       className="w-full appearance-none rounded-lg border border-border bg-background px-3 py-2.5 pr-8 text-sm text-foreground focus:border-foreground/40 focus:outline-none"
                     >
                       <option value="openai">openai</option>
+                      <option value="openai-responses">openai-responses</option>
                       <option value="anthropic">anthropic</option>
                       <option value="google">google</option>
                     </select>
@@ -341,6 +342,11 @@ export default function LlmConfigurationStep({ onSaved }: LlmConfigurationStepPr
                 {customProtocol === 'openai' && (
                   <p className="mt-1 text-[11px] text-muted-foreground">
                     OpenAI-compatible base URLs should include the API version path, for example ending in <span className="font-mono">/v1</span>.
+                  </p>
+                )}
+                {customProtocol === 'openai-responses' && (
+                  <p className="mt-1 text-[11px] text-muted-foreground">
+                    OpenAI Responses API base URLs should include the API version path, for example ending in <span className="font-mono">/v1</span>.
                   </p>
                 )}
                 {customProtocol === 'google' && (
@@ -445,6 +451,11 @@ export default function LlmConfigurationStep({ onSaved }: LlmConfigurationStepPr
                   {(selectedProvider?.protocol ?? customProtocol) === 'openai' && (
                     <p className="mt-1 text-[11px] text-muted-foreground">
                       OpenAI-compatible base URLs should include the API version path, for example ending in <span className="font-mono">/v1</span>.
+                    </p>
+                  )}
+                  {(selectedProvider?.protocol ?? customProtocol) === 'openai-responses' && (
+                    <p className="mt-1 text-[11px] text-muted-foreground">
+                      OpenAI Responses API base URLs should include the API version path, for example ending in <span className="font-mono">/v1</span>.
                     </p>
                   )}
                   {(selectedProvider?.protocol ?? customProtocol) === 'google' && (

--- a/ui/src/components/settings/view/tabs/PilotDeckConfigTab.tsx
+++ b/ui/src/components/settings/view/tabs/PilotDeckConfigTab.tsx
@@ -805,6 +805,7 @@ function ProviderCard({
             onChange={(v) => update({ protocol: v as CatalogProviderProtocol })}
             options={[
               { value: 'openai',    label: t('pilotDeckConfig.panels.models.protocolOptions.openai') },
+              { value: 'openai-responses', label: t('pilotDeckConfig.panels.models.protocolOptions.openaiResponses') },
               { value: 'anthropic', label: t('pilotDeckConfig.panels.models.protocolOptions.anthropic') },
               { value: 'google',    label: t('pilotDeckConfig.panels.models.protocolOptions.google') },
             ]}

--- a/ui/src/i18n/locales/en/settings.json
+++ b/ui/src/i18n/locales/en/settings.json
@@ -690,11 +690,12 @@
         "protocol": "Protocol",
         "protocolOptions": {
           "openai": "openai (chat-completions)",
+          "openaiResponses": "openai-responses (Responses API)",
           "anthropic": "anthropic (messages API)",
           "google": "google (Gemini API)"
         },
         "baseUrl": "Base URL",
-        "baseUrlHint": "For native Google Gemini, use https://generativelanguage.googleapis.com. For OpenAI-compatible providers, include the /v1 suffix.",
+        "baseUrlHint": "For native Google Gemini, use https://generativelanguage.googleapis.com. For OpenAI-compatible and Responses API providers, include the /v1 suffix.",
         "defaultsTo": "Defaults to",
         "fromCatalog": "from catalog.",
         "effective": "Effective:",

--- a/ui/src/i18n/locales/zh-CN/settings.json
+++ b/ui/src/i18n/locales/zh-CN/settings.json
@@ -690,11 +690,12 @@
         "protocol": "协议",
         "protocolOptions": {
           "openai": "openai（聊天补全）",
+          "openaiResponses": "openai-responses（Responses API）",
           "anthropic": "anthropic（消息 API）",
           "google": "google（Gemini API）"
         },
         "baseUrl": "接口地址",
-        "baseUrlHint": "原生 Google Gemini 使用 https://generativelanguage.googleapis.com。OpenAI 兼容接口请填到 /v1。",
+        "baseUrlHint": "原生 Google Gemini 使用 https://generativelanguage.googleapis.com。OpenAI 兼容接口与 Responses API 请填到 /v1。",
         "defaultsTo": "默认使用目录中的",
         "fromCatalog": "。",
         "effective": "实际地址：",

--- a/ui/src/shared/catalogProviders.ts
+++ b/ui/src/shared/catalogProviders.ts
@@ -19,7 +19,7 @@ export type CatalogModel = {
   maxOutputTokens?: number;
 };
 
-export type CatalogProviderProtocol = 'anthropic' | 'openai' | 'google';
+export type CatalogProviderProtocol = 'anthropic' | 'openai' | 'openai-responses' | 'google';
 
 export type CatalogProvider = {
   id: string;
@@ -47,6 +47,20 @@ export const CATALOG_PROVIDERS: CatalogProvider[] = [
     id: 'openai',
     displayName: 'OpenAI',
     protocol: 'openai',
+    defaultUrl: 'https://api.openai.com/v1',
+    models: [
+      { id: 'gpt-4.1', displayName: 'GPT-4.1', supportsImage: true, maxContextTokens: 1047576, maxOutputTokens: 32768 },
+      { id: 'gpt-4.1-mini', displayName: 'GPT-4.1 Mini', supportsImage: true, maxContextTokens: 1047576, maxOutputTokens: 32768 },
+      { id: 'gpt-4o', displayName: 'GPT-4o', supportsImage: true, maxContextTokens: 128000, maxOutputTokens: 16384 },
+      { id: 'gpt-4o-mini', displayName: 'GPT-4o Mini', supportsImage: true, maxContextTokens: 128000, maxOutputTokens: 16384 },
+      { id: 'o3', displayName: 'o3', supportsImage: true, maxContextTokens: 200000, maxOutputTokens: 100000 },
+      { id: 'o3-mini', displayName: 'o3 Mini', maxContextTokens: 200000, maxOutputTokens: 100000 },
+    ],
+  },
+  {
+    id: 'openai-responses',
+    displayName: 'OpenAI (Responses API)',
+    protocol: 'openai-responses',
     defaultUrl: 'https://api.openai.com/v1',
     models: [
       { id: 'gpt-4.1', displayName: 'GPT-4.1', supportsImage: true, maxContextTokens: 1047576, maxOutputTokens: 32768 },


### PR DESCRIPTION
## Summary
- add a separate `openai-responses` protocol while preserving existing OpenAI Chat Completions behavior
- add Responses API request/response/stream adapters and route runtime calls to `/responses`
- expose the provider/protocol in engine catalog, UI catalog, settings/onboarding, and provider connection testing

## Verification
- `npx tsc --noEmit --target ES2022 --module NodeNext --moduleResolution NodeNext --strict --esModuleInterop --forceConsistentCasingInFileNames --skipLibCheck --jsx react-jsx --types node src/context/instructions/InstructionDiscovery.ts
src/context/extension/PluginRuntimeExtensionResolver.ts
src/context/extension/ExtensionResolver.ts
src/context/memory/edgeclaw-memory-core/node_modules/@types/node/compatibility/indexable.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/@types/node/compatibility/index.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/@types/node/compatibility/iterators.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/@types/node/compatibility/disposable.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/@types/node/path.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/@types/node/constants.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/@types/node/domain.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/@types/node/diagnostics_channel.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/@types/node/globals.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/@types/node/sea.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/@types/node/string_decoder.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/@types/node/tls.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/@types/node/tty.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/@types/node/punycode.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/@types/node/readline.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/@types/node/crypto.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/@types/node/trace_events.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/@types/node/events.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/@types/node/os.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/@types/node/buffer.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/@types/node/querystring.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/@types/node/worker_threads.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/@types/node/timers/promises.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/@types/node/console.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/@types/node/async_hooks.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/@types/node/stream/consumers.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/@types/node/stream/web.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/@types/node/stream/promises.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/@types/node/dns.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/@types/node/readline/promises.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/@types/node/vm.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/@types/node/web-globals/events.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/@types/node/web-globals/fetch.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/@types/node/web-globals/navigator.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/@types/node/web-globals/domexception.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/@types/node/web-globals/abortcontroller.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/@types/node/web-globals/storage.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/@types/node/inspector.generated.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/@types/node/buffer.buffer.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/@types/node/timers.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/@types/node/test.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/@types/node/http.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/@types/node/http2.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/@types/node/stream.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/@types/node/inspector.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/@types/node/assert/strict.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/@types/node/v8.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/@types/node/perf_hooks.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/@types/node/url.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/@types/node/cluster.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/@types/node/https.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/@types/node/assert.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/@types/node/fs.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/@types/node/repl.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/@types/node/dgram.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/@types/node/child_process.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/@types/node/zlib.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/@types/node/module.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/@types/node/sqlite.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/@types/node/globals.typedarray.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/@types/node/process.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/@types/node/util.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/@types/node/wasi.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/@types/node/index.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/@types/node/ts5.6/buffer.buffer.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/@types/node/ts5.6/globals.typedarray.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/@types/node/ts5.6/index.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/@types/node/dns/promises.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/@types/node/fs/promises.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/@types/node/net.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/undici-types/global-origin.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/undici-types/header.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/undici-types/pool-stats.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/undici-types/mock-client.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/undici-types/eventsource.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/undici-types/env-http-proxy-agent.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/undici-types/api.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/undici-types/readable.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/undici-types/dispatcher.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/undici-types/errors.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/undici-types/websocket.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/undici-types/file.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/undici-types/connector.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/undici-types/retry-handler.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/undici-types/balanced-pool.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/undici-types/agent.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/undici-types/mock-agent.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/undici-types/interceptors.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/undici-types/fetch.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/undici-types/webidl.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/undici-types/formdata.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/undici-types/handlers.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/undici-types/filereader.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/undici-types/cache.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/undici-types/cookies.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/undici-types/pool.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/undici-types/diagnostics-channel.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/undici-types/util.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/undici-types/patch.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/undici-types/index.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/undici-types/mock-pool.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/undici-types/proxy-agent.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/undici-types/retry-agent.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/undici-types/global-dispatcher.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/undici-types/client.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/undici-types/content-type.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/undici-types/mock-interceptor.d.ts
src/context/memory/edgeclaw-memory-core/node_modules/undici-types/mock-errors.d.ts
src/context/memory/edgeclaw-memory-core/lib/core/pipeline/heartbeat.d.ts
src/context/memory/edgeclaw-memory-core/lib/core/general-projects.d.ts
src/context/memory/edgeclaw-memory-core/lib/core/types.d.ts
src/context/memory/edgeclaw-memory-core/lib/core/utils/id.d.ts
src/context/memory/edgeclaw-memory-core/lib/core/utils/text.d.ts
src/context/memory/edgeclaw-memory-core/lib/core/trace-i18n.d.ts
src/context/memory/edgeclaw-memory-core/lib/core/file-memory.d.ts
src/context/memory/edgeclaw-memory-core/lib/core/storage/sqlite.d.ts
src/context/memory/edgeclaw-memory-core/lib/core/retrieval/reasoning-loop.d.ts
src/context/memory/edgeclaw-memory-core/lib/core/review/dream-review.d.ts
src/context/memory/edgeclaw-memory-core/lib/core/skills/llm-extraction.d.ts
src/context/memory/edgeclaw-memory-core/lib/core/index.d.ts
src/context/memory/edgeclaw-memory-core/lib/service.d.ts
src/context/memory/edgeclaw-memory-core/lib/message-utils.d.ts
src/context/memory/edgeclaw-memory-core/lib/index.d.ts
src/context/memory/edgeclaw-memory-core/src/core/pipeline/heartbeat.ts
src/context/memory/edgeclaw-memory-core/src/core/file-memory.ts
src/context/memory/edgeclaw-memory-core/src/core/general-projects.ts
src/context/memory/edgeclaw-memory-core/src/core/utils/text.ts
src/context/memory/edgeclaw-memory-core/src/core/utils/id.ts
src/context/memory/edgeclaw-memory-core/src/core/trace-i18n.ts
src/context/memory/edgeclaw-memory-core/src/core/storage/sqlite.ts
src/context/memory/edgeclaw-memory-core/src/core/types.ts
src/context/memory/edgeclaw-memory-core/src/core/retrieval/reasoning-loop.ts
src/context/memory/edgeclaw-memory-core/src/core/review/dream-review.ts
src/context/memory/edgeclaw-memory-core/src/core/skills/llm-extraction.ts
src/context/memory/edgeclaw-memory-core/src/core/index.ts
src/context/memory/edgeclaw-memory-core/src/message-utils.ts
src/context/memory/edgeclaw-memory-core/src/index.ts
src/context/memory/edgeclaw-memory-core/src/service.ts
src/context/memory/createEdgeClawMemoryProviderFromConfig.ts
src/context/memory/EdgeClawMemoryProvider.ts
src/context/memory/MemoryResolver.ts
src/context/memory/MemoryAttachmentBuilder.ts
src/context/input/InputProcessor.ts
src/context/ContextRuntime.ts
src/context/recovery/ContextOverflowRecovery.ts
src/context/compaction/stripMultimedia.ts
src/context/compaction/CompactionEngine.ts
src/context/compaction/MicroCompactionEngine.ts
src/context/compaction/toolPairIntegrity.ts
src/context/compaction/AutoCompactionPolicy.ts
src/context/compaction/CachedMicroCompactionEngine.ts
src/context/compaction/SnipEngine.ts
src/context/protocol/types.ts
src/context/DefaultContextRuntime.ts
src/context/prompt/PromptAssembler.ts
src/context/NullContextRuntime.ts
src/context/index.ts
src/context/attachments/AttachmentResolver.ts
src/context/projection/MessageProjector.ts
src/context/budget/ToolResultBudget.ts
src/context/budget/tokenizer.ts
src/context/budget/TokenBudgetManager.ts
src/extension/contributions/McpContribution.ts
src/extension/contributions/PermissionRuleContribution.ts
src/extension/contributions/PromptContribution.ts
src/extension/contributions/CommandContribution.ts
src/extension/contributions/RouterContribution.ts
src/extension/contributions/ToolContribution.ts
src/extension/contributions/HookContribution.ts
src/extension/plugins/loading/PluginContributionLoader.ts
src/extension/plugins/loading/PluginLoader.ts
src/extension/plugins/loading/PluginHookLoader.ts
src/extension/plugins/loading/PluginCommandLoader.ts
src/extension/plugins/config/validateMarketplaceName.ts
src/extension/plugins/config/parsePluginManifest.ts
src/extension/plugins/config/validatePluginSource.ts
src/extension/plugins/runtime/PluginReloadPolicy.ts
src/extension/plugins/runtime/PluginRegistry.ts
src/extension/plugins/runtime/PluginRuntime.ts
src/extension/plugins/runtime/truncateMcpString.ts
src/extension/plugins/discovery/discoverBuiltinPlugins.ts
src/extension/plugins/discovery/discoverLocalPlugins.ts
src/extension/plugins/discovery/PluginDirectoryResolver.ts
src/extension/plugins/protocol/errors.ts
src/extension/plugins/protocol/marketplace.ts
src/extension/plugins/protocol/plugin.ts
src/extension/plugins/protocol/manifest.ts
src/extension/plugins/builtin/loadBuiltinPlugins.ts
src/extension/protocol/source.ts
src/extension/protocol/errors.ts
src/extension/protocol/contribution.ts
src/extension/hooks/config/matchHookCondition.ts
src/extension/hooks/config/matchHook.ts
src/extension/hooks/config/parseHooksConfig.ts
src/extension/hooks/protocol/output.ts
src/extension/hooks/protocol/settings.ts
src/extension/hooks/protocol/input.ts
src/extension/hooks/protocol/events.ts
src/extension/hooks/execution/CallbackHookExecutor.ts
src/extension/hooks/execution/AgentHookExecutor.ts
src/extension/hooks/execution/aggregateHookResults.ts
src/extension/hooks/execution/AsyncHookRegistry.ts
src/extension/hooks/execution/parseHookOutput.ts
src/extension/hooks/execution/HookRuntime.ts
src/extension/hooks/execution/HttpHookExecutor.ts
src/extension/hooks/execution/HookExecutor.ts
src/extension/hooks/execution/PromptHookExecutor.ts
src/extension/hooks/execution/CommandHookExecutor.ts
src/extension/hooks/events/HookExecutionEventBus.ts
src/extension/skills/migrateSkills.ts
src/extension/skills/types.ts
src/extension/skills/SkillManager.ts
src/extension/skills/index.ts
src/extension/index.ts
src/web/server/listProjects.ts
src/web/server/readSessionMessages.ts
src/web/server/forkSession.ts
src/web/server/legacySessionPresentation.ts
src/web/client/webMessage.ts
src/web/client/GatewayBrowserClient.ts
src/web/client/protocol.ts
src/web/client/index.ts
src/lifecycle/runtime/LifecycleDispatcher.ts
src/lifecycle/runtime/LifecycleRuntime.ts
src/lifecycle/runtime/LifecycleObserver.ts
src/lifecycle/protocol/errors.ts
src/lifecycle/protocol/payloads.ts
src/lifecycle/protocol/events.ts
src/lifecycle/protocol/effects.ts
src/lifecycle/index.ts
src/agent/runtime/modelContextWindow.ts
src/agent/runtime/AgentRuntimeDependencies.ts
src/agent/runtime/PlanTodoState.ts
src/agent/runtime/AgentRuntimeConfig.ts
src/agent/protocol/state.ts
src/agent/protocol/errors.ts
src/agent/protocol/input.ts
src/agent/protocol/result.ts
src/agent/protocol/events.ts
src/agent/turn/TurnInputProcessor.ts
src/agent/turn/TurnRunner.ts
src/agent/sub/builtinSubagentTypes.ts
src/agent/sub/contextInheritance.ts
src/agent/sub/buildForkedMessages.ts
src/agent/sub/SubAgentSession.ts
src/agent/sub/types.ts
src/agent/sub/index.ts
src/agent/sub/filterIncompleteToolCalls.ts
src/agent/index.ts
src/agent/loop/collectToolCalls.ts
src/agent/loop/ensureToolResultPairing.ts
src/agent/loop/outputTokenRetry.ts
src/agent/loop/LargeFileRepair.ts
src/agent/loop/decideLoopContinuation.ts
src/agent/loop/AgentLoop.ts
src/agent/loop/projectToolResults.ts
src/agent/session/AgentSession.ts
src/agent/session/createAgentSession.ts
src/agent/session/AgentSessionState.ts
src/mcp/config/loadMcpServerConfig.ts
src/mcp/runtime/sanitize.ts
src/mcp/runtime/parsePluginMcpServers.ts
src/mcp/runtime/PluginToToolBridge.ts
src/mcp/runtime/McpRuntime.ts
src/mcp/runtime/wireName.ts
src/mcp/runtime/truncate.ts
src/mcp/protocol/types.ts
src/mcp/index.ts
src/mcp/client/McpClient.ts
src/cli/shutdownCoordinator.ts
src/cli/pilotdeck.ts
src/cli/proxy.ts
src/cli/ExtensionWatchManager.ts
src/cli/commands/gatewaySetup.ts
src/cli/index.ts
src/cli/createLocalGateway.ts
src/cli/pilotdeckServer.ts
src/adapters/web/projectGit.ts
src/adapters/web/httpRouter.ts
src/adapters/web/projectFiles.ts
src/adapters/web/static-mount.ts
src/adapters/channel/webhook/WebhookSessionMapper.ts
src/adapters/channel/webhook/webhook-render.ts
src/adapters/channel/webhook/WebhookChannel.ts
src/adapters/channel/dingtalk/dingtalk-render.ts
src/adapters/channel/dingtalk/DingTalkSessionMapper.ts
src/adapters/channel/dingtalk/DingTalkChannel.ts
src/adapters/channel/api-server/ApiServerChannel.ts
src/adapters/channel/api-server/api-server-render.ts
src/adapters/channel/api-server/ApiServerSessionMapper.ts
src/adapters/channel/loadEnabledChannels.ts
src/adapters/channel/discord/discord-render.ts
src/adapters/channel/discord/DiscordSessionMapper.ts
src/adapters/channel/discord/DiscordChannel.ts
src/adapters/channel/homeassistant/HomeAssistantChannel.ts
src/adapters/channel/homeassistant/homeassistant-render.ts
src/adapters/channel/homeassistant/HomeAssistantSessionMapper.ts
src/adapters/channel/sms/SmsChannel.ts
src/adapters/channel/sms/SmsSessionMapper.ts
src/adapters/channel/sms/sms-render.ts
src/adapters/channel/feishu/FeishuSessionMapper.ts
src/adapters/channel/feishu/FeishuChannel.ts
src/adapters/channel/feishu/feishu-render.ts
src/adapters/channel/tui/app/StatusLine.tsx
src/adapters/channel/tui/app/MessageResponse.tsx
src/adapters/channel/tui/app/HelpDialog.tsx
src/adapters/channel/tui/app/ActivityLine.tsx
src/adapters/channel/tui/app/ToolOutputViewer.tsx
src/adapters/channel/tui/app/sidebar-helpers.ts
src/adapters/channel/tui/app/WelcomeCard.tsx
src/adapters/channel/tui/app/SessionSidebar.tsx
src/adapters/channel/tui/app/formatToolSummary.ts
src/adapters/channel/tui/app/types.ts
src/adapters/channel/tui/app/PilotDeckLogo.tsx
src/adapters/channel/tui/app/MessageList.tsx
src/adapters/channel/tui/app/PermissionPrompt.tsx
src/adapters/channel/tui/app/PromptInput.tsx
src/adapters/channel/tui/app/Header.tsx
src/adapters/channel/tui/app/theme.ts
src/adapters/channel/tui/app/groupConsecutiveTools.ts
src/adapters/channel/tui/app/TuiApp.tsx
src/adapters/channel/tui/app/truncate.ts
src/adapters/channel/tui/tui-render.ts
src/adapters/channel/tui/TuiChannel.ts
src/adapters/channel/wecom/WeComChannel.ts
src/adapters/channel/wecom/WeComSessionMapper.ts
src/adapters/channel/wecom/wecom-render.ts
src/adapters/channel/wecom-callback/WeComCallbackSessionMapper.ts
src/adapters/channel/wecom-callback/WeComCallbackChannel.ts
src/adapters/channel/wecom-callback/wecom-callback-render.ts
src/adapters/channel/bluebubbles/BlueBubblesSessionMapper.ts
src/adapters/channel/bluebubbles/BlueBubblesChannel.ts
src/adapters/channel/bluebubbles/bluebubbles-render.ts
src/adapters/channel/protocol/ChannelAdapter.ts
src/adapters/channel/protocol/ImPermissionHelper.ts
src/adapters/channel/protocol/ChannelCommandRegistry.ts
src/adapters/channel/protocol/ImLiveReplyController.ts
src/adapters/channel/protocol/types.ts
src/adapters/channel/protocol/ImElicitationHelper.ts
src/adapters/channel/cli/CliChannel.ts
src/adapters/channel/cli/cli-render.ts
src/adapters/channel/weixin/WeixinChannel.ts
src/adapters/channel/weixin/WeixinSessionMapper.ts
src/adapters/channel/weixin/weixin-render.ts
src/adapters/channel/telegram/telegram-render.ts
src/adapters/channel/telegram/TelegramChannel.ts
src/adapters/channel/telegram/TelegramSessionMapper.ts
src/adapters/channel/slack/slack-render.ts
src/adapters/channel/slack/SlackChannel.ts
src/adapters/channel/slack/SlackSessionMapper.ts
src/adapters/channel/mattermost/MattermostSessionMapper.ts
src/adapters/channel/mattermost/mattermost-render.ts
src/adapters/channel/mattermost/MattermostChannel.ts
src/adapters/channel/matrix/matrix-render.ts
src/adapters/channel/matrix/MatrixSessionMapper.ts
src/adapters/channel/matrix/MatrixChannel.ts
src/adapters/channel/signal/signal-render.ts
src/adapters/channel/signal/SignalSessionMapper.ts
src/adapters/channel/signal/SignalChannel.ts
src/adapters/channel/email/EmailSessionMapper.ts
src/adapters/channel/email/email-render.ts
src/adapters/channel/email/EmailChannel.ts
src/adapters/channel/whatsapp/WhatsAppSessionMapper.ts
src/adapters/channel/whatsapp/WhatsAppChannel.ts
src/adapters/channel/whatsapp/whatsapp-render.ts
src/adapters/channel/qq/QQChannel.ts
src/adapters/channel/qq/QQSessionMapper.ts
src/adapters/channel/qq/qq-render.ts
src/adapters/channel/qq/qqbot-gateway.ts
src/adapters/index.ts
src/task/runtime/BackgroundTaskRuntime.ts
src/task/protocol/types.ts
src/task/storage/TaskOutputStore.ts
src/task/index.ts
src/model/response/parseModelResponse.ts
src/model/response/normalizeUsage.ts
src/model/response/normalizeFinishReason.ts
src/model/normalizeProviderBaseUrl.ts
src/model/config/schema.ts
src/model/config/resolveCredentials.ts
src/model/config/parseModelConfig.ts
src/model/providers/google/schema.ts
src/model/providers/google/modelId.ts
src/model/providers/google/defaults.ts
src/model/providers/google/stream.ts
src/model/providers/google/response.ts
src/model/providers/google/request.ts
src/model/providers/google/client.ts
src/model/providers/registry.ts
src/model/providers/anthropic/defaults.ts
src/model/providers/anthropic/stream.ts
src/model/providers/anthropic/response.ts
src/model/providers/anthropic/request.ts
src/model/providers/openai/defaults.ts
src/model/providers/openai/stream.ts
src/model/providers/openai/response.ts
src/model/providers/openai/request.ts
src/model/providers/openai-responses/stream.ts
src/model/providers/openai-responses/response.ts
src/model/providers/openai-responses/request.ts
src/model/catalog/providers.ts
src/model/catalog/types.ts
src/model/catalog/lookup.ts
src/model/catalog/index.ts
src/model/ModelRuntime.ts
src/model/protocol/clone.ts
src/model/protocol/errors.ts
src/model/protocol/canonical.ts
src/model/protocol/capabilities.ts
src/model/protocol/multimodal.ts
src/model/protocol/toolResultContent.ts
src/model/streaming/streamModel.ts
src/model/streaming/StreamingCheckpoint.ts
src/model/streaming/parseTextToolCalls.ts
src/model/streaming/normalizeStreamEvent.ts
src/model/streaming/assembleModelMessage.ts
src/model/request/validateModelRequest.ts
src/model/request/materializeMediaReferences.ts
src/model/request/buildModelRequest.ts
src/model/index.ts
src/model/structuredOutput/extractStructuredOutput.ts
src/model/errors/normalizeModelError.ts
src/pilot/config/loadPilotConfig.ts
src/pilot/config/parseToolsConfig.ts
src/pilot/config/redact.ts
src/pilot/config/parseMemoryConfig.ts
src/pilot/config/PilotConfigStore.ts
src/pilot/config/hash.ts
src/pilot/config/types.ts
src/pilot/config/classifyChanges.ts
src/pilot/config/index.ts
src/pilot/config/merge.ts
src/pilot/config/parseGatewayConfig.ts
src/pilot/index.ts
src/pilot/paths.ts
src/always-on/context/ChatDigestBuilder.ts
src/always-on/config/parseAlwaysOnConfig.ts
src/always-on/web/DiscoveryPlanStatus.ts
src/always-on/web/DiscoveryPlanContext.ts
src/always-on/web/AlwaysOnRunHistoryService.ts
src/always-on/web/DiscoveryPlanService.ts
src/always-on/contracts/PlanContract.ts
src/always-on/contracts/ReportContract.ts
src/always-on/workspace/GitWorktreeProvider.ts
src/always-on/workspace/WorkspaceProviderRegistry.ts
src/always-on/workspace/SnapshotCopyProvider.ts
src/always-on/workspace/WorkspaceApply.ts
src/always-on/workspace/WorkspaceProvider.ts
src/always-on/runtime/discoveryPrompts.ts
src/always-on/runtime/SignalWatcher.ts
src/always-on/runtime/AlwaysOnManager.ts
src/always-on/runtime/DiscoveryScheduler.ts
src/always-on/runtime/DiscoveryFire.ts
src/always-on/runtime/SessionConfigOverrides.ts
src/always-on/runtime/AlwaysOnRunContextRegistry.ts
src/always-on/runtime/ChannelLeaseRegistry.ts
src/always-on/runtime/discoveryPrompts.zh.ts
src/always-on/runtime/DiscoveryGates.ts
src/always-on/runtime/AlwaysOnRuntime.ts
src/always-on/runtime/createApplyHandler.ts
src/always-on/protocol/errors.ts
src/always-on/protocol/types.ts
src/always-on/storage/AlwaysOnEventStore.ts
src/always-on/storage/DiscoveryReportStore.ts
src/always-on/storage/DiscoveryStateStore.ts
src/always-on/storage/AlwaysOnPaths.ts
src/always-on/storage/WorkCycleStore.ts
src/always-on/storage/DiscoveryPlanStore.ts
src/always-on/index.ts
src/always-on/tool/AlwaysOnWorkspaceTool.ts
src/always-on/tool/AlwaysOnDiscoveryPlanTool.ts
src/always-on/tool/AlwaysOnReportTool.ts
src/always-on/tool/AlwaysOnChatHistoryTool.ts
src/telemetry/context.ts
src/telemetry/types.ts
src/telemetry/collector.ts
src/telemetry/index.ts
src/telemetry/sender.ts
src/permission/settings.ts
src/permission/protocol/types.ts
src/permission/decision/PermissionRuntime.ts
src/permission/index.ts
src/permission/policy/matchPermissionRule.ts
src/tool/scheduler/ToolScheduler.ts
src/tool/scheduler/SequentialToolScheduler.ts
src/tool/scheduler/ConcurrentToolScheduler.ts
src/tool/elicitation/PilotDeckElicitationChannel.ts
src/tool/elicitation/validateHtmlPreview.ts
src/tool/protocol/schema.ts
src/tool/protocol/errors.ts
src/tool/protocol/result.ts
src/tool/protocol/types.ts
src/tool/audit/ToolAuditRecorder.ts
src/tool/execution/validateToolInput.ts
src/tool/execution/ToolRuntime.ts
src/tool/execution/formatValidationError.ts
src/tool/registry/createBuiltinRegistry.ts
src/tool/registry/ToolRegistry.ts
src/tool/userInteractionConstraints.ts
src/tool/index.ts
src/tool/builtin/editNotebook.ts
src/tool/builtin/webFetch.ts
src/tool/builtin/readFile.ts
src/tool/builtin/mcpResources.ts
src/tool/builtin/readSkill.ts
src/tool/builtin/planFile.ts
src/tool/builtin/web/urlFetcher.ts
src/tool/builtin/web/preapprovedHosts.ts
src/tool/builtin/web/urlValidation.ts
src/tool/builtin/web/urlContentCache.ts
src/tool/builtin/web/secondaryPrompt.ts
src/tool/builtin/mcpTool.ts
src/tool/builtin/agent.ts
src/tool/builtin/planMode.ts
src/tool/builtin/webSearch.ts
src/tool/builtin/filesystem/readTextFile.ts
src/tool/builtin/filesystem/pathSafety.ts
src/tool/builtin/filesystem/globPattern.ts
src/tool/builtin/filesystem/structuredPatch.ts
src/tool/builtin/filesystem/writeSnapshots.ts
src/tool/builtin/filesystem/writeTextFile.ts
src/tool/builtin/filesystem/walk.ts
src/tool/builtin/filesystem/editNormalization.ts
src/tool/builtin/filesystem/ripgrepFiles.ts
src/tool/builtin/filesystem/ripgrep.ts
src/tool/builtin/filesystem/readNotebook.ts
src/tool/builtin/filesystem/readFileInRange.ts
src/tool/builtin/filesystem/writePermissions.ts
src/tool/builtin/filesystem/fileTypeSafety.ts
src/tool/builtin/todoWrite.ts
src/tool/builtin/glob.ts
src/tool/builtin/bash/permissions.ts
src/tool/builtin/bash/commandRunner.ts
src/tool/builtin/grep.ts
src/tool/builtin/taskTools.ts
src/tool/builtin/writeFile.ts
src/tool/builtin/bash.ts
src/tool/builtin/askUserQuestion.ts
src/tool/builtin/structuredOutput.ts
src/tool/builtin/editFile.ts
src/tool/planModeConstraints.ts
src/gateway/util/AsyncQueue.ts
src/gateway/elicitation/GatewayElicitationChannel.ts
src/gateway/elicitation/GatewayElicitationBus.ts
src/gateway/server/websocket.ts
src/gateway/server/GatewayWsConnection.ts
src/gateway/server/authToken.ts
src/gateway/server/staticAssets.ts
src/gateway/server/GatewayServer.ts
src/gateway/protocol/frames.ts
src/gateway/protocol/types.ts
src/gateway/protocol/index.ts
src/gateway/protocol/version.ts
src/gateway/memoryDiagnostics.ts
src/gateway/SessionRouter.ts
src/gateway/index.ts
src/gateway/permission/createGatewayPermissionHook.ts
src/gateway/permission/GatewayPermissionBus.ts
src/gateway/Gateway.ts
src/gateway/client/probeServer.ts
src/gateway/client/GatewayWsClient.ts
src/gateway/client/InProcessGateway.ts
src/gateway/client/RemoteGateway.ts
src/cron/config/parseCronConfig.ts
src/cron/runtime/CronRuntime.ts
src/cron/runtime/CronFire.ts
src/cron/runtime/CronManager.ts
src/cron/runtime/CronSchedule.ts
src/cron/runtime/CronScheduler.ts
src/cron/protocol/types.ts
src/cron/storage/CronPaths.ts
src/cron/storage/CronTaskStore.ts
src/cron/storage/CronStoreMigration.ts
src/cron/CronTimezone.ts
src/cron/index.ts
src/cron/tool/CronToolRuntime.ts
src/cron/tool/CronCreateTool.ts
src/cron/tool/CronDeleteTool.ts
src/cron/tool/CronListTool.ts
src/cron/tool/CronSchemas.ts
src/cron/tool/CronStopTool.ts
src/session/transcript/replaySubagentTranscript.ts
src/session/transcript/TranscriptChain.ts
src/session/transcript/TranscriptReplay.ts
src/session/transcript/TranscriptEntry.ts
src/session/transcript/TranscriptReader.ts
src/session/transcript/TranscriptWriter.ts
src/session/transcript/JsonlTranscriptWriter.ts
src/session/transcript/InMemoryTranscriptWriter.ts
src/session/resume/resumeAgentSession.ts
src/session/worktree/findCanonicalProjectRoot.ts
src/session/worktree/LRUMap.ts
src/session/worktree/findGitRoot.ts
src/session/worktree/index.ts
src/session/worktree/resolveCanonicalRoot.ts
src/session/filesystem/FileHistoryStore.ts
src/session/filesystem/backupNaming.ts
src/session/filesystem/types.ts
src/session/filesystem/restoreBackup.ts
src/session/filesystem/index.ts
src/session/filesystem/createBackup.ts
src/session/storage/ProjectSessionStorage.ts
src/session/storage/SessionLiteReader.ts
src/session/storage/SessionList.ts
src/session/index.ts
src/session/metadata/SessionMetadataStore.ts
src/router/retry/zeroUsageRetry.ts
src/router/fallback/runFallbackChain.ts
src/router/config/schema.ts
src/router/config/parseRouterConfig.ts
src/router/config/resolveProviderRef.ts
src/router/tokenSaver/classifyAndRoute.ts
src/router/tokenSaver/generateJudgePrompt.ts
src/router/tokenSaver/extractLastUserMessage.ts
src/router/tokenSaver/parseTier.ts
src/router/health/ProviderHealthTracker.ts
src/router/utils/mediaRequirements.ts
src/router/utils/countTokens.ts
src/router/protocol/errors.ts
src/router/protocol/decision.ts
src/router/protocol/events.ts
src/router/scenario/subagentDetector.ts
src/router/scenario/decideScenario.ts
src/router/RouterRuntime.ts
src/router/index.ts
src/router/orchestrate/applyOrchestration.ts
src/router/stats/TokenStatsCollector.ts
src/router/customRouter/customRouter.ts
src/router/session/sessionUsageCache.ts
src/router/session/SessionRouterStore.ts
scripts/tui-e2e-record.tsx
scripts/tui-e2e-permission.tsx
scripts/mock-ilink.ts`
- Responses API stream smoke via `node --import tsx --input-type=module`
- `npm --prefix ui run build`

## Notes
- `npm run build` still hits pre-existing repository test type errors unrelated to this change.
