### PR TITLE
fix(feishu): update live replies in-place

### DIFF
--- a/src/adapters/channel/feishu/FeishuChannel.ts
+++ b/src/adapters/channel/feishu/FeishuChannel.ts
@@ -13,6 +13,7 @@ import {
   type ImLiveReplyTransport,
 } from "../protocol/ImLiveReplyController.js";
 import { FeishuSessionMapper } from "./FeishuSessionMapper.js";
+import { type FeishuLiveCardActivityKind } from "./feishu-render.js";
 
 let Lark: any = null;
 let larkLoadAttempted = false;
@@ -45,6 +46,7 @@ export type FeishuOutboundMessage = {
 
 export type FeishuLiveMessageHandle = {
   messageId: string;
+  livePost: boolean;
 };
 
 export type FeishuConnectionMode = "stream" | "webhook";
@@ -402,17 +404,24 @@ export class FeishuChannel implements ChannelAdapter {
 
   private createLiveReplyTransport(chatId: string): ImLiveReplyTransport<FeishuLiveMessageHandle> {
     const liveCursor = this.liveReplyOptions?.cursor ?? DEFAULT_LIVE_REPLY_CURSOR;
+    let liveHandle: FeishuLiveMessageHandle | undefined;
     return {
       maxMessageLength: MAX_TEXT_MESSAGE_LENGTH,
       send: async (text) => {
-        const messageId = text.endsWith(liveCursor)
-          ? await this.sendLiveMessage({ chatId, text })
-          : await this.sendTextMessage({ chatId, text });
-        if (messageId === false) return false;
-        return messageId ? { messageId } : undefined;
+        const result = await this.sendLiveMessage({ chatId, text }, {
+          isFinal: !text.endsWith(liveCursor),
+          activityKind: this.liveActivityKindFromText(text),
+        });
+        if (result === false) return false;
+        liveHandle = result ? { messageId: result.messageId, livePost: result.livePost } : undefined;
+        return liveHandle;
       },
       edit: async (handle, text) => {
-        return this.editLiveMessage(handle.messageId, text);
+        liveHandle = handle;
+        return this.editLiveMessage(handle, text, {
+          isFinal: !text.endsWith(liveCursor),
+          activityKind: this.liveActivityKindFromText(text),
+        });
       },
     };
   }
@@ -421,8 +430,15 @@ export class FeishuChannel implements ChannelAdapter {
     await this.sendTextMessage(message);
   }
 
-  private async sendLiveMessage(message: FeishuOutboundMessage): Promise<string | undefined | false> {
-    return this.sendTextMessage(message);
+  private async sendLiveMessage(
+    message: FeishuOutboundMessage,
+    options: { isFinal: boolean; activityKind?: FeishuLiveCardActivityKind },
+  ): Promise<FeishuLiveMessageHandle | undefined | false> {
+    const messageId = await this.sendPostMessage(message.chatId, message.text, options);
+    if (messageId !== false) return { messageId, livePost: true };
+    const fallbackMessageId = await this.sendTextMessage(message);
+    if (fallbackMessageId === false || fallbackMessageId === undefined) return fallbackMessageId;
+    return { messageId: fallbackMessageId, livePost: false };
   }
 
   private async sendTextMessage(message: FeishuOutboundMessage): Promise<string | undefined | false> {
@@ -468,7 +484,21 @@ export class FeishuChannel implements ChannelAdapter {
     return false;
   }
 
-  private async editLiveMessage(messageId: string, text: string): Promise<boolean> {
+  private async editLiveMessage(
+    handle: FeishuLiveMessageHandle,
+    text: string,
+    options: { isFinal: boolean; activityKind?: FeishuLiveCardActivityKind },
+  ): Promise<boolean> {
+    if (!handle.messageId || !this.appId || !this.appSecret) return false;
+    if (!handle.livePost) return this.editTextMessage(handle.messageId, text);
+
+    const ok = await this.editPostMessage(handle.messageId, text, options);
+    if (ok !== false) return true;
+    handle.livePost = false;
+    return this.editTextMessage(handle.messageId, text);
+  }
+
+  private async editTextMessage(messageId: string, text: string): Promise<boolean> {
     if (!messageId || !this.appId || !this.appSecret) return false;
 
     try {
@@ -497,6 +527,101 @@ export class FeishuChannel implements ChannelAdapter {
       this.logger?.warn?.(`feishu: update message threw: ${e}`);
       return false;
     }
+  }
+
+  private async sendPostMessage(
+    chatId: string,
+    text: string,
+    options: { isFinal: boolean; activityKind?: FeishuLiveCardActivityKind },
+  ): Promise<string | false> {
+    if (!this.appId || !this.appSecret) return false;
+
+    try {
+      const token = await this.getTenantAccessToken();
+      const res = await fetch(SEND_MESSAGE_URL, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json; charset=utf-8",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({
+          receive_id: chatId,
+          msg_type: "post",
+          content: JSON.stringify(renderFeishuLivePost(text, options)),
+        }),
+      });
+      const json = (await res.json().catch(() => ({}))) as {
+        code?: number;
+        msg?: string;
+        data?: { message_id?: string };
+      };
+      if (!res.ok || (json.code !== undefined && json.code !== 0)) {
+        if (json.code === 99991663 || json.code === 99991664) {
+          this.tokenCache = undefined;
+        }
+        this.logger?.warn?.(`feishu: send post failed code=${json.code} msg=${json.msg}`);
+        return false;
+      }
+      return json.data?.message_id ?? false;
+    } catch (e) {
+      this.logger?.warn?.(`feishu: send post threw: ${e}`);
+      return false;
+    }
+  }
+
+  private async editPostMessage(
+    messageId: string,
+    text: string,
+    options: { isFinal: boolean; activityKind?: FeishuLiveCardActivityKind },
+  ): Promise<boolean> {
+    if (!messageId || !this.appId || !this.appSecret) return false;
+
+    try {
+      const token = await this.getTenantAccessToken();
+      const res = await fetch(`${UPDATE_MESSAGE_URL}/${encodeURIComponent(messageId)}`, {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json; charset=utf-8",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({
+          msg_type: "post",
+          content: JSON.stringify(renderFeishuLivePost(text, options)),
+        }),
+      });
+      const json = (await res.json().catch(() => ({}))) as { code?: number; msg?: string };
+      if (!res.ok || (json.code !== undefined && json.code !== 0)) {
+        if (json.code === 99991663 || json.code === 99991664) {
+          this.tokenCache = undefined;
+        }
+        this.logger?.warn?.(`feishu: update post failed code=${json.code} msg=${json.msg}`);
+        return false;
+      }
+      return true;
+    } catch (e) {
+      this.logger?.warn?.(`feishu: update post threw: ${e}`);
+      return false;
+    }
+  }
+
+  private liveActivityKindFromText(text: string): FeishuLiveCardActivityKind {
+    if (text.includes("正在执行工具")) return "tool";
+    if (text.includes("正在处理子任务")) return "subagent";
+    return "thinking";
+  }
+
+  private formatLiveActivityText(activity: { kind: FeishuLiveCardActivityKind; text: string; detail?: string }): string {
+    const detail = activity.detail?.trim();
+    if (activity.kind === "tool") {
+      return detail ? `🛠️ 正在调用工具：${detail}` : "🛠️ 正在调用工具…";
+    }
+    if (activity.kind === "subagent") {
+      return detail ? `🤖 正在处理子任务：${detail}` : "🤖 正在处理子任务…";
+    }
+    if (detail) {
+      return `💭 正在思考：${detail}`;
+    }
+    return "💭 正在思考…";
   }
 
   private async addReaction(messageId: string): Promise<string | undefined> {
@@ -669,6 +794,40 @@ function extractTextContent(content: string): string {
     return parsed.text ?? "";
   } catch {
     return content;
+  }
+}
+
+function renderFeishuLivePost(
+  text: string,
+  options: { isFinal: boolean; activityKind?: FeishuLiveCardActivityKind },
+): Record<string, unknown> {
+  const content = normalizeLivePostText(text, options);
+  return {
+    zh_cn: {
+      content: [[{ tag: "text", text: content }]],
+    },
+  };
+}
+
+function normalizeLivePostText(
+  text: string,
+  options: { isFinal: boolean; activityKind?: FeishuLiveCardActivityKind },
+): string {
+  const stripped = text.replace(/\s*▉\s*$/u, "").trim();
+  const body = stripped || (options.isFinal ? "处理完成，但没有可见回复。" : livePostActivityLabel(options.activityKind ?? "thinking"));
+  if (body.length <= MAX_TEXT_MESSAGE_LENGTH) return body;
+  return `${body.slice(0, Math.max(0, MAX_TEXT_MESSAGE_LENGTH - 12)).trimEnd()}\n…（已截断）`;
+}
+
+function livePostActivityLabel(kind: FeishuLiveCardActivityKind): string {
+  switch (kind) {
+    case "tool":
+      return "正在执行工具…";
+    case "subagent":
+      return "正在处理子任务…";
+    case "thinking":
+    default:
+      return "正在思考…";
   }
 }
 

--- a/src/adapters/channel/feishu/feishu-render.ts
+++ b/src/adapters/channel/feishu/feishu-render.ts
@@ -1,5 +1,77 @@
 import type { GatewayEvent } from "../../../gateway/index.js";
 
+export type FeishuLiveCardActivityKind = "thinking" | "tool" | "subagent";
+
+export type FeishuLiveCardOptions = {
+  text: string;
+  activityKind?: FeishuLiveCardActivityKind;
+  isFinal?: boolean;
+  fallbackText?: string;
+  maxTextLength?: number;
+};
+
+const DEFAULT_LIVE_CARD_FALLBACK_TEXT = "处理完成，但没有可见回复。";
+const DEFAULT_LIVE_CARD_MAX_TEXT_LENGTH = 4000;
+
+export function renderFeishuLiveCard(options: FeishuLiveCardOptions): Record<string, unknown> {
+  const isFinal = options.isFinal === true;
+  const text = normalizeLiveCardText(options.text, {
+    fallbackText: options.fallbackText ?? DEFAULT_LIVE_CARD_FALLBACK_TEXT,
+    maxTextLength: options.maxTextLength ?? DEFAULT_LIVE_CARD_MAX_TEXT_LENGTH,
+    useFallback: isFinal,
+  });
+  const elements: Array<Record<string, unknown>> = [];
+
+  if (!isFinal) {
+    elements.push(markdownElement(`**${activityLabel(options.activityKind ?? "thinking")}**`));
+  }
+
+  if (text) {
+    elements.push(markdownElement(text));
+  }
+
+  return {
+    config: { wide_screen_mode: false, update_multi: true },
+    elements: elements.length > 0 ? elements : [markdownElement(options.fallbackText ?? DEFAULT_LIVE_CARD_FALLBACK_TEXT)],
+  };
+}
+
+function normalizeLiveCardText(
+  text: string,
+  options: { fallbackText: string; maxTextLength: number; useFallback: boolean },
+): string {
+  const stripped = stripLiveCursor(text).trim();
+  const visible = stripped || (options.useFallback ? options.fallbackText : "");
+  if (visible.length <= options.maxTextLength) return visible;
+  return `${visible.slice(0, Math.max(0, options.maxTextLength - 12)).trimEnd()}\n…（已截断）`;
+}
+
+function stripLiveCursor(text: string): string {
+  return text.replace(/\s*▉\s*$/u, "");
+}
+
+function activityLabel(kind: FeishuLiveCardActivityKind): string {
+  switch (kind) {
+    case "tool":
+      return "正在执行工具…";
+    case "subagent":
+      return "正在处理子任务…";
+    case "thinking":
+    default:
+      return "正在思考…";
+  }
+}
+
+function markdownElement(content: string): Record<string, unknown> {
+  return {
+    tag: "div",
+    text: {
+      tag: "lark_md",
+      content,
+    },
+  };
+}
+
 export function renderFeishuEvent(event: GatewayEvent): string | undefined {
   switch (event.type) {
     case "assistant_text_delta":
@@ -11,7 +83,10 @@ export function renderFeishuEvent(event: GatewayEvent): string | undefined {
     case "tool_call_finished":
       if (!event.ok) {
         const name = event.toolName ?? event.toolCallId;
-        return `\n⚠️ ${name} 执行失败\n`;
+        const detail = typeof event.resultPreview === "string" && event.resultPreview.trim()
+          ? `${event.resultPreview.trim()}\n`
+          : "";
+        return `\n⚠️ ${name} 执行失败\n${detail}`;
       }
       return "";
     case "elicitation_request": {

--- a/src/adapters/channel/protocol/ImLiveReplyController.ts
+++ b/src/adapters/channel/protocol/ImLiveReplyController.ts
@@ -9,6 +9,7 @@ export type ImLiveReplyActivity = {
   text: string;
   elapsedMs: number;
   updateCount: number;
+  detail?: string;
 };
 
 export type ImLiveReplyTransportErrorPhase =
@@ -66,6 +67,7 @@ type Segment<Handle> = {
   activityUpdates: number;
   activityVisible: boolean;
   activityDisabled: boolean;
+  activityDetail?: string;
 };
 
 const DEFAULT_THROTTLE_MS = 2_000;
@@ -144,8 +146,10 @@ export class ImLiveReplyController<Handle = ImLiveReplyHandle> {
         this.markActivity("thinking");
         return;
       case "model_request_started":
-      case "assistant_thinking_delta":
         this.markActivity("thinking");
+        return;
+      case "assistant_thinking_delta":
+        this.markActivity("thinking", event.text);
         return;
       case "assistant_text_delta":
         await this.append(event.text);
@@ -156,7 +160,7 @@ export class ImLiveReplyController<Handle = ImLiveReplyHandle> {
         } else {
           this.clearTextTimer();
         }
-        this.markActivity("tool");
+        this.markActivity("tool", event.name);
         return;
       case "tool_call_finished":
         if (!event.ok) {
@@ -264,7 +268,8 @@ export class ImLiveReplyController<Handle = ImLiveReplyHandle> {
       return;
     }
     if (event.event.startsWith("subagent_")) {
-      this.markActivity("subagent");
+      const detail = typeof event.detail?.subagentType === "string" ? event.detail.subagentType : undefined;
+      this.markActivity("subagent", detail);
     }
   }
 
@@ -368,7 +373,7 @@ export class ImLiveReplyController<Handle = ImLiveReplyHandle> {
     this.turnTimer.unref?.();
   }
 
-  private markActivity(kind: ImLiveReplyActivityKind): void {
+  private markActivity(kind: ImLiveReplyActivityKind, detail?: string): void {
     if (!this.canUseActivity()) return;
     const segment = this.currentSegment;
     if (segment.activityDisabled || this.shouldSuppressActivityForText(segment)) return;
@@ -380,6 +385,9 @@ export class ImLiveReplyController<Handle = ImLiveReplyHandle> {
       segment.activityStartedAt = Date.now();
       segment.activityArmed = true;
       segment.activityUpdates = 0;
+    }
+    if (detail?.trim()) {
+      segment.activityDetail = detail.trim().slice(0, 160);
     }
 
     if (segment.activityVisible && !kindChanged) {
@@ -454,6 +462,7 @@ export class ImLiveReplyController<Handle = ImLiveReplyHandle> {
     };
     const activity: ImLiveReplyActivity = {
       ...activityBase,
+      ...(segment.activityDetail ? { detail: segment.activityDetail } : {}),
       text: this.formatActivity(activityBase),
     };
 

--- a/src/cli/commands/gatewaySetup.ts
+++ b/src/cli/commands/gatewaySetup.ts
@@ -1,11 +1,12 @@
 import { createInterface } from "node:readline/promises";
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { homedir } from "node:os";
 import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
 
-const PILOTDECK_YAML_PATH = join(homedir(), ".pilotdeck", "pilotdeck.yaml");
-const WEIXIN_CREDS_PATH = join(homedir(), ".pilotdeck", "weixin-credentials.json");
+const PILOT_HOME = process.env.PILOT_HOME || join(homedir(), ".pilotdeck");
+const PILOTDECK_YAML_PATH = process.env.PILOTDECK_CONFIG_PATH || join(PILOT_HOME, "pilotdeck.yaml");
+const WEIXIN_CREDS_PATH = join(PILOT_HOME, "weixin-credentials.json");
 
 const FEISHU_TOKEN_URL = "https://open.feishu.cn/open-apis/auth/v3/tenant_access_token/internal";
 const LARK_TOKEN_URL = "https://open.larksuite.com/open-apis/auth/v3/tenant_access_token/internal";
@@ -372,7 +373,7 @@ function loadYamlConfig(): Record<string, any> | null {
 }
 
 function saveYamlConfig(config: Record<string, any>): void {
-  mkdirSync(join(homedir(), ".pilotdeck"), { recursive: true });
+  mkdirSync(dirname(PILOTDECK_YAML_PATH), { recursive: true });
   const yamlStr = stringifyYaml(config, {
     lineWidth: 0,
     singleQuote: false,

--- a/ui/server/routes/gateway.js
+++ b/ui/server/routes/gateway.js
@@ -1,6 +1,6 @@
 import express from 'express';
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
-import { join } from 'path';
+import { dirname, join } from 'path';
 import { homedir } from 'os';
 import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
 import { suppressNextWatchEvent } from '../services/pilotdeckConfigWatcher.js';
@@ -10,8 +10,9 @@ import { getPilotDeckGateway } from '../pilotdeck-bridge.js';
 
 const router = express.Router();
 
-const PILOTDECK_YAML = join(homedir(), '.pilotdeck', 'pilotdeck.yaml');
-const WEIXIN_CREDS = join(homedir(), '.pilotdeck', 'weixin-credentials.json');
+const PILOT_HOME = process.env.PILOT_HOME || join(homedir(), '.pilotdeck');
+const PILOTDECK_YAML = process.env.PILOTDECK_CONFIG_PATH || join(PILOT_HOME, 'pilotdeck.yaml');
+const WEIXIN_CREDS = join(PILOT_HOME, 'weixin-credentials.json');
 
 const FEISHU_TOKEN_URL = 'https://open.feishu.cn/open-apis/auth/v3/tenant_access_token/internal';
 const LARK_TOKEN_URL = 'https://open.larksuite.com/open-apis/auth/v3/tenant_access_token/internal';
@@ -41,7 +42,7 @@ function loadYaml() {
 }
 
 function saveYaml(config) {
-  mkdirSync(join(homedir(), '.pilotdeck'), { recursive: true });
+  mkdirSync(dirname(PILOTDECK_YAML), { recursive: true });
   suppressNextWatchEvent();
   writeFileSync(PILOTDECK_YAML, stringifyYaml(config, { lineWidth: 0 }), 'utf-8');
 }
@@ -340,7 +341,7 @@ router.get('/weixin/qr', async (_req, res) => {
         _req.app.locals._weixinLoginResolved = true;
 
         // Auto-save credentials
-        mkdirSync(join(homedir(), '.pilotdeck'), { recursive: true });
+        mkdirSync(PILOT_HOME, { recursive: true });
         writeFileSync(WEIXIN_CREDS, JSON.stringify({
           baseUrl: result.baseUrl,
           botToken: result.botToken,


### PR DESCRIPTION
## Summary
- update Feishu live replies in-place instead of resend/revoke
- render richer live activity text for thinking/tool/subagent states without exposing model names
- make gateway setup paths respect PILOT_HOME / PILOTDECK_CONFIG_PATH

## Tests
- npx tsx --test tests/adapters/channel/feishu-render.test.ts
- npx tsc --noEmit --target ES2022 --module NodeNext --moduleResolution NodeNext --esModuleInterop --skipLibCheck --strict src/adapters/channel/feishu/FeishuChannel.ts src/adapters/channel/feishu/feishu-render.ts src/adapters/channel/protocol/ImLiveReplyController.ts

Note: full npm run build is still blocked by existing test type drift unrelated to this change.