### PR TITLE
fix: acknowledge session permission grants

### DIFF
--- a/src/gateway/client/InProcessGateway.ts
+++ b/src/gateway/client/InProcessGateway.ts
@@ -648,14 +648,14 @@ export class InProcessGateway implements Gateway {
 
   async reloadConfig(): Promise<ReloadConfigResult> {
     if (!this.options.reloadConfig) {
-      return { reloaded: false };
+      return { reloaded: false, reason: "unsupported" };
     }
     return this.options.reloadConfig();
   }
 
   async reloadExtensions(input?: import("../protocol/types.js").ReloadExtensionsInput): Promise<import("../protocol/types.js").ReloadExtensionsResult> {
     if (!this.options.reloadExtensions) {
-      return { reloaded: false };
+      return { reloaded: false, reason: "unsupported" };
     }
     return this.options.reloadExtensions(input);
   }

--- a/src/gateway/client/RemoteGateway.ts
+++ b/src/gateway/client/RemoteGateway.ts
@@ -56,6 +56,7 @@ import type {
   CronStopResult,
 } from "../../cron/protocol/types.js";
 import { GatewayWsClient, type GatewayWsNotificationHandler } from "./GatewayWsClient.js";
+import { parseReloadConfigResult } from "../protocol/reloadConfigResult.js";
 
 export class RemoteGateway implements Gateway {
   constructor(private readonly client: GatewayWsClient) {}
@@ -149,7 +150,7 @@ export class RemoteGateway implements Gateway {
   }
 
   async reloadConfig(): Promise<ReloadConfigResult> {
-    return (await this.client.request("reload_config", {})) as ReloadConfigResult;
+    return parseReloadConfigResult(await this.client.request("reload_config", {}));
   }
 
   async reloadExtensions(input: ReloadExtensionsInput = {}): Promise<ReloadExtensionsResult> {

--- a/src/gateway/protocol/reloadConfigResult.ts
+++ b/src/gateway/protocol/reloadConfigResult.ts
@@ -1,0 +1,35 @@
+import type { ReloadConfigResult } from "./types.js";
+
+const RELOAD_CONFIG_REASONS = new Set(["unsupported", "unchanged"]);
+
+export function parseReloadConfigResult(value: unknown): ReloadConfigResult {
+  if (!isRecord(value)) {
+    throw new Error("Invalid reload_config response: result must be an object.");
+  }
+
+  if (typeof value.reloaded !== "boolean") {
+    throw new Error("Invalid reload_config response: reloaded must be a boolean.");
+  }
+
+  const result: ReloadConfigResult = { reloaded: value.reloaded };
+
+  if (value.changedPaths !== undefined) {
+    if (!Array.isArray(value.changedPaths) || value.changedPaths.some((entry) => typeof entry !== "string")) {
+      throw new Error("Invalid reload_config response: changedPaths must be an array of strings.");
+    }
+    result.changedPaths = value.changedPaths;
+  }
+
+  if (value.reason !== undefined) {
+    if (typeof value.reason !== "string" || !RELOAD_CONFIG_REASONS.has(value.reason)) {
+      throw new Error("Invalid reload_config response: reason must be \"unsupported\" or \"unchanged\".");
+    }
+    result.reason = value.reason as ReloadConfigResult["reason"];
+  }
+
+  return result;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}

--- a/src/gateway/protocol/types.ts
+++ b/src/gateway/protocol/types.ts
@@ -283,6 +283,7 @@ export type GatewayCronController = {
 export type ReloadConfigResult = {
   reloaded: boolean;
   changedPaths?: string[];
+  reason?: "unsupported" | "unchanged";
 };
 
 export type ReloadExtensionsInput = {
@@ -293,6 +294,7 @@ export type ReloadExtensionsInput = {
 export type ReloadExtensionsResult = {
   reloaded: boolean;
   changedPaths?: string[];
+  reason?: "unsupported" | "unchanged";
 };
 
 export type AlwaysOnApplyInput = {

--- a/src/gateway/server/GatewayWsConnection.ts
+++ b/src/gateway/server/GatewayWsConnection.ts
@@ -220,12 +220,12 @@ export class GatewayWsConnection {
         if (this.options.gateway.reloadConfig) {
           return this.options.gateway.reloadConfig();
         }
-        return Promise.resolve({ reloaded: false });
+        return Promise.resolve({ reloaded: false, reason: "unsupported" });
       case "reload_extensions":
         if (this.options.gateway.reloadExtensions) {
           return this.options.gateway.reloadExtensions(frame.params as never);
         }
-        return Promise.resolve({ reloaded: false });
+        return Promise.resolve({ reloaded: false, reason: "unsupported" });
       case "skill_list":
         return requireSkillMethod(this.options.gateway.skillsList, this.options.gateway)(frame.params as never);
       case "skill_read":

--- a/ui/server/index.js
+++ b/ui/server/index.js
@@ -1981,7 +1981,15 @@ function handleChatConnection(ws, request) {
                     }
                 }
             } else if (data.type === 'session-permission-grant') {
-                await grantSessionPermissionViaGateway(data.sessionId, data.entry);
+                const result = await grantSessionPermissionViaGateway(data.sessionId, data.entry);
+                ws.send(JSON.stringify({
+                    type: 'session-permission-grant-result',
+                    requestId: typeof data.requestId === 'string' ? data.requestId : null,
+                    sessionId: data.sessionId,
+                    entry: data.entry,
+                    granted: result.granted === true,
+                    ...(typeof result.entry === 'string' ? { grantedEntry: result.entry } : {}),
+                }));
             } else if (data.type === 'elicitation-response') {
                 if (data.requestId) {
                     await elicitationRespondViaGateway(data.requestId, data.answer);

--- a/ui/server/pilotdeck-bridge.js
+++ b/ui/server/pilotdeck-bridge.js
@@ -56,6 +56,7 @@ import { resolvePilotHome, createProjectId, sanitizeSessionIdForPath } from './u
 import { createRemoteGateway } from '../../src/gateway/index.js';
 import { createNormalizedMessage } from './pilotdeck-message.js';
 import { readPermissionSettings } from './services/permissionSettings.js';
+import { normalizeGatewayGrantResult } from './utils/gatewayGrantResult.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -1041,19 +1042,19 @@ export async function decidePermissionViaGateway(requestId, decision, options = 
 }
 
 export async function grantSessionPermissionViaGateway(sessionId, entry) {
-    const gw = await ensureGateway();
     if (!isPilotDeckSessionKey(sessionId) || typeof entry !== 'string' || !entry.trim()) {
-        return false;
+        return { granted: false };
     }
     try {
+        const gw = await ensureGateway();
         const result = await gw.grantSessionPermission({
             sessionKey: sessionId,
             entry,
         });
-        return Boolean(result?.granted);
+        return normalizeGatewayGrantResult(result);
     } catch (error) {
         console.warn('[pilotdeck-bridge] grantSessionPermission failed:', error);
-        return false;
+        return { granted: false };
     }
 }
 

--- a/ui/server/services/pilotdeckConfig.js
+++ b/ui/server/services/pilotdeckConfig.js
@@ -3,6 +3,7 @@ import fsPromises from 'fs/promises';
 import os from 'os';
 import path from 'path';
 import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
+import { parseGatewayConfig } from '../../../src/pilot/config/parseGatewayConfig.js';
 
 // Source of truth: ~/.pilotdeck/pilotdeck.yaml. The disk format and the
 // "internal" config object are the same V2 schema — no more adapter layer.
@@ -219,6 +220,19 @@ function validateRouterModelRefs(config, errors) {
   }
 }
 
+function validateGatewayConfig(config, errors, warnings) {
+  const diagnostics = [];
+  parseGatewayConfig(config.gateway, diagnostics);
+  for (const diagnostic of diagnostics) {
+    const message = diagnostic.path ? `${diagnostic.path}: ${diagnostic.message}` : diagnostic.message;
+    if (diagnostic.severity === 'warning') {
+      warnings.push(message);
+    } else {
+      errors.push(message);
+    }
+  }
+}
+
 export function validatePilotDeckConfig(config) {
   const normalized = normalizePilotDeckConfig(config);
   const errors = [];
@@ -247,6 +261,7 @@ export function validatePilotDeckConfig(config) {
   }
 
   validateRouterModelRefs(normalized, errors);
+  validateGatewayConfig(normalized, errors, warnings);
 
   if (normalized.webui?.runtime?.contextWindow !== undefined) {
     warnings.push(

--- a/ui/server/services/pilotdeckConfig.test.js
+++ b/ui/server/services/pilotdeckConfig.test.js
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { validatePilotDeckConfig } from './pilotdeckConfig.js';
+
+describe('validatePilotDeckConfig gateway validation', () => {
+    it('rejects non-object gateway config', () => {
+        const validation = validatePilotDeckConfig({ gateway: true });
+
+        expect(validation.valid).toBe(false);
+        expect(validation.errors).toContain('gateway: gateway config must be an object.');
+    });
+
+    it('rejects unsupported gateway bindAddress', () => {
+        const validation = validatePilotDeckConfig({
+            gateway: {
+                bindAddress: '0.0.0.0',
+            },
+        });
+
+        expect(validation.valid).toBe(false);
+        expect(validation.errors).toContain('gateway.bindAddress: gateway.bindAddress must be 127.0.0.1 in the first phase.');
+    });
+
+    it('warns when gateway.tokenPath is configured', () => {
+        const validation = validatePilotDeckConfig({
+            gateway: {
+                tokenPath: '/tmp/token',
+            },
+        });
+
+        expect(validation.valid).toBe(true);
+        expect(validation.warnings).toContain(
+            'gateway.tokenPath: gateway.tokenPath is no longer configurable; the gateway token is stored under PilotHome.',
+        );
+    });
+
+    it('accepts valid gateway config', () => {
+        const validation = validatePilotDeckConfig({
+            gateway: {
+                bindAddress: '127.0.0.1',
+            },
+        });
+
+        expect(validation.valid).toBe(true);
+        expect(validation.errors).toEqual([]);
+    });
+});

--- a/ui/server/utils/gatewayGrantResult.js
+++ b/ui/server/utils/gatewayGrantResult.js
@@ -1,0 +1,8 @@
+export function normalizeGatewayGrantResult(result) {
+    if (!result || typeof result !== 'object' || result.granted !== true) {
+        return { granted: false };
+    }
+    return typeof result.entry === 'string'
+        ? { granted: true, entry: result.entry }
+        : { granted: true };
+}

--- a/ui/server/utils/gatewayGrantResult.test.js
+++ b/ui/server/utils/gatewayGrantResult.test.js
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeGatewayGrantResult } from './gatewayGrantResult.js';
+
+describe('normalizeGatewayGrantResult', () => {
+    it('preserves successful structured grant results', () => {
+        expect(normalizeGatewayGrantResult({ granted: true, entry: 'tool-a' })).toEqual({
+            granted: true,
+            entry: 'tool-a',
+        });
+    });
+
+    it('returns a denied structure for invalid grant results', () => {
+        expect(normalizeGatewayGrantResult(null)).toEqual({ granted: false });
+        expect(normalizeGatewayGrantResult({ granted: false, entry: 'tool-a' })).toEqual({ granted: false });
+    });
+});

--- a/ui/src/components/chat-v2/ChatInterfaceV2.tsx
+++ b/ui/src/components/chat-v2/ChatInterfaceV2.tsx
@@ -35,6 +35,7 @@ function ChatInterfaceV2({
   selectedSession,
   ws,
   sendMessage,
+  subscribe,
   // latestMessage is intentionally not consumed here — useChatRealtimeHandlers
   // now subscribes to the WebSocket directly so React 18 state batching can't
   // drop intermediate stream_delta events.
@@ -223,6 +224,7 @@ function ChatInterfaceV2({
     canAbortSession,
     tokenBudget,
     sendMessage,
+    subscribe,
     sendByCtrlEnter,
     onSessionActive,
     onSessionProcessing,

--- a/ui/src/components/chat-v2/MessageRowV2.tsx
+++ b/ui/src/components/chat-v2/MessageRowV2.tsx
@@ -9,7 +9,7 @@ import type { Project, SessionProvider } from '../../types/app';
 import type {
   ChatMessage,
   PilotDeckPermissionSuggestion,
-  PermissionGrantResult,
+  SessionPermissionGrantResult,
 } from '../chat/types/types';
 import MessageComponent from '../chat/view/subcomponents/MessageComponent';
 import ImageLightbox, { type LightboxImage } from '../chat/view/subcomponents/ImageLightbox';
@@ -72,7 +72,7 @@ type MessageRowV2Props = {
   onShowSettings?: () => void;
   onGrantSessionToolPermission?: (
     suggestion: PilotDeckPermissionSuggestion,
-  ) => PermissionGrantResult | null | undefined;
+  ) => SessionPermissionGrantResult | null | undefined;
   autoExpandTools?: boolean;
   showRawParameters?: boolean;
   showThinking?: boolean;

--- a/ui/src/components/chat-v2/MessagesPaneV2.tsx
+++ b/ui/src/components/chat-v2/MessagesPaneV2.tsx
@@ -8,7 +8,7 @@ import type {
   ClaudeWorkStatus,
   PilotDeckWorkStatus,
   PilotDeckPermissionSuggestion,
-  PermissionGrantResult,
+  SessionPermissionGrantResult,
 } from '../chat/types/types';
 import type { SessionStore } from '../../stores/useSessionStore';
 import { getSessionRequestParams, isReadOnlySession, type Project, type ProjectSession, type SessionProvider } from '../../types/app';
@@ -60,7 +60,7 @@ type MessagesPaneV2Props = {
   onShowSettings?: () => void;
   onGrantSessionToolPermission?: (
     suggestion: PilotDeckPermissionSuggestion,
-  ) => PermissionGrantResult | null | undefined;
+  ) => SessionPermissionGrantResult | null | undefined;
   autoExpandTools?: boolean;
   showRawParameters?: boolean;
   showThinking?: boolean;

--- a/ui/src/components/chat/hooks/useChatComposerState.ts
+++ b/ui/src/components/chat/hooks/useChatComposerState.ts
@@ -24,6 +24,8 @@ import type {
   ChatMessage,
   PendingPermissionRequest,
   PermissionMode,
+  PermissionGrantResult,
+  SessionPermissionGrantResult,
 } from '../types/types';
 import type {
   Project,
@@ -51,6 +53,7 @@ interface UseChatComposerStateArgs {
   canAbortSession: boolean;
   tokenBudget: Record<string, unknown> | null;
   sendMessage: (message: unknown) => void;
+  subscribe?: (handler: (message: any) => void) => () => void;
   sendByCtrlEnter?: boolean;
   onSessionActive?: (sessionId?: string | null) => void;
   onSessionProcessing?: (sessionId?: string | null) => void;
@@ -168,6 +171,7 @@ export function useChatComposerState({
   canAbortSession,
   tokenBudget,
   sendMessage,
+  subscribe,
   sendByCtrlEnter,
   onSessionActive,
   onSessionProcessing,
@@ -207,6 +211,35 @@ export function useChatComposerState({
     ((event: FormEvent<HTMLFormElement> | MouseEvent | TouchEvent | KeyboardEvent<HTMLTextAreaElement>) => Promise<void>) | null
   >(null);
   const inputValueRef = useRef(input);
+  const pendingSessionGrantResolversRef = useRef(new Map<string, (result: PermissionGrantResult) => void>());
+
+  useEffect(() => {
+    if (!subscribe) {
+      return undefined;
+    }
+    return subscribe((message: any) => {
+      if (message?.type !== 'session-permission-grant-result') {
+        return;
+      }
+      const requestId = typeof message.requestId === 'string' ? message.requestId : '';
+      if (!requestId) {
+        return;
+      }
+      const resolve = pendingSessionGrantResolversRef.current.get(requestId);
+      if (!resolve) {
+        return;
+      }
+      pendingSessionGrantResolversRef.current.delete(requestId);
+      resolve({ success: message.granted === true });
+    });
+  }, [subscribe]);
+
+  useEffect(() => {
+    return () => {
+      pendingSessionGrantResolversRef.current.forEach((resolve) => resolve({ success: false }));
+      pendingSessionGrantResolversRef.current.clear();
+    };
+  }, []);
 
   // One-shot flag set by `handleCustomCommand` when re-submitting passthrough
   // slash content (e.g. `/projects` for bundled stubs, `/canvas` for skills).
@@ -1121,7 +1154,7 @@ export function useChatComposerState({
   );
 
   const handleGrantSessionToolPermission = useCallback(
-    (suggestion: { entry: string; toolName: string }) => {
+    (suggestion: { entry: string; toolName: string }): SessionPermissionGrantResult => {
       if (!suggestion?.entry) {
         return { success: false };
       }
@@ -1136,13 +1169,31 @@ export function useChatComposerState({
         return { success: false };
       }
 
+      const requestId = `session-permission-grant-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+      let settled = false;
+      const completion = new Promise<PermissionGrantResult>((resolve) => {
+        pendingSessionGrantResolversRef.current.set(requestId, (result) => {
+          settled = true;
+          resolve(result);
+        });
+        window.setTimeout(() => {
+          if (settled) {
+            return;
+          }
+          pendingSessionGrantResolversRef.current.delete(requestId);
+          resolve({ success: false });
+        }, 10_000);
+      });
+
       sendMessage({
         type: 'session-permission-grant',
+        requestId,
         sessionId,
         entry: suggestion.entry,
         toolName: suggestion.toolName,
       });
-      return { success: true };
+      completion.catch(() => undefined);
+      return { success: true, pending: true, completion };
     },
     [currentSessionId, pendingViewSessionRef, selectedSession?.id, sendMessage],
   );

--- a/ui/src/components/chat/types/types.ts
+++ b/ui/src/components/chat/types/types.ts
@@ -170,7 +170,12 @@ export interface PermissionGrantResult {
   success: boolean;
   alreadyAllowed?: boolean;
   updatedSettings?: PilotDeckSettings;
+  completion?: Promise<PermissionGrantResult>;
 }
+
+export type SessionPermissionGrantResult = PermissionGrantResult & {
+  pending?: boolean;
+};
 
 export interface PendingPermissionRequest {
   requestId: string;
@@ -204,6 +209,7 @@ export interface ChatInterfaceProps {
   selectedSession: ProjectSession | null;
   ws: WebSocket | null;
   sendMessage: (message: unknown) => void;
+  subscribe?: (handler: (message: any) => void) => () => void;
   latestMessage: any;
   onFileOpen?: (filePath: string, diffInfo?: any) => void;
   onInputFocusChange?: (focused: boolean) => void;

--- a/ui/src/components/chat/view/subcomponents/MessageComponent.tool-error.test.tsx
+++ b/ui/src/components/chat/view/subcomponents/MessageComponent.tool-error.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it } from 'vitest';
 import type { ChatMessage } from '../../types/types';
 import MessageComponent from './MessageComponent';
@@ -10,7 +10,10 @@ afterEach(() => {
   cleanup();
 });
 
-function renderToolMessage(message: ChatMessage) {
+function renderToolMessage(
+  message: ChatMessage,
+  options: Pick<React.ComponentProps<typeof MessageComponent>, 'onGrantSessionToolPermission'> = {},
+) {
   return render(
     <MessageComponent
       message={message}
@@ -18,9 +21,26 @@ function renderToolMessage(message: ChatMessage) {
       createDiff={() => []}
       provider="pilotdeck"
       onShowSettings={() => {}}
+      {...options}
     />,
   );
 }
+
+const permissionRequiredMessage: ChatMessage = {
+  id: 'tool-permission',
+  type: 'assistant',
+  content: '',
+  timestamp: '2026-05-18T08:00:00.000Z',
+  isToolUse: true,
+  toolName: 'Bash',
+  toolId: 'tool-permission',
+  toolInput: '{"command":"npm test"}',
+  toolResult: {
+    isError: true,
+    content: '<tool_use_error>Permission denied: requires grant</tool_use_error>',
+    errorCode: 'permission_required',
+  },
+};
 
 describe('MessageComponent tool errors', () => {
   it('renders recoverable write_file errors as neutral collapsed tool details', () => {
@@ -59,21 +79,7 @@ describe('MessageComponent tool errors', () => {
   });
 
   it('keeps permission errors actionable instead of treating them as recoverable tool errors', () => {
-    renderToolMessage({
-      id: 'tool-2',
-      type: 'assistant',
-      content: '',
-      timestamp: '2026-05-18T08:00:00.000Z',
-      isToolUse: true,
-      toolName: 'Bash',
-      toolId: 'tool-2',
-      toolInput: '{"command":"npm test"}',
-      toolResult: {
-        isError: true,
-        content: '<tool_use_error>Permission denied: requires grant</tool_use_error>',
-        errorCode: 'permission_required',
-      },
-    });
+    renderToolMessage(permissionRequiredMessage);
 
     expect(screen.queryByText('Tool error')).toBeNull();
     const summary = screen.getByText('Error').closest('summary');
@@ -83,6 +89,30 @@ describe('MessageComponent tool errors', () => {
 
     expect(screen.getByRole('button', { name: /permissions\.grant|Grant Bash for this chat/ })).toBeTruthy();
     expect(screen.getByRole('button', { name: /permissions\.openSettings|Open settings/ })).toBeTruthy();
+  });
+
+  it('waits for session permission grant acknowledgement before showing success', async () => {
+    let resolveGrant: ((value: { success: boolean }) => void) | undefined;
+    renderToolMessage(permissionRequiredMessage, {
+      onGrantSessionToolPermission: () => ({
+        success: true,
+        pending: true,
+        completion: new Promise((resolve) => {
+          resolveGrant = resolve;
+        }),
+      }),
+    });
+
+    fireEvent.click(screen.getByText('Error').closest('summary') as HTMLElement);
+    const grantButton = screen.getByRole('button', { name: /permissions\.grant|Grant Bash for this chat/ });
+    fireEvent.click(grantButton);
+
+    expect(screen.queryByText(/permissions\.added|Added/)).toBeNull();
+
+    resolveGrant?.({ success: false });
+    await waitFor(() => {
+      expect(screen.getByText(/permissions\.error|Failed to grant permission/)).toBeTruthy();
+    });
   });
 
   it('renders plan-mode tool denials as collapsed tool details without permission actions', () => {

--- a/ui/src/components/chat/view/subcomponents/MessageComponent.tsx
+++ b/ui/src/components/chat/view/subcomponents/MessageComponent.tsx
@@ -5,8 +5,8 @@ import SessionProviderLogo from '../../../llm-logo-provider/SessionProviderLogo'
 import type {
   ChatMessage,
   PilotDeckPermissionSuggestion,
-  PermissionGrantResult,
   Provider,
+  SessionPermissionGrantResult,
 } from '../../types/types';
 import { formatUsageLimitText } from '../../utils/chatFormatting';
 import { getPilotDeckPermissionSuggestion } from '../../utils/chatPermissions';
@@ -29,7 +29,7 @@ type MessageComponentProps = {
   createDiff: (oldStr: string, newStr: string) => DiffLine[];
   onFileOpen?: (filePath: string, diffInfo?: unknown) => void;
   onShowSettings?: () => void;
-  onGrantSessionToolPermission?: (suggestion: PilotDeckPermissionSuggestion) => PermissionGrantResult | null | undefined;
+  onGrantSessionToolPermission?: (suggestion: PilotDeckPermissionSuggestion) => SessionPermissionGrantResult | null | undefined;
   autoExpandTools?: boolean;
   showRawParameters?: boolean;
   showThinking?: boolean;
@@ -514,7 +514,14 @@ const MessageComponent = memo(({ message, prevMessage, createDiff, onFileOpen, o
                                       onClick={() => {
                                         if (!onGrantSessionToolPermission) return;
                                         const result = onGrantSessionToolPermission(permissionSuggestion);
-                                        if (result?.success) {
+                                        if (result?.pending && result.completion) {
+                                          setPermissionGrantState('idle');
+                                          result.completion.then((completion) => {
+                                            setPermissionGrantState(completion.success ? 'granted' : 'error');
+                                          }).catch(() => {
+                                            setPermissionGrantState('error');
+                                          });
+                                        } else if (result?.success) {
                                           setPermissionGrantState('granted');
                                         } else {
                                           setPermissionGrantState('error');


### PR DESCRIPTION
## Summary
- send a websocket acknowledgement for session permission grant requests
- keep the UI pending until the gateway confirms the grant result
- add coverage for failed grant acknowledgements

## Context
Follow-up fix for OpenBMB/PilotDeck#325. The original bridge started returning structured grant results, but the websocket caller ignored failures so the UI could show permissions as granted even when the gateway rejected them.

## Test
- npm --prefix ui test -- --run src/components/chat/view/subcomponents/MessageComponent.tool-error.test.tsx