### PR TITLE
fix(router): avoid costly cache-breaking downgrades

### DIFF
--- a/src/agent/loop/AgentLoop.ts
+++ b/src/agent/loop/AgentLoop.ts
@@ -347,7 +347,13 @@ export class AgentLoop {
         request,
         sessionId: input.sessionId,
         isMainAgent: !this.config.isSubagent,
-        metadata: previousTier ? { previousTier } : undefined,
+        metadata: stickyInfo
+          ? {
+            previousTier,
+            previousProvider: stickyInfo.previousProvider,
+            previousModel: stickyInfo.previousModel,
+          }
+          : previousTier ? { previousTier } : undefined,
       });
       const routedMaxOutputTokens = this.dependencies.getModelMaxOutputTokens?.(decision.provider, decision.model);
 

--- a/src/router/RouterRuntime.ts
+++ b/src/router/RouterRuntime.ts
@@ -39,6 +39,7 @@ import {
 import { TokenStatsCollector } from "./stats/TokenStatsCollector.js";
 import { classifyAndRoute } from "./tokenSaver/classifyAndRoute.js";
 import { countMessagesTokens, countResponseTokens, dispose as disposeTokenizer } from "./utils/countTokens.js";
+import { calculateCacheReadCost, calculateInputCost } from "./utils/modelPricing.js";
 import {
   collectRequiredInputModalities,
   missingInputModalities,
@@ -63,6 +64,8 @@ export type RouterRuntimeDeps = {
 
 export type InvalidateStickyResult = {
   previousTier?: string;
+  previousProvider?: string;
+  previousModel?: string;
   orchestrating: boolean;
 };
 
@@ -204,6 +207,75 @@ export function createRouterRuntime(
     };
   }
 
+  function maybePreserveStickyForCache(
+    current: RouterModelRef | undefined,
+    next: RouterModelRef,
+    messages: CanonicalModelRequest["messages"],
+  ): { selection: RouterModelRef; mutation?: RouterMutationsLog["cacheAwareSwitch"] } {
+    const cacheAware = config.tokenSaver?.cacheAwareSwitching;
+    if (cacheAware?.enabled === false || !current) {
+      return { selection: next };
+    }
+    if (current.provider === next.provider && current.model === next.model) {
+      return { selection: next };
+    }
+
+    const estimatedInputTokens = countMessagesTokens(messages);
+    const cachedCost = calculateCacheReadCost(
+      estimatedInputTokens,
+      current.provider,
+      current.model,
+      config.stats?.modelPricing,
+    );
+    const currentPrefillCost = calculateInputCost(
+      estimatedInputTokens,
+      current.provider,
+      current.model,
+      config.stats?.modelPricing,
+    );
+    const prefillCost = calculateInputCost(
+      estimatedInputTokens,
+      next.provider,
+      next.model,
+      config.stats?.modelPricing,
+    );
+    if (prefillCost >= currentPrefillCost) {
+      return { selection: next };
+    }
+
+    const minSavingsRatio = cacheAware?.minSavingsRatio ?? 0;
+    const requiredSavings = cachedCost * minSavingsRatio;
+    const shouldSwitch = prefillCost + Number.EPSILON < cachedCost - requiredSavings;
+    const from = `${current.provider}/${current.model}`;
+    const to = `${next.provider}/${next.model}`;
+
+    if (shouldSwitch) {
+      return {
+        selection: next,
+        mutation: {
+          action: "switched",
+          from,
+          to,
+          cachedCost,
+          prefillCost,
+          estimatedInputTokens,
+        },
+      };
+    }
+
+    return {
+      selection: current,
+      mutation: {
+        action: "kept_sticky",
+        from,
+        to,
+        cachedCost,
+        prefillCost,
+        estimatedInputTokens,
+      },
+    };
+  }
+
   async function resolveCustom(
     input: RouterDecisionInput,
   ): Promise<Partial<RouterDecision> | undefined> {
@@ -267,6 +339,15 @@ export function createRouterRuntime(
     const scenarioOutcome = decideScenario(inputWithUsage, config.scenarios ?? {} as any);
 
     let scenarioType: RouterScenarioType = scenarioOutcome.scenarioType;
+    const previousStickySelection = (input.metadata?.previousProvider && input.metadata.previousModel)
+      ? {
+        id: `${input.metadata.previousProvider}/${input.metadata.previousModel}`,
+        provider: input.metadata.previousProvider,
+        model: input.metadata.previousModel,
+      }
+      : sticky?.stickyProvider && sticky.stickyModel
+      ? { id: `${sticky.stickyProvider}/${sticky.stickyModel}`, provider: sticky.stickyProvider, model: sticky.stickyModel }
+      : undefined;
     let selection: RouterModelRef | undefined =
       custom?.provider && custom.model
         ? { id: `${custom.provider}/${custom.model}`, provider: custom.provider, model: custom.model }
@@ -279,6 +360,7 @@ export function createRouterRuntime(
         : "scenario";
 
     let tokenSaverTier: string | undefined;
+    let cacheAwareSwitch: RouterMutationsLog["cacheAwareSwitch"];
     const subagentPolicy = config.tokenSaver?.subagent?.policy ?? DEFAULT_SUBAGENT_POLICY;
     if (
       !custom?.provider &&
@@ -337,8 +419,17 @@ export function createRouterRuntime(
           if (tokenSaver.selection) {
             selection = tokenSaver.selection;
             resolvedFrom = "tokenSaver";
+            const cacheAware = maybePreserveStickyForCache(
+              previousStickySelection,
+              selection,
+              input.request.messages,
+            );
+            selection = cacheAware.selection;
+            cacheAwareSwitch = cacheAware.mutation;
           }
-          tokenSaverTier = tokenSaver.tier;
+          tokenSaverTier = cacheAwareSwitch?.action === "kept_sticky"
+            ? (sticky?.tokenSaverTier ?? input.metadata?.previousTier ?? tokenSaver.tier)
+            : tokenSaver.tier;
         }
       }
     }
@@ -383,6 +474,9 @@ export function createRouterRuntime(
     );
 
     let mutations: RouterMutationsLog = {};
+    if (cacheAwareSwitch) {
+      mutations = { ...mutations, cacheAwareSwitch };
+    }
     if (config.autoOrchestrate?.enabled && orchGate) {
       const orchestrated = applyOrchestration({
         config: config.autoOrchestrate,
@@ -904,6 +998,8 @@ export function createRouterRuntime(
 
     const current = sessionStore.get(sessionId, false);
     const previousTier = current?.tokenSaverTier;
+    const previousProvider = current?.stickyProvider;
+    const previousModel = current?.stickyModel;
     const orchestrating = current?.orchestrating ?? false;
     if (orchestrating && previousTier) {
       // While orchestrating, preserve the tier sticky so continuation turns
@@ -925,7 +1021,7 @@ export function createRouterRuntime(
         updatedAt: (deps.now?.() ?? new Date()).getTime(),
       });
     }
-    return { previousTier, orchestrating };
+    return { previousTier, previousProvider, previousModel, orchestrating };
   }
 
   return {

--- a/src/router/RouterRuntime.ts
+++ b/src/router/RouterRuntime.ts
@@ -211,6 +211,7 @@ export function createRouterRuntime(
     current: RouterModelRef | undefined,
     next: RouterModelRef,
     messages: CanonicalModelRequest["messages"],
+    lastUsage: import("../model/index.js").CanonicalUsage | undefined,
   ): { selection: RouterModelRef; mutation?: RouterMutationsLog["cacheAwareSwitch"] } {
     const cacheAware = config.tokenSaver?.cacheAwareSwitching;
     if (cacheAware?.enabled === false || !current) {
@@ -221,8 +222,24 @@ export function createRouterRuntime(
     }
 
     const estimatedInputTokens = countMessagesTokens(messages);
+    const observedInputTokens = lastUsage?.inputTokens ?? 0;
+    const observedCacheReadTokens = lastUsage?.cacheReadTokens ?? 0;
+    const observedCacheHitRatio = observedInputTokens > 0
+      ? Math.min(1, Math.max(0, observedCacheReadTokens / observedInputTokens))
+      : 0;
+    if (observedCacheHitRatio <= 0) {
+      return { selection: next };
+    }
+
+    const estimatedCacheReadTokens = Math.floor(estimatedInputTokens * observedCacheHitRatio);
+    const estimatedUncachedTokens = Math.max(0, estimatedInputTokens - estimatedCacheReadTokens);
     const cachedCost = calculateCacheReadCost(
-      estimatedInputTokens,
+      estimatedCacheReadTokens,
+      current.provider,
+      current.model,
+      config.stats?.modelPricing,
+    ) + calculateInputCost(
+      estimatedUncachedTokens,
       current.provider,
       current.model,
       config.stats?.modelPricing,
@@ -423,6 +440,7 @@ export function createRouterRuntime(
               previousStickySelection,
               selection,
               input.request.messages,
+              baseUsage,
             );
             selection = cacheAware.selection;
             cacheAwareSwitch = cacheAware.mutation;

--- a/src/router/config/parseRouterConfig.ts
+++ b/src/router/config/parseRouterConfig.ts
@@ -365,6 +365,40 @@ function parseTokenSaver(
     }
   }
 
+  let cacheAwareSwitching: RouterTokenSaverConfig["cacheAwareSwitching"] = {
+    enabled: true,
+    minSavingsRatio: 0,
+  };
+  if (raw.cacheAwareSwitching !== undefined) {
+    if (!isRecord(raw.cacheAwareSwitching)) {
+      diagnostics.push({
+        code: "ROUTER_TOKEN_SAVER_CACHE_AWARE_SWITCHING_INVALID",
+        severity: "fatal",
+        path: "router.tokenSaver.cacheAwareSwitching",
+        message: "cacheAwareSwitching must be an object.",
+      });
+    } else {
+      const enabled = typeof raw.cacheAwareSwitching.enabled === "boolean"
+        ? raw.cacheAwareSwitching.enabled
+        : true;
+      const minSavingsRatioRaw = raw.cacheAwareSwitching.minSavingsRatio;
+      let minSavingsRatio = 0;
+      if (minSavingsRatioRaw !== undefined) {
+        if (typeof minSavingsRatioRaw === "number" && Number.isFinite(minSavingsRatioRaw) && minSavingsRatioRaw >= 0) {
+          minSavingsRatio = minSavingsRatioRaw;
+        } else {
+          diagnostics.push({
+            code: "ROUTER_TOKEN_SAVER_CACHE_AWARE_SWITCHING_MIN_SAVINGS_INVALID",
+            severity: "fatal",
+            path: "router.tokenSaver.cacheAwareSwitching.minSavingsRatio",
+            message: "cacheAwareSwitching.minSavingsRatio must be a non-negative number.",
+          });
+        }
+      }
+      cacheAwareSwitching = { enabled, minSavingsRatio };
+    }
+  }
+
   return {
     enabled,
     judge: judgeRef,
@@ -373,6 +407,7 @@ function parseTokenSaver(
     rules,
     subagent,
     judgeTimeoutMs,
+    cacheAwareSwitching,
   };
 }
 

--- a/src/router/config/schema.ts
+++ b/src/router/config/schema.ts
@@ -1,5 +1,6 @@
 import type { ModelConfig } from "../../model/index.js";
 import type { RouterScenarioType } from "../protocol/decision.js";
+import type { RouterModelPricingMap } from "../utils/modelPricing.js";
 
 export type RouterModelRef = {
   /** Original "provider/model" string. */
@@ -31,6 +32,11 @@ export type RouterTokenSaverConfig = {
     policy: RouterTokenSaverSubagentPolicy;
   };
   judgeTimeoutMs: number;
+  /**
+   * Preserve the session's current model when its cache-read input cost is
+   * cheaper than switching models and re-prefilling the full prompt.
+   */
+  cacheAwareSwitching?: { enabled: boolean; minSavingsRatio: number };
 };
 
 export type RouterAutoOrchestrateConfig = {
@@ -52,7 +58,7 @@ export type RouterAutoOrchestrateConfig = {
 
 export type RouterStatsConfig = {
   enabled: boolean;
-  modelPricing?: Record<string, { input?: number; output?: number; cacheRead?: number }>;
+  modelPricing?: RouterModelPricingMap;
   /** Override the default ~/.pilotdeck/router/stats.json path (useful for tests). */
   filePath?: string;
   /** Provider/model ref used as the "no-router" baseline for savedCost calculation. */

--- a/src/router/protocol/decision.ts
+++ b/src/router/protocol/decision.ts
@@ -23,6 +23,14 @@ export type RouterMutationsLog = {
     from: string;
     to: string;
   };
+  cacheAwareSwitch?: {
+    action: "kept_sticky" | "switched";
+    from: string;
+    to: string;
+    cachedCost: number;
+    prefillCost: number;
+    estimatedInputTokens: number;
+  };
 };
 
 export type RouterRequestPatch = Pick<
@@ -69,6 +77,8 @@ export type RouterDecisionInput = {
     explicitModel?: string;
     /** Tier from the previous turn; fed to the judge for context-aware classification. */
     previousTier?: string;
+    previousProvider?: string;
+    previousModel?: string;
   };
 };
 

--- a/src/router/stats/TokenStatsCollector.ts
+++ b/src/router/stats/TokenStatsCollector.ts
@@ -4,6 +4,7 @@ import type { CanonicalUsage } from "../../model/index.js";
 import type { RouterStatsConfig } from "../config/schema.js";
 import { resolvePilotHome } from "../../pilot/paths.js";
 import type { RouterDecision } from "../protocol/decision.js";
+import { lookupModelPricing } from "../utils/modelPricing.js";
 
 export type RouterStatsRecord = {
   sessionId: string;
@@ -280,7 +281,7 @@ export class TokenStatsCollector {
     provider: string,
     model: string,
   ): { input: number; output: number; cacheRead: number; total: number } {
-    const pricing = this.lookupPricing(provider, model);
+    const pricing = lookupModelPricing(provider, model, this.modelPricing);
     if (!pricing) return { input: 0, output: 0, cacheRead: 0, total: 0 };
     const inputCost = ((usage.inputTokens ?? 0) / 1_000_000) * (pricing.input ?? 0);
     const outputCost = ((usage.outputTokens ?? 0) / 1_000_000) * (pricing.output ?? 0);
@@ -292,21 +293,6 @@ export class TokenStatsCollector {
       cacheRead: cacheReadCost,
       total: inputCost + outputCost + cacheReadCost + cacheWriteCost,
     };
-  }
-
-  private lookupPricing(
-    provider: string,
-    model: string,
-  ): { input?: number; output?: number; cacheRead?: number } | undefined {
-    const combined = `${provider}/${model}`;
-    if (this.modelPricing) {
-      const exact = this.modelPricing[combined];
-      if (exact) return exact;
-      for (const [key, val] of Object.entries(this.modelPricing)) {
-        if (model.includes(key) || key.includes(model)) return val;
-      }
-    }
-    return lookupDefaultPricing(combined, model);
   }
 
   private calculateBaselineCostForRecord(
@@ -431,63 +417,4 @@ function migrateJsonToJsonl(routerDir: string, jsonlPath: string): void {
       return;
     } catch { /* skip this candidate */ }
   }
-}
-
-// $/million tokens – fallback when neither nativeCost nor user modelPricing is available
-const DEFAULT_PRICING: Array<{ pattern: RegExp; input: number; output: number; cacheRead?: number }> = [
-  // DeepSeek
-  { pattern: /deepseek.*flash/i, input: 0.20, output: 0.60 },
-  { pattern: /deepseek.*chat/i, input: 0.50, output: 1.50 },
-  { pattern: /deepseek.*reasoner/i, input: 0.80, output: 2.00 },
-  { pattern: /deepseek.*v3/i, input: 0.27, output: 1.10 },
-  // Anthropic Claude
-  { pattern: /claude.*opus/i, input: 15.00, output: 75.00, cacheRead: 1.50 },
-  { pattern: /claude.*sonnet/i, input: 3.00, output: 15.00, cacheRead: 0.30 },
-  { pattern: /claude.*haiku/i, input: 0.80, output: 4.00, cacheRead: 0.08 },
-  // OpenAI
-  { pattern: /gpt-4o-mini/i, input: 0.15, output: 0.60, cacheRead: 0.075 },
-  { pattern: /gpt-4o/i, input: 2.50, output: 10.00, cacheRead: 1.25 },
-  { pattern: /gpt-4\.1/i, input: 2.00, output: 8.00, cacheRead: 0.50 },
-  { pattern: /gpt-5/i, input: 2.00, output: 8.00, cacheRead: 0.50 },
-  { pattern: /o[134]-mini/i, input: 1.10, output: 4.40 },
-  { pattern: /o[134]-pro/i, input: 10.00, output: 40.00 },
-  { pattern: /o[134]/i, input: 2.50, output: 10.00 },
-  // Google Gemini
-  { pattern: /gemini.*flash/i, input: 0.10, output: 0.40 },
-  { pattern: /gemini.*pro/i, input: 1.25, output: 5.00 },
-  // GLM / ChatGLM / Zhipu
-  { pattern: /glm/i, input: 0.50, output: 1.00 },
-  // Qwen / Tongyi
-  { pattern: /qwen.*turbo/i, input: 0.30, output: 0.60 },
-  { pattern: /qwen.*plus/i, input: 0.80, output: 2.00 },
-  { pattern: /qwen.*max/i, input: 2.00, output: 6.00 },
-  { pattern: /qwen/i, input: 0.50, output: 1.50 },
-  // Llama / Meta
-  { pattern: /llama.*70b/i, input: 0.80, output: 0.80 },
-  { pattern: /llama.*405b/i, input: 3.00, output: 3.00 },
-  { pattern: /llama/i, input: 0.20, output: 0.20 },
-  // Mistral
-  { pattern: /mistral.*large/i, input: 2.00, output: 6.00 },
-  { pattern: /mistral.*small/i, input: 0.10, output: 0.30 },
-  { pattern: /mistral/i, input: 0.25, output: 0.25 },
-  // Yi / 01.AI
-  { pattern: /yi-/i, input: 0.30, output: 0.30 },
-  // Moonshot / Kimi
-  { pattern: /moonshot|kimi/i, input: 1.00, output: 2.00 },
-  // Doubao / ByteDance
-  { pattern: /doubao/i, input: 0.40, output: 0.80 },
-];
-
-const FALLBACK_PRICING = { input: 0.50, output: 1.50 };
-
-function lookupDefaultPricing(
-  combined: string,
-  model: string,
-): { input?: number; output?: number; cacheRead?: number } {
-  for (const entry of DEFAULT_PRICING) {
-    if (entry.pattern.test(combined) || entry.pattern.test(model)) {
-      return { input: entry.input, output: entry.output, cacheRead: entry.cacheRead };
-    }
-  }
-  return FALLBACK_PRICING;
 }

--- a/src/router/utils/modelPricing.ts
+++ b/src/router/utils/modelPricing.ts
@@ -1,0 +1,95 @@
+export type RouterModelPricing = {
+  input?: number;
+  output?: number;
+  cacheRead?: number;
+};
+
+export type RouterModelPricingMap = Record<string, RouterModelPricing>;
+
+// $/million tokens – fallback when neither nativeCost nor user modelPricing is available
+const DEFAULT_PRICING: Array<{ pattern: RegExp; input: number; output: number; cacheRead?: number }> = [
+  // DeepSeek
+  { pattern: /deepseek.*flash/i, input: 0.20, output: 0.60 },
+  { pattern: /deepseek.*chat/i, input: 0.50, output: 1.50 },
+  { pattern: /deepseek.*reasoner/i, input: 0.80, output: 2.00 },
+  { pattern: /deepseek.*v3/i, input: 0.27, output: 1.10 },
+  // Anthropic Claude
+  { pattern: /claude.*opus/i, input: 15.00, output: 75.00, cacheRead: 1.50 },
+  { pattern: /claude.*sonnet/i, input: 3.00, output: 15.00, cacheRead: 0.30 },
+  { pattern: /claude.*haiku/i, input: 0.80, output: 4.00, cacheRead: 0.08 },
+  // OpenAI
+  { pattern: /gpt-4o-mini/i, input: 0.15, output: 0.60, cacheRead: 0.075 },
+  { pattern: /gpt-4o/i, input: 2.50, output: 10.00, cacheRead: 1.25 },
+  { pattern: /gpt-4\.1/i, input: 2.00, output: 8.00, cacheRead: 0.50 },
+  { pattern: /gpt-5/i, input: 2.00, output: 8.00, cacheRead: 0.50 },
+  { pattern: /o[134]-mini/i, input: 1.10, output: 4.40 },
+  { pattern: /o[134]-pro/i, input: 10.00, output: 40.00 },
+  { pattern: /o[134]/i, input: 2.50, output: 10.00 },
+  // Google Gemini
+  { pattern: /gemini.*flash/i, input: 0.10, output: 0.40 },
+  { pattern: /gemini.*pro/i, input: 1.25, output: 5.00 },
+  // GLM / ChatGLM / Zhipu
+  { pattern: /glm/i, input: 0.50, output: 1.00 },
+  // Qwen / Tongyi
+  { pattern: /qwen.*turbo/i, input: 0.30, output: 0.60 },
+  { pattern: /qwen.*plus/i, input: 0.80, output: 2.00 },
+  { pattern: /qwen.*max/i, input: 2.00, output: 6.00 },
+  { pattern: /qwen/i, input: 0.50, output: 1.50 },
+  // Llama / Meta
+  { pattern: /llama.*70b/i, input: 0.80, output: 0.80 },
+  { pattern: /llama.*405b/i, input: 3.00, output: 3.00 },
+  { pattern: /llama/i, input: 0.20, output: 0.20 },
+  // Mistral
+  { pattern: /mistral.*large/i, input: 2.00, output: 6.00 },
+  { pattern: /mistral.*small/i, input: 0.10, output: 0.30 },
+  { pattern: /mistral/i, input: 0.25, output: 0.25 },
+  // Yi / 01.AI
+  { pattern: /yi-/i, input: 0.30, output: 0.30 },
+  // Moonshot / Kimi
+  { pattern: /moonshot|kimi/i, input: 1.00, output: 2.00 },
+  // Doubao / ByteDance
+  { pattern: /doubao/i, input: 0.40, output: 0.80 },
+];
+
+const FALLBACK_PRICING = { input: 0.50, output: 1.50 };
+
+export function lookupModelPricing(
+  provider: string,
+  model: string,
+  modelPricing?: RouterModelPricingMap,
+): RouterModelPricing {
+  const combined = `${provider}/${model}`;
+  if (modelPricing) {
+    const exact = modelPricing[combined];
+    if (exact) return exact;
+    for (const [key, val] of Object.entries(modelPricing)) {
+      if (model.includes(key) || key.includes(model)) return val;
+    }
+  }
+  for (const entry of DEFAULT_PRICING) {
+    if (entry.pattern.test(combined) || entry.pattern.test(model)) {
+      return { input: entry.input, output: entry.output, cacheRead: entry.cacheRead };
+    }
+  }
+  return FALLBACK_PRICING;
+}
+
+export function calculateInputCost(
+  tokens: number,
+  provider: string,
+  model: string,
+  modelPricing?: RouterModelPricingMap,
+): number {
+  const pricing = lookupModelPricing(provider, model, modelPricing);
+  return (tokens / 1_000_000) * (pricing.input ?? 0);
+}
+
+export function calculateCacheReadCost(
+  tokens: number,
+  provider: string,
+  model: string,
+  modelPricing?: RouterModelPricingMap,
+): number {
+  const pricing = lookupModelPricing(provider, model, modelPricing);
+  return (tokens / 1_000_000) * (pricing.cacheRead ?? pricing.input ?? 0);
+}


### PR DESCRIPTION
## Summary
- add cache-aware tokenSaver switching so downgrades only happen when full prefill is cheaper than staying on the cached current model
- pass previous routed provider/model into router decisions after sticky invalidation
- share model pricing lookup between stats and router cost estimates

## Tests
- pnpm exec tsc -p tsconfig.json --noEmit