### PR TITLE
Fetch provider models dynamically

### DIFF
--- a/ui/server/routes/config.js
+++ b/ui/server/routes/config.js
@@ -90,6 +90,54 @@ function buildGoogleGenerateContentUrl(baseUrl, model) {
   return url.toString();
 }
 
+function buildGoogleModelsUrl(baseUrl) {
+  const normalizedBaseUrl = String(baseUrl || 'https://generativelanguage.googleapis.com').trim().replace(/\/+$/, '')
+    || 'https://generativelanguage.googleapis.com';
+  const url = new URL(normalizedBaseUrl);
+  const parts = url.pathname.split('/').filter(Boolean);
+  const last = parts.at(-1);
+  const apiVersion = last === 'v1' || last === 'v1beta' ? last : 'v1beta';
+  const baseParts = last === 'v1' || last === 'v1beta' ? parts.slice(0, -1) : parts;
+  url.pathname = `/${[...baseParts, apiVersion, 'models'].join('/')}`;
+  url.search = '';
+  url.hash = '';
+  return url.toString();
+}
+
+function normalizeModelListItem(item) {
+  if (!item || typeof item !== 'object') return null;
+  const rawId = typeof item.id === 'string'
+    ? item.id
+    : typeof item.name === 'string'
+      ? item.name
+      : '';
+  const id = rawId.replace(/^models\//, '').trim();
+  if (!id) return null;
+  const displayName = typeof item.display_name === 'string'
+    ? item.display_name
+    : typeof item.displayName === 'string'
+      ? item.displayName
+      : id;
+  return { id, displayName };
+}
+
+function parseModelListResponse(body) {
+  const rawModels = Array.isArray(body?.data)
+    ? body.data
+    : Array.isArray(body?.models)
+      ? body.models
+      : [];
+  const seen = new Set();
+  const models = [];
+  for (const item of rawModels) {
+    const model = normalizeModelListItem(item);
+    if (!model || seen.has(model.id)) continue;
+    seen.add(model.id);
+    models.push(model);
+  }
+  return models;
+}
+
 router.get('/', (_req, res) => {
   try {
     const record = readPilotDeckConfigFile();
@@ -237,6 +285,63 @@ router.get('/provider', (_req, res) => {
     });
   } catch (error) {
     res.status(500).json({ error: error instanceof Error ? error.message : String(error) });
+  }
+});
+
+router.post('/models', async (req, res) => {
+  const { providerId, providerType, baseUrl, apiKey } = req.body || {};
+  let effectiveApiKey = typeof apiKey === 'string' ? apiKey : '';
+  if ((!effectiveApiKey || effectiveApiKey === '********') && typeof providerId === 'string' && providerId.trim()) {
+    try {
+      const record = readPilotDeckConfigFile();
+      const provider = record.config?.model?.providers?.[providerId.trim()];
+      if (typeof provider?.apiKey === 'string') effectiveApiKey = provider.apiKey;
+    } catch { /* fall through to validation below */ }
+  }
+  if (!baseUrl || !effectiveApiKey || effectiveApiKey === '********') {
+    return res.status(400).json({ ok: false, error: 'baseUrl and apiKey are required' });
+  }
+
+  const normalizedType = String(providerType || '').toLowerCase();
+  const isAnthropic = normalizedType === 'anthropic';
+  const isGoogle = normalizedType === 'google';
+  const normalizedBaseUrl = String(baseUrl).trim().replace(/\/+$/, '');
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 10_000);
+
+  try {
+    const url = isGoogle
+      ? buildGoogleModelsUrl(normalizedBaseUrl)
+      : isAnthropic
+        ? `${normalizedBaseUrl}/v1/models`
+        : `${normalizedBaseUrl}/models`;
+    const headers = isGoogle
+      ? { 'x-goog-api-key': effectiveApiKey }
+      : isAnthropic
+        ? { 'x-api-key': effectiveApiKey, 'anthropic-version': '2023-06-01' }
+        : { Authorization: `Bearer ${effectiveApiKey}` };
+    const response = await fetch(url, { method: 'GET', headers, signal: controller.signal });
+    clearTimeout(timer);
+    const responseText = await response.text();
+    let body;
+    try {
+      body = responseText ? JSON.parse(responseText) : {};
+    } catch {
+      return res.status(502).json({ ok: false, error: `Expected JSON from ${url}, but received non-JSON content.` });
+    }
+
+    if (!response.ok) {
+      const message = body?.error?.message || body?.message || responseText || `HTTP ${response.status}`;
+      return res.status(response.status).json({ ok: false, error: message });
+    }
+
+    res.json({ ok: true, models: parseModelListResponse(body) });
+  } catch (error) {
+    clearTimeout(timer);
+    const message = error?.name === 'AbortError'
+      ? 'Model list request timed out after 10s.'
+      : error instanceof Error ? error.message : String(error);
+    res.status(500).json({ ok: false, error: message });
   }
 });
 

--- a/ui/src/components/onboarding/view/subcomponents/LlmConfigurationStep.tsx
+++ b/ui/src/components/onboarding/view/subcomponents/LlmConfigurationStep.tsx
@@ -7,6 +7,7 @@ import {
   type CatalogProvider,
   type CatalogProviderProtocol,
 } from '../../../../shared/catalogProviders';
+import { fetchProviderModels, type ApiModelListItem } from '../../../../shared/modelListApi';
 
 type LlmConfigurationStepProps = {
   onSaved: () => void | Promise<void>;
@@ -56,13 +57,16 @@ export default function LlmConfigurationStep({ onSaved }: LlmConfigurationStepPr
   const [testStatus, setTestStatus] = useState<TestStatus>('idle');
   const [testMessage, setTestMessage] = useState('');
   const [saving, setSaving] = useState(false);
+  const [apiModels, setApiModels] = useState<ApiModelListItem[] | null>(null);
+  const [modelListStatus, setModelListStatus] = useState<'idle' | 'loading' | 'error'>('idle');
+  const [modelListMessage, setModelListMessage] = useState('');
 
   // Inputs that are only relevant when the user picks the "+" (custom) tile.
   const [customProviderId, setCustomProviderId] = useState('');
   const [customProtocol, setCustomProtocol] = useState<CatalogProviderProtocol>('openai');
 
   const isCustomMode = selectedProvider?.id === CUSTOM_PROVIDER_ID;
-  const selectedModels = selectedProvider?.models ?? [];
+  const selectedModels = apiModels ?? selectedProvider?.models ?? [];
   const selectedDefaultUrl = selectedProvider?.defaultUrl ?? '';
 
   useEffect(() => {
@@ -102,6 +106,35 @@ export default function LlmConfigurationStep({ onSaved }: LlmConfigurationStepPr
     (!isCustomMode || effectiveUrl.trim()),
   );
 
+  useEffect(() => {
+    setApiModels(null);
+    setModelListStatus('idle');
+    setModelListMessage('');
+  }, [effectiveProviderId, effectiveUrl, effectiveProtocol]);
+
+  useEffect(() => {
+    const key = apiKey.trim();
+    if (!selectedProvider || !effectiveProviderId || !effectiveUrl || !key || hasUsableApiKey(key) === false) return;
+    const controller = new AbortController();
+    setModelListStatus('loading');
+    setModelListMessage('');
+    fetchProviderModels({ protocol: effectiveProtocol, baseUrl: effectiveUrl, apiKey: key })
+      .then((models) => {
+        if (controller.signal.aborted) return;
+        setApiModels(models);
+        setModelListStatus('idle');
+        if (models.length > 0 && !models.some((model) => model.id === selectedModelId)) {
+          setSelectedModelId(models[0].id);
+        }
+      })
+      .catch((error) => {
+        if (controller.signal.aborted) return;
+        setModelListStatus('error');
+        setModelListMessage(error instanceof Error ? error.message : String(error));
+      });
+    return () => controller.abort();
+  }, [apiKey, effectiveProviderId, effectiveProtocol, effectiveUrl, selectedModelId, selectedProvider]);
+
   const handleProviderSelect = useCallback((provider: CatalogProvider) => {
     setSelectedProvider((prev) => {
       // Switching to a different provider should not carry over the API key
@@ -113,6 +146,9 @@ export default function LlmConfigurationStep({ onSaved }: LlmConfigurationStepPr
       return provider;
     });
     setSelectedModelId(defaultModelForProvider(provider));
+    setApiModels(null);
+    setModelListStatus('idle');
+    setModelListMessage('');
     setCustomModelId('');
     setCustomUrl('');
     setCustomProviderId('');
@@ -406,6 +442,14 @@ export default function LlmConfigurationStep({ onSaved }: LlmConfigurationStepPr
                 autoComplete="off"
                 spellCheck={false}
               />
+            )}
+            {modelListStatus === 'loading' && (
+              <p className="mt-1 inline-flex items-center gap-1 text-[11px] text-muted-foreground">
+                <Loader2 className="h-3 w-3 animate-spin" /> Fetching models from API...
+              </p>
+            )}
+            {modelListStatus === 'error' && modelListMessage && (
+              <p className="mt-1 text-[11px] text-destructive">{modelListMessage}</p>
             )}
             {selectedModels.length > 0 && (
               <div className="mt-2">

--- a/ui/src/components/settings/view/tabs/PilotDeckConfigTab.tsx
+++ b/ui/src/components/settings/view/tabs/PilotDeckConfigTab.tsx
@@ -51,6 +51,7 @@ import {
   type CatalogProviderProtocol,
   type CatalogModel,
 } from '../../../../shared/catalogProviders';
+import { fetchProviderModels, type ApiModelListItem } from '../../../../shared/modelListApi';
 import type { SettingsProject } from '../../types/types';
 import { isCronConfigEnabled, patch } from './pilotDeckConfigForm';
 
@@ -726,6 +727,9 @@ function ProviderCard({
   const [showProviderAdvanced, setShowProviderAdvanced] = useState(false);
   const [providerIdDraft, setProviderIdDraft] = useState(providerId);
   const [providerIdError, setProviderIdError] = useState('');
+  const [apiModels, setApiModels] = useState<ApiModelListItem[] | null>(null);
+  const [apiModelsStatus, setApiModelsStatus] = useState<'idle' | 'loading' | 'error'>('idle');
+  const [apiModelsError, setApiModelsError] = useState('');
   const displayName = providerDisplayName(
     providerIdDraft || providerId,
     catalogEntry,
@@ -770,6 +774,21 @@ function ProviderCard({
       removeModel(mid);
     } else {
       addModel(mid);
+    }
+  };
+  const visibleModels: Array<ApiModelListItem | CatalogModel> = apiModels ?? catalogEntry?.models ?? [];
+  const canFetchModels = Boolean(effectiveUrl && provider.apiKey);
+  const refreshModels = async () => {
+    if (!canFetchModels) return;
+    setApiModelsStatus('loading');
+    setApiModelsError('');
+    try {
+      const models = await fetchProviderModels({ protocol, baseUrl: effectiveUrl, apiKey: provider.apiKey ?? '', providerId });
+      setApiModels(models);
+      setApiModelsStatus('idle');
+    } catch (error) {
+      setApiModelsStatus('error');
+      setApiModelsError(error instanceof Error ? error.message : String(error));
     }
   };
 
@@ -881,10 +900,24 @@ function ProviderCard({
           <span className="text-[10px] text-muted-foreground/60">
             · <ImageIcon className="inline h-2.5 w-2.5" /> {t('pilotDeckConfig.panels.models.supportsImageInput')}
           </span>
+          <button
+            type="button"
+            onClick={refreshModels}
+            disabled={!canFetchModels || apiModelsStatus === 'loading'}
+            className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] text-muted-foreground hover:bg-accent hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            <RefreshCw className={cn('h-2.5 w-2.5', apiModelsStatus === 'loading' && 'animate-spin')} />
+            Fetch API models
+          </button>
         </div>
-        {catalogEntry && catalogEntry.models.length > 0 && (
+        {apiModelsStatus === 'error' && apiModelsError && (
+          <div className="mb-2 rounded-md border border-destructive/30 bg-destructive/5 px-2 py-1 text-[11px] text-destructive">
+            {apiModelsError}
+          </div>
+        )}
+        {visibleModels.length > 0 && (
           <div className="mb-2 flex flex-wrap gap-1.5">
-            {catalogEntry.models.map((m) => {
+            {visibleModels.map((m) => {
               const on = provider.models && m.id in provider.models;
               return (
                 <div
@@ -904,7 +937,7 @@ function ProviderCard({
                   >
                     {on && <Check className="h-3 w-3 text-foreground" strokeWidth={2.5} />}
                     {m.displayName}
-                    {m.supportsImage && (
+                    {'supportsImage' in m && m.supportsImage && (
                       <ImageIcon
                         className="h-3 w-3 text-muted-foreground/70"
                         strokeWidth={2}
@@ -917,7 +950,7 @@ function ProviderCard({
           </div>
         )}
         {/* Custom (off-catalog) models currently enabled */}
-        {enabledModels.filter((mid) => !catalogEntry || !catalogEntry.models.some((m) => m.id === mid)).map((mid) => {
+        {enabledModels.filter((mid) => !visibleModels.some((m) => m.id === mid)).map((mid) => {
           return (
             <div key={mid} className="mb-1 flex items-center gap-2 rounded-md border border-border bg-muted/40 px-2 py-1 text-[11px]">
               <code className="flex-1 truncate font-mono">{mid}</code>

--- a/ui/src/shared/modelListApi.ts
+++ b/ui/src/shared/modelListApi.ts
@@ -1,0 +1,45 @@
+import { authenticatedFetch } from '../utils/api';
+import type { CatalogModel, CatalogProviderProtocol } from './catalogProviders';
+
+export type ApiModelListItem = Pick<CatalogModel, 'id' | 'displayName'>;
+
+export async function fetchProviderModels({
+  protocol,
+  baseUrl,
+  apiKey,
+  providerId,
+}: {
+  protocol: CatalogProviderProtocol;
+  baseUrl: string;
+  apiKey: string;
+  providerId?: string;
+}): Promise<ApiModelListItem[]> {
+  const res = await authenticatedFetch('/api/config/models', {
+    method: 'POST',
+    body: JSON.stringify({
+      providerType: protocol,
+      baseUrl,
+      apiKey,
+      providerId,
+    }),
+  });
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok || data?.ok === false) {
+    throw new Error(data?.error || 'Failed to fetch model list.');
+  }
+  const models = Array.isArray(data?.models) ? data.models : [];
+  return models
+    .map((model: unknown) => {
+      if (!model || typeof model !== 'object') return null;
+      const record = model as Record<string, unknown>;
+      const id = typeof record.id === 'string' ? record.id.trim() : '';
+      if (!id) return null;
+      return {
+        id,
+        displayName: typeof record.displayName === 'string' && record.displayName.trim()
+          ? record.displayName.trim()
+          : id,
+      };
+    })
+    .filter((model: ApiModelListItem | null): model is ApiModelListItem => Boolean(model));
+}


### PR DESCRIPTION
## Summary
- add a config API endpoint to fetch provider model lists dynamically
- support OpenAI-compatible, OpenAI Responses, Anthropic, and Google Gemini model list endpoints
- update onboarding and Settings model selection UI to use API-provided models

## Test
- node --import tsx /tmp/test-models-route.mjs
- npm --prefix ui run build