### PR TITLE
fix: sync router fallback when default model changes

### DIFF
--- a/ui/src/components/settings/view/tabs/PilotDeckConfigTab.tsx
+++ b/ui/src/components/settings/view/tabs/PilotDeckConfigTab.tsx
@@ -440,6 +440,25 @@ function rewriteProviderRefs(config: PilotDeckConfig, oldProviderId: string, new
   return next;
 }
 
+function replaceFallbackModelRef(config: PilotDeckConfig, oldRef: string, newRef: string): PilotDeckConfig {
+  const fallback = config.router?.fallback;
+  if (!fallback || !oldRef || oldRef === newRef) return config;
+
+  let changed = false;
+  const rewritten = Object.fromEntries(
+    Object.entries(fallback).map(([key, refs]) => {
+      const nextRefs = refs.map((ref) => {
+        if (ref !== oldRef) return ref;
+        changed = true;
+        return newRef;
+      });
+      return [key, nextRefs];
+    }),
+  );
+
+  return changed ? patch(config, ['router', 'fallback'], rewritten) : config;
+}
+
 const MASK = '********';
 
 function isMaskedSecret(value: string | undefined): boolean {
@@ -2619,6 +2638,7 @@ function RouterLevelEditor({ config, onChange }: { config: PilotDeckConfig; onCh
 
   const setDefault = (value: string) => {
     let next = patch(ensureModelRefConfigured(config, value), ['router', 'scenarios', 'default'], value);
+    next = replaceFallbackModelRef(next, defaultValue, value);
     const fallbackDefault = config.router?.fallback?.default ?? [];
     if (
       fallbackDefault.length === 0 ||


### PR DESCRIPTION
## Summary
- replace stale router default model refs across fallback chains when the default model changes
- keep the existing behavior that seeds or normalizes fallback.default for default-only chains

## Validation
- pnpm --filter pilotdeck-ui exec eslint src/components/settings/view/tabs/PilotDeckConfigTab.tsx
  - passes with no errors
  - existing warning: RouterScenarioEditor is defined but never used