### PR TITLE
fix(router): downgrade unsupported media in passthrough mode

### DIFF
--- a/src/router/RouterRuntime.ts
+++ b/src/router/RouterRuntime.ts
@@ -463,7 +463,12 @@ export function createRouterRuntime(
         provider: decision.provider,
         model: decision.model,
       };
-      const cappedPassthroughRequest = clampMaxOutputTokensToModelCap(passthroughRequest, deps.modelRuntime);
+      const downgradedPassthrough = downgradeRequestForAttempt(
+        passthroughRequest,
+        { id: `${decision.provider}/${decision.model}`, provider: decision.provider, model: decision.model },
+        deps.modelRuntime,
+      );
+      const cappedPassthroughRequest = clampMaxOutputTokensToModelCap(downgradedPassthrough, deps.modelRuntime);
       let sawErrorEvent = false;
       for await (const item of streamAttempt(cappedPassthroughRequest, deps.modelRuntime, ctx.abortSignal)) {
         if (item.kind === "event") {


### PR DESCRIPTION
## Summary

- When `router.enabled: false`, the passthrough path now applies `downgradeRequestForAttempt()` before streaming, replacing unsupported media (image/pdf/audio) blocks with text placeholders.
- Fixes a bug where switching from a multimodal model to a text-only model caused hard errors (`unsupported_modality` or upstream API 400) due to historical image messages in the chat session.

## Root Cause

The `downgradeUnsupportedContent()` function was only invoked inside the router-enabled fallback chain. When the router was disabled (`router.enabled: false`), the passthrough path sent the request directly to `streamAttempt()` without any content downgrade, causing `assertContentSupported()` to throw a hard error.

## Change

Single-line insertion in the passthrough block of `RouterRuntime.execute()`:

```typescript
const downgradedPassthrough = downgradeRequestForAttempt(
  passthroughRequest,
  { id: `${decision.provider}/${decision.model}`, ... },
  deps.modelRuntime,
);
```

This reuses the existing `downgradeRequestForAttempt()` helper which:
- Clones messages (no mutation of the original request)
- Is a no-op when the model supports all modalities (early return)
- Gracefully returns the original request unchanged if `getMultimodal()` throws

## Test plan

- [ ] Verify: router disabled + text-only model + historical image messages → image replaced with `[Image: ... omitted]` placeholder, request succeeds
- [ ] Verify: router disabled + multimodal model + image messages → image preserved, no change in behavior
- [ ] Verify: router enabled path is unaffected


Made with [Cursor](https://cursor.com)