### PR TITLE
[codex] fix gateway config issue contracts

### DIFF
--- a/src/gateway/client/InProcessGateway.ts
+++ b/src/gateway/client/InProcessGateway.ts
@@ -648,14 +648,14 @@ export class InProcessGateway implements Gateway {
 
   async reloadConfig(): Promise<ReloadConfigResult> {
     if (!this.options.reloadConfig) {
-      return { reloaded: false };
+      return { reloaded: false, reason: "unsupported" };
     }
     return this.options.reloadConfig();
   }
 
   async reloadExtensions(input?: import("../protocol/types.js").ReloadExtensionsInput): Promise<import("../protocol/types.js").ReloadExtensionsResult> {
     if (!this.options.reloadExtensions) {
-      return { reloaded: false };
+      return { reloaded: false, reason: "unsupported" };
     }
     return this.options.reloadExtensions(input);
   }

--- a/src/gateway/client/RemoteGateway.ts
+++ b/src/gateway/client/RemoteGateway.ts
@@ -56,6 +56,7 @@ import type {
   CronStopResult,
 } from "../../cron/protocol/types.js";
 import { GatewayWsClient, type GatewayWsNotificationHandler } from "./GatewayWsClient.js";
+import { parseReloadConfigResult } from "../protocol/reloadConfigResult.js";
 
 export class RemoteGateway implements Gateway {
   constructor(private readonly client: GatewayWsClient) {}
@@ -149,7 +150,7 @@ export class RemoteGateway implements Gateway {
   }
 
   async reloadConfig(): Promise<ReloadConfigResult> {
-    return (await this.client.request("reload_config", {})) as ReloadConfigResult;
+    return parseReloadConfigResult(await this.client.request("reload_config", {}));
   }
 
   async reloadExtensions(input: ReloadExtensionsInput = {}): Promise<ReloadExtensionsResult> {

--- a/src/gateway/protocol/reloadConfigResult.ts
+++ b/src/gateway/protocol/reloadConfigResult.ts
@@ -1,0 +1,35 @@
+import type { ReloadConfigResult } from "./types.js";
+
+const RELOAD_CONFIG_REASONS = new Set(["unsupported", "unchanged"]);
+
+export function parseReloadConfigResult(value: unknown): ReloadConfigResult {
+  if (!isRecord(value)) {
+    throw new Error("Invalid reload_config response: result must be an object.");
+  }
+
+  if (typeof value.reloaded !== "boolean") {
+    throw new Error("Invalid reload_config response: reloaded must be a boolean.");
+  }
+
+  const result: ReloadConfigResult = { reloaded: value.reloaded };
+
+  if (value.changedPaths !== undefined) {
+    if (!Array.isArray(value.changedPaths) || value.changedPaths.some((entry) => typeof entry !== "string")) {
+      throw new Error("Invalid reload_config response: changedPaths must be an array of strings.");
+    }
+    result.changedPaths = value.changedPaths;
+  }
+
+  if (value.reason !== undefined) {
+    if (typeof value.reason !== "string" || !RELOAD_CONFIG_REASONS.has(value.reason)) {
+      throw new Error("Invalid reload_config response: reason must be \"unsupported\" or \"unchanged\".");
+    }
+    result.reason = value.reason as ReloadConfigResult["reason"];
+  }
+
+  return result;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}

--- a/src/gateway/protocol/types.ts
+++ b/src/gateway/protocol/types.ts
@@ -283,6 +283,7 @@ export type GatewayCronController = {
 export type ReloadConfigResult = {
   reloaded: boolean;
   changedPaths?: string[];
+  reason?: "unsupported" | "unchanged";
 };
 
 export type ReloadExtensionsInput = {
@@ -293,6 +294,7 @@ export type ReloadExtensionsInput = {
 export type ReloadExtensionsResult = {
   reloaded: boolean;
   changedPaths?: string[];
+  reason?: "unsupported" | "unchanged";
 };
 
 export type AlwaysOnApplyInput = {

--- a/src/gateway/server/GatewayWsConnection.ts
+++ b/src/gateway/server/GatewayWsConnection.ts
@@ -220,12 +220,12 @@ export class GatewayWsConnection {
         if (this.options.gateway.reloadConfig) {
           return this.options.gateway.reloadConfig();
         }
-        return Promise.resolve({ reloaded: false });
+        return Promise.resolve({ reloaded: false, reason: "unsupported" });
       case "reload_extensions":
         if (this.options.gateway.reloadExtensions) {
           return this.options.gateway.reloadExtensions(frame.params as never);
         }
-        return Promise.resolve({ reloaded: false });
+        return Promise.resolve({ reloaded: false, reason: "unsupported" });
       case "skill_list":
         return requireSkillMethod(this.options.gateway.skillsList, this.options.gateway)(frame.params as never);
       case "skill_read":

--- a/ui/server/pilotdeck-bridge.js
+++ b/ui/server/pilotdeck-bridge.js
@@ -56,6 +56,7 @@ import { resolvePilotHome, createProjectId, sanitizeSessionIdForPath } from './u
 import { createRemoteGateway } from '../../src/gateway/index.js';
 import { createNormalizedMessage } from './pilotdeck-message.js';
 import { readPermissionSettings } from './services/permissionSettings.js';
+import { normalizeGatewayGrantResult } from './utils/gatewayGrantResult.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -1041,19 +1042,19 @@ export async function decidePermissionViaGateway(requestId, decision, options = 
 }
 
 export async function grantSessionPermissionViaGateway(sessionId, entry) {
-    const gw = await ensureGateway();
     if (!isPilotDeckSessionKey(sessionId) || typeof entry !== 'string' || !entry.trim()) {
-        return false;
+        return { granted: false };
     }
     try {
+        const gw = await ensureGateway();
         const result = await gw.grantSessionPermission({
             sessionKey: sessionId,
             entry,
         });
-        return Boolean(result?.granted);
+        return normalizeGatewayGrantResult(result);
     } catch (error) {
         console.warn('[pilotdeck-bridge] grantSessionPermission failed:', error);
-        return false;
+        return { granted: false };
     }
 }
 

--- a/ui/server/services/pilotdeckConfig.js
+++ b/ui/server/services/pilotdeckConfig.js
@@ -3,6 +3,7 @@ import fsPromises from 'fs/promises';
 import os from 'os';
 import path from 'path';
 import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
+import { parseGatewayConfig } from '../../../src/pilot/config/parseGatewayConfig.js';
 
 // Source of truth: ~/.pilotdeck/pilotdeck.yaml. The disk format and the
 // "internal" config object are the same V2 schema — no more adapter layer.
@@ -219,6 +220,19 @@ function validateRouterModelRefs(config, errors) {
   }
 }
 
+function validateGatewayConfig(config, errors, warnings) {
+  const diagnostics = [];
+  parseGatewayConfig(config.gateway, diagnostics);
+  for (const diagnostic of diagnostics) {
+    const message = diagnostic.path ? `${diagnostic.path}: ${diagnostic.message}` : diagnostic.message;
+    if (diagnostic.severity === 'warning') {
+      warnings.push(message);
+    } else {
+      errors.push(message);
+    }
+  }
+}
+
 export function validatePilotDeckConfig(config) {
   const normalized = normalizePilotDeckConfig(config);
   const errors = [];
@@ -247,6 +261,7 @@ export function validatePilotDeckConfig(config) {
   }
 
   validateRouterModelRefs(normalized, errors);
+  validateGatewayConfig(normalized, errors, warnings);
 
   if (normalized.webui?.runtime?.contextWindow !== undefined) {
     warnings.push(

--- a/ui/server/services/pilotdeckConfig.test.js
+++ b/ui/server/services/pilotdeckConfig.test.js
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { validatePilotDeckConfig } from './pilotdeckConfig.js';
+
+describe('validatePilotDeckConfig gateway validation', () => {
+    it('rejects non-object gateway config', () => {
+        const validation = validatePilotDeckConfig({ gateway: true });
+
+        expect(validation.valid).toBe(false);
+        expect(validation.errors).toContain('gateway: gateway config must be an object.');
+    });
+
+    it('rejects unsupported gateway bindAddress', () => {
+        const validation = validatePilotDeckConfig({
+            gateway: {
+                bindAddress: '0.0.0.0',
+            },
+        });
+
+        expect(validation.valid).toBe(false);
+        expect(validation.errors).toContain('gateway.bindAddress: gateway.bindAddress must be 127.0.0.1 in the first phase.');
+    });
+
+    it('warns when gateway.tokenPath is configured', () => {
+        const validation = validatePilotDeckConfig({
+            gateway: {
+                tokenPath: '/tmp/token',
+            },
+        });
+
+        expect(validation.valid).toBe(true);
+        expect(validation.warnings).toContain(
+            'gateway.tokenPath: gateway.tokenPath is no longer configurable; the gateway token is stored under PilotHome.',
+        );
+    });
+
+    it('accepts valid gateway config', () => {
+        const validation = validatePilotDeckConfig({
+            gateway: {
+                bindAddress: '127.0.0.1',
+            },
+        });
+
+        expect(validation.valid).toBe(true);
+        expect(validation.errors).toEqual([]);
+    });
+});

--- a/ui/server/utils/gatewayGrantResult.js
+++ b/ui/server/utils/gatewayGrantResult.js
@@ -1,0 +1,8 @@
+export function normalizeGatewayGrantResult(result) {
+    if (!result || typeof result !== 'object' || result.granted !== true) {
+        return { granted: false };
+    }
+    return typeof result.entry === 'string'
+        ? { granted: true, entry: result.entry }
+        : { granted: true };
+}

--- a/ui/server/utils/gatewayGrantResult.test.js
+++ b/ui/server/utils/gatewayGrantResult.test.js
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeGatewayGrantResult } from './gatewayGrantResult.js';
+
+describe('normalizeGatewayGrantResult', () => {
+    it('preserves successful structured grant results', () => {
+        expect(normalizeGatewayGrantResult({ granted: true, entry: 'tool-a' })).toEqual({
+            granted: true,
+            entry: 'tool-a',
+        });
+    });
+
+    it('returns a denied structure for invalid grant results', () => {
+        expect(normalizeGatewayGrantResult(null)).toEqual({ granted: false });
+        expect(normalizeGatewayGrantResult({ granted: false, entry: 'tool-a' })).toEqual({ granted: false });
+    });
+});


### PR DESCRIPTION
## Summary
- validate gateway config in the UI server with the runtime gateway parser diagnostics
- validate `reload_config` responses at the remote gateway boundary
- distinguish unsupported reload handlers with `reason: "unsupported"`
- preserve structured session permission grant results in the UI bridge

## Root cause
The UI server validation path did not include gateway runtime parser constraints, and several gateway/bridge boundaries relied on loose casts or collapsed structured protocol responses into less informative values.

## Validation
- `npm run build`
- `npm --prefix ui test -- server/services/pilotdeckConfig.test.js server/utils/gatewayGrantResult.test.js`

## Linked issues
Closes #218
Closes #225
Closes #226
Closes #228
