### PR TITLE
feat: add multi-provider thinking mode selector

### DIFF
--- a/src/agent/loop/AgentLoop.ts
+++ b/src/agent/loop/AgentLoop.ts
@@ -11,6 +11,7 @@ import {
   type CanonicalMessage,
   type CanonicalModelError,
   type CanonicalModelRequest,
+  type CanonicalThinkingConfig,
   type CanonicalToolSchema,
   type CanonicalUsage,
   materializeMediaReferences,
@@ -78,6 +79,7 @@ export type AgentLoopInput = {
   maxTurns?: number;
   runMode?: AgentRunMode;
   permissionMode?: PermissionMode;
+  thinking?: CanonicalThinkingConfig;
   /** The user's actual permission preference before plan-mode override. */
   basePermissionMode?: PermissionMode;
   /** Allow model-visible plan mode tools for this turn. */
@@ -1261,7 +1263,7 @@ export class AgentLoop {
       toolChoice: this.config.toolChoice,
       maxOutputTokens: this.config.maxOutputTokens,
       temperature: this.config.temperature,
-      thinking: this.config.thinking,
+      thinking: input.thinking ?? this.config.thinking,
       stream: true,
       metadata: this.config.metadata,
       cacheBreakpoints: prepared.cacheBreakpoints,

--- a/src/agent/protocol/input.ts
+++ b/src/agent/protocol/input.ts
@@ -1,4 +1,4 @@
-import type { CanonicalContentBlock } from "../../model/index.js";
+import type { CanonicalContentBlock, CanonicalThinkingConfig } from "../../model/index.js";
 import type { PermissionMode, PermissionRuleSet } from "../../permission/index.js";
 
 export type AgentRunMode = "agent" | "plan" | "ask";
@@ -13,6 +13,7 @@ export type AgentSubmitOptions = {
   metadata?: Record<string, unknown>;
   runMode?: AgentRunMode;
   permissionMode?: PermissionMode;
+  thinking?: CanonicalThinkingConfig;
   /** The user's actual permission preference before plan-mode override. */
   basePermissionMode?: PermissionMode;
   /** Allow model-visible plan mode tools for this turn. */

--- a/src/agent/session/AgentSession.ts
+++ b/src/agent/session/AgentSession.ts
@@ -79,6 +79,7 @@ export class AgentSession {
       maxTurns: submitOptions.maxTurns,
       runMode: submitOptions.runMode,
       permissionMode: submitOptions.permissionMode,
+      thinking: submitOptions.thinking,
       basePermissionMode: submitOptions.basePermissionMode,
       allowPlanModeTools: submitOptions.allowPlanModeTools,
       canPrompt: submitOptions.canPrompt,

--- a/src/agent/turn/TurnRunner.ts
+++ b/src/agent/turn/TurnRunner.ts
@@ -6,7 +6,7 @@ import type { AgentTurnResult } from "../protocol/result.js";
 import type { AgentLoop, AgentLoopSeedState } from "../loop/AgentLoop.js";
 import type { AgentTranscriptWriter } from "../../session/transcript/TranscriptWriter.js";
 import { TurnInputProcessor } from "./TurnInputProcessor.js";
-import type { CanonicalMessage, CanonicalUsage } from "../../model/index.js";
+import type { CanonicalMessage, CanonicalThinkingConfig, CanonicalUsage } from "../../model/index.js";
 import type { LifecycleRuntime } from "../../lifecycle/index.js";
 import type { PermissionMode, PermissionRuleSet } from "../../permission/index.js";
 import type { AgentTranscriptWriterState } from "../../session/transcript/TranscriptWriter.js";
@@ -19,6 +19,7 @@ export type TurnRunnerOptions = {
   maxTurns?: number;
   runMode?: AgentRunMode;
   permissionMode?: PermissionMode;
+  thinking?: CanonicalThinkingConfig;
   /** The user's actual permission preference before plan-mode override. */
   basePermissionMode?: PermissionMode;
   /** Allow model-visible plan mode tools for this turn. */
@@ -118,6 +119,7 @@ export class TurnRunner {
         maxTurns: options.maxTurns,
         runMode: options.runMode,
         permissionMode: options.permissionMode,
+        thinking: options.thinking,
         basePermissionMode: options.basePermissionMode,
         allowPlanModeTools: options.allowPlanModeTools,
         canPrompt: options.canPrompt,

--- a/src/gateway/client/InProcessGateway.ts
+++ b/src/gateway/client/InProcessGateway.ts
@@ -392,6 +392,7 @@ export class InProcessGateway implements Gateway {
             maxTurns: input.maxTurns,
             runMode,
             permissionMode,
+            thinking: input.thinking,
             basePermissionMode,
             allowPlanModeTools,
             canPrompt: input.canPrompt,

--- a/src/gateway/protocol/types.ts
+++ b/src/gateway/protocol/types.ts
@@ -12,7 +12,7 @@ import type {
   CronStopInput,
   CronStopResult,
 } from "../../cron/protocol/types.js";
-import type { CanonicalUsage } from "../../model/index.js";
+import type { CanonicalThinkingConfig, CanonicalUsage } from "../../model/index.js";
 import type { TelemetryExecutionKind, TelemetryModule } from "../../telemetry/index.js";
 import type { SessionInfo as ProjectSessionInfo } from "../../session/index.js";
 import type {
@@ -79,6 +79,7 @@ export type GatewaySubmitTurnInput = {
   /** Override the agent session's working directory for this session. */
   workspaceCwd?: string;
   attachments?: ChannelAttachment[];
+  thinking?: CanonicalThinkingConfig;
   runMode?: AgentRunMode;
   mode?: GatewayMode;
   /** The user's actual permission preference before plan-mode override. */

--- a/src/model/protocol/canonical.ts
+++ b/src/model/protocol/canonical.ts
@@ -163,8 +163,11 @@ export type CanonicalToolChoice =
     };
 
 export type CanonicalThinkingConfig = {
+  mode?: "default" | "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
   enabled: boolean;
   budgetTokens?: number;
+  preserve?: boolean;
+  splitReasoning?: boolean;
 };
 
 /**

--- a/src/model/providers/anthropic/request.ts
+++ b/src/model/providers/anthropic/request.ts
@@ -7,6 +7,7 @@ import type {
   CanonicalToolSchema,
   ModelDefinition,
 } from "../../protocol/canonical.js";
+import { resolveThinkingPlan } from "../../thinking/registry.js";
 
 export type AnthropicRequestBody = {
   model: string;
@@ -17,8 +18,11 @@ export type AnthropicRequestBody = {
   tool_choice?: Record<string, unknown>;
   temperature?: number;
   thinking?: {
-    type: "enabled";
+    type: "enabled" | "adaptive";
     budget_tokens?: number;
+  };
+  output_config?: {
+    effort?: string;
   };
   stream?: boolean;
   metadata?: Record<string, unknown>;
@@ -45,6 +49,7 @@ export function buildAnthropicRequest(
   request: CanonicalModelRequest,
   model: ModelDefinition,
 ): AnthropicRequestBody {
+  const thinkingPlan = resolveThinkingPlan(request.thinking, { id: "anthropic", protocol: "anthropic", url: "", apiKey: "", headers: {}, models: {} }, model);
   // A3: lower outputSchema → forced hidden tool. This goes BEFORE the
   // user-supplied tools so the dispatch order is stable, but Anthropic
   // does not actually care about ordering. We force `tool_choice` to point
@@ -89,10 +94,17 @@ export function buildAnthropicRequest(
     tools: tools.length > 0 ? tools : undefined,
     tool_choice: toolChoice,
     temperature: request.temperature,
-    thinking:
-      request.thinking?.enabled && model.capabilities.supportsThinking
-        ? { type: "enabled", budget_tokens: request.thinking.budgetTokens }
-        : undefined,
+    thinking: thinkingPlan.enabled && thinkingPlan.thinkingType
+      ? {
+          type: thinkingPlan.thinkingType === "adaptive" ? "adaptive" : "enabled",
+          ...(thinkingPlan.thinkingType === "enabled" && thinkingPlan.budgetTokens !== undefined
+            ? { budget_tokens: thinkingPlan.budgetTokens }
+            : {}),
+        }
+      : undefined,
+    output_config: thinkingPlan.useAnthropicOutputEffort && thinkingPlan.effort
+      ? { effort: thinkingPlan.effort }
+      : undefined,
     stream: request.stream,
     metadata: toAnthropicMetadata(request.metadata),
   };

--- a/src/model/providers/anthropic/request.ts
+++ b/src/model/providers/anthropic/request.ts
@@ -7,7 +7,7 @@ import type {
   CanonicalToolSchema,
   ModelDefinition,
 } from "../../protocol/canonical.js";
-import { resolveThinkingPlan } from "../../thinking/registry.js";
+import { resolveThinkingPlan, throwIfUnsupportedThinkingPlan } from "../../thinking/registry.js";
 
 export type AnthropicRequestBody = {
   model: string;
@@ -50,6 +50,7 @@ export function buildAnthropicRequest(
   model: ModelDefinition,
 ): AnthropicRequestBody {
   const thinkingPlan = resolveThinkingPlan(request.thinking, { id: "anthropic", protocol: "anthropic", url: "", apiKey: "", headers: {}, models: {} }, model);
+  throwIfUnsupportedThinkingPlan(thinkingPlan, request);
   // A3: lower outputSchema → forced hidden tool. This goes BEFORE the
   // user-supplied tools so the dispatch order is stable, but Anthropic
   // does not actually care about ordering. We force `tool_choice` to point

--- a/src/model/providers/google/request.ts
+++ b/src/model/providers/google/request.ts
@@ -20,6 +20,7 @@ import type {
 import { flattenToolResultBlockText } from "../../protocol/toolResultContent.js";
 import { normalizeGoogleModelId } from "./modelId.js";
 import { cleanSchemaForGoogle, normalizeGoogleToolSchema } from "./schema.js";
+import { resolveThinkingPlan } from "../../thinking/registry.js";
 
 export type GoogleRequestBody = GenerateContentParameters;
 
@@ -83,10 +84,17 @@ function toGoogleThinkingConfig(
   request: CanonicalModelRequest,
   model: ModelDefinition,
 ): GenerateContentConfig["thinkingConfig"] {
-  if (!request.thinking?.enabled || !model.capabilities.supportsThinking) {
+  const thinkingPlan = resolveThinkingPlan(request.thinking, { id: "google", protocol: "google", url: "", apiKey: "", headers: {}, models: {} }, model);
+  if (!thinkingPlan.enabled || !model.capabilities.supportsThinking) {
     return undefined;
   }
-  const budget = request.thinking.budgetTokens;
+  if (thinkingPlan.useGeminiLevel && thinkingPlan.thinkingLevel) {
+    return {
+      includeThoughts: true,
+      thinkingLevel: thinkingPlan.thinkingLevel,
+    } as unknown as GenerateContentConfig["thinkingConfig"];
+  }
+  const budget = thinkingPlan.budgetTokens;
   return {
     includeThoughts: true,
     ...(typeof budget === "number" && Number.isFinite(budget) && budget >= 0

--- a/src/model/providers/google/request.ts
+++ b/src/model/providers/google/request.ts
@@ -20,7 +20,7 @@ import type {
 import { flattenToolResultBlockText } from "../../protocol/toolResultContent.js";
 import { normalizeGoogleModelId } from "./modelId.js";
 import { cleanSchemaForGoogle, normalizeGoogleToolSchema } from "./schema.js";
-import { resolveThinkingPlan } from "../../thinking/registry.js";
+import { resolveThinkingPlan, throwIfUnsupportedThinkingPlan } from "../../thinking/registry.js";
 
 export type GoogleRequestBody = GenerateContentParameters;
 
@@ -85,6 +85,7 @@ function toGoogleThinkingConfig(
   model: ModelDefinition,
 ): GenerateContentConfig["thinkingConfig"] {
   const thinkingPlan = resolveThinkingPlan(request.thinking, { id: "google", protocol: "google", url: "", apiKey: "", headers: {}, models: {} }, model);
+  throwIfUnsupportedThinkingPlan(thinkingPlan, request);
   if (!thinkingPlan.enabled || !model.capabilities.supportsThinking) {
     return undefined;
   }

--- a/src/model/providers/openai-responses/request.ts
+++ b/src/model/providers/openai-responses/request.ts
@@ -9,6 +9,7 @@ import type {
 } from "../../protocol/canonical.js";
 import { flattenToolResultBlockText } from "../../protocol/toolResultContent.js";
 import { normalizeOpenAISchema } from "../openai/schema.js";
+import { resolveThinkingPlan } from "../../thinking/registry.js";
 
 export type OpenAIResponsesRequestBody = {
   model: string;
@@ -30,6 +31,9 @@ export type OpenAIResponsesRequestBody = {
     };
   };
   store?: boolean;
+  reasoning?: {
+    effort?: string;
+  };
 };
 
 type OpenAIResponsesInputItem =
@@ -62,6 +66,7 @@ export function buildOpenAIResponsesRequest(
   model: ModelDefinition,
   _provider?: ProviderConfig,
 ): OpenAIResponsesRequestBody {
+  const thinkingPlan = resolveThinkingPlan(request.thinking, _provider ?? { id: "openai", protocol: "openai-responses", url: "", apiKey: "", headers: {}, models: {} }, model);
   const body: OpenAIResponsesRequestBody = {
     model: request.model,
     input: request.messages.flatMap(toResponsesInputItems),
@@ -78,6 +83,10 @@ export function buildOpenAIResponsesRequest(
       : undefined,
     store: false,
   };
+
+  if (thinkingPlan.useOpenAIReasoning && thinkingPlan.effort) {
+    body.reasoning = { effort: thinkingPlan.effort };
+  }
 
   if (request.outputSchema) {
     body.text = {

--- a/src/model/providers/openai-responses/request.ts
+++ b/src/model/providers/openai-responses/request.ts
@@ -9,7 +9,7 @@ import type {
 } from "../../protocol/canonical.js";
 import { flattenToolResultBlockText } from "../../protocol/toolResultContent.js";
 import { normalizeOpenAISchema } from "../openai/schema.js";
-import { resolveThinkingPlan } from "../../thinking/registry.js";
+import { resolveThinkingPlan, throwIfUnsupportedThinkingPlan } from "../../thinking/registry.js";
 
 export type OpenAIResponsesRequestBody = {
   model: string;
@@ -67,6 +67,7 @@ export function buildOpenAIResponsesRequest(
   _provider?: ProviderConfig,
 ): OpenAIResponsesRequestBody {
   const thinkingPlan = resolveThinkingPlan(request.thinking, _provider ?? { id: "openai", protocol: "openai-responses", url: "", apiKey: "", headers: {}, models: {} }, model);
+  throwIfUnsupportedThinkingPlan(thinkingPlan, request);
   const body: OpenAIResponsesRequestBody = {
     model: request.model,
     input: request.messages.flatMap(toResponsesInputItems),

--- a/src/model/providers/openai/request.ts
+++ b/src/model/providers/openai/request.ts
@@ -12,7 +12,7 @@ import type {
 import { flattenToolResultBlockText } from "../../protocol/toolResultContent.js";
 import { cleanSchemaForGoogle, normalizeGoogleToolSchema } from "../google/schema.js";
 import { normalizeOpenAISchema } from "./schema.js";
-import { resolveThinkingPlan } from "../../thinking/registry.js";
+import { resolveThinkingPlan, throwIfUnsupportedThinkingPlan } from "../../thinking/registry.js";
 
 export type OpenAIRequestBody = {
   model: string;
@@ -66,6 +66,7 @@ export function buildOpenAIRequest(
 ): OpenAIRequestBody {
   const googleOpenAICompatible = isGoogleOpenAICompatibleProvider(provider);
   const thinkingPlan = resolveThinkingPlan(request.thinking, provider ?? { id: "openai", protocol: "openai", url: "", apiKey: "", headers: {}, models: {} }, model);
+  throwIfUnsupportedThinkingPlan(thinkingPlan, request);
   const messages = repairOpenAIToolPairing(
     request.messages.flatMap((message, messageIndex) => toOpenAIMessages(message, messageIndex)),
   );

--- a/src/model/providers/openai/request.ts
+++ b/src/model/providers/openai/request.ts
@@ -12,6 +12,7 @@ import type {
 import { flattenToolResultBlockText } from "../../protocol/toolResultContent.js";
 import { cleanSchemaForGoogle, normalizeGoogleToolSchema } from "../google/schema.js";
 import { normalizeOpenAISchema } from "./schema.js";
+import { resolveThinkingPlan } from "../../thinking/registry.js";
 
 export type OpenAIRequestBody = {
   model: string;
@@ -22,6 +23,11 @@ export type OpenAIRequestBody = {
   temperature?: number;
   stream?: boolean;
   metadata?: Record<string, unknown>;
+  reasoning?: { effort?: string };
+  extra_body?: Record<string, unknown>;
+  thinking?: Record<string, unknown>;
+  reasoning_effort?: string;
+  reasoning_split?: boolean;
   /**
    * Provider-native structured output. Set when `request.outputSchema` is
    * provided. `strict` defaults to true unless the schema opts out.
@@ -60,6 +66,7 @@ export function buildOpenAIRequest(
   provider?: ProviderConfig,
 ): OpenAIRequestBody {
   const googleOpenAICompatible = isGoogleOpenAICompatibleProvider(provider);
+  const thinkingPlan = resolveThinkingPlan(request.thinking, provider ?? { id: "openai", protocol: "openai", url: "", apiKey: "", headers: {}, models: {} }, model);
   const messages = repairOpenAIToolPairing(
     request.messages.flatMap((message, messageIndex) => toOpenAIMessages(message, messageIndex)),
   );
@@ -73,7 +80,7 @@ export function buildOpenAIRequest(
     max_tokens: request.maxOutputTokens ?? model.capabilities.maxOutputTokens,
     tools: request.tools?.map((tool) => toOpenAITool(tool, googleOpenAICompatible)),
     tool_choice: toOpenAIToolChoice(request.toolChoice),
-    temperature: request.temperature,
+    temperature: thinkingPlan.omitTemperature ? undefined : request.temperature,
     stream: request.stream,
     metadata: request.metadata
       ? Object.fromEntries(
@@ -96,7 +103,33 @@ export function buildOpenAIRequest(
     };
   }
 
-  if (request.thinking?.enabled) {
+  if (thinkingPlan.useOpenAIReasoning && thinkingPlan.effort) {
+    body.reasoning = { effort: thinkingPlan.effort };
+  } else if (thinkingPlan.useExtraBody) {
+    const extraBody: Record<string, unknown> = {};
+    if (thinkingPlan.thinkingType) {
+      extraBody.thinking = { type: thinkingPlan.thinkingType };
+    }
+    extraBody.enable_thinking = thinkingPlan.enabled;
+    if (thinkingPlan.enabled && thinkingPlan.budgetTokens !== undefined) {
+      extraBody.thinking_budget = thinkingPlan.budgetTokens;
+    }
+    body.extra_body = extraBody;
+    if (thinkingPlan.effort) {
+      body.reasoning_effort = thinkingPlan.effort;
+    }
+  } else if (thinkingPlan.useOpenAICompatibleThinking) {
+    if (thinkingPlan.thinkingType) {
+      body.thinking = { type: thinkingPlan.thinkingType };
+    } else if (thinkingPlan.enabled) {
+      body.thinking = { type: "enabled" };
+    }
+    if (thinkingPlan.effort) {
+      body.reasoning_effort = thinkingPlan.effort;
+    }
+  } else if (thinkingPlan.splitReasoning) {
+    body.reasoning_split = true;
+  } else if (request.thinking?.enabled) {
     (body as Record<string, unknown>).enable_thinking = true;
     const budget = request.thinking.budgetTokens;
     if (googleOpenAICompatible) {

--- a/src/model/providers/openai/request.ts
+++ b/src/model/providers/openai/request.ts
@@ -24,7 +24,6 @@ export type OpenAIRequestBody = {
   stream?: boolean;
   metadata?: Record<string, unknown>;
   reasoning?: { effort?: string };
-  extra_body?: Record<string, unknown>;
   thinking?: Record<string, unknown>;
   reasoning_effort?: string;
   reasoning_split?: boolean;
@@ -105,19 +104,8 @@ export function buildOpenAIRequest(
 
   if (thinkingPlan.useOpenAIReasoning && thinkingPlan.effort) {
     body.reasoning = { effort: thinkingPlan.effort };
-  } else if (thinkingPlan.useExtraBody) {
-    const extraBody: Record<string, unknown> = {};
-    if (thinkingPlan.thinkingType) {
-      extraBody.thinking = { type: thinkingPlan.thinkingType };
-    }
-    extraBody.enable_thinking = thinkingPlan.enabled;
-    if (thinkingPlan.enabled && thinkingPlan.budgetTokens !== undefined) {
-      extraBody.thinking_budget = thinkingPlan.budgetTokens;
-    }
-    body.extra_body = extraBody;
-    if (thinkingPlan.effort) {
-      body.reasoning_effort = thinkingPlan.effort;
-    }
+  } else if (thinkingPlan.bodyPatch) {
+    Object.assign(body, thinkingPlan.bodyPatch);
   } else if (thinkingPlan.useOpenAICompatibleThinking) {
     if (thinkingPlan.thinkingType) {
       body.thinking = { type: thinkingPlan.thinkingType };

--- a/src/model/providers/openai/response.ts
+++ b/src/model/providers/openai/response.ts
@@ -23,6 +23,19 @@ export function parseOpenAIResponse(raw: unknown, provider = "openai"): Canonica
   const content: CanonicalContentBlock[] = [];
   const idState = createResponseToolCallIdState(response);
 
+  if (typeof message.reasoning_content === "string" && message.reasoning_content.length > 0) {
+    content.push({ type: "thinking", text: message.reasoning_content });
+  }
+  if (Array.isArray(message.reasoning_details)) {
+    const reasoning = message.reasoning_details
+      .map((part) => readReasoningDetailText(asRecord(part)))
+      .filter((text): text is string => Boolean(text))
+      .join("\n");
+    if (reasoning.length > 0) {
+      content.push({ type: "thinking", text: reasoning });
+    }
+  }
+
   if (typeof message.content === "string" && message.content.length > 0) {
     content.push({ type: "text", text: message.content });
   } else if (Array.isArray(message.content)) {
@@ -87,6 +100,16 @@ function toCanonicalToolCall(
     input,
     raw: toolCall,
   };
+}
+
+function readReasoningDetailText(part: Record<string, unknown>): string | undefined {
+  for (const key of ["text", "content", "reasoning", "summary"]) {
+    const value = part[key];
+    if (typeof value === "string" && value.length > 0) {
+      return value;
+    }
+  }
+  return undefined;
 }
 
 function asRecord(value: unknown): Record<string, unknown> {

--- a/src/model/providers/openai/response.ts
+++ b/src/model/providers/openai/response.ts
@@ -23,8 +23,9 @@ export function parseOpenAIResponse(raw: unknown, provider = "openai"): Canonica
   const content: CanonicalContentBlock[] = [];
   const idState = createResponseToolCallIdState(response);
 
-  if (typeof message.reasoning_content === "string" && message.reasoning_content.length > 0) {
-    content.push({ type: "thinking", text: message.reasoning_content });
+  const reasoningText = readReasoningText(message.reasoning_content) ?? readReasoningText(message.reasoning);
+  if (reasoningText) {
+    content.push({ type: "thinking", text: reasoningText });
   }
   if (Array.isArray(message.reasoning_details)) {
     const reasoning = message.reasoning_details
@@ -110,6 +111,14 @@ function readReasoningDetailText(part: Record<string, unknown>): string | undefi
     }
   }
   return undefined;
+}
+
+function readReasoningText(value: unknown): string | undefined {
+  if (typeof value === "string" && value.length > 0) {
+    return value;
+  }
+  const record = asRecord(value);
+  return readReasoningDetailText(record);
 }
 
 function asRecord(value: unknown): Record<string, unknown> {

--- a/src/model/thinking/registry.ts
+++ b/src/model/thinking/registry.ts
@@ -1,4 +1,5 @@
-import type { CanonicalThinkingConfig, ModelDefinition, ProviderConfig } from "../protocol/canonical.js";
+import type { CanonicalModelRequest, CanonicalThinkingConfig, ModelDefinition, ProviderConfig } from "../protocol/canonical.js";
+import { ModelRequestError } from "../protocol/errors.js";
 
 export type ThinkingMode = NonNullable<CanonicalThinkingConfig["mode"]>;
 
@@ -18,6 +19,7 @@ export type ThinkingPlan = {
   bodyPatch?: Record<string, unknown>;
   useAnthropicOutputEffort?: boolean;
   omitTemperature?: boolean;
+  unsupportedReason?: string;
 };
 
 const GEMINI_25_BUDGETS: Partial<Record<ThinkingMode, number>> = {
@@ -41,7 +43,6 @@ const QWEN_BUDGETS: Partial<Record<ThinkingMode, number>> = {
 export function normalizeThinkingMode(thinking?: CanonicalThinkingConfig): ThinkingMode {
   if (!thinking) return "default";
   if (thinking.mode) return thinking.mode;
-  if (thinking.enabled === false) return "off";
   if (thinking.enabled === true) return "medium";
   return "default";
 }
@@ -52,6 +53,7 @@ export function resolveThinkingPlan(
   model: ModelDefinition,
 ): ThinkingPlan {
   const requestedMode = normalizeThinkingMode(requestThinking);
+  const explicitMode = requestThinking?.mode !== undefined;
   const providerId = provider.id.toLowerCase();
   const providerUrl = (provider.url ?? "").toLowerCase();
   const modelId = model.id.toLowerCase();
@@ -95,7 +97,26 @@ export function resolveThinkingPlan(
   if (model.capabilities.supportsThinking && !isOff) {
     return { mode, enabled: true, budgetTokens };
   }
+  if (explicitMode) {
+    return {
+      mode,
+      enabled: false,
+      unsupportedReason: `Model ${model.id} does not support thinking mode '${mode}'. Switch thinking strength back to Default.`,
+    };
+  }
   return { mode, enabled: false };
+}
+
+export function throwIfUnsupportedThinkingPlan(
+  plan: ThinkingPlan,
+  request: CanonicalModelRequest,
+): void {
+  if (!plan.unsupportedReason) return;
+  throw new ModelRequestError("unsupported_thinking", plan.unsupportedReason, {
+    provider: request.provider,
+    model: request.model,
+    thinkingMode: plan.mode,
+  });
 }
 
 function isOpenAIProvider(providerId: string, providerUrl: string): boolean {
@@ -117,7 +138,11 @@ function openAIPlan(mode: ThinkingMode, modelId: string): ThinkingPlan {
   if (modelId.includes("gpt-5")) {
     return { mode, enabled: true, effort: clampEffort(mode, ["minimal", "low", "medium", "high"]), useOpenAIReasoning: true };
   }
-  return { mode, enabled: false };
+  return {
+    mode,
+    enabled: false,
+    unsupportedReason: `OpenAI-compatible model ${modelId} does not advertise a known thinking mode adapter. Switch thinking strength back to Default.`,
+  };
 }
 
 function anthropicPlan(mode: ThinkingMode, modelId: string, budgetTokens?: number): ThinkingPlan {

--- a/src/model/thinking/registry.ts
+++ b/src/model/thinking/registry.ts
@@ -1,0 +1,231 @@
+import type { CanonicalThinkingConfig, ModelDefinition, ProviderConfig } from "../protocol/canonical.js";
+
+export type ThinkingMode = NonNullable<CanonicalThinkingConfig["mode"]>;
+
+export type ThinkingPlan = {
+  mode: ThinkingMode;
+  enabled: boolean;
+  budgetTokens?: number;
+  preserve?: boolean;
+  splitReasoning?: boolean;
+  effort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
+  thinkingType?: "enabled" | "disabled" | "adaptive";
+  thinkingLevel?: "low" | "medium" | "high";
+  useGeminiBudget?: boolean;
+  useGeminiLevel?: boolean;
+  useOpenAIReasoning?: boolean;
+  useOpenAICompatibleThinking?: boolean;
+  useExtraBody?: boolean;
+  useAnthropicOutputEffort?: boolean;
+  omitTemperature?: boolean;
+};
+
+const GEMINI_25_BUDGETS: Partial<Record<ThinkingMode, number>> = {
+  minimal: 1024,
+  low: 1024,
+  medium: 8192,
+  high: 24576,
+  xhigh: 24576,
+  max: 24576,
+};
+
+const QWEN_BUDGETS: Partial<Record<ThinkingMode, number>> = {
+  minimal: 1024,
+  low: 2048,
+  medium: 8192,
+  high: 24576,
+  xhigh: 38912,
+  max: 38912,
+};
+
+export function normalizeThinkingMode(thinking?: CanonicalThinkingConfig): ThinkingMode {
+  if (!thinking) return "default";
+  if (thinking.mode) return thinking.mode;
+  if (thinking.enabled === false) return "off";
+  if (thinking.enabled === true) return "medium";
+  return "default";
+}
+
+export function resolveThinkingPlan(
+  requestThinking: CanonicalThinkingConfig | undefined,
+  provider: ProviderConfig,
+  model: ModelDefinition,
+): ThinkingPlan {
+  const requestedMode = normalizeThinkingMode(requestThinking);
+  const providerId = provider.id.toLowerCase();
+  const providerUrl = (provider.url ?? "").toLowerCase();
+  const modelId = model.id.toLowerCase();
+  const enabledByLegacy = requestThinking?.enabled === true && requestedMode === "default";
+  const mode = enabledByLegacy ? "medium" : requestedMode;
+
+  if (mode === "default") {
+    return { mode, enabled: false };
+  }
+
+  const budgetTokens = typeof requestThinking?.budgetTokens === "number" && Number.isFinite(requestThinking.budgetTokens)
+    ? requestThinking.budgetTokens
+    : undefined;
+  const isOff = mode === "off";
+
+  if (provider.protocol === "openai-responses" || isOpenAIProvider(providerId, providerUrl)) {
+    return openAIPlan(mode, modelId);
+  }
+  if (provider.protocol === "anthropic" || /anthropic|claude/.test(providerId + providerUrl + modelId)) {
+    return anthropicPlan(mode, modelId, budgetTokens);
+  }
+  if (provider.protocol === "google" || /google|gemini|generativelanguage/.test(providerId + providerUrl + modelId)) {
+    return googlePlan(mode, modelId, budgetTokens);
+  }
+  if (/zhipu|bigmodel|z\.ai|z-ai|glm/.test(providerId + providerUrl + modelId)) {
+    return glmPlan(mode, modelId);
+  }
+  if (/qwen|dashscope|aliyun|alibaba|tongyi/.test(providerId + providerUrl + modelId)) {
+    return qwenPlan(mode, modelId, budgetTokens);
+  }
+  if (/deepseek/.test(providerId + providerUrl + modelId)) {
+    return deepSeekPlan(mode, modelId);
+  }
+  if (/kimi|moonshot/.test(providerId + providerUrl + modelId)) {
+    return kimiPlan(mode, modelId);
+  }
+  if (/minimax/.test(providerId + providerUrl + modelId)) {
+    return minimaxPlan(mode);
+  }
+
+  if (model.capabilities.supportsThinking && !isOff) {
+    return { mode, enabled: true, budgetTokens };
+  }
+  return { mode, enabled: false };
+}
+
+function isOpenAIProvider(providerId: string, providerUrl: string): boolean {
+  return /(^|[^a-z])openai([^a-z]|$)|api\.openai\.com/.test(providerId + " " + providerUrl);
+}
+
+function openAIPlan(mode: ThinkingMode, modelId: string): ThinkingPlan {
+  if (mode === "off") {
+    return modelId.includes("gpt-5.5")
+      ? { mode, enabled: true, effort: "none", useOpenAIReasoning: true }
+      : { mode, enabled: false };
+  }
+  if (modelId.includes("gpt-5.5-pro")) {
+    return { mode, enabled: true, effort: clampEffort(mode, ["medium", "high", "xhigh"]), useOpenAIReasoning: true };
+  }
+  if (modelId.includes("gpt-5.5")) {
+    return { mode, enabled: true, effort: clampEffort(mode, ["none", "low", "medium", "high", "xhigh"]), useOpenAIReasoning: true };
+  }
+  if (modelId.includes("gpt-5")) {
+    return { mode, enabled: true, effort: clampEffort(mode, ["minimal", "low", "medium", "high"]), useOpenAIReasoning: true };
+  }
+  return { mode, enabled: false };
+}
+
+function anthropicPlan(mode: ThinkingMode, modelId: string, budgetTokens?: number): ThinkingPlan {
+  if (mode === "off") return { mode, enabled: false };
+  if (/opus-4\.8|opus-4\.7|sonnet-5|claude-.*(4\.8|4\.7|5)/.test(modelId)) {
+    return {
+      mode,
+      enabled: true,
+      thinkingType: "adaptive",
+      effort: clampEffort(mode, ["low", "medium", "high", "xhigh"]),
+      useAnthropicOutputEffort: true,
+    };
+  }
+  return { mode, enabled: true, thinkingType: "enabled", budgetTokens: budgetTokens ?? effortBudget(mode) };
+}
+
+function googlePlan(mode: ThinkingMode, modelId: string, budgetTokens?: number): ThinkingPlan {
+  if (/gemini-?3|gemini.*3\./.test(modelId)) {
+    if (mode === "off") return { mode, enabled: false };
+    return { mode, enabled: true, thinkingLevel: clampLevel(mode), useGeminiLevel: true };
+  }
+  if (/gemini-?2\.5|gemini.*2\.5/.test(modelId)) {
+    if (mode === "off") return { mode, enabled: true, budgetTokens: 0, useGeminiBudget: true };
+    return { mode, enabled: true, budgetTokens: budgetTokens ?? GEMINI_25_BUDGETS[mode] ?? 8192, useGeminiBudget: true };
+  }
+  if (mode === "off") return { mode, enabled: false };
+  return { mode, enabled: true, budgetTokens, useGeminiBudget: true };
+}
+
+function glmPlan(mode: ThinkingMode, modelId: string): ThinkingPlan {
+  if (mode === "off" || mode === "minimal") {
+    return { mode, enabled: false, thinkingType: "disabled", useOpenAICompatibleThinking: true };
+  }
+  const plan: ThinkingPlan = { mode, enabled: true, thinkingType: "enabled", useOpenAICompatibleThinking: true };
+  if (/glm-?5\.2|glm.*5\.2/.test(modelId)) {
+    plan.effort = mode === "xhigh" || mode === "max" ? "max" : "high";
+  }
+  return plan;
+}
+
+function qwenPlan(mode: ThinkingMode, modelId: string, budgetTokens?: number): ThinkingPlan {
+  const thinkingOnly = /thinking|qwq|qvq/.test(modelId) && !/hybrid/.test(modelId);
+  if (mode === "off" && thinkingOnly) return { mode, enabled: true, useExtraBody: true };
+  if (mode === "off") return { mode, enabled: false, useExtraBody: true };
+  return {
+    mode,
+    enabled: true,
+    budgetTokens: budgetTokens ?? QWEN_BUDGETS[mode] ?? 8192,
+    preserve: true,
+    useExtraBody: true,
+  };
+}
+
+function deepSeekPlan(mode: ThinkingMode, _modelId: string): ThinkingPlan {
+  if (mode === "off" || mode === "minimal") {
+    return { mode, enabled: false, thinkingType: "disabled", useExtraBody: true, preserve: true };
+  }
+  return {
+    mode,
+    enabled: true,
+    thinkingType: "enabled",
+    effort: mode === "xhigh" || mode === "max" ? "max" : "high",
+    preserve: true,
+    useExtraBody: true,
+  };
+}
+
+function kimiPlan(mode: ThinkingMode, _modelId: string): ThinkingPlan {
+  if (mode === "off") {
+    return { mode, enabled: false, thinkingType: "disabled", preserve: true, useOpenAICompatibleThinking: true, omitTemperature: true };
+  }
+  return { mode, enabled: mode !== "default", preserve: true, useOpenAICompatibleThinking: false, omitTemperature: true };
+}
+
+function minimaxPlan(mode: ThinkingMode): ThinkingPlan {
+  if (mode === "off" || mode === "default") return { mode, enabled: false };
+  return { mode, enabled: true, splitReasoning: true };
+}
+
+function clampEffort(mode: ThinkingMode, allowed: ThinkingPlan["effort"][]): NonNullable<ThinkingPlan["effort"]> {
+  const normalized = mode === "max" ? "xhigh" : mode;
+  if (allowed.includes(normalized as ThinkingPlan["effort"])) {
+    return normalized as NonNullable<ThinkingPlan["effort"]>;
+  }
+  const rank: Record<string, number> = { none: 0, off: 0, minimal: 1, low: 2, medium: 3, high: 4, xhigh: 5, max: 6 };
+  const requested = rank[mode] ?? 3;
+  let best = allowed[0] as NonNullable<ThinkingPlan["effort"]>;
+  let bestDistance = Infinity;
+  for (const effort of allowed) {
+    if (!effort) continue;
+    const distance = Math.abs((rank[effort] ?? 3) - requested);
+    if (distance < bestDistance) {
+      best = effort;
+      bestDistance = distance;
+    }
+  }
+  return best;
+}
+
+function clampLevel(mode: ThinkingMode): "low" | "medium" | "high" {
+  if (mode === "minimal" || mode === "low") return "low";
+  if (mode === "high" || mode === "xhigh" || mode === "max") return "high";
+  return "medium";
+}
+
+function effortBudget(mode: ThinkingMode): number {
+  if (mode === "minimal" || mode === "low") return 1024;
+  if (mode === "high") return 8192;
+  if (mode === "xhigh" || mode === "max") return 16000;
+  return 4096;
+}

--- a/src/model/thinking/registry.ts
+++ b/src/model/thinking/registry.ts
@@ -220,7 +220,10 @@ function kimiPlan(mode: ThinkingMode, _modelId: string): ThinkingPlan {
 }
 
 function minimaxPlan(mode: ThinkingMode): ThinkingPlan {
-  if (mode === "off" || mode === "default") return { mode, enabled: false };
+  if (mode === "off") {
+    return { mode, enabled: false, thinkingType: "disabled", useOpenAICompatibleThinking: true };
+  }
+  if (mode === "default") return { mode, enabled: false };
   return { mode, enabled: true, splitReasoning: true };
 }
 

--- a/src/model/thinking/registry.ts
+++ b/src/model/thinking/registry.ts
@@ -15,7 +15,7 @@ export type ThinkingPlan = {
   useGeminiLevel?: boolean;
   useOpenAIReasoning?: boolean;
   useOpenAICompatibleThinking?: boolean;
-  useExtraBody?: boolean;
+  bodyPatch?: Record<string, unknown>;
   useAnthropicOutputEffort?: boolean;
   omitTemperature?: boolean;
 };
@@ -80,7 +80,7 @@ export function resolveThinkingPlan(
     return glmPlan(mode, modelId);
   }
   if (/qwen|dashscope|aliyun|alibaba|tongyi/.test(providerId + providerUrl + modelId)) {
-    return qwenPlan(mode, modelId, budgetTokens);
+    return qwenPlan(mode, modelId, providerUrl, budgetTokens);
   }
   if (/deepseek/.test(providerId + providerUrl + modelId)) {
     return deepSeekPlan(mode, modelId);
@@ -158,22 +158,49 @@ function glmPlan(mode: ThinkingMode, modelId: string): ThinkingPlan {
   return plan;
 }
 
-function qwenPlan(mode: ThinkingMode, modelId: string, budgetTokens?: number): ThinkingPlan {
+function qwenPlan(mode: ThinkingMode, modelId: string, providerUrl: string, budgetTokens?: number): ThinkingPlan {
+  const isModelBest = providerUrl.includes("llm-center.ali.modelbest.cn") || /^qwen_/.test(modelId);
+  if (isModelBest) {
+    if (mode === "off") {
+      return { mode, enabled: false, thinkingType: "disabled", useOpenAICompatibleThinking: true, preserve: true };
+    }
+    return {
+      mode,
+      enabled: true,
+      thinkingType: "enabled",
+      effort: clampEffort(mode, ["minimal", "low", "medium", "high", "xhigh"]),
+      useOpenAICompatibleThinking: true,
+      preserve: true,
+    };
+  }
   const thinkingOnly = /thinking|qwq|qvq/.test(modelId) && !/hybrid/.test(modelId);
-  if (mode === "off" && thinkingOnly) return { mode, enabled: true, useExtraBody: true };
-  if (mode === "off") return { mode, enabled: false, useExtraBody: true };
+  if (mode === "off" && thinkingOnly) return { mode, enabled: false };
+  if (mode === "off") return { mode, enabled: false, bodyPatch: { enable_thinking: false } };
   return {
     mode,
     enabled: true,
     budgetTokens: budgetTokens ?? QWEN_BUDGETS[mode] ?? 8192,
     preserve: true,
-    useExtraBody: true,
+    bodyPatch: {
+      enable_thinking: true,
+      thinking_budget: budgetTokens ?? QWEN_BUDGETS[mode] ?? 8192,
+    },
   };
 }
 
-function deepSeekPlan(mode: ThinkingMode, _modelId: string): ThinkingPlan {
+function deepSeekPlan(mode: ThinkingMode, modelId: string): ThinkingPlan {
+  const isModelBest = /^deepseek_/.test(modelId);
   if (mode === "off" || mode === "minimal") {
-    return { mode, enabled: false, thinkingType: "disabled", useExtraBody: true, preserve: true };
+    return { mode, enabled: false, thinkingType: "disabled", useOpenAICompatibleThinking: true, preserve: true };
+  }
+  if (isModelBest) {
+    return {
+      mode,
+      enabled: true,
+      thinkingType: "enabled",
+      useOpenAICompatibleThinking: true,
+      preserve: true,
+    };
   }
   return {
     mode,
@@ -181,7 +208,7 @@ function deepSeekPlan(mode: ThinkingMode, _modelId: string): ThinkingPlan {
     thinkingType: "enabled",
     effort: mode === "xhigh" || mode === "max" ? "max" : "high",
     preserve: true,
-    useExtraBody: true,
+    useOpenAICompatibleThinking: true,
   };
 }
 

--- a/src/model/thinking/registry.ts
+++ b/src/model/thinking/registry.ts
@@ -94,9 +94,6 @@ export function resolveThinkingPlan(
     return minimaxPlan(mode);
   }
 
-  if (model.capabilities.supportsThinking && !isOff) {
-    return { mode, enabled: true, budgetTokens };
-  }
   if (explicitMode) {
     return {
       mode,
@@ -127,7 +124,11 @@ function openAIPlan(mode: ThinkingMode, modelId: string): ThinkingPlan {
   if (mode === "off") {
     return modelId.includes("gpt-5.5")
       ? { mode, enabled: true, effort: "none", useOpenAIReasoning: true }
-      : { mode, enabled: false };
+      : {
+        mode,
+        enabled: false,
+        unsupportedReason: `OpenAI model ${modelId} does not support an explicit off thinking mode. Switch thinking strength back to Default.`,
+      };
   }
   if (modelId.includes("gpt-5.5-pro")) {
     return { mode, enabled: true, effort: clampEffort(mode, ["medium", "high", "xhigh"]), useOpenAIReasoning: true };
@@ -137,6 +138,9 @@ function openAIPlan(mode: ThinkingMode, modelId: string): ThinkingPlan {
   }
   if (modelId.includes("gpt-5")) {
     return { mode, enabled: true, effort: clampEffort(mode, ["minimal", "low", "medium", "high"]), useOpenAIReasoning: true };
+  }
+  if (/^(?:o1|o3|o4)(?:\b|[-_])/.test(modelId)) {
+    return { mode, enabled: true, effort: clampEffort(mode, ["low", "medium", "high"]), useOpenAIReasoning: true };
   }
   return {
     mode,

--- a/tests/model/openaiReasoningResponse.spec.ts
+++ b/tests/model/openaiReasoningResponse.spec.ts
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseOpenAIResponse } from "../../src/model/providers/openai/response.js";
+
+test("OpenAI-compatible response parser preserves message.reasoning", () => {
+  const parsed = parseOpenAIResponse({
+    choices: [{
+      index: 0,
+      message: {
+        role: "assistant",
+        content: null,
+        reasoning: "provider reasoning text",
+      },
+      finish_reason: "stop",
+    }],
+  }, "hxapi");
+
+  assert.deepEqual(parsed.content, [{ type: "thinking", text: "provider reasoning text" }]);
+});

--- a/tests/model/request/thinkingAdapters.spec.ts
+++ b/tests/model/request/thinkingAdapters.spec.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import { buildModelRequest } from "../../../src/model/index.js";
+import { ModelRequestError } from "../../../src/model/index.js";
 import type { CanonicalModelRequest, ModelCapabilities, ModelConfig, ModelDefinition, ModelProtocol, ProviderConfig } from "../../../src/model/index.js";
 
 const capabilities: ModelCapabilities = {
@@ -91,7 +92,23 @@ test("Gemini 3.1 Pro uses thinkingLevel not thinkingBudget", () => {
   assert.deepEqual(body.config.thinkingConfig, { includeThoughts: true, thinkingLevel: "medium" });
 });
 
-function bodyFor(providerId: string, protocol: ModelProtocol, modelId: string, thinking: CanonicalModelRequest["thinking"], url?: string): any {
+test("unknown explicit thinking mode returns an actionable unsupported error", () => {
+  assert.throws(
+    () => bodyFor("local", "openai", "plain-chat", { mode: "high", enabled: true }, "https://local.example.invalid/v1", false),
+    (error: unknown) => error instanceof ModelRequestError
+      && error.code === "unsupported_thinking"
+      && /Switch thinking strength back to Default/.test(error.message),
+  );
+});
+
+test("legacy disabled thinking remains a no-op for ordinary models", () => {
+  const body = bodyFor("local", "openai", "plain-chat", { enabled: false }, "https://local.example.invalid/v1", false);
+  assert.equal(body.thinking, undefined);
+  assert.equal(body.reasoning_effort, undefined);
+  assert.equal(body.enable_thinking, undefined);
+});
+
+function bodyFor(providerId: string, protocol: ModelProtocol, modelId: string, thinking: CanonicalModelRequest["thinking"], url?: string, supportsThinking = true): any {
   const request: CanonicalModelRequest = {
     provider: providerId,
     model: modelId,
@@ -99,13 +116,13 @@ function bodyFor(providerId: string, protocol: ModelProtocol, modelId: string, t
     stream: true,
     thinking,
   };
-  return buildModelRequest(request, configFor(providerId, protocol, modelId, url)) as any;
+  return buildModelRequest(request, configFor(providerId, protocol, modelId, url, supportsThinking)) as any;
 }
 
-function configFor(providerId: string, protocol: ModelProtocol, modelId: string, url?: string): ModelConfig {
+function configFor(providerId: string, protocol: ModelProtocol, modelId: string, url?: string, supportsThinking = true): ModelConfig {
   const model: ModelDefinition = {
     id: modelId,
-    capabilities,
+    capabilities: { ...capabilities, supportsThinking },
     multimodal: { input: ["text"] },
   };
   const provider: ProviderConfig = {

--- a/tests/model/request/thinkingAdapters.spec.ts
+++ b/tests/model/request/thinkingAdapters.spec.ts
@@ -1,0 +1,103 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { buildModelRequest } from "../../../src/model/index.js";
+import type { CanonicalModelRequest, ModelCapabilities, ModelConfig, ModelDefinition, ModelProtocol, ProviderConfig } from "../../../src/model/index.js";
+
+const capabilities: ModelCapabilities = {
+  supportsToolUse: true,
+  supportsStreaming: true,
+  supportsParallelToolCalls: true,
+  supportsThinking: true,
+  supportsJsonSchema: true,
+  supportsSystemPrompt: true,
+  supportsPromptCache: false,
+  maxContextTokens: 128_000,
+  maxOutputTokens: 16_384,
+};
+
+const messages: CanonicalModelRequest["messages"] = [
+  { role: "user", content: [{ type: "text", text: "hi" }] },
+];
+
+test("GLM-5.2 Max sends thinking enabled and reasoning_effort=max", () => {
+  const body = bodyFor("zai", "openai", "glm-5.2", { mode: "max", enabled: true });
+  assert.deepEqual(body.thinking, { type: "enabled" });
+  assert.equal(body.reasoning_effort, "max");
+});
+
+test("GLM-4.6 High sends thinking enabled without reasoning_effort", () => {
+  const body = bodyFor("zai", "openai", "glm-4.6", { mode: "high", enabled: true });
+  assert.deepEqual(body.thinking, { type: "enabled" });
+  assert.equal(body.reasoning_effort, undefined);
+});
+
+test("Qwen hybrid Off and High map to enable_thinking and budget", () => {
+  const off = bodyFor("dashscope", "openai", "qwen3-next-hybrid", { mode: "off", enabled: false });
+  assert.deepEqual(off.extra_body, { enable_thinking: false });
+
+  const high = bodyFor("dashscope", "openai", "qwen3-next-hybrid", { mode: "high", enabled: true });
+  assert.deepEqual(high.extra_body, { enable_thinking: true, thinking_budget: 24576 });
+});
+
+test("DeepSeek Medium and Max legalize to high/max effort", () => {
+  const medium = bodyFor("deepseek", "openai", "deepseek-chat", { mode: "medium", enabled: true });
+  assert.deepEqual(medium.extra_body, { thinking: { type: "enabled" }, enable_thinking: true });
+  assert.equal(medium.reasoning_effort, "high");
+
+  const max = bodyFor("deepseek", "openai", "deepseek-chat", { mode: "max", enabled: true });
+  assert.equal(max.reasoning_effort, "max");
+});
+
+test("Kimi K2.6 Off disables thinking without effort or budget", () => {
+  const body = bodyFor("moonshot", "openai", "kimi-k2.6", { mode: "off", enabled: false });
+  assert.deepEqual(body.thinking, { type: "disabled" });
+  assert.equal(body.reasoning_effort, undefined);
+  assert.equal(body.thinking_budget, undefined);
+  assert.equal(body.temperature, undefined);
+});
+
+test("MiniMax M2 enables reasoning_split without fake effort", () => {
+  const body = bodyFor("minimax", "openai", "minimax-m2", { mode: "medium", enabled: true });
+  assert.equal(body.reasoning_split, true);
+  assert.equal(body.reasoning_effort, undefined);
+  assert.equal(body.thinking_budget, undefined);
+});
+
+test("GPT-5.5 Pro Low legalizes to Medium", () => {
+  const body = bodyFor("openai", "openai-responses", "gpt-5.5-pro", { mode: "low", enabled: true });
+  assert.deepEqual(body.reasoning, { effort: "medium" });
+});
+
+test("Gemini 3.1 Pro uses thinkingLevel not thinkingBudget", () => {
+  const body = bodyFor("google", "google", "gemini-3.1-pro", { mode: "medium", enabled: true });
+  assert.deepEqual(body.config.thinkingConfig, { includeThoughts: true, thinkingLevel: "medium" });
+});
+
+function bodyFor(providerId: string, protocol: ModelProtocol, modelId: string, thinking: CanonicalModelRequest["thinking"]): any {
+  const request: CanonicalModelRequest = {
+    provider: providerId,
+    model: modelId,
+    messages,
+    stream: true,
+    thinking,
+  };
+  return buildModelRequest(request, configFor(providerId, protocol, modelId)) as any;
+}
+
+function configFor(providerId: string, protocol: ModelProtocol, modelId: string): ModelConfig {
+  const model: ModelDefinition = {
+    id: modelId,
+    capabilities,
+    multimodal: { input: ["text"] },
+  };
+  const provider: ProviderConfig = {
+    id: providerId,
+    protocol,
+    url: `https://${providerId}.example.invalid/v1`,
+    apiKey: "test",
+    headers: {},
+    models: { [modelId]: model },
+  };
+  return { providers: { [providerId]: provider } };
+}

--- a/tests/model/request/thinkingAdapters.spec.ts
+++ b/tests/model/request/thinkingAdapters.spec.ts
@@ -71,7 +71,10 @@ test("Kimi K2.6 Off disables thinking without effort or budget", () => {
   assert.equal(body.temperature, undefined);
 });
 
-test("MiniMax M2 enables reasoning_split without fake effort", () => {
+test("MiniMax M2 supports Off and reasoning split without fake effort", () => {
+  const off = bodyFor("minimax", "openai", "minimax-m2", { mode: "off", enabled: false });
+  assert.deepEqual(off.thinking, { type: "disabled" });
+
   const body = bodyFor("minimax", "openai", "minimax-m2", { mode: "medium", enabled: true });
   assert.equal(body.reasoning_split, true);
   assert.equal(body.reasoning_effort, undefined);

--- a/tests/model/request/thinkingAdapters.spec.ts
+++ b/tests/model/request/thinkingAdapters.spec.ts
@@ -34,19 +34,33 @@ test("GLM-4.6 High sends thinking enabled without reasoning_effort", () => {
 
 test("Qwen hybrid Off and High map to enable_thinking and budget", () => {
   const off = bodyFor("dashscope", "openai", "qwen3-next-hybrid", { mode: "off", enabled: false });
-  assert.deepEqual(off.extra_body, { enable_thinking: false });
+  assert.equal(off.enable_thinking, false);
 
   const high = bodyFor("dashscope", "openai", "qwen3-next-hybrid", { mode: "high", enabled: true });
-  assert.deepEqual(high.extra_body, { enable_thinking: true, thinking_budget: 24576 });
+  assert.equal(high.enable_thinking, true);
+  assert.equal(high.thinking_budget, 24576);
 });
 
 test("DeepSeek Medium and Max legalize to high/max effort", () => {
   const medium = bodyFor("deepseek", "openai", "deepseek-chat", { mode: "medium", enabled: true });
-  assert.deepEqual(medium.extra_body, { thinking: { type: "enabled" }, enable_thinking: true });
+  assert.deepEqual(medium.thinking, { type: "enabled" });
   assert.equal(medium.reasoning_effort, "high");
 
   const max = bodyFor("deepseek", "openai", "deepseek-chat", { mode: "max", enabled: true });
   assert.equal(max.reasoning_effort, "max");
+});
+
+test("ModelBest Qwen uses thinking/reasoning_effort instead of enable_thinking", () => {
+  const high = bodyFor("qwen", "openai", "QWEN_40e5sh", { mode: "high", enabled: true }, "https://llm-center.ali.modelbest.cn/llm/v1");
+  assert.deepEqual(high.thinking, { type: "enabled" });
+  assert.equal(high.reasoning_effort, "high");
+  assert.equal(high.enable_thinking, undefined);
+});
+
+test("ModelBest DeepSeek avoids combining thinking and reasoning_effort", () => {
+  const high = bodyFor("deepseek", "openai", "DEEPSEEK_rtwgny", { mode: "high", enabled: true }, "https://llm-center.ali.modelbest.cn/llm/v1");
+  assert.deepEqual(high.thinking, { type: "enabled" });
+  assert.equal(high.reasoning_effort, undefined);
 });
 
 test("Kimi K2.6 Off disables thinking without effort or budget", () => {
@@ -74,7 +88,7 @@ test("Gemini 3.1 Pro uses thinkingLevel not thinkingBudget", () => {
   assert.deepEqual(body.config.thinkingConfig, { includeThoughts: true, thinkingLevel: "medium" });
 });
 
-function bodyFor(providerId: string, protocol: ModelProtocol, modelId: string, thinking: CanonicalModelRequest["thinking"]): any {
+function bodyFor(providerId: string, protocol: ModelProtocol, modelId: string, thinking: CanonicalModelRequest["thinking"], url?: string): any {
   const request: CanonicalModelRequest = {
     provider: providerId,
     model: modelId,
@@ -82,10 +96,10 @@ function bodyFor(providerId: string, protocol: ModelProtocol, modelId: string, t
     stream: true,
     thinking,
   };
-  return buildModelRequest(request, configFor(providerId, protocol, modelId)) as any;
+  return buildModelRequest(request, configFor(providerId, protocol, modelId, url)) as any;
 }
 
-function configFor(providerId: string, protocol: ModelProtocol, modelId: string): ModelConfig {
+function configFor(providerId: string, protocol: ModelProtocol, modelId: string, url?: string): ModelConfig {
   const model: ModelDefinition = {
     id: modelId,
     capabilities,
@@ -94,7 +108,7 @@ function configFor(providerId: string, protocol: ModelProtocol, modelId: string)
   const provider: ProviderConfig = {
     id: providerId,
     protocol,
-    url: `https://${providerId}.example.invalid/v1`,
+    url: url ?? `https://${providerId}.example.invalid/v1`,
     apiKey: "test",
     headers: {},
     models: { [modelId]: model },

--- a/tests/model/request/thinkingAdapters.spec.ts
+++ b/tests/model/request/thinkingAdapters.spec.ts
@@ -87,6 +87,21 @@ test("GPT-5.5 Pro Low legalizes to Medium", () => {
   assert.deepEqual(body.reasoning, { effort: "medium" });
 });
 
+test("OpenAI o-series maps explicit thinking to reasoning effort", () => {
+  const body = bodyFor("openai", "openai-responses", "o3", { mode: "high", enabled: true });
+  assert.deepEqual(body.reasoning, { effort: "high" });
+});
+
+test("OpenAI GPT-5 explicit Off reports unsupported instead of silently no-oping", () => {
+  assert.throws(
+    () => bodyFor("openai", "openai-responses", "gpt-5", { mode: "off", enabled: false }),
+    (error: unknown) => error instanceof ModelRequestError
+      && error.code === "unsupported_thinking"
+      && /does not support an explicit off thinking mode/.test(error.message)
+      && /Switch thinking strength back to Default/.test(error.message),
+  );
+});
+
 test("Gemini 3.1 Pro uses thinkingLevel not thinkingBudget", () => {
   const body = bodyFor("google", "google", "gemini-3.1-pro", { mode: "medium", enabled: true });
   assert.deepEqual(body.config.thinkingConfig, { includeThoughts: true, thinkingLevel: "medium" });
@@ -95,6 +110,15 @@ test("Gemini 3.1 Pro uses thinkingLevel not thinkingBudget", () => {
 test("unknown explicit thinking mode returns an actionable unsupported error", () => {
   assert.throws(
     () => bodyFor("local", "openai", "plain-chat", { mode: "high", enabled: true }, "https://local.example.invalid/v1", false),
+    (error: unknown) => error instanceof ModelRequestError
+      && error.code === "unsupported_thinking"
+      && /Switch thinking strength back to Default/.test(error.message),
+  );
+});
+
+test("unknown supportsThinking model still requires an explicit adapter", () => {
+  assert.throws(
+    () => bodyFor("local", "openai", "plain-thinking-chat", { mode: "high", enabled: true }, "https://local.example.invalid/v1", true),
     (error: unknown) => error instanceof ModelRequestError
       && error.code === "unsupported_thinking"
       && /Switch thinking strength back to Default/.test(error.message),

--- a/ui/server/pilotdeck-bridge.js
+++ b/ui/server/pilotdeck-bridge.js
@@ -925,6 +925,7 @@ export async function runChatViaGateway(
             runMode,
             mode: resolvedMode,
             runId,
+            ...(options?.thinking ? { thinking: options.thinking } : {}),
             ...(basePermissionMode ? { basePermissionMode } : {}),
             ...(attachments.length > 0 ? { attachments } : {}),
             ...(options.workspaceCwd ? { workspaceCwd: options.workspaceCwd } : {}),

--- a/ui/src/components/chat-v2/ChatInterfaceV2.tsx
+++ b/ui/src/components/chat-v2/ChatInterfaceV2.tsx
@@ -172,8 +172,8 @@ function ChatInterfaceV2({
     textareaRef,
     inputHighlightRef,
     isTextareaExpanded: _isTextareaExpanded,
-    thinkingMode: _thinkingMode,
-    setThinkingMode: _setThinkingMode,
+    thinkingMode,
+    setThinkingMode,
     slashCommandsCount: _slashCommandsCount,
     filteredCommands,
     frequentCommands,
@@ -505,6 +505,8 @@ function ChatInterfaceV2({
       canAbortSession={canAbortSession}
       isAbortPending={isAbortPending}
       tokenBudget={tokenBudget}
+      thinkingMode={thinkingMode}
+      onThinkingModeChange={setThinkingMode}
       pendingPermissionRequests={pendingPermissionRequests}
       handlePermissionDecision={handlePermissionDecision}
       handleGrantToolPermission={handleGrantToolPermission}

--- a/ui/src/components/chat-v2/ComposerV2.tsx
+++ b/ui/src/components/chat-v2/ComposerV2.tsx
@@ -12,6 +12,7 @@ import type {
 import {
   ArrowUp,
   AtSign,
+  Brain,
   Bot,
   Check,
   ChevronDown,
@@ -27,6 +28,7 @@ import {
 } from 'lucide-react';
 import type { ChatRunMode, PendingPermissionRequest, PermissionMode } from '../chat/types/types';
 import { MAX_ATTACHMENTS_ERROR_KEY } from '../chat/hooks/useChatComposerState';
+import { thinkingModes, type ThinkingModeId } from '../chat/constants/thinkingModes';
 import PermissionRequestsBanner from '../chat/view/subcomponents/PermissionRequestsBanner';
 import ImageAttachment from '../chat/view/subcomponents/ImageAttachment';
 import CommandMenu from '../chat/view/subcomponents/CommandMenu';
@@ -92,6 +94,8 @@ export type ComposerV2Props = {
   isAbortPending?: boolean;
   isSubmitPending?: boolean;
   tokenBudget?: Record<string, unknown> | null;
+  thinkingMode: ThinkingModeId;
+  onThinkingModeChange: (mode: ThinkingModeId) => void;
 
   pendingPermissionRequests: PendingPermissionRequest[];
   handlePermissionDecision: (
@@ -192,7 +196,6 @@ const BLOCKING_PERMISSION_TOOLS = new Set([
   'exit_plan_mode',
 ]);
 
-
 function readNumber(value: unknown): number | null {
   if (typeof value === 'number' && Number.isFinite(value)) return value;
   if (typeof value === 'string' && value.trim()) {
@@ -289,6 +292,8 @@ export default function ComposerV2({
   isAbortPending = false,
   isSubmitPending = false,
   tokenBudget,
+  thinkingMode,
+  onThinkingModeChange,
   pendingPermissionRequests,
   handlePermissionDecision,
   handleGrantToolPermission,
@@ -302,6 +307,7 @@ export default function ComposerV2({
 }: ComposerV2Props) {
   const { t } = useTranslation('chat');
   const [isContextPopoverOpen, setIsContextPopoverOpen] = useState(false);
+  const [isThinkingModeMenuOpen, setIsThinkingModeMenuOpen] = useState(false);
   const [isRunModeMenuOpen, setIsRunModeMenuOpen] = useState(false);
   const [isPermissionMenuOpen, setIsPermissionMenuOpen] = useState(false);
   const permissionSelectorDisabled = runMode === 'plan';
@@ -321,6 +327,8 @@ export default function ComposerV2({
   const attachmentLimitError = imageErrors.get(MAX_ATTACHMENTS_ERROR_KEY);
   const disabled = !hasDraftContent || isLoading || isSubmitPending || hasUploadingImages;
   const contextStatus = getContextStatus(tokenBudget);
+  const selectedThinkingMode = thinkingModes.find((option) => option.id === thinkingMode) || thinkingModes[0];
+  const SelectedThinkingIcon = selectedThinkingMode.icon || Brain;
   const selectedPermissionOption =
     PERMISSION_MODE_OPTIONS.find((option) => option.mode === permissionMode) ||
     PERMISSION_MODE_OPTIONS[0];
@@ -807,6 +815,82 @@ export default function ComposerV2({
                               })}
                             </div>
                           )}
+                        </div>
+                      ) : null}
+                    </div>
+
+                    <div
+                      className="relative"
+                      onBlur={(event) => {
+                        const nextTarget = event.relatedTarget as Node | null;
+                        if (!nextTarget || !event.currentTarget.contains(nextTarget)) {
+                          setIsThinkingModeMenuOpen(false);
+                        }
+                      }}
+                    >
+                      <button
+                        type="button"
+                        onClick={() => setIsThinkingModeMenuOpen((open) => !open)}
+                        className={cn(
+                          'inline-flex h-7 max-w-[116px] items-center justify-center gap-1.5 rounded-md px-2 text-[12px] font-medium transition sm:max-w-[140px]',
+                          thinkingMode === 'default'
+                            ? 'text-neutral-600 hover:bg-neutral-100 dark:text-neutral-300 dark:hover:bg-neutral-800'
+                            : 'text-purple-600 hover:bg-purple-50 dark:text-purple-300 dark:hover:bg-purple-950/30',
+                        )}
+                        title={t('input.thinking.change', { defaultValue: 'Select thinking strength' }) as string}
+                        aria-haspopup="menu"
+                        aria-expanded={isThinkingModeMenuOpen}
+                      >
+                        <SelectedThinkingIcon className="h-4 w-4 shrink-0" strokeWidth={1.9} />
+                        <span className="hidden truncate sm:inline">{selectedThinkingMode.name}</span>
+                        <ChevronDown
+                          className={cn(
+                            'h-3.5 w-3.5 shrink-0 transition-transform',
+                            isThinkingModeMenuOpen && 'rotate-180',
+                          )}
+                          strokeWidth={2}
+                        />
+                      </button>
+                      {isThinkingModeMenuOpen ? (
+                        <div
+                          role="menu"
+                          className="absolute bottom-full right-0 z-50 mb-2 w-64 rounded-xl border border-neutral-200 bg-white p-1.5 text-left shadow-lg dark:border-neutral-800 dark:bg-neutral-900"
+                        >
+                          {thinkingModes.map((option) => {
+                            const Icon = option.icon || Brain;
+                            const isSelected = option.id === thinkingMode;
+                            const unavailableReason = null;
+                            return (
+                              <button
+                                key={option.id}
+                                type="button"
+                                role="menuitemradio"
+                                aria-checked={isSelected}
+                                disabled={Boolean(unavailableReason)}
+                                onClick={() => {
+                                  if (unavailableReason) return;
+                                  onThinkingModeChange(option.id);
+                                  setIsThinkingModeMenuOpen(false);
+                                }}
+                                className={cn(
+                                  'flex w-full items-center gap-2 rounded-lg px-2.5 py-2 text-left transition',
+                                  isSelected
+                                    ? 'bg-neutral-100 text-neutral-950 dark:bg-neutral-800 dark:text-neutral-50'
+                                    : 'text-neutral-700 hover:bg-neutral-50 dark:text-neutral-200 dark:hover:bg-neutral-800/70',
+                                  unavailableReason && 'cursor-not-allowed opacity-45 hover:bg-transparent dark:hover:bg-transparent',
+                                )}
+                                title={option.name}
+                              >
+                                <Icon className={cn('h-4 w-4 shrink-0', option.color)} strokeWidth={1.9} />
+                                <span className="min-w-0 flex-1">
+                                  <span className="block text-[13px] font-medium">{option.name}</span>
+                                </span>
+                                {isSelected ? (
+                                  <Check className="h-4 w-4 shrink-0 text-neutral-500 dark:text-neutral-300" strokeWidth={2} />
+                                ) : null}
+                              </button>
+                            );
+                          })}
                         </div>
                       ) : null}
                     </div>

--- a/ui/src/components/chat/constants/thinkingModes.ts
+++ b/ui/src/components/chat/constants/thinkingModes.ts
@@ -1,44 +1,83 @@
-import { Brain, Zap, Sparkles, Atom } from 'lucide-react';
+import { Atom, Brain, Gauge, MinusCircle, Sparkles, Zap } from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
 
-export const thinkingModes = [
+export type ThinkingModeId = 'default' | 'off' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | 'max';
+
+export type ThinkingModeOption = {
+  id: ThinkingModeId;
+  name: string;
+  description: string;
+  icon: LucideIcon | null;
+  color: string;
+};
+
+export const thinkingModes: ThinkingModeOption[] = [
   {
-    id: 'none',
-    name: 'Standard',
-    description: 'Regular response',
+    id: 'default',
+    name: 'Default',
+    description: 'Use the model/provider default',
     icon: null,
-    prefix: '',
-    color: 'text-gray-600'
+    color: 'text-neutral-600',
   },
   {
-    id: 'think',
-    name: 'Think',
-    description: 'Basic extended thinking',
+    id: 'off',
+    name: 'Off',
+    description: 'Disable reasoning when the model supports it',
+    icon: MinusCircle,
+    color: 'text-neutral-500',
+  },
+  {
+    id: 'minimal',
+    name: 'Minimal',
+    description: 'Smallest supported reasoning effort',
+    icon: Gauge,
+    color: 'text-sky-600',
+  },
+  {
+    id: 'low',
+    name: 'Low',
+    description: 'Light reasoning effort',
     icon: Brain,
-    prefix: 'think',
-    color: 'text-blue-600'
+    color: 'text-blue-600',
   },
   {
-    id: 'think-hard',
-    name: 'Think Hard',
-    description: 'More thorough evaluation',
+    id: 'medium',
+    name: 'Medium',
+    description: 'Balanced reasoning effort',
     icon: Zap,
-    prefix: 'think hard',
-    color: 'text-purple-600'
+    color: 'text-purple-600',
   },
   {
-    id: 'think-harder',
-    name: 'Think Harder',
-    description: 'Deep analysis with alternatives',
+    id: 'high',
+    name: 'High',
+    description: 'Deeper reasoning for harder tasks',
     icon: Sparkles,
-    prefix: 'think harder',
-    color: 'text-indigo-600'
+    color: 'text-indigo-600',
   },
   {
-    id: 'ultrathink',
-    name: 'Ultrathink',
-    description: 'Maximum thinking budget',
+    id: 'xhigh',
+    name: 'Extra High',
+    description: 'Maximum effort for supported models',
     icon: Atom,
-    prefix: 'ultrathink',
-    color: 'text-red-600'
-  }
+    color: 'text-red-600',
+  },
+  {
+    id: 'max',
+    name: 'Max',
+    description: 'Provider maximum reasoning mode',
+    icon: Atom,
+    color: 'text-red-700',
+  },
 ];
+
+export function isThinkingModeId(value: unknown): value is ThinkingModeId {
+  return typeof value === 'string' && thinkingModes.some((mode) => mode.id === value);
+}
+
+export function thinkingModeToConfig(mode: ThinkingModeId) {
+  return {
+    mode,
+    enabled: mode !== 'default' && mode !== 'off',
+    ...(mode === 'off' ? { enabled: false } : {}),
+  };
+}

--- a/ui/src/components/chat/hooks/useChatComposerState.ts
+++ b/ui/src/components/chat/hooks/useChatComposerState.ts
@@ -11,7 +11,7 @@ import type {
 } from 'react';
 import { useDropzone } from 'react-dropzone';
 import { authenticatedFetch } from '../../../utils/api';
-import { thinkingModes } from '../constants/thinkingModes';
+import { isThinkingModeId, thinkingModeToConfig, type ThinkingModeId } from '../constants/thinkingModes';
 import { grantPilotDeckToolPermission } from '../utils/chatPermissions';
 import { safeLocalStorage } from '../utils/chatStorage';
 import {
@@ -199,14 +199,44 @@ export function useChatComposerState({
   const [uploadingImages, setUploadingImages] = useState<Map<string, number>>(new Map());
   const [imageErrors, setImageErrors] = useState<Map<string, string>>(new Map());
   const [isTextareaExpanded, setIsTextareaExpanded] = useState(false);
-  const [thinkingMode, setThinkingMode] = useState('none');
+  const [thinkingMode, setThinkingModeState] = useState<ThinkingModeId>('default');
 
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const inputHighlightRef = useRef<HTMLDivElement>(null);
+  const pendingNewSessionThinkingModeRef = useRef<ThinkingModeId | null>(null);
   const handleSubmitRef = useRef<
     ((event: FormEvent<HTMLFormElement> | MouseEvent | TouchEvent | KeyboardEvent<HTMLTextAreaElement>) => Promise<void>) | null
   >(null);
   const inputValueRef = useRef(input);
+
+  const activeThinkingSessionId = selectedSession?.id || currentSessionId || null;
+  const setThinkingMode = useCallback((nextMode: ThinkingModeId | string) => {
+    const normalizedMode = isThinkingModeId(nextMode) ? nextMode : 'default';
+    setThinkingModeState(normalizedMode);
+    if (activeThinkingSessionId && !isTemporarySessionId(activeThinkingSessionId)) {
+      safeLocalStorage.setItem(`thinkingMode-${activeThinkingSessionId}`, normalizedMode);
+    }
+  }, [activeThinkingSessionId]);
+
+  useEffect(() => {
+    if (!activeThinkingSessionId || isTemporarySessionId(activeThinkingSessionId)) {
+      setThinkingModeState('default');
+      return;
+    }
+    const stored = safeLocalStorage.getItem(`thinkingMode-${activeThinkingSessionId}`);
+    if (isThinkingModeId(stored)) {
+      setThinkingModeState(stored);
+      return;
+    }
+    if (pendingNewSessionThinkingModeRef.current) {
+      const pendingMode = pendingNewSessionThinkingModeRef.current;
+      pendingNewSessionThinkingModeRef.current = null;
+      safeLocalStorage.setItem(`thinkingMode-${activeThinkingSessionId}`, pendingMode);
+      setThinkingModeState(pendingMode);
+      return;
+    }
+    setThinkingModeState('default');
+  }, [activeThinkingSessionId]);
 
   // One-shot flag set by `handleCustomCommand` when re-submitting passthrough
   // slash content (e.g. `/projects` for bundled stubs, `/canvas` for skills).
@@ -693,10 +723,6 @@ export function useChatComposerState({
 
       const userVisibleInput = currentInput.trim() || 'Please review the attached file(s).';
       let messageContent = userVisibleInput;
-      const selectedThinkingMode = thinkingModes.find((mode: { id: string; prefix?: string }) => mode.id === thinkingMode);
-      if (selectedThinkingMode && selectedThinkingMode.prefix) {
-        messageContent = `${selectedThinkingMode.prefix}: ${userVisibleInput}`;
-      }
 
       // Pin the target session before any await so attachment upload cannot
       // race with a sidebar session switch and leak the optimistic bubble.
@@ -708,6 +734,9 @@ export function useChatComposerState({
         selectedSession?.id ||
         (canResumeCurrentSession ? currentSessionId : null);
       const submitSelectedSession = selectedSession;
+      if (!submitTargetSessionId || isTemporarySessionId(submitTargetSessionId)) {
+        pendingNewSessionThinkingModeRef.current = thinkingMode;
+      }
 
       // Optimistic sidebar refresh — fire BEFORE the attachment upload so
       // the sidebar reorders/spawns the row the instant the user clicks
@@ -833,6 +862,7 @@ export function useChatComposerState({
         permissionMode,
         basePermissionMode,
         model,
+        thinking: thinkingModeToConfig(thinkingMode),
         sessionSummary,
         images: uploadedImages,
       });
@@ -844,7 +874,6 @@ export function useChatComposerState({
       setUploadingImages(new Map());
       setImageErrors(new Map());
       setIsTextareaExpanded(false);
-      setThinkingMode('none');
 
       if (textareaRef.current) {
         textareaRef.current.style.height = 'auto';

--- a/ui/src/components/chat/utils/sessionLauncher.ts
+++ b/ui/src/components/chat/utils/sessionLauncher.ts
@@ -13,6 +13,7 @@ type StartSessionOptions = {
   basePermissionMode?: PermissionMode | string;
   runMode?: ChatRunMode | string;
   model?: string;
+  thinking?: unknown;
   sessionSummary?: string | null;
   toolsSettings?: PilotDeckSettings;
   images?: unknown[];
@@ -88,6 +89,7 @@ export function startSessionCommand({
   basePermissionMode,
   runMode,
   model,
+  thinking,
   sessionSummary,
   toolsSettings = getPilotDeckSettings(),
   images,
@@ -112,6 +114,7 @@ export function startSessionCommand({
       permissionMode,
       ...(basePermissionMode ? { basePermissionMode } : {}),
       ...(model ? { model } : {}),
+      ...(thinking ? { thinking } : {}),
       sessionSummary,
       ...(typeof userVisibleInput === 'string' && userVisibleInput.trim()
         ? { userVisibleInput: userVisibleInput.trim() }


### PR DESCRIPTION
## Summary\n- add a session-persisted thinking mode selector next to the composer send button\n- thread structured thinking config through UI, gateway, agent, and model request builders\n- add provider-native thinking/reasoning adapters for OpenAI, Anthropic, Google, GLM/Z.AI, Qwen, DeepSeek, Kimi, and MiniMax\n- parse OpenAI-compatible reasoning content into canonical thinking blocks\n\n## Tests\n- node --import tsx --test tests/model/request/thinkingAdapters.spec.ts\n\n## Notes\n- Full npm run build currently hits pre-existing repository test type errors unrelated to this change.\n- UI typecheck currently hits pre-existing React/Lucide type incompatibilities unrelated to this change.