### PR TITLE
fix(ui): display glob result files

### DIFF
--- a/src/web/server/readSessionMessages.ts
+++ b/src/web/server/readSessionMessages.ts
@@ -465,7 +465,9 @@ function flushBlock(
       flushText();
       const resultText = flattenToolResultBlockText(block);
       const errorCode = readToolResultErrorCode(block.raw);
+      const toolName = readToolResultToolName(block.raw);
       const planData = readPlanData(block.raw);
+      const searchData = readSearchToolData(block.raw);
       const resultImages: NonNullable<WebMessage["images"]> = [];
       for (const sub of block.content) {
         if (sub.type === "image") {
@@ -481,10 +483,11 @@ function flushBlock(
         role: "tool",
         kind: "tool_result",
         toolCallId: block.toolCallId,
+        ...(toolName ? { toolName } : {}),
         ok: !block.isError,
         text: resultText,
         ...(errorCode ? { errorCode } : {}),
-        ...(planData ? { payload: planData } : {}),
+        ...(planData || searchData ? { payload: planData ?? searchData } : {}),
         ...(resultImages.length > 0 ? { images: resultImages } : {}),
         source: "history",
       });
@@ -821,6 +824,12 @@ function readToolResultErrorCode(raw: unknown): string | undefined {
   return typeof code === "string" && code.length > 0 ? code : undefined;
 }
 
+function readToolResultToolName(raw: unknown): string | undefined {
+  if (!raw || typeof raw !== "object") return undefined;
+  const toolName = (raw as { toolName?: unknown }).toolName;
+  return typeof toolName === "string" && toolName.length > 0 ? toolName : undefined;
+}
+
 function readPlanData(raw: unknown): Record<string, unknown> | undefined {
   if (!raw || typeof raw !== "object") return undefined;
   const data = (raw as { data?: unknown }).data;
@@ -832,4 +841,18 @@ function readPlanData(raw: unknown): Record<string, unknown> | undefined {
     planTitle: d.planTitle,
     planSummary: d.planSummary,
   };
+}
+
+function readSearchToolData(raw: unknown): Record<string, unknown> | undefined {
+  if (!raw || typeof raw !== "object") return undefined;
+  const record = raw as { toolName?: unknown; data?: unknown };
+  if (!isSearchToolName(record.toolName)) return undefined;
+  return record.data && typeof record.data === "object"
+    ? record.data as Record<string, unknown>
+    : undefined;
+}
+
+function isSearchToolName(name: unknown): boolean {
+  const normalized = typeof name === "string" ? name.toLowerCase() : "";
+  return normalized === "grep" || normalized === "glob";
 }

--- a/ui/server/pilotdeck-bridge.js
+++ b/ui/server/pilotdeck-bridge.js
@@ -106,6 +106,11 @@ function readOnlyModeToolDenyCode(text) {
     return undefined;
 }
 
+function isSearchToolName(name) {
+    const normalized = String(name || '').toLowerCase();
+    return normalized === 'grep' || normalized === 'glob';
+}
+
 function normalizeToolErrorCode(errorCode, resultPreview) {
     if (errorCode === 'plan_mode_violation') return 'plan_mode_denied';
     if (errorCode === 'ask_mode_violation') return 'ask_mode_denied';
@@ -441,6 +446,9 @@ export function gatewayEventToFrames(event, sessionId, provider) {
                           }
                         : {}),
                     ...(event.toolName === 'ask_user_question' && event.data
+                        ? { toolUseResult: event.data }
+                        : {}),
+                    ...(isSearchToolName(event.toolName) && event.data
                         ? { toolUseResult: event.data }
                         : {}),
                 }),

--- a/ui/server/routes/messages.js
+++ b/ui/server/routes/messages.js
@@ -21,6 +21,11 @@ import { createNormalizedMessage } from '../pilotdeck-message.js';
 const router = express.Router();
 const REPO_ROOT = process.cwd();
 
+function isSearchToolName(name) {
+  const normalized = String(name || '').toLowerCase();
+  return normalized === 'grep' || normalized === 'glob';
+}
+
 router.get('/:sessionId/messages', async (req, res) => {
   try {
     const { sessionId } = req.params;
@@ -184,6 +189,9 @@ function mapWebMessageToNormalized(message, sessionId) {
       const planPayload = message.payload && typeof message.payload === 'object'
           ? message.payload
           : {};
+      const searchPayload = isSearchToolName(message.toolName) && message.payload && typeof message.payload === 'object'
+          ? message.payload
+          : null;
       return createNormalizedMessage({
         ...base,
         kind: 'tool_result',
@@ -206,6 +214,7 @@ function mapWebMessageToNormalized(message, sessionId) {
             planTitle: planPayload.planTitle,
             planSummary: planPayload.planSummary,
         } : {}),
+        ...(searchPayload ? { toolUseResult: searchPayload } : {}),
       });
     }
     case 'permission_request':

--- a/ui/src/components/chat/tools/configs/toolConfigs.ts
+++ b/ui/src/components/chat/tools/configs/toolConfigs.ts
@@ -47,6 +47,13 @@ type ParsedTodoItem = {
   status: 'pending' | 'in_progress' | 'completed';
 };
 
+type SearchToolResultData = {
+  files?: unknown;
+  filenames?: unknown;
+  count?: unknown;
+  numFiles?: unknown;
+};
+
 const TODO_LINE_PATTERN = /^\s*[-*]\s+\[( |x|X)\]\s+(.*?)\s*$/u;
 
 function parseTodoMarkdown(markdown: unknown): ParsedTodoItem[] {
@@ -83,6 +90,26 @@ function parseTodoMarkdown(markdown: unknown): ParsedTodoItem[] {
       status,
     };
   });
+}
+
+export function getSearchToolResultFiles(result: unknown): unknown[] {
+  const toolData = ((result as { toolUseResult?: SearchToolResultData } | undefined)?.toolUseResult || {}) as SearchToolResultData;
+  if (Array.isArray(toolData.files)) return toolData.files;
+  if (Array.isArray(toolData.filenames)) return toolData.filenames;
+  return [];
+}
+
+export function getSearchToolResultCount(result: unknown): number {
+  const toolData = ((result as { toolUseResult?: SearchToolResultData } | undefined)?.toolUseResult || {}) as SearchToolResultData;
+  if (typeof toolData.count === 'number') return toolData.count;
+  if (typeof toolData.numFiles === 'number') return toolData.numFiles;
+  return getSearchToolResultFiles(result).length;
+}
+
+export function getSearchToolResultFileCount(result: unknown): number {
+  const toolData = ((result as { toolUseResult?: SearchToolResultData } | undefined)?.toolUseResult || {}) as SearchToolResultData;
+  if (typeof toolData.numFiles === 'number') return toolData.numFiles;
+  return getSearchToolResultFiles(result).length;
 }
 
 export const TOOL_CONFIGS: Record<string, ToolDisplayConfig> = {
@@ -238,15 +265,13 @@ export const TOOL_CONFIGS: Record<string, ToolDisplayConfig> = {
       type: 'collapsible',
       defaultOpen: false,
       title: (result) => {
-        const toolData = result.toolUseResult || {};
-        const count = toolData.numFiles || toolData.filenames?.length || 0;
+        const count = getSearchToolResultFileCount(result);
         return `Found ${count} ${count === 1 ? 'file' : 'files'}`;
       },
       contentType: 'file-list',
       getContentProps: (result) => {
-        const toolData = result.toolUseResult || {};
         return {
-          files: toolData.filenames || []
+          files: getSearchToolResultFiles(result)
         };
       }
     }
@@ -271,15 +296,13 @@ export const TOOL_CONFIGS: Record<string, ToolDisplayConfig> = {
       type: 'collapsible',
       defaultOpen: false,
       title: (result) => {
-        const toolData = result.toolUseResult || {};
-        const count = toolData.numFiles || toolData.filenames?.length || 0;
+        const count = getSearchToolResultCount(result);
         return `Found ${count} ${count === 1 ? 'file' : 'files'}`;
       },
       contentType: 'file-list',
       getContentProps: (result) => {
-        const toolData = result.toolUseResult || {};
         return {
-          files: toolData.filenames || []
+          files: getSearchToolResultFiles(result)
         };
       }
     }


### PR DESCRIPTION
## Summary
- Support current search tool result fields (files/count) in Grep and Glob renderers
- Keep compatibility with legacy filenames/numFiles fields

## Tests
- Not run (per request: no test changes in PR)