### PR TITLE
fix: improve cold-start onboarding and skill folder scan

### DIFF
--- a/src/extension/skills/SkillManager.ts
+++ b/src/extension/skills/SkillManager.ts
@@ -339,15 +339,21 @@ export class SkillManager {
     const resolvedRoot = resolve(expandHome(input.parentPath.trim()));
     let entries: import("node:fs").Dirent[];
     try {
+      const rootStat = await fs.stat(resolvedRoot);
+      if (!rootStat.isDirectory()) {
+        throw new SkillManagerError("not_directory", `Path is not a directory: ${resolvedRoot}`);
+      }
       entries = await fs.readdir(resolvedRoot, { withFileTypes: true });
     } catch (e) {
+      if (e instanceof SkillManagerError) throw e;
       if ((e as NodeJS.ErrnoException).code === "ENOENT") {
         throw new SkillManagerError("not_found", `Directory not found: ${resolvedRoot}`);
       }
       throw e;
     }
 
-    const folders: SkillScanFolder[] = [];
+    const currentFolder = await buildSkillScanFolder(resolvedRoot, basename(resolvedRoot));
+    const childFolders: SkillScanFolder[] = [];
     for (const entry of entries) {
       if (!entry.isDirectory() && !entry.isSymbolicLink()) continue;
       let isDir = entry.isDirectory();
@@ -362,52 +368,17 @@ export class SkillManager {
       if (!isDir) continue;
 
       const subDir = join(resolvedRoot, entry.name);
-      let hasSkillMd = false;
-      let meta: SkillSummary | null = null;
-      try {
-        await fs.access(join(subDir, "SKILL.md"));
-        hasSkillMd = true;
-        meta = await readSkillMeta(subDir, "user");
-      } catch {
-        /* no SKILL.md */
-      }
-
-      let fileCount = 0;
-      let totalSize = 0;
-      if (hasSkillMd) {
-        try {
-          const files = await fs.readdir(subDir, { recursive: true, withFileTypes: false });
-          for (const f of files) {
-            try {
-              const st = await fs.stat(join(subDir, String(f)));
-              if (st.isFile()) {
-                fileCount++;
-                totalSize += st.size;
-              }
-            } catch {
-              /* skip */
-            }
-          }
-        } catch {
-          /* skip */
-        }
-      }
-
-      folders.push({
-        folderName: entry.name,
-        hasSkillMd,
-        name: meta?.name ?? null,
-        description: meta?.description ?? null,
-        sourcePath: subDir,
-        fileCount,
-        totalSize,
-      });
+      childFolders.push(await buildSkillScanFolder(subDir, entry.name));
     }
 
-    folders.sort((a, b) => {
+    childFolders.sort((a, b) => {
       if (a.hasSkillMd !== b.hasSkillMd) return a.hasSkillMd ? -1 : 1;
       return a.folderName.localeCompare(b.folderName);
     });
+
+    const folders = currentFolder.hasSkillMd
+      ? [currentFolder, ...childFolders]
+      : childFolders;
 
     return { parentPath: resolvedRoot, folders };
   }
@@ -591,6 +562,49 @@ async function readSkillMeta(skillDir: string, scope: SkillScope): Promise<Skill
     skillDir,
     scope,
     mtime,
+  };
+}
+
+async function buildSkillScanFolder(skillDir: string, folderName: string): Promise<SkillScanFolder> {
+  let hasSkillMd = false;
+  let meta: SkillSummary | null = null;
+  try {
+    await fs.access(join(skillDir, "SKILL.md"));
+    hasSkillMd = true;
+    meta = await readSkillMeta(skillDir, "user");
+  } catch {
+    /* no SKILL.md */
+  }
+
+  let fileCount = 0;
+  let totalSize = 0;
+  if (hasSkillMd) {
+    try {
+      const files = await fs.readdir(skillDir, { recursive: true, withFileTypes: false });
+      for (const file of files) {
+        try {
+          const stats = await fs.stat(join(skillDir, String(file)));
+          if (stats.isFile()) {
+            fileCount++;
+            totalSize += stats.size;
+          }
+        } catch {
+          /* skip */
+        }
+      }
+    } catch {
+      /* skip */
+    }
+  }
+
+  return {
+    folderName,
+    hasSkillMd,
+    name: meta?.name ?? null,
+    description: meta?.description ?? null,
+    sourcePath: skillDir,
+    fileCount,
+    totalSize,
   };
 }
 

--- a/tests/extension/skills/SkillManager.scan.spec.ts
+++ b/tests/extension/skills/SkillManager.scan.spec.ts
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import { SkillManager } from "../../../src/extension/skills/index.js";
+import { SkillManagerError } from "../../../src/extension/skills/SkillManager.js";
+
+async function writeSkill(dir: string, name: string): Promise<void> {
+  await mkdir(dir, { recursive: true });
+  await writeFile(join(dir, "SKILL.md"), `---\nname: ${name}\ndescription: ${name} description\n---\n\nUse ${name}.\n`);
+}
+
+test("scan finds child skill folders and direct skill folders", async () => {
+  const root = await mkdtemp(join(tmpdir(), "pilotdeck-skill-scan-"));
+  try {
+    const pilotHome = join(root, "pilot-home");
+    const parent = join(root, "parent");
+    const skillA = join(parent, "skill-a");
+    const emptyChild = join(parent, "empty-child");
+    await writeSkill(skillA, "Skill A");
+    await mkdir(emptyChild, { recursive: true });
+
+    const manager = new SkillManager({ pilotHome });
+
+    const parentScan = await manager.scan({ parentPath: parent });
+    assert.deepEqual(parentScan.folders.map((folder) => ({ folderName: folder.folderName, hasSkillMd: folder.hasSkillMd })), [
+      { folderName: "skill-a", hasSkillMd: true },
+      { folderName: "empty-child", hasSkillMd: false },
+    ]);
+
+    const directScan = await manager.scan({ parentPath: skillA });
+    assert.equal(directScan.folders[0]?.folderName, "skill-a");
+    assert.equal(directScan.folders[0]?.hasSkillMd, true);
+    assert.equal(directScan.folders[0]?.sourcePath, skillA);
+    assert.equal(directScan.folders[0]?.name, "Skill A");
+
+    const imported = await manager.import({ sourcePath: directScan.folders[0]!.sourcePath, scope: "user", mode: "copy" });
+    assert.equal(imported.ok, true);
+    assert.equal(imported.slug, "skill-a");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("scan returns an empty list for an empty non-skill directory", async () => {
+  const root = await mkdtemp(join(tmpdir(), "pilotdeck-skill-scan-empty-"));
+  try {
+    const manager = new SkillManager({ pilotHome: join(root, "pilot-home") });
+    const scan = await manager.scan({ parentPath: root });
+    assert.deepEqual(scan.folders, []);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("scan rejects file paths", async () => {
+  const root = await mkdtemp(join(tmpdir(), "pilotdeck-skill-scan-file-"));
+  try {
+    const filePath = join(root, "SKILL.md");
+    await writeFile(filePath, "---\nname: File\n---\n");
+    const manager = new SkillManager({ pilotHome: join(root, "pilot-home") });
+
+    await assert.rejects(
+      () => manager.scan({ parentPath: filePath }),
+      (error) => error instanceof SkillManagerError && error.code === "not_directory",
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

- Fix local-auth-disabled cold start so the Web UI still checks onboarding status instead of bypassing setup.
- Fix Skills import scan so selecting a single skill directory containing `SKILL.md` returns an importable candidate.
- Add a focused `SkillManager.scan()` regression test.
- Add `new_docs/zhihu-cold-start-rebuttal.md` with a point-by-point response draft for the Zhihu cold-start review.

## Validation

- `npm run build`
- `node --test --test-force-exit --test-timeout 60000 dist/tests/extension/skills/SkillManager.scan.spec.js`
- Browser Use smoke test:
  - Opened the Web UI with a temporary `PILOT_HOME`.
  - Verified direct skill-folder scan shows the candidate.
  - Imported the scanned skill and confirmed it appears in User Skills with editable `SKILL.md`.

## Notes

- `localhost:3001` remains the production/install entrypoint; the onboarding bug was caused by the frontend local-auth-disabled branch marking onboarding complete without checking `/api/user/onboarding-status`.
