### PR TITLE
fix(cron): support relative schedules

### DIFF
--- a/src/cron/protocol/types.ts
+++ b/src/cron/protocol/types.ts
@@ -1,6 +1,6 @@
 import type { GatewayChannelKey, GatewayMode } from "../../gateway/index.js";
 
-export type CronSchedule =
+export type CronTaskSchedule =
   | {
       type: "once";
       runAt: string;
@@ -11,13 +11,23 @@ export type CronSchedule =
       timezone?: string;
     };
 
+export type CronCreateSchedule =
+  | CronTaskSchedule
+  | {
+      type: "delay";
+      amount: number;
+      unit: "second" | "minute" | "hour" | "day";
+    };
+
+export type CronSchedule = CronCreateSchedule;
+
 export type CronTaskStatus = "scheduled" | "running";
 
 export type CronTask = {
   schemaVersion: 1;
   taskId: string;
   message: string;
-  schedule: CronSchedule;
+  schedule: CronTaskSchedule;
   status: CronTaskStatus;
   sessionKey: string;
   channelKey: GatewayChannelKey;
@@ -50,7 +60,7 @@ export type CronRunRecord = {
 
 export type CronCreateInput = {
   message: string;
-  schedule: CronSchedule;
+  schedule: CronCreateSchedule;
   sessionKey?: string;
   channelKey?: GatewayChannelKey;
   projectKey?: string;

--- a/src/cron/runtime/CronRuntime.ts
+++ b/src/cron/runtime/CronRuntime.ts
@@ -200,7 +200,7 @@ export class CronRuntime {
     const now = this.now();
     const taskId = this.uuid();
     const sessionKey = buildCronSessionKey(taskId);
-    const schedule = normalizeSchedule(input, this.config.timezone);
+    const schedule = normalizeSchedule(input, this.config.timezone, now);
     const timezone = schedule.type === "cron"
       ? schedule.timezone
       : input.timezone ?? this.config.timezone;
@@ -468,9 +468,16 @@ export function createCronRuntime(options: CreateCronRuntimeOptions): CronRuntim
   return new CronRuntime(options);
 }
 
-function normalizeSchedule(input: CronCreateInput, configTimezone: string): CronTask["schedule"] {
+function normalizeSchedule(input: CronCreateInput, configTimezone: string, now: Date): CronTask["schedule"] {
   if (input.schedule.type === "once") {
     return { type: "once", runAt: input.schedule.runAt };
+  }
+  if (input.schedule.type === "delay") {
+    const runAt = computeNextRunAt(input.schedule, now);
+    if (!runAt) {
+      throw new Error("Cron delay schedule must use a positive finite amount.");
+    }
+    return { type: "once", runAt: runAt.toISOString() };
   }
   const requestedTimezone = input.schedule.timezone ?? input.timezone;
   if (requestedTimezone && !isValidCronTimezone(requestedTimezone)) {

--- a/src/cron/runtime/CronSchedule.ts
+++ b/src/cron/runtime/CronSchedule.ts
@@ -1,11 +1,17 @@
-import type { CronSchedule } from "../protocol/types.js";
+import type { CronCreateSchedule } from "../protocol/types.js";
 import { isValidCronTimezone } from "../CronTimezone.js";
 
 const MINUTE_MS = 60_000;
 const MAX_SEARCH_MINUTES = 366 * 24 * 60;
+const DELAY_UNIT_MS: Record<"second" | "minute" | "hour" | "day", number> = {
+  second: 1_000,
+  minute: MINUTE_MS,
+  hour: 60 * MINUTE_MS,
+  day: 24 * 60 * MINUTE_MS,
+};
 
 export function computeNextRunAt(
-  schedule: CronSchedule,
+  schedule: CronCreateSchedule,
   after: Date,
   fallbackTimezone = "UTC",
 ): Date | undefined {
@@ -13,7 +19,19 @@ export function computeNextRunAt(
     const runAt = new Date(schedule.runAt);
     return Number.isNaN(runAt.getTime()) ? undefined : runAt;
   }
+  if (schedule.type === "delay") {
+    const delayMs = delayToMilliseconds(schedule.amount, schedule.unit);
+    return delayMs === undefined ? undefined : new Date(after.getTime() + delayMs);
+  }
   return computeNextCronRunAt(schedule.expression, after, schedule.timezone ?? fallbackTimezone);
+}
+
+export function delayToMilliseconds(
+  amount: number,
+  unit: "second" | "minute" | "hour" | "day",
+): number | undefined {
+  if (!Number.isFinite(amount) || amount <= 0) return undefined;
+  return amount * DELAY_UNIT_MS[unit];
 }
 
 export function computeNextCronRunAt(

--- a/src/cron/tool/CronCreateTool.ts
+++ b/src/cron/tool/CronCreateTool.ts
@@ -7,7 +7,7 @@ export function createCronCreateTool(runtime: CronToolRuntime): PilotDeckToolDef
   return {
     name: "cron_create",
     title: "Create Cron Task",
-    description: "Create a one-time or recurring background Cron task that submits future work back into a session.",
+    description: "Create a one-time or recurring background Cron task that submits future work back into a session. For relative reminders like 'in 10 minutes', use schedule.type='delay'. For absolute natural-language times like tonight, tomorrow morning, or next Monday, call get_current_time first to resolve the current local time/timezone, then pass a future schedule.type='once' runAt.",
     kind: "session",
     inputSchema: {
       type: "object",

--- a/src/cron/tool/CronSchemas.ts
+++ b/src/cron/tool/CronSchemas.ts
@@ -19,5 +19,15 @@ export const CRON_SCHEDULE_SCHEMA = {
         timezone: { type: "string" },
       },
     },
+    {
+      type: "object",
+      required: ["type", "amount", "unit"],
+      additionalProperties: false,
+      properties: {
+        type: { const: "delay" },
+        amount: { type: "number", exclusiveMinimum: 0 },
+        unit: { enum: ["second", "minute", "hour", "day"] },
+      },
+    },
   ],
 } as const;

--- a/src/tool/askModeConstraints.ts
+++ b/src/tool/askModeConstraints.ts
@@ -8,6 +8,7 @@ import { isReadOnlyShellCommand } from "./builtin/bash/permissions.js";
 
 export const ASK_MODE_ALLOWED_TOOLS = new Set([
   "read_file",
+  "get_current_time",
   "grep",
   "glob",
   "web_search",

--- a/src/tool/builtin/getCurrentTime.ts
+++ b/src/tool/builtin/getCurrentTime.ts
@@ -1,0 +1,113 @@
+import type { PilotDeckToolDefinition } from "../protocol/types.js";
+import { PilotDeckToolRuntimeError } from "../protocol/errors.js";
+
+export type GetCurrentTimeInput = {
+  timezone?: string;
+};
+
+export type GetCurrentTimeOutput = {
+  timezone: string;
+  iso: string;
+  local: string;
+  date: string;
+  weekday: string;
+  unixMs: number;
+};
+
+export function createGetCurrentTimeTool(): PilotDeckToolDefinition<GetCurrentTimeInput, GetCurrentTimeOutput> {
+  return {
+    name: "get_current_time",
+    title: "Get Current Time",
+    description: "Return the current local time for a timezone. Use this before creating cron_create tasks with absolute dates/times such as tonight, tomorrow morning, or next Monday. For simple relative delays like 'in 10 minutes', prefer cron_create with schedule.type='delay' instead of calling this tool.",
+    kind: "custom",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        timezone: {
+          type: "string",
+          description: "IANA timezone, e.g. Asia/Shanghai. Defaults to the host local timezone.",
+        },
+      },
+    },
+    isReadOnly: () => true,
+    isConcurrencySafe: () => true,
+    execute: async (input, context) => {
+      const timezone = input.timezone?.trim() || Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
+      assertValidTimezone(timezone);
+      const now = context.now?.() ?? new Date();
+      const output: GetCurrentTimeOutput = {
+        timezone,
+        iso: now.toISOString(),
+        local: formatLocalDateTime(now, timezone),
+        date: formatLocalDate(now, timezone),
+        weekday: formatWeekday(now, timezone),
+        unixMs: now.getTime(),
+      };
+      return {
+        content: [{ type: "json", value: output }],
+        data: output,
+      };
+    },
+  };
+}
+
+function assertValidTimezone(timezone: string): void {
+  try {
+    new Intl.DateTimeFormat("en-US", { timeZone: timezone }).format();
+  } catch {
+    throw new PilotDeckToolRuntimeError(
+      "tool_execution_failed",
+      `Invalid timezone: ${timezone}`,
+    );
+  }
+}
+
+function formatLocalDateTime(date: Date, timezone: string): string {
+  const values = dateParts(date, timezone, {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+  });
+  const offset = formatOffset(date, timezone);
+  return `${values.year}-${values.month}-${values.day}T${values.hour}:${values.minute}:${values.second}${offset}`;
+}
+
+function formatLocalDate(date: Date, timezone: string): string {
+  const values = dateParts(date, timezone, {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  });
+  return `${values.year}-${values.month}-${values.day}`;
+}
+
+function formatWeekday(date: Date, timezone: string): string {
+  const values = dateParts(date, timezone, { weekday: "long" });
+  return values.weekday ?? "";
+}
+
+function dateParts(
+  date: Date,
+  timezone: string,
+  options: Intl.DateTimeFormatOptions,
+): Record<string, string> {
+  return Object.fromEntries(
+    new Intl.DateTimeFormat("en-CA", { timeZone: timezone, ...options })
+      .formatToParts(date)
+      .map((part) => [part.type, part.value]),
+  );
+}
+
+function formatOffset(date: Date, timezone: string): string {
+  const value = new Intl.DateTimeFormat("en-US", {
+    timeZone: timezone,
+    timeZoneName: "longOffset",
+  }).formatToParts(date).find((part) => part.type === "timeZoneName")?.value;
+  const match = value?.match(/GMT([+-]\d{2}:\d{2})/);
+  return match?.[1] ?? "+00:00";
+}

--- a/src/tool/index.ts
+++ b/src/tool/index.ts
@@ -69,6 +69,11 @@ export { createReadFileTool, type ReadFileInput } from "./builtin/readFile.js";
 export { createReadSkillTool, type ReadSkillDeps, type ReadSkillInput } from "./builtin/readSkill.js";
 export { createGlobTool, extractGlobBaseDirectory, type GlobInput } from "./builtin/glob.js";
 export { createGrepTool, type GrepInput } from "./builtin/grep.js";
+export {
+  createGetCurrentTimeTool,
+  type GetCurrentTimeInput,
+  type GetCurrentTimeOutput,
+} from "./builtin/getCurrentTime.js";
 export { createEditFileTool, type EditFileInput } from "./builtin/editFile.js";
 export {
   createEditNotebookTool,

--- a/src/tool/planModeConstraints.ts
+++ b/src/tool/planModeConstraints.ts
@@ -10,6 +10,7 @@
  */
 export const PLAN_MODE_ALLOWED_TOOLS = new Set([
   "read_file",
+  "get_current_time",
   "grep",
   "glob",
   "web_search",

--- a/src/tool/registry/createBuiltinRegistry.ts
+++ b/src/tool/registry/createBuiltinRegistry.ts
@@ -6,6 +6,7 @@ import { createEditFileTool } from "../builtin/editFile.js";
 import { createEditNotebookTool } from "../builtin/editNotebook.js";
 import { createGlobTool } from "../builtin/glob.js";
 import { createGrepTool } from "../builtin/grep.js";
+import { createGetCurrentTimeTool } from "../builtin/getCurrentTime.js";
 import { createReadFileTool } from "../builtin/readFile.js";
 import { createEnterPlanModeTool, createExitPlanModeTool } from "../builtin/planMode.js";
 import { createStructuredOutputTool } from "../builtin/structuredOutput.js";
@@ -86,6 +87,7 @@ export type CreateBuiltinRegistryOptions = {
 
 export function createBuiltinRegistry(options?: CreateBuiltinRegistryOptions): ToolRegistry {
   const registry = new ToolRegistry();
+  registry.register(createGetCurrentTimeTool());
   registry.register(createReadFileTool());
   registry.register(createGlobTool());
   registry.register(createGrepTool());


### PR DESCRIPTION
## Summary
- add a read-only get_current_time tool for resolving absolute cron times without dynamic system prompt timestamps
- allow cron_create to accept relative delay schedules such as { type: "delay", amount: 10, unit: "minute" }
- normalize delay schedules to persisted one-time tasks so existing cron storage stays compatible

## Tests
- node --import tsx --test tests/cron/CronDelaySchedule.spec.ts tests/tool/GetCurrentTimeTool.spec.ts
- npx tsc --noEmit --target ES2022 --module NodeNext --moduleResolution NodeNext --strict --esModuleInterop --skipLibCheck --types node src/cron/protocol/types.ts src/cron/tool/CronSchemas.ts src/cron/tool/CronCreateTool.ts src/cron/runtime/CronSchedule.ts src/cron/runtime/CronRuntime.ts src/tool/builtin/getCurrentTime.ts src/tool/registry/createBuiltinRegistry.ts src/tool/index.ts tests/cron/CronDelaySchedule.spec.ts tests/tool/GetCurrentTimeTool.spec.ts