### PR TITLE
fix: correct chat search match positioning

### DIFF
--- a/src/session/search/searchChatHistory.ts
+++ b/src/session/search/searchChatHistory.ts
@@ -178,7 +178,10 @@ type SearchableLine = {
   createdAt: string;
 };
 
-type Matcher = (text: string) => boolean;
+type Matcher = {
+  test: (text: string) => boolean;
+  findIndex: (text: string) => number;
+};
 
 function buildMatcher(
   query: string,
@@ -187,13 +190,26 @@ function buildMatcher(
   if (options.regex) {
     const flags = options.caseSensitive ? "" : "i";
     const pattern = new RegExp(query, flags);
-    return (text) => pattern.test(text);
+    return {
+      test: (text) => pattern.test(text),
+      findIndex: (text) => {
+        pattern.lastIndex = 0;
+        const match = pattern.exec(text);
+        return match?.index ?? -1;
+      },
+    };
   }
 
   const needle = options.caseSensitive ? query : query.toLowerCase();
-  return (text) => {
-    const haystack = options.caseSensitive ? text : text.toLowerCase();
-    return haystack.includes(needle);
+  return {
+    test: (text) => {
+      const haystack = options.caseSensitive ? text : text.toLowerCase();
+      return haystack.includes(needle);
+    },
+    findIndex: (text) => {
+      const haystack = options.caseSensitive ? text : text.toLowerCase();
+      return haystack.indexOf(needle);
+    },
   };
 }
 
@@ -307,7 +323,7 @@ async function searchSessionFile(
     const searchable = extractSearchableLines(entry);
     for (const item of searchable) {
       if (roleFilter !== "all" && item.role !== roleFilter) continue;
-      if (!matcher(item.text)) continue;
+      if (!matcher.test(item.text)) continue;
       matches.push({
         sessionId,
         role: item.role,
@@ -363,36 +379,13 @@ function buildSnippet(text: string, matcher: Matcher): string {
   const normalized = text.replace(/\s+/g, " ").trim();
   if (!normalized) return "";
 
-  const lowerText = normalized.toLowerCase();
-  let index = 0;
-  for (let start = 0; start < normalized.length; start += 1) {
-    const candidate = normalized.slice(start);
-    if (matcher(candidate) || matcher(normalized.slice(Math.max(0, start - 1)))) {
-      index = start;
-      break;
-    }
-    if (matcher(normalized.slice(start, start + lowerText.length))) {
-      index = start;
-      break;
-    }
-  }
-
-  const matchIndex = findFirstMatchIndex(normalized, matcher);
-  const center = matchIndex >= 0 ? matchIndex : index;
+  const matchIndex = matcher.findIndex(normalized);
+  const center = matchIndex >= 0 ? matchIndex : 0;
   const start = Math.max(0, center - SNIPPET_RADIUS);
   const end = Math.min(normalized.length, center + SNIPPET_RADIUS);
   const prefix = start > 0 ? "..." : "";
   const suffix = end < normalized.length ? "..." : "";
   return `${prefix}${normalized.slice(start, end)}${suffix}`;
-}
-
-function findFirstMatchIndex(text: string, matcher: Matcher): number {
-  for (let index = 0; index < text.length; index += 1) {
-    if (matcher(text.slice(index))) {
-      return index;
-    }
-  }
-  return -1;
 }
 
 function isInternalSession(sessionId: string): boolean {

--- a/ui/src/components/chat-v2/chatHistorySearchUtils.ts
+++ b/ui/src/components/chat-v2/chatHistorySearchUtils.ts
@@ -1,7 +1,7 @@
 import type { ChatMessage } from '../chat/types/types';
 
 export type ChatHistorySearchMatch = {
-  /** Index in the searchable message list. */
+  /** Index in the rendered message list. */
   messageIndex: number;
   /** Stable key used on `.chat-message[data-message-key]`. */
   messageKey: string;
@@ -14,6 +14,7 @@ export type ChatHistorySearchMatch = {
 export type SearchableChatMessage = {
   message: ChatMessage;
   messageKey: string;
+  messageIndex: number;
   text: string;
 };
 
@@ -45,9 +46,10 @@ export function buildSearchableMessages(
   items: Array<{ message: ChatMessage; messageKey: string }>,
 ): SearchableChatMessage[] {
   return items
-    .map(({ message, messageKey }) => ({
+    .map(({ message, messageKey }, messageIndex) => ({
       message,
       messageKey,
+      messageIndex,
       text: extractSearchableText(message),
     }))
     .filter((entry) => entry.text.trim().length > 0);
@@ -64,7 +66,7 @@ export function findChatHistoryMatches(
   const lowerNeedle = needle.toLowerCase();
   const matches: ChatHistorySearchMatch[] = [];
 
-  items.forEach((entry, messageIndex) => {
+  items.forEach((entry) => {
     const haystack = entry.text;
     const lowerHaystack = haystack.toLowerCase();
     let fromIndex = 0;
@@ -73,7 +75,7 @@ export function findChatHistoryMatches(
       const found = lowerHaystack.indexOf(lowerNeedle, fromIndex);
       if (found < 0) break;
       matches.push({
-        messageIndex,
+        messageIndex: entry.messageIndex,
         messageKey: entry.messageKey,
         offset: found,
         length: needle.length,

--- a/ui/src/components/chat-v2/useChatHistorySearch.ts
+++ b/ui/src/components/chat-v2/useChatHistorySearch.ts
@@ -82,7 +82,7 @@ export function useChatHistorySearch({
       });
     });
 
-    const entry = searchableMessages[match.messageIndex];
+    const entry = searchableMessages.find((item) => item.messageKey === match.messageKey);
     if (!entry) return;
 
     highlightActiveMatch(


### PR DESCRIPTION
## Summary\n- center cross-session search snippets on the actual match\n- keep rendered message indexes for in-chat search after filtering unsearchable messages\n\n## Validation\n- npm run build\n