### PR TITLE
Improve tool execution and generic todo workflow

### DIFF
--- a/docs/agent-todo-workflow.md
+++ b/docs/agent-todo-workflow.md
@@ -11,7 +11,7 @@ This document defines the common PilotDeck agent workflow for using `todo_write`
 
 ## When To Use Todo
 
-Agents must create a todo list before substantive work when a task has any of these properties:
+Agents should usually do a small amount of exploration before creating a detailed todo list. Use todo once the likely shape of the work is visible, especially when a task has any of these properties:
 
 - Three or more meaningful steps.
 - Multiple requested outcomes or deliverables.
@@ -20,7 +20,7 @@ Agents must create a todo list before substantive work when a task has any of th
 - Any task where verification is expected.
 - Any task where intermediate findings must survive context compaction or handoff.
 
-Short factual answers and single-step local edits do not require todo tracking unless the agent expects the work to grow.
+Short factual answers and single-step local edits do not require todo tracking unless the agent expects the work to grow. Do not let an early todo list lock the agent into a bad route: if evidence contradicts the current approach, cancel the stale item and add a revised one.
 
 ## Editable Todo Rules
 
@@ -29,11 +29,11 @@ Short factual answers and single-step local edits do not require todo tracking u
 - Use stable `id` values for structured todos so later updates can merge by id.
 - Use `merge=true` when updating only part of the list or adding discovered work.
 - Keep at most one item `in_progress` when possible.
-- Mark completed items immediately after the work is actually done.
+- Mark completed items only after checking the relevant evidence.
 - Mark obsolete or superseded work as `cancelled` with a reason instead of silently deleting it.
 - Add newly discovered required work as a new todo rather than burying it in prose.
 - Split oversized todos when they become too broad to verify cleanly.
-- Preserve completed facts when restructuring the list.
+- Preserve completed facts when restructuring the list, but do not keep obsolete active work alive merely because it was previously written down.
 
 Legacy markdown checklist input remains supported for simple replace-style updates. Structured todo input is preferred for long-running work because it is easier to edit safely.
 
@@ -41,7 +41,7 @@ Legacy markdown checklist input remains supported for simple replace-style updat
 
 Agents should keep the user and future context synchronized.
 
-- Update `todo_write` after each meaningful implementation or investigation step.
+- Update `todo_write` after meaningful implementation or investigation steps, not after every trivial command.
 - Send a short progress message before and after high-latency work when the user may otherwise see no movement.
 - When todo structure changes, explain the reason in the tool input `reason` or the next progress note.
 - Before the final response, update `todo_write` so its state matches the final answer.

--- a/docs/agent-todo-workflow.md
+++ b/docs/agent-todo-workflow.md
@@ -1,0 +1,96 @@
+# Agent Todo Workflow
+
+This document defines the common PilotDeck agent workflow for using `todo_write` outside and inside Plan Mode. It is an implementation-facing specification for prompt, tool, and runtime behavior.
+
+## Goals
+
+- Make todo tracking a general agent state mechanism, not only a Plan Mode helper.
+- Let agents revise todos mid-task when discovery changes the work.
+- Preserve progress across long tasks through periodic updates and workspace artifacts.
+- Require final verification before reporting completion.
+
+## When To Use Todo
+
+Agents must create a todo list before substantive work when a task has any of these properties:
+
+- Three or more meaningful steps.
+- Multiple requested outcomes or deliverables.
+- Multi-file or cross-module code changes.
+- Long-running commands, batch work, or background tasks.
+- Any task where verification is expected.
+- Any task where intermediate findings must survive context compaction or handoff.
+
+Short factual answers and single-step local edits do not require todo tracking unless the agent expects the work to grow.
+
+## Editable Todo Rules
+
+`todo_write` is the session todo state tool. Agents may read and update it throughout execution.
+
+- Use stable `id` values for structured todos so later updates can merge by id.
+- Use `merge=true` when updating only part of the list or adding discovered work.
+- Keep at most one item `in_progress` when possible.
+- Mark completed items immediately after the work is actually done.
+- Mark obsolete or superseded work as `cancelled` with a reason instead of silently deleting it.
+- Add newly discovered required work as a new todo rather than burying it in prose.
+- Split oversized todos when they become too broad to verify cleanly.
+- Preserve completed facts when restructuring the list.
+
+Legacy markdown checklist input remains supported for simple replace-style updates. Structured todo input is preferred for long-running work because it is easier to edit safely.
+
+## Progress Updates
+
+Agents should keep the user and future context synchronized.
+
+- Update `todo_write` after each meaningful implementation or investigation step.
+- Send a short progress message before and after high-latency work when the user may otherwise see no movement.
+- When todo structure changes, explain the reason in the tool input `reason` or the next progress note.
+- Before the final response, update `todo_write` so its state matches the final answer.
+
+Final responses should include what was completed, what was verified, where artifacts were saved, and any remaining risk or incomplete work.
+
+## Workspace Artifacts
+
+Use the current session workspace path (`cwd`) as the root for intermediate files. Web or subsystem sessions may point `cwd` at an isolated worktree or snapshot workspace, so do not infer workspace paths from the global project root.
+
+Recommended layout:
+
+```text
+.pilotdeck/work/<session-id>/
+  findings.md
+  todo_history.md
+  verification.md
+  artifacts/
+```
+
+If a stable session id is not available to the model, use a clear fallback such as `.pilotdeck/work/current/` and mention it in the final response.
+
+Artifact guidelines:
+
+- `findings.md`: durable discoveries, decisions, constraints, and facts needed later.
+- `todo_history.md`: structural todo changes, especially added, cancelled, split, or reordered work.
+- `verification.md`: commands, checks, outputs, and unresolved verification gaps.
+- `artifacts/`: generated intermediate files that are useful for handoff or final delivery.
+
+Do not persist secrets, large raw logs, binary caches, or files that are trivial to regenerate unless the user explicitly asks.
+
+## Verification
+
+Every completed deliverable should have a matching verification step when feasible.
+
+Acceptable verification includes:
+
+- Targeted tests.
+- Build or type checks.
+- Static checks.
+- Smoke runs.
+- Manual inspection with a clear explanation.
+- A documented reason why verification was not possible.
+
+The final todo state and final answer must agree: completed items were done and verified when feasible, pending items are called out, and cancelled items have a reason.
+
+## Implementation Notes
+
+- `todo_write` is registered as a built-in session tool and can be used outside Plan Mode.
+- Plan Mode approved-plan gating still requires todo initialization before non-read-only tools.
+- The current workspace is the tool/runtime `cwd`; this is the correct root for `.pilotdeck/work/...` artifacts.
+- The preferred editable shape is structured todos with stable ids, `merge`, and `reason`; markdown checklist input is retained for compatibility.

--- a/src/agent/loop/AgentLoop.ts
+++ b/src/agent/loop/AgentLoop.ts
@@ -55,6 +55,13 @@ import { buildAskModeAgentToolSchema } from "../../tool/builtin/agent.js";
 
 const TOOL_EVENT_PUMP_INTERVAL_MS = 500;
 const SUBAGENT_STATUS_HEARTBEAT_MS = 2_000;
+const CIRCUIT_BREAKER_GRACE_PROMPT = [
+  "Your last several tool calls all failed input validation with the same error.",
+  "This may indicate a tool-side issue rather than a problem with your approach.",
+  "Options: (1) try a different tool or different parameters,",
+  "(2) explain the situation in text without calling tools,",
+  "(3) if you believe the tool should work, try once more with corrected input.",
+].join(" ");
 const PLAN_MODE_REMINDER_MESSAGE = [
   "Plan mode is active.",
   "Read first using read-only tools, then write or refine plan markdown only under `.pilotdeck/plans/`.",
@@ -177,14 +184,16 @@ export class AgentLoop {
     const largeFileRepair = new LargeFileRepair();
 
     /**
-     * Circuit breaker: consecutive turns where ALL tool calls are
-     * `invalid_tool_input` errors. When the model is stuck in a loop
-     * (e.g. qwen repeatedly emitting empty-param bash calls), terminate
-     * early instead of burning tokens. Resets on any turn with at least
-     * one successful tool call.
+     * Circuit breaker: detects loops by fingerprinting each turn's
+     * invalid_tool_input errors (toolName + errorMessage). Only identical
+     * repeated failures trigger recovery, so changed parameters/tools are not
+     * mistaken for the same stuck loop. A one-time grace prompt gives the
+     * model a final chance to change strategy before termination.
      */
-    const MAX_CONSECUTIVE_ALL_INVALID_TURNS = 3;
-    let consecutiveAllInvalidTurns = 0;
+    const MAX_SAME_INVALID_FINGERPRINT = 3;
+    let lastInvalidFingerprint: string | undefined;
+    let sameInvalidFingerprintCount = 0;
+    let hasUsedInvalidGracePeriod = false;
     let lastToolFailureFingerprint: string | undefined;
     let transientPromptCounter = 0;
     const activeTransientPromptIds = new Set<string>();
@@ -1065,8 +1074,8 @@ export class AgentLoop {
       }
 
       // Circuit breaker: detect turns where ALL tool calls returned
-      // invalid_tool_input. If the model is stuck (e.g. repeatedly emitting
-      // empty-param bash), terminate early after MAX_CONSECUTIVE_ALL_INVALID_TURNS.
+      // invalid_tool_input. Uses fingerprint-based detection (toolName +
+      // errorMessage), and injects one grace prompt before final termination.
       // When LargeFileRepair is actively managing recovery, defer to its own
       // attempt limits instead of terminating here.
       const allInvalid = pairedResults.length > 0 && pairedResults.every(
@@ -1087,8 +1096,23 @@ export class AgentLoop {
         }
       }
       if (allInvalid) {
-        consecutiveAllInvalidTurns++;
-        if (consecutiveAllInvalidTurns >= MAX_CONSECUTIVE_ALL_INVALID_TURNS) {
+        const fingerprint = buildInvalidFingerprint(pairedResults);
+        if (fingerprint === lastInvalidFingerprint) {
+          sameInvalidFingerprintCount++;
+        } else {
+          sameInvalidFingerprintCount = 1;
+          lastInvalidFingerprint = fingerprint;
+          hasUsedInvalidGracePeriod = false;
+        }
+
+        if (sameInvalidFingerprintCount >= MAX_SAME_INVALID_FINGERPRINT) {
+          if (!hasUsedInvalidGracePeriod) {
+            hasUsedInvalidGracePeriod = true;
+            pushTransientSyntheticPrompt(CIRCUIT_BREAKER_GRACE_PROMPT, "circuit_breaker_grace");
+            yield { type: "turn_continued", sessionId: input.sessionId, turnId: input.turnId, reason: "model_error" };
+            continue;
+          }
+
           const result = this.createTurnResult(input, {
             type: "error",
             stopReason: "tool_error",
@@ -1100,7 +1124,7 @@ export class AgentLoop {
             structuredOutput,
             errors: [agentError(
               "agent_tool_error_loop",
-              `Terminated: ${consecutiveAllInvalidTurns} consecutive turns with all tool calls failing input validation. The model appears stuck in a loop.`,
+              `Terminated: ${sameInvalidFingerprintCount} consecutive turns with identical tool input validation failures (same tool + same error). The model appears stuck in a loop.`,
               undefined,
               "The model is repeatedly producing invalid tool calls. Consider switching to a more capable model via settings.",
             )],
@@ -1111,7 +1135,9 @@ export class AgentLoop {
           return { result, messages };
         }
       } else {
-        consecutiveAllInvalidTurns = 0;
+        sameInvalidFingerprintCount = 0;
+        lastInvalidFingerprint = undefined;
+        hasUsedInvalidGracePeriod = false;
         if (!pairedResults.some((r) => r.type === "error")) {
           lastToolFailureFingerprint = undefined;
         }
@@ -1811,6 +1837,17 @@ function truncateHeadKeepRatio(messages: CanonicalMessage[], keepRatio: number):
   const ratio = Math.max(0.05, Math.min(1, keepRatio));
   const keep = Math.max(1, Math.floor(messages.length * ratio));
   return messages.slice(-keep);
+}
+
+function buildInvalidFingerprint(results: PilotDeckToolResult[]): string {
+  return results
+    .filter(
+      (result): result is PilotDeckToolErrorResult =>
+        result.type === "error" && result.error.code === "invalid_tool_input",
+    )
+    .map((result) => `${result.toolName}::${result.error.message}`)
+    .sort()
+    .join("\n");
 }
 
 /**

--- a/src/agent/runtime/PlanTodoState.ts
+++ b/src/agent/runtime/PlanTodoState.ts
@@ -1,7 +1,9 @@
 import type {
+  PilotDeckTodoDiagnostics,
   PilotDeckPlanTodoStateHandle,
   PilotDeckPlanTodoStateSnapshot,
   PilotDeckTodoItem,
+  PilotDeckTodoWriteHistoryEntry,
 } from "../../tool/protocol/types.js";
 
 type SessionPlanTodoState = {
@@ -10,6 +12,11 @@ type SessionPlanTodoState = {
   toolCallsSinceLastTodoWrite: number;
   lastMarkdown?: string;
   todos: PilotDeckTodoItem[];
+  todoHistory: PilotDeckTodoWriteHistoryEntry[];
+  largeRewriteCount: number;
+  deletedOpenItemCount: number;
+  completedWithoutActiveCount: number;
+  lastWrite?: PilotDeckTodoDiagnostics["lastWrite"];
 };
 
 export type PlanTodoStateManager = {
@@ -46,6 +53,14 @@ function dedupeById(todos: PilotDeckTodoItem[]): PilotDeckTodoItem[] {
 
 function replaceTodos(todos: PilotDeckTodoItem[]): PilotDeckTodoItem[] {
   return dedupeById(todos).map((todo, index) => normalizeTodoItem(todo, index));
+}
+
+function activeTodos(todos: PilotDeckTodoItem[]): PilotDeckTodoItem[] {
+  return todos.filter((todo) => todo.status === "pending" || todo.status === "in_progress");
+}
+
+function cloneTodos(todos: PilotDeckTodoItem[]): PilotDeckTodoItem[] {
+  return todos.map((todo) => ({ ...todo }));
 }
 
 function mergeTodos(existingTodos: PilotDeckTodoItem[], updates: PilotDeckTodoItem[]): PilotDeckTodoItem[] {
@@ -92,6 +107,81 @@ function mergeTodos(existingTodos: PilotDeckTodoItem[], updates: PilotDeckTodoIt
   return merged;
 }
 
+function buildTodoDiagnostics(state: SessionPlanTodoState): PilotDeckTodoDiagnostics {
+  const activeCount = activeTodos(state.todos).length;
+  const completedCount = state.todos.filter((todo) => todo.status === "completed").length;
+  const cancelledCount = state.todos.filter((todo) => todo.status === "cancelled").length;
+  return {
+    writeCount: state.todoHistory.length,
+    todoCount: state.todos.length,
+    activeCount,
+    completedCount,
+    cancelledCount,
+    largeRewriteCount: state.largeRewriteCount,
+    deletedOpenItemCount: state.deletedOpenItemCount,
+    completedWithoutActiveCount: state.completedWithoutActiveCount,
+    ...(state.lastWrite ? { lastWrite: state.lastWrite } : {}),
+  };
+}
+
+function recordWrite(
+  state: SessionPlanTodoState,
+  nextTodos: PilotDeckTodoItem[],
+  options: { mode: "markdown" | "structured"; merge?: boolean; markdown?: string; reason?: string },
+): PilotDeckTodoItem[] {
+  const previousTodos = state.todos;
+  const previousById = new Map(previousTodos.map((todo) => [todo.id ?? todo.content, todo]));
+  const nextById = new Map(nextTodos.map((todo) => [todo.id ?? todo.content, todo]));
+  const removed = previousTodos.filter((todo) => !nextById.has(todo.id ?? todo.content));
+  const added = nextTodos.filter((todo) => !previousById.has(todo.id ?? todo.content));
+  const changed = nextTodos.filter((todo) => {
+    const previous = previousById.get(todo.id ?? todo.content);
+    return Boolean(previous) && (
+      previous!.content !== todo.content ||
+      previous!.status !== todo.status ||
+      previous!.priority !== todo.priority
+    );
+  });
+  const deletedOpenItemCount = removed.filter((todo) => todo.status === "pending" || todo.status === "in_progress").length;
+  const previousActiveCount = activeTodos(previousTodos).length;
+  const preservedCount = nextTodos.filter((todo) => previousById.has(todo.id ?? todo.content)).length;
+  const largeRewrite = previousTodos.length > 0 && nextTodos.length > 0 && preservedCount < Math.ceil(previousTodos.length / 2);
+  const allCompleted = nextTodos.length > 0 && activeTodos(nextTodos).length === 0 && nextTodos.every((todo) => todo.status === "completed" || todo.status === "cancelled");
+
+  state.todos = cloneTodos(nextTodos);
+  state.lastMarkdown = options.markdown;
+  state.requiresInitialization = false;
+  state.toolCallsSinceLastTodoWrite = 0;
+
+  if (largeRewrite) state.largeRewriteCount += 1;
+  state.deletedOpenItemCount += deletedOpenItemCount;
+  if (allCompleted && previousActiveCount > 0) state.completedWithoutActiveCount += 1;
+
+  state.lastWrite = {
+    mode: options.mode,
+    merge: Boolean(options.merge),
+    ...(options.reason?.trim() ? { reason: options.reason.trim() } : {}),
+    addedCount: added.length,
+    removedCount: removed.length,
+    changedCount: changed.length,
+    deletedOpenItemCount,
+    largeRewrite,
+    allCompleted,
+  };
+
+  const diagnostics = buildTodoDiagnostics(state);
+  state.todoHistory.push({
+    createdAt: new Date().toISOString(),
+    mode: options.mode,
+    merge: Boolean(options.merge),
+    ...(options.reason?.trim() ? { reason: options.reason.trim() } : {}),
+    ...(options.markdown !== undefined ? { markdown: options.markdown } : {}),
+    todos: cloneTodos(state.todos),
+    diagnostics,
+  });
+  return state.todos;
+}
+
 export function createPlanTodoStateManager(): PlanTodoStateManager {
   const states = new Map<string, SessionPlanTodoState>();
 
@@ -102,6 +192,10 @@ export function createPlanTodoStateManager(): PlanTodoStateManager {
         requiresInitialization: false,
         toolCallsSinceLastTodoWrite: 0,
         todos: [],
+        todoHistory: [],
+        largeRewriteCount: 0,
+        deletedOpenItemCount: 0,
+        completedWithoutActiveCount: 0,
       };
       states.set(sessionId, state);
     }
@@ -115,6 +209,9 @@ export function createPlanTodoStateManager(): PlanTodoStateManager {
       toolCallsSinceLastTodoWrite: state.toolCallsSinceLastTodoWrite,
       lastMarkdown: state.lastMarkdown,
       todos: state.todos,
+      activeTodos: activeTodos(state.todos),
+      todoHistory: state.todoHistory,
+      todoDiagnostics: buildTodoDiagnostics(state),
     };
   }
 
@@ -165,19 +262,23 @@ export function createPlanTodoStateManager(): PlanTodoStateManager {
           state.toolCallsSinceLastTodoWrite = 0;
           state.lastMarkdown = undefined;
           state.todos = [];
+          state.todoHistory = [];
+          state.largeRewriteCount = 0;
+          state.deletedOpenItemCount = 0;
+          state.completedWithoutActiveCount = 0;
+          state.lastWrite = undefined;
         },
-        recordTodoWrite(markdown: string, todos: PilotDeckTodoItem[]) {
-          state.lastMarkdown = markdown;
-          state.todos = replaceTodos(todos);
-          state.requiresInitialization = false;
-          state.toolCallsSinceLastTodoWrite = 0;
+        recordTodoWrite(markdown: string, todos: PilotDeckTodoItem[], options?: { reason?: string }) {
+          return recordWrite(state, replaceTodos(todos), { mode: "markdown", markdown, reason: options?.reason });
         },
-        writeTodos(todos: PilotDeckTodoItem[], options?: { markdown?: string; merge?: boolean }) {
-          state.todos = options?.merge ? mergeTodos(state.todos, todos) : replaceTodos(todos);
-          state.lastMarkdown = options?.markdown;
-          state.requiresInitialization = false;
-          state.toolCallsSinceLastTodoWrite = 0;
-          return state.todos;
+        writeTodos(todos: PilotDeckTodoItem[], options?: { markdown?: string; merge?: boolean; reason?: string }) {
+          const nextTodos = options?.merge ? mergeTodos(state.todos, todos) : replaceTodos(todos);
+          return recordWrite(state, nextTodos, {
+            mode: "structured",
+            merge: options?.merge,
+            markdown: options?.markdown,
+            reason: options?.reason,
+          });
         },
         markToolProgressChanged(toolName: string) {
           if (!state.approvedPlan || toolName === TODO_WRITE_TOOL_NAME) {

--- a/src/agent/runtime/PlanTodoState.ts
+++ b/src/agent/runtime/PlanTodoState.ts
@@ -17,6 +17,80 @@ export type PlanTodoStateManager = {
 };
 
 const TODO_WRITE_TOOL_NAME = "todo_write";
+const VALID_TODO_STATUSES = new Set<PilotDeckTodoItem["status"]>([
+  "pending",
+  "in_progress",
+  "completed",
+  "cancelled",
+]);
+
+function normalizeTodoItem(item: PilotDeckTodoItem, index: number): PilotDeckTodoItem {
+  const content = item.content.trim() || "(no description)";
+  const status = VALID_TODO_STATUSES.has(item.status) ? item.status : "pending";
+  return {
+    id: item.id?.trim() || `todo-${index + 1}`,
+    content,
+    status,
+    ...(item.priority?.trim() ? { priority: item.priority.trim() } : {}),
+  };
+}
+
+function dedupeById(todos: PilotDeckTodoItem[]): PilotDeckTodoItem[] {
+  const lastIndex = new Map<string, number>();
+  todos.forEach((todo, index) => {
+    const id = todo.id?.trim() || `todo-${index + 1}`;
+    lastIndex.set(id, index);
+  });
+  return [...lastIndex.values()].sort((a, b) => a - b).map((index) => todos[index]!);
+}
+
+function replaceTodos(todos: PilotDeckTodoItem[]): PilotDeckTodoItem[] {
+  return dedupeById(todos).map((todo, index) => normalizeTodoItem(todo, index));
+}
+
+function mergeTodos(existingTodos: PilotDeckTodoItem[], updates: PilotDeckTodoItem[]): PilotDeckTodoItem[] {
+  const existingById = new Map<string, PilotDeckTodoItem>();
+  for (const [index, todo] of existingTodos.entries()) {
+    const normalized = normalizeTodoItem(todo, index);
+    existingById.set(normalized.id!, normalized);
+  }
+
+  const append: PilotDeckTodoItem[] = [];
+  for (const update of dedupeById(updates)) {
+    const id = update.id?.trim();
+    if (id && existingById.has(id)) {
+      const current = existingById.get(id)!;
+      existingById.set(id, {
+        ...current,
+        ...(update.content.trim() ? { content: update.content.trim() } : {}),
+        ...(VALID_TODO_STATUSES.has(update.status) ? { status: update.status } : {}),
+        ...(update.priority?.trim() ? { priority: update.priority.trim() } : {}),
+      });
+      continue;
+    }
+    append.push(update);
+  }
+
+  const merged: PilotDeckTodoItem[] = [];
+  const seen = new Set<string>();
+  for (const [index, todo] of existingTodos.entries()) {
+    const id = todo.id?.trim() || `todo-${index + 1}`;
+    const current = existingById.get(id) ?? normalizeTodoItem(todo, index);
+    if (!seen.has(current.id!)) {
+      merged.push(current);
+      seen.add(current.id!);
+    }
+  }
+  const firstNewIndex = merged.length;
+  append.forEach((todo, index) => {
+    const normalized = normalizeTodoItem(todo, firstNewIndex + index);
+    if (!seen.has(normalized.id!)) {
+      merged.push(normalized);
+      seen.add(normalized.id!);
+    }
+  });
+  return merged;
+}
 
 export function createPlanTodoStateManager(): PlanTodoStateManager {
   const states = new Map<string, SessionPlanTodoState>();
@@ -94,9 +168,16 @@ export function createPlanTodoStateManager(): PlanTodoStateManager {
         },
         recordTodoWrite(markdown: string, todos: PilotDeckTodoItem[]) {
           state.lastMarkdown = markdown;
-          state.todos = todos;
+          state.todos = replaceTodos(todos);
           state.requiresInitialization = false;
           state.toolCallsSinceLastTodoWrite = 0;
+        },
+        writeTodos(todos: PilotDeckTodoItem[], options?: { markdown?: string; merge?: boolean }) {
+          state.todos = options?.merge ? mergeTodos(state.todos, todos) : replaceTodos(todos);
+          state.lastMarkdown = options?.markdown;
+          state.requiresInitialization = false;
+          state.toolCallsSinceLastTodoWrite = 0;
+          return state.todos;
         },
         markToolProgressChanged(toolName: string) {
           if (!state.approvedPlan || toolName === TODO_WRITE_TOOL_NAME) {

--- a/src/agent/runtime/PlanTodoState.ts
+++ b/src/agent/runtime/PlanTodoState.ts
@@ -3,6 +3,7 @@ import type {
   PilotDeckPlanTodoStateHandle,
   PilotDeckPlanTodoStateSnapshot,
   PilotDeckTodoItem,
+  PilotDeckTodoUpdate,
   PilotDeckTodoWriteHistoryEntry,
 } from "../../tool/protocol/types.js";
 
@@ -31,9 +32,9 @@ const VALID_TODO_STATUSES = new Set<PilotDeckTodoItem["status"]>([
   "cancelled",
 ]);
 
-function normalizeTodoItem(item: PilotDeckTodoItem, index: number): PilotDeckTodoItem {
-  const content = item.content.trim() || "(no description)";
-  const status = VALID_TODO_STATUSES.has(item.status) ? item.status : "pending";
+function normalizeTodoItem(item: PilotDeckTodoUpdate, index: number): PilotDeckTodoItem {
+  const content = item.content?.trim() || "(no description)";
+  const status = item.status && VALID_TODO_STATUSES.has(item.status) ? item.status : "pending";
   return {
     id: item.id?.trim() || `todo-${index + 1}`,
     content,
@@ -42,7 +43,7 @@ function normalizeTodoItem(item: PilotDeckTodoItem, index: number): PilotDeckTod
   };
 }
 
-function dedupeById(todos: PilotDeckTodoItem[]): PilotDeckTodoItem[] {
+function dedupeById<T extends PilotDeckTodoUpdate>(todos: T[]): T[] {
   const lastIndex = new Map<string, number>();
   todos.forEach((todo, index) => {
     const id = todo.id?.trim() || `todo-${index + 1}`;
@@ -51,7 +52,7 @@ function dedupeById(todos: PilotDeckTodoItem[]): PilotDeckTodoItem[] {
   return [...lastIndex.values()].sort((a, b) => a - b).map((index) => todos[index]!);
 }
 
-function replaceTodos(todos: PilotDeckTodoItem[]): PilotDeckTodoItem[] {
+function replaceTodos(todos: PilotDeckTodoUpdate[]): PilotDeckTodoItem[] {
   return dedupeById(todos).map((todo, index) => normalizeTodoItem(todo, index));
 }
 
@@ -63,22 +64,22 @@ function cloneTodos(todos: PilotDeckTodoItem[]): PilotDeckTodoItem[] {
   return todos.map((todo) => ({ ...todo }));
 }
 
-function mergeTodos(existingTodos: PilotDeckTodoItem[], updates: PilotDeckTodoItem[]): PilotDeckTodoItem[] {
+function mergeTodos(existingTodos: PilotDeckTodoItem[], updates: PilotDeckTodoUpdate[]): PilotDeckTodoItem[] {
   const existingById = new Map<string, PilotDeckTodoItem>();
   for (const [index, todo] of existingTodos.entries()) {
     const normalized = normalizeTodoItem(todo, index);
     existingById.set(normalized.id!, normalized);
   }
 
-  const append: PilotDeckTodoItem[] = [];
+  const append: PilotDeckTodoUpdate[] = [];
   for (const update of dedupeById(updates)) {
     const id = update.id?.trim();
     if (id && existingById.has(id)) {
       const current = existingById.get(id)!;
       existingById.set(id, {
         ...current,
-        ...(update.content.trim() ? { content: update.content.trim() } : {}),
-        ...(VALID_TODO_STATUSES.has(update.status) ? { status: update.status } : {}),
+        ...(update.content?.trim() ? { content: update.content.trim() } : {}),
+        ...(update.status && VALID_TODO_STATUSES.has(update.status) ? { status: update.status } : {}),
         ...(update.priority?.trim() ? { priority: update.priority.trim() } : {}),
       });
       continue;
@@ -271,7 +272,7 @@ export function createPlanTodoStateManager(): PlanTodoStateManager {
         recordTodoWrite(markdown: string, todos: PilotDeckTodoItem[], options?: { reason?: string }) {
           return recordWrite(state, replaceTodos(todos), { mode: "markdown", markdown, reason: options?.reason });
         },
-        writeTodos(todos: PilotDeckTodoItem[], options?: { markdown?: string; merge?: boolean; reason?: string }) {
+        writeTodos(todos: PilotDeckTodoUpdate[], options?: { markdown?: string; merge?: boolean; reason?: string }) {
           const nextTodos = options?.merge ? mergeTodos(state.todos, todos) : replaceTodos(todos);
           return recordWrite(state, nextTodos, {
             mode: "structured",

--- a/src/context/prompt/PromptAssembler.ts
+++ b/src/context/prompt/PromptAssembler.ts
@@ -98,6 +98,9 @@ export class PromptAssembler {
       "",
       "Reusable script workflow:",
       "When code is more than a tiny one-off command, or you expect to rerun it with changed parameters, write it to a workspace file first with write_file, then run it with bash. Prefer scripts with CLI arguments, environment variables, or a small config section so parameters can be adjusted with edit_file or command args. Do not pack large Python/JS/shell programs into bash heredocs or long `python -c` / `node -e` strings. After each run, inspect output and edit the saved script instead of regenerating a new inline command.",
+      "",
+      "Todo workflow:",
+      "For complex tasks, tasks with 3+ steps, multi-file changes, long-running work, or tasks that require verification, create a todo list with todo_write before making substantive changes. Keep the list editable: update it after each meaningful step, before and after long-running commands when useful, when new required work or risks are discovered, and before the final response. Use stable ids and merge updates when available; preserve completed facts and mark obsolete work as cancelled instead of silently deleting it. Persist important intermediate findings under the current workspace (cwd) when they are needed for recovery or final handoff, such as `.pilotdeck/work/<session-id>/findings.md`, `todo_history.md`, `verification.md`, and `artifacts/`; if no session id is available, use `.pilotdeck/work/current/`. Verify completed work when possible and align the final todo state with the final answer.",
     ];
 
     const permissionLine = formatPermissionMode(input.permissionMode);

--- a/src/model/streaming/parseTextToolCalls.ts
+++ b/src/model/streaming/parseTextToolCalls.ts
@@ -120,11 +120,7 @@ function tryParseQwenXml(text: string): TextToolCallParseResult | null {
     return {
       toolCalls: [],
       remainingText: text,
-      partialToolCall: partialInfo(
-        "qwen_xml",
-        "qwen_xml_marker_without_complete_function",
-        text,
-      ),
+      partialToolCall: partialInfo("qwen_xml", classifyIncompleteQwenXml(text), text),
     };
   }
 
@@ -138,6 +134,16 @@ function tryParseQwenXml(text: string): TextToolCallParseResult | null {
   });
 
   return { toolCalls, remainingText: remaining, partialToolCall };
+}
+
+function classifyIncompleteQwenXml(text: string): string {
+  if (/<parameter=/u.test(text) && !/<function=/u.test(text)) {
+    return "orphan_qwen_parameter";
+  }
+  if ((/<\/parameter>/u.test(text) || /<\/function>/u.test(text)) && !/<function=/u.test(text)) {
+    return "orphan_qwen_function_close";
+  }
+  return "qwen_xml_marker_without_complete_function";
 }
 
 // ---------------------------------------------------------------------------
@@ -177,11 +183,7 @@ function tryParseDeepSeekDsml(text: string): TextToolCallParseResult | null {
     return {
       toolCalls: [],
       remainingText: text,
-      partialToolCall: partialInfo(
-        "deepseek_dsml",
-        "dsml_marker_without_complete_invoke",
-        text,
-      ),
+      partialToolCall: partialInfo("deepseek_dsml", classifyIncompleteDsml(text), text),
     };
   }
 
@@ -190,6 +192,17 @@ function tryParseDeepSeekDsml(text: string): TextToolCallParseResult | null {
     preferredFormat: "deepseek_dsml",
   });
   return { toolCalls, remainingText: remaining, partialToolCall };
+}
+
+function classifyIncompleteDsml(text: string): string {
+  if (/<\uff5cDSML\uff5cparameter\b/u.test(text) && !/<\uff5cDSML\uff5cinvoke\b/u.test(text)) {
+    return "orphan_dsml_parameter";
+  }
+  if ((/<\/\uff5cDSML\uff5cinvoke>/u.test(text) || /<\/\uff5cDSML\uff5ctool_calls>/u.test(text))
+    && !/<\uff5cDSML\uff5cinvoke\b/u.test(text)) {
+    return "orphan_dsml_tool_call_close";
+  }
+  return "dsml_marker_without_complete_invoke";
 }
 
 // ---------------------------------------------------------------------------
@@ -233,11 +246,7 @@ function tryParseHermesJson(text: string): TextToolCallParseResult | null {
     return {
       toolCalls: [],
       remainingText: text,
-      partialToolCall: partialToolCall ?? partialInfo(
-        "hermes_json",
-        "tool_call_marker_without_valid_json",
-        text,
-      ),
+      partialToolCall: partialToolCall ?? partialInfo("hermes_json", classifyIncompleteHermesJson(text), text),
     };
   }
 
@@ -246,6 +255,13 @@ function tryParseHermesJson(text: string): TextToolCallParseResult | null {
     preferredFormat: "hermes_json",
   });
   return { toolCalls, remainingText: remaining, partialToolCall };
+}
+
+function classifyIncompleteHermesJson(text: string): string {
+  if (/<\/tool_call>/u.test(text) && !/<tool_call>/u.test(text)) {
+    return "orphan_hermes_tool_call_close";
+  }
+  return "tool_call_marker_without_valid_json";
 }
 
 // ---------------------------------------------------------------------------
@@ -614,20 +630,29 @@ function detectPartialTextToolCall(
     );
   }
   if (options.preferredFormat && hasFormatMarker(text, options.preferredFormat)) {
+    if (options.preferredFormat === "qwen_xml") {
+      return partialInfo("qwen_xml", classifyIncompleteQwenXml(text), text);
+    }
+    if (options.preferredFormat === "hermes_json") {
+      return partialInfo("hermes_json", classifyIncompleteHermesJson(text), text);
+    }
+    if (options.preferredFormat === "deepseek_dsml") {
+      return partialInfo("deepseek_dsml", classifyIncompleteDsml(text), text);
+    }
     return partialInfo(
       options.preferredFormat,
       "dangling_tool_call_fragment_after_parse",
       text,
     );
   }
-  if (hasQwenMarker(text)) {
-    return partialInfo("qwen_xml", "dangling_qwen_xml_fragment", text);
-  }
   if (hasDsmlMarker(text)) {
-    return partialInfo("deepseek_dsml", "dangling_dsml_fragment", text);
+    return partialInfo("deepseek_dsml", classifyIncompleteDsml(text), text);
   }
   if (hasHermesMarker(text)) {
-    return partialInfo("hermes_json", "dangling_hermes_tool_call_fragment", text);
+    return partialInfo("hermes_json", classifyIncompleteHermesJson(text), text);
+  }
+  if (hasQwenMarker(text)) {
+    return partialInfo("qwen_xml", classifyIncompleteQwenXml(text), text);
   }
   if (hasMistralMarker(text)) {
     return partialInfo("mistral", "dangling_mistral_tool_call_fragment", text);
@@ -654,15 +679,11 @@ function hasFormatMarker(text: string, format: PartialTextToolCallFormat): boole
 }
 
 function hasQwenMarker(text: string): boolean {
-  return hasQwenSpecificMarker(text) || (hasQwenToolCallWrapper(text) && !looksLikeHermesToolCall(text));
+  return hasQwenSpecificMarker(text);
 }
 
 function hasQwenSpecificMarker(text: string): boolean {
   return /<function=|<\/function>|<parameter=|<\/parameter>/u.test(text);
-}
-
-function hasQwenToolCallWrapper(text: string): boolean {
-  return /<\/?tool_call>/u.test(text);
 }
 
 function hasQwenParameterMarker(text: string): boolean {
@@ -675,10 +696,6 @@ function hasDsmlMarker(text: string): boolean {
 
 function hasHermesMarker(text: string): boolean {
   return /<\/?tool_call>/u.test(text);
-}
-
-function looksLikeHermesToolCall(text: string): boolean {
-  return /<tool_call>\s*\{/u.test(text);
 }
 
 function hasMistralMarker(text: string): boolean {

--- a/src/tool/askModeConstraints.ts
+++ b/src/tool/askModeConstraints.ts
@@ -17,12 +17,14 @@ export const ASK_MODE_ALLOWED_TOOLS = new Set([
   "read_skill",
   "structured_output",
   "agent",
+  "execute_code",
   "bash",
 ]);
 
 export const ASK_MODE_DESCRIPTION_SUFFIX: Record<string, string> = {
   bash: "\n\n[ASK MODE] READ-ONLY commands only. Write/modify/delete commands will be rejected.",
   agent: "\n\n[ASK MODE] Subagents inherit ask mode and the same permission setting. They can read and search, but cannot modify files.",
+  execute_code: "\n\n[ASK MODE] READ-ONLY Python scripts only. Scripts that call write_file, edit_file, or non-read-only bash commands will be rejected.",
 };
 
 const ASK_MODE_VIOLATION_HEADER = "[ASK_MODE_VIOLATION]";

--- a/src/tool/builtin/executeCode.ts
+++ b/src/tool/builtin/executeCode.ts
@@ -12,6 +12,7 @@ import { collectPythonSyntaxDiagnostics } from "./filesystem/syntaxDiagnostics.j
 
 type ExecuteCodeInput = {
   code: string;
+  description?: string;
   timeout_seconds?: number;
   max_tool_calls?: number;
 };
@@ -127,6 +128,10 @@ export function createExecuteCodeTool(): PilotDeckToolDefinition<ExecuteCodeInpu
         code: {
           type: "string",
           description: "Python 3 source code to execute. Use `from pilotdeck_tools import ...` to call allowed PilotDeck tools.",
+        },
+        description: {
+          type: "string",
+          description: "Optional human-readable note; ignored by execution.",
         },
         timeout_seconds: {
           type: "integer",

--- a/src/tool/builtin/executeCode.ts
+++ b/src/tool/builtin/executeCode.ts
@@ -1,0 +1,785 @@
+import { createServer, type AddressInfo, type Server, type Socket } from "node:net";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { spawn, type ChildProcessByStdio } from "node:child_process";
+import { randomBytes } from "node:crypto";
+import type { Readable } from "node:stream";
+import type { PilotDeckToolDefinition, PilotDeckToolRuntimeContext } from "../protocol/types.js";
+import { contentToText, type PilotDeckToolResult } from "../protocol/result.js";
+import type { PilotDeckToolValidationIssue } from "../protocol/schema.js";
+
+type ExecuteCodeInput = {
+  code: string;
+  timeout_seconds?: number;
+  max_tool_calls?: number;
+};
+
+export type ExecuteCodeStatus = "success" | "error" | "timeout" | "cancelled" | "unsupported";
+
+export type ExecuteCodeToolCallLogEntry = {
+  tool: string;
+  duration_ms: number;
+  ok: boolean;
+};
+
+export type ExecuteCodeOutput = {
+  status: ExecuteCodeStatus;
+  output: string;
+  error?: string;
+  tool_calls_made: number;
+  duration_seconds: number;
+  tool_call_log: ExecuteCodeToolCallLogEntry[];
+};
+
+type RpcRequest = {
+  token?: unknown;
+  tool?: unknown;
+  args?: unknown;
+};
+
+type RpcResponse = {
+  content?: string;
+  data?: unknown;
+  metadata?: Record<string, unknown>;
+  error?: string;
+  code?: string;
+};
+
+type RpcTransport =
+  | { kind: "uds"; socketPath: string }
+  | { kind: "tcp"; host: "127.0.0.1"; port: number; token: string };
+
+export type ExecuteCodeTransportKind = RpcTransport["kind"];
+
+let executeCodeTransportOverride: ExecuteCodeTransportKind | undefined;
+
+export function setExecuteCodeTransportOverrideForTests(kind: ExecuteCodeTransportKind | undefined): void {
+  executeCodeTransportOverride = kind;
+}
+
+export async function handleExecuteCodeRpcLineForTests(
+  line: string,
+  options: {
+    expectedToken?: string;
+    executeTool?: NonNullable<PilotDeckToolRuntimeContext["executeTool"]>;
+  } = {},
+): Promise<RpcResponse> {
+  return handleRpcLine(line, {
+    context: {
+      sessionId: "test-session",
+      turnId: "test-turn",
+      cwd: process.cwd(),
+      permissionMode: "bypassPermissions",
+      permissionContext: {
+        mode: "bypassPermissions",
+        rules: { allow: [], deny: [], ask: [] },
+        cwd: process.cwd(),
+        additionalWorkingDirectories: [],
+        canPrompt: false,
+        bypassAvailable: false,
+      },
+    },
+    executeTool: options.executeTool ?? (async () => {
+      throw new Error("executeTool should not be called by this test.");
+    }),
+    maxToolCalls: 50,
+    toolCallLog: [],
+    nextToolCall: () => 1,
+    canCallTool: () => true,
+    expectedToken: options.expectedToken,
+  });
+}
+
+const DEFAULT_TIMEOUT_SECONDS = 300;
+const DEFAULT_MAX_TOOL_CALLS = 50;
+const MAX_STDOUT_BYTES = 50_000;
+const MAX_STDERR_BYTES = 10_000;
+const EXECUTE_CODE_ALLOWED_TOOLS = new Set([
+  "web_search",
+  "web_fetch",
+  "read_file",
+  "write_file",
+  "edit_file",
+  "grep",
+  "glob",
+  "bash",
+]);
+const SECRET_ENV_SUBSTRINGS = ["KEY", "TOKEN", "SECRET", "PASSWORD", "CREDENTIAL", "PASSWD", "AUTH"];
+const SAFE_ENV_PREFIXES = [
+  "PATH",
+  "HOME",
+  "USER",
+  "LANG",
+  "LC_",
+  "TERM",
+  "TMPDIR",
+  "TMP",
+  "TEMP",
+  "SHELL",
+  "LOGNAME",
+  "XDG_",
+  "PYTHONPATH",
+  "VIRTUAL_ENV",
+  "CONDA",
+  "TZ",
+];
+
+export function createExecuteCodeTool(): PilotDeckToolDefinition<ExecuteCodeInput, ExecuteCodeOutput> {
+  return {
+    name: "execute_code",
+    description:
+      "Run a local Python 3 script that can call a small allow-list of PilotDeck tools via `import pilotdeck_tools`. " +
+      "Only the script's final stdout/stderr summary is returned to the model; intermediate tool results stay inside the script. " +
+      "Available helper functions: web_search, web_fetch, read_file, write_file, edit_file, grep, glob, bash. " +
+      "Use normal Python control flow to orchestrate tools: loops for batch work, conditionals for branching, data structures for aggregation, and try/except around individual helper calls when one failure should not abort the whole script. Helper failures raise RuntimeError. You can chain helper results, e.g. grep -> read_file -> edit_file. Print only the concise final result needed by the agent. " +
+      "Before modifying an existing file, call read_file first so PilotDeck can verify freshness. Prefer edit_file for targeted changes and write_file for new files or complete rewrites. " +
+      "Notebook edits, agent, task tools, MCP tools, and execute_code itself are not available.",
+    kind: "custom",
+    inputSchema: {
+      type: "object",
+      required: ["code"],
+      additionalProperties: false,
+      properties: {
+        code: {
+          type: "string",
+          description: "Python 3 source code to execute. Use `from pilotdeck_tools import ...` to call allowed PilotDeck tools.",
+        },
+        timeout_seconds: {
+          type: "integer",
+          description: "Maximum execution time in seconds. Defaults to 300; maximum 300.",
+        },
+        max_tool_calls: {
+          type: "integer",
+          description: "Maximum number of PilotDeck tool calls the script may make. Defaults to 50; maximum 50.",
+        },
+      },
+    },
+    outputSchema: {
+      type: "object",
+      properties: {
+        status: { type: "string" },
+        output: { type: "string" },
+        error: { type: "string" },
+        tool_calls_made: { type: "integer" },
+        duration_seconds: { type: "number" },
+        tool_call_log: { type: "array" },
+      },
+    },
+    isReadOnly: () => false,
+    isConcurrencySafe: () => false,
+    validateInput: async (input) => validateExecuteCodeInput(input as ExecuteCodeInput),
+    execute: async (input, context) => {
+      const startedAt = Date.now();
+      const result = await runExecuteCode(input, context, startedAt);
+      return {
+        content: [{ type: "text", text: formatExecuteCodeResult(result) }],
+        data: result,
+        metadata: {
+          status: result.status,
+          tool_calls_made: result.tool_calls_made,
+          duration_seconds: result.duration_seconds,
+        },
+      };
+    },
+  };
+}
+
+function validateExecuteCodeInput(input: ExecuteCodeInput) {
+  const issues: PilotDeckToolValidationIssue[] = [];
+  if (!input.code.trim()) {
+    issues.push({ path: "$.code", code: "invalid_schema", message: "$.code must not be empty." });
+  }
+  if (input.timeout_seconds !== undefined && (input.timeout_seconds < 1 || input.timeout_seconds > DEFAULT_TIMEOUT_SECONDS)) {
+    issues.push({
+      path: "$.timeout_seconds",
+      code: "invalid_schema",
+      message: `$.timeout_seconds must be between 1 and ${DEFAULT_TIMEOUT_SECONDS}.`,
+    });
+  }
+  if (input.max_tool_calls !== undefined && (input.max_tool_calls < 0 || input.max_tool_calls > DEFAULT_MAX_TOOL_CALLS)) {
+    issues.push({
+      path: "$.max_tool_calls",
+      code: "invalid_schema",
+      message: `$.max_tool_calls must be between 0 and ${DEFAULT_MAX_TOOL_CALLS}.`,
+    });
+  }
+  return issues.length === 0 ? { ok: true as const, input } : { ok: false as const, issues };
+}
+
+function createRpcTransport(): RpcTransport {
+  const kind = executeCodeTransportOverride ?? (process.platform === "win32" ? "tcp" : "uds");
+  if (kind === "tcp") {
+    return {
+      kind: "tcp",
+      host: "127.0.0.1",
+      port: 0,
+      token: randomBytes(32).toString("hex"),
+    };
+  }
+  return {
+    kind: "uds",
+    socketPath: path.join(
+      process.platform === "darwin" ? "/tmp" : tmpdir(),
+      `pilotdeck_rpc_${process.pid}_${Date.now()}_${Math.random().toString(16).slice(2)}.sock`,
+    ),
+  };
+}
+
+async function runExecuteCode(
+  input: ExecuteCodeInput,
+  context: PilotDeckToolRuntimeContext,
+  startedAt: number,
+): Promise<ExecuteCodeOutput> {
+  const timeoutSeconds = input.timeout_seconds ?? DEFAULT_TIMEOUT_SECONDS;
+  const maxToolCalls = input.max_tool_calls ?? DEFAULT_MAX_TOOL_CALLS;
+  const toolCallLog: ExecuteCodeToolCallLogEntry[] = [];
+  let toolCallsMade = 0;
+
+  const executeTool = context.executeTool;
+  if (!executeTool) {
+    return buildOutput(
+      "unsupported",
+      "",
+      "execute_code requires a ToolRuntime recursion hook, but this host did not provide one.",
+      startedAt,
+      toolCallsMade,
+      toolCallLog,
+    );
+  }
+
+  const python = await findPython3(context.env);
+  if (!python) {
+    return buildOutput("unsupported", "", "execute_code requires python3 on PATH.", startedAt, toolCallsMade, toolCallLog);
+  }
+
+  const tempRoot = await mkdtemp(path.join(tmpdir(), "pilotdeck_execute_code_"));
+  let transport = createRpcTransport();
+  let server: Server | undefined;
+  let child: ChildProcessByStdio<null, Readable, Readable> | undefined;
+  let settled = false;
+  let status: ExecuteCodeStatus = "success";
+  let statusError: string | undefined;
+
+  const cleanup = async () => {
+    await closeServer(server);
+    await rm(tempRoot, { recursive: true, force: true });
+    if (transport.kind === "uds") {
+      await rm(transport.socketPath, { force: true });
+    }
+  };
+
+  try {
+    await writeFile(path.join(tempRoot, "pilotdeck_tools.py"), generatePilotDeckToolsModule(transport.kind), "utf8");
+    await writeFile(path.join(tempRoot, "script.py"), input.code, "utf8");
+
+    server = createRpcServer({
+      context,
+      executeTool,
+      maxToolCalls,
+      toolCallLog,
+      nextToolCall: () => {
+        toolCallsMade += 1;
+        return toolCallsMade;
+      },
+      canCallTool: () => toolCallsMade < maxToolCalls,
+      expectedToken: transport.kind === "tcp" ? transport.token : undefined,
+    });
+    transport = await listen(server, transport);
+
+    child = spawn(python, ["script.py"], {
+      cwd: tempRoot,
+      env: buildChildEnv(context.env ?? process.env, transport),
+      stdio: ["ignore", "pipe", "pipe"],
+      detached: true,
+    });
+
+    const activeChild = child;
+    const stdout = collectHeadTail(activeChild.stdout, MAX_STDOUT_BYTES);
+    const stderr = collectHead(activeChild.stderr, MAX_STDERR_BYTES);
+
+    const timeout = setTimeout(() => {
+      if (!settled) {
+        status = "timeout";
+        statusError = `Script timed out after ${timeoutSeconds}s and was killed.`;
+        killProcess(activeChild, true);
+      }
+    }, timeoutSeconds * 1000);
+
+    const abortHandler = () => {
+      if (!settled) {
+        status = "cancelled";
+        statusError = "Script execution was cancelled.";
+        killProcess(activeChild, true);
+      }
+    };
+    context.abortSignal?.addEventListener("abort", abortHandler, { once: true });
+
+    const exit = await waitForExit(activeChild);
+    settled = true;
+    clearTimeout(timeout);
+    context.abortSignal?.removeEventListener("abort", abortHandler);
+
+    const stdoutText = await stdout;
+    const stderrText = await stderr;
+    if (status === "success" && exit.code !== 0) {
+      status = "error";
+      statusError = stderrText || `Script exited with code ${exit.code ?? "unknown"}.`;
+    }
+
+    const output = status === "error" && stderrText ? `${stdoutText}\n--- stderr ---\n${stderrText}`.trim() : stdoutText;
+    return buildOutput(status, stripAnsi(output), statusError ? stripAnsi(statusError) : undefined, startedAt, toolCallsMade, toolCallLog);
+  } catch (error) {
+    return buildOutput("error", "", error instanceof Error ? error.message : String(error), startedAt, toolCallsMade, toolCallLog);
+  } finally {
+    await cleanup();
+  }
+}
+
+function createRpcServer(options: {
+  context: PilotDeckToolRuntimeContext;
+  executeTool: NonNullable<PilotDeckToolRuntimeContext["executeTool"]>;
+  maxToolCalls: number;
+  toolCallLog: ExecuteCodeToolCallLogEntry[];
+  nextToolCall: () => number;
+  canCallTool: () => boolean;
+  expectedToken?: string;
+}): Server {
+  return createServer((socket) => {
+    let buffer = "";
+    socket.setEncoding("utf8");
+    socket.on("data", (chunk) => {
+      buffer += chunk;
+      void processBufferedRequests(socket, () => {
+        const lines: string[] = [];
+        let index = buffer.indexOf("\n");
+        while (index >= 0) {
+          const line = buffer.slice(0, index);
+          buffer = buffer.slice(index + 1);
+          lines.push(line);
+          index = buffer.indexOf("\n");
+        }
+        return lines;
+      }, options);
+    });
+  });
+}
+
+async function processBufferedRequests(
+  socket: Socket,
+  takeLines: () => string[],
+  options: {
+    context: PilotDeckToolRuntimeContext;
+    executeTool: NonNullable<PilotDeckToolRuntimeContext["executeTool"]>;
+    maxToolCalls: number;
+    toolCallLog: ExecuteCodeToolCallLogEntry[];
+    nextToolCall: () => number;
+    canCallTool: () => boolean;
+    expectedToken?: string;
+  },
+): Promise<void> {
+  for (const rawLine of takeLines()) {
+    const line = rawLine.trim();
+    if (!line) continue;
+    const response = await handleRpcLine(line, options);
+    socket.write(`${JSON.stringify(response)}\n`);
+  }
+}
+
+async function handleRpcLine(
+  line: string,
+  options: {
+    context: PilotDeckToolRuntimeContext;
+    executeTool: NonNullable<PilotDeckToolRuntimeContext["executeTool"]>;
+    maxToolCalls: number;
+    toolCallLog: ExecuteCodeToolCallLogEntry[];
+    nextToolCall: () => number;
+    canCallTool: () => boolean;
+    expectedToken?: string;
+  },
+): Promise<RpcResponse> {
+  let request: RpcRequest;
+  try {
+    request = JSON.parse(line) as RpcRequest;
+  } catch (error) {
+    return { error: `Invalid RPC request: ${error instanceof Error ? error.message : String(error)}`, code: "invalid_rpc" };
+  }
+
+  const toolName = typeof request.tool === "string" ? request.tool : "";
+  const args = isRecord(request.args) ? request.args : {};
+  if (options.expectedToken && request.token !== options.expectedToken) {
+    return { error: "Invalid execute_code RPC token.", code: "invalid_rpc_token" };
+  }
+  if (!EXECUTE_CODE_ALLOWED_TOOLS.has(toolName)) {
+    return { error: `Tool '${toolName}' is not available in execute_code.`, code: "tool_not_allowed" };
+  }
+  if (!options.canCallTool()) {
+    return {
+      error: `Tool call limit reached (${options.maxToolCalls}). No more tool calls allowed in this execution.`,
+      code: "tool_call_limit_reached",
+    };
+  }
+
+  const sequence = options.nextToolCall();
+  const started = Date.now();
+  const outerId = options.context.currentToolCallId ?? "execute_code";
+  const result = await options.executeTool(
+    { id: `${outerId}:code:${sequence}`, name: toolName, input: args },
+    { currentToolCallId: `${outerId}:code:${sequence}` },
+  );
+  const ok = result.type === "success";
+  options.toolCallLog.push({ tool: toolName, duration_ms: Date.now() - started, ok });
+  return toolResultToRpcResponse(result);
+}
+
+function toolResultToRpcResponse(result: PilotDeckToolResult): RpcResponse {
+  const content = result.content.map(contentToText).join("\n");
+  if (result.type === "error") {
+    const details = formatToolErrorDetails(result);
+    return {
+      error: details ? `${result.error.message}\n${details}` : result.error.message,
+      code: result.error.code,
+      content,
+      metadata: result.metadata,
+    };
+  }
+  return {
+    content,
+    data: result.data,
+    metadata: result.metadata,
+  };
+}
+
+function formatToolErrorDetails(result: Extract<PilotDeckToolResult, { type: "error" }>): string | undefined {
+  const issues = result.error.details?.issues;
+  if (!Array.isArray(issues)) return undefined;
+  const messages = issues
+    .map((issue) => isRecord(issue) && typeof issue.message === "string" ? issue.message : undefined)
+    .filter((message): message is string => !!message);
+  return messages.length > 0 ? messages.join("\n") : undefined;
+}
+
+function generatePilotDeckToolsModule(kind: RpcTransport["kind"]): string {
+  const transportHeader = kind === "tcp" ? TCP_PYTHON_TRANSPORT_HEADER : UDS_PYTHON_TRANSPORT_HEADER;
+  return `${transportHeader}
+
+def web_search(query, country=None):
+    args = {"query": query}
+    if country is not None:
+        args["country"] = country
+    return _call("web_search", args)
+
+
+def web_fetch(url, extract="markdown"):
+    mode = "raw" if extract == "markdown" else extract
+    return _call("web_fetch", {"url": url, "mode": mode})
+
+
+def read_file(file_path, offset=0, limit=None):
+    args = {"file_path": file_path}
+    if offset is not None and offset > 0:
+        args["offset"] = offset
+    if limit is not None:
+        args["limit"] = limit
+    return _call("read_file", args)
+
+
+def write_file(file_path, content):
+    return _call("write_file", {"file_path": file_path, "content": content})
+
+
+def edit_file(file_path, old_string, new_string, replace_all=False):
+    return _call("edit_file", {
+        "file_path": file_path,
+        "old_string": old_string,
+        "new_string": new_string,
+        "replace_all": replace_all,
+    })
+
+
+def grep(pattern, path=None, glob=None):
+    args = {"pattern": pattern}
+    if path is not None:
+        args["path"] = path
+    if glob is not None:
+        args["glob"] = glob
+    return _call("grep", args)
+
+
+def glob(pattern, path=None):
+    args = {"pattern": pattern}
+    if path is not None:
+        args["path"] = path
+    return _call("glob", args)
+
+
+def bash(command, timeout_ms=None, workdir=None):
+    args = {"command": command}
+    if workdir is not None:
+        args["command"] = "cd " + shlex.quote(workdir) + " && " + command
+    if timeout_ms is not None:
+        args["timeout"] = timeout_ms
+    return _call("bash", args)
+`;
+}
+
+const UDS_PYTHON_TRANSPORT_HEADER = `"""Auto-generated PilotDeck execute_code RPC helpers."""
+import json
+import os
+import shlex
+import socket
+
+_sock = None
+
+
+def _connect():
+    global _sock
+    if _sock is None:
+        _sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        _sock.connect(os.environ["PILOTDECK_RPC_SOCKET"])
+        _sock.settimeout(300)
+    return _sock
+
+
+def _call(tool_name, args):
+    conn = _connect()
+    conn.sendall((json.dumps({"tool": tool_name, "args": args}) + "\\n").encode("utf-8"))
+    chunks = []
+    while True:
+        chunk = conn.recv(65536)
+        if not chunk:
+            raise RuntimeError("PilotDeck RPC server disconnected")
+        chunks.append(chunk)
+        if chunk.endswith(b"\\n"):
+            break
+    response = json.loads(b"".join(chunks).decode("utf-8").strip())
+    if response.get("error"):
+        raise RuntimeError(response.get("error"))
+    return response
+`;
+
+const TCP_PYTHON_TRANSPORT_HEADER = `"""Auto-generated PilotDeck execute_code RPC helpers."""
+import json
+import os
+import shlex
+import socket
+
+_sock = None
+_token = os.environ["PILOTDECK_RPC_TOKEN"]
+
+
+def _connect():
+    global _sock
+    if _sock is None:
+        host = os.environ.get("PILOTDECK_RPC_HOST", "127.0.0.1")
+        port = int(os.environ["PILOTDECK_RPC_PORT"])
+        _sock = socket.create_connection((host, port), timeout=300)
+        _sock.settimeout(300)
+    return _sock
+
+
+def _call(tool_name, args):
+    conn = _connect()
+    conn.sendall((json.dumps({"token": _token, "tool": tool_name, "args": args}) + "\\n").encode("utf-8"))
+    chunks = []
+    while True:
+        chunk = conn.recv(65536)
+        if not chunk:
+            raise RuntimeError("PilotDeck RPC server disconnected")
+        chunks.append(chunk)
+        if chunk.endswith(b"\\n"):
+            break
+    response = json.loads(b"".join(chunks).decode("utf-8").strip())
+    if response.get("error"):
+        raise RuntimeError(response.get("error"))
+    return response
+`;
+
+async function findPython3(env: NodeJS.ProcessEnv | undefined): Promise<string | undefined> {
+  const candidates = ["python3", "python"];
+  for (const candidate of candidates) {
+    const result = await new Promise<boolean>((resolve) => {
+      const child = spawn(candidate, ["--version"], { env, stdio: "ignore" });
+      child.on("error", () => resolve(false));
+      child.on("exit", (code) => resolve(code === 0));
+    });
+    if (result) return candidate;
+  }
+  return undefined;
+}
+
+function buildChildEnv(source: NodeJS.ProcessEnv, transport: RpcTransport): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {};
+  for (const [key, value] of Object.entries(source)) {
+    if (value === undefined) continue;
+    if (SECRET_ENV_SUBSTRINGS.some((part) => key.toUpperCase().includes(part))) continue;
+    if (SAFE_ENV_PREFIXES.some((prefix) => key === prefix || key.startsWith(prefix))) {
+      env[key] = value;
+    }
+  }
+  if (transport.kind === "uds") {
+    env.PILOTDECK_RPC_SOCKET = transport.socketPath;
+  } else {
+    env.PILOTDECK_RPC_HOST = transport.host;
+    env.PILOTDECK_RPC_PORT = String(transport.port);
+    env.PILOTDECK_RPC_TOKEN = transport.token;
+  }
+  env.PYTHONDONTWRITEBYTECODE = "1";
+  return env;
+}
+
+function collectHead(stream: NodeJS.ReadableStream, maxBytes: number): Promise<string> {
+  return new Promise((resolve) => {
+    const chunks: Buffer[] = [];
+    let total = 0;
+    stream.on("data", (chunk: Buffer | string) => {
+      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      if (total < maxBytes) {
+        chunks.push(buffer.subarray(0, maxBytes - total));
+      }
+      total += buffer.byteLength;
+    });
+    stream.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+    stream.on("error", () => resolve(Buffer.concat(chunks).toString("utf8")));
+  });
+}
+
+function collectHeadTail(stream: NodeJS.ReadableStream, maxBytes: number): Promise<string> {
+  const headBytes = Math.floor(maxBytes * 0.4);
+  const tailBytes = maxBytes - headBytes;
+  return new Promise((resolve) => {
+    const head: Buffer[] = [];
+    const tail: Buffer[] = [];
+    let headCollected = 0;
+    let tailCollected = 0;
+    let total = 0;
+    stream.on("data", (chunk: Buffer | string) => {
+      let buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      total += buffer.byteLength;
+      if (headCollected < headBytes) {
+        const keep = Math.min(buffer.byteLength, headBytes - headCollected);
+        head.push(buffer.subarray(0, keep));
+        headCollected += keep;
+        buffer = buffer.subarray(keep);
+      }
+      if (buffer.byteLength > 0) {
+        tail.push(buffer);
+        tailCollected += buffer.byteLength;
+        while (tailCollected > tailBytes && tail.length > 0) {
+          const first = tail[0]!;
+          const overflow = tailCollected - tailBytes;
+          if (overflow >= first.byteLength) {
+            tail.shift();
+            tailCollected -= first.byteLength;
+          } else {
+            tail[0] = first.subarray(overflow);
+            tailCollected -= overflow;
+          }
+        }
+      }
+    });
+    const finish = () => {
+      const headText = Buffer.concat(head).toString("utf8");
+      const tailText = Buffer.concat(tail).toString("utf8");
+      if (total > maxBytes && tailText) {
+        const omitted = Math.max(0, total - Buffer.byteLength(headText) - Buffer.byteLength(tailText));
+        resolve(`${headText}\n\n... [OUTPUT TRUNCATED - ${omitted.toLocaleString()} bytes omitted out of ${total.toLocaleString()} total] ...\n\n${tailText}`);
+      } else {
+        resolve(headText + tailText);
+      }
+    };
+    stream.on("end", finish);
+    stream.on("error", finish);
+  });
+}
+
+function waitForExit(child: ChildProcessByStdio<null, Readable, Readable>): Promise<{ code: number | null; signal: NodeJS.Signals | null }> {
+  return new Promise((resolve, reject) => {
+    child.on("error", reject);
+    child.on("exit", (code, signal) => resolve({ code, signal }));
+  });
+}
+
+function killProcess(child: ChildProcessByStdio<null, Readable, Readable> | undefined, escalate: boolean): void {
+  if (!child || child.killed) return;
+  try {
+    if (process.platform !== "win32" && child.pid) {
+      process.kill(-child.pid, "SIGTERM");
+      if (escalate) setTimeout(() => {
+        try { process.kill(-child.pid!, "SIGKILL"); } catch { /* noop */ }
+      }, 500).unref();
+    } else {
+      child.kill("SIGTERM");
+      if (escalate) setTimeout(() => child?.kill("SIGKILL"), 500).unref();
+    }
+  } catch {
+    try { child.kill("SIGKILL"); } catch { /* noop */ }
+  }
+}
+
+function listen(server: Server, transport: RpcTransport): Promise<RpcTransport> {
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    const onListening = () => {
+      server.off("error", reject);
+      if (transport.kind === "tcp") {
+        const address = server.address();
+        if (!address || typeof address === "string") {
+          reject(new Error("Unable to determine execute_code TCP RPC port."));
+          return;
+        }
+        resolve({ ...transport, port: (address as AddressInfo).port });
+        return;
+      }
+      resolve(transport);
+    };
+    if (transport.kind === "tcp") {
+      server.listen(transport.port, transport.host, onListening);
+    } else {
+      server.listen(transport.socketPath, onListening);
+    }
+  });
+}
+
+function closeServer(server: Server | undefined): Promise<void> {
+  return new Promise((resolve) => {
+    if (!server || !server.listening) {
+      resolve();
+      return;
+    }
+    server.close(() => resolve());
+  });
+}
+
+function buildOutput(
+  status: ExecuteCodeStatus,
+  output: string,
+  error: string | undefined,
+  startedAt: number,
+  toolCallsMade: number,
+  toolCallLog: ExecuteCodeToolCallLogEntry[],
+): ExecuteCodeOutput {
+  return {
+    status,
+    output,
+    ...(error ? { error } : {}),
+    tool_calls_made: toolCallsMade,
+    duration_seconds: Math.round(((Date.now() - startedAt) / 1000) * 100) / 100,
+    tool_call_log: toolCallLog,
+  };
+}
+
+function formatExecuteCodeResult(result: ExecuteCodeOutput): string {
+  const lines = [`status: ${result.status}`, `duration_seconds: ${result.duration_seconds}`, `tool_calls_made: ${result.tool_calls_made}`];
+  if (result.error) lines.push(`error: ${result.error}`);
+  if (result.output) lines.push("", result.output);
+  return lines.join("\n");
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stripAnsi(value: string): string {
+  return value.replace(/\u001b\[[0-?]*[ -/]*[@-~]/g, "");
+}

--- a/src/tool/builtin/executeCode.ts
+++ b/src/tool/builtin/executeCode.ts
@@ -8,6 +8,7 @@ import type { Readable } from "node:stream";
 import type { PilotDeckToolDefinition, PilotDeckToolRuntimeContext } from "../protocol/types.js";
 import { contentToText, type PilotDeckToolResult } from "../protocol/result.js";
 import type { PilotDeckToolValidationIssue } from "../protocol/schema.js";
+import { collectPythonSyntaxDiagnostics } from "./filesystem/syntaxDiagnostics.js";
 
 type ExecuteCodeInput = {
   code: string;
@@ -105,31 +106,13 @@ const EXECUTE_CODE_ALLOWED_TOOLS = new Set([
   "glob",
   "bash",
 ]);
-const SECRET_ENV_SUBSTRINGS = ["KEY", "TOKEN", "SECRET", "PASSWORD", "CREDENTIAL", "PASSWD", "AUTH"];
-const SAFE_ENV_PREFIXES = [
-  "PATH",
-  "HOME",
-  "USER",
-  "LANG",
-  "LC_",
-  "TERM",
-  "TMPDIR",
-  "TMP",
-  "TEMP",
-  "SHELL",
-  "LOGNAME",
-  "XDG_",
-  "PYTHONPATH",
-  "VIRTUAL_ENV",
-  "CONDA",
-  "TZ",
-];
 
 export function createExecuteCodeTool(): PilotDeckToolDefinition<ExecuteCodeInput, ExecuteCodeOutput> {
   return {
     name: "execute_code",
     description:
       "Run a local Python 3 script that can call a small allow-list of PilotDeck tools via `import pilotdeck_tools`. " +
+      "The script runs from the workspace cwd and inherits the same runtime environment as normal tools such as bash, including configured API, proxy, PATH, virtualenv, and conda variables; do not print secrets or dump the full environment. " +
       "Only the script's final stdout/stderr summary is returned to the model; intermediate tool results stay inside the script. " +
       "Available helper functions: web_search, web_fetch, read_file, write_file, edit_file, grep, glob, bash. " +
       "Use normal Python control flow to orchestrate tools: loops for batch work, conditionals for branching, data structures for aggregation, and try/except around individual helper calls when one failure should not abort the whole script. Helper failures raise RuntimeError. You can chain helper results, e.g. grep -> read_file -> edit_file. Print only the concise final result needed by the agent. " +
@@ -179,13 +162,16 @@ export function createExecuteCodeTool(): PilotDeckToolDefinition<ExecuteCodeInpu
           status: result.status,
           tool_calls_made: result.tool_calls_made,
           duration_seconds: result.duration_seconds,
+          cwd: context.cwd,
+          env_inheritance: "full",
+          python_path_augmented: true,
         },
       };
     },
   };
 }
 
-function validateExecuteCodeInput(input: ExecuteCodeInput) {
+async function validateExecuteCodeInput(input: ExecuteCodeInput) {
   const issues: PilotDeckToolValidationIssue[] = [];
   if (!input.code.trim()) {
     issues.push({ path: "$.code", code: "invalid_schema", message: "$.code must not be empty." });
@@ -203,6 +189,16 @@ function validateExecuteCodeInput(input: ExecuteCodeInput) {
       code: "invalid_schema",
       message: `$.max_tool_calls must be between 0 and ${DEFAULT_MAX_TOOL_CALLS}.`,
     });
+  }
+  if (issues.length === 0) {
+    const syntaxDiagnostics = await collectPythonSyntaxDiagnostics("execute_code.py", input.code);
+    for (const diagnostic of syntaxDiagnostics) {
+      issues.push({
+        path: "$.code",
+        code: "invalid_schema",
+        message: `Python syntax error at L${diagnostic.line}:${diagnostic.column}: ${diagnostic.message}`,
+      });
+    }
   }
   return issues.length === 0 ? { ok: true as const, input } : { ok: false as const, issues };
 }
@@ -287,9 +283,9 @@ async function runExecuteCode(
     });
     transport = await listen(server, transport);
 
-    child = spawn(python, ["script.py"], {
-      cwd: tempRoot,
-      env: buildChildEnv(context.env ?? process.env, transport),
+    child = spawn(python, [path.join(tempRoot, "script.py")], {
+      cwd: context.cwd,
+      env: buildChildEnv(context.env ?? process.env, transport, tempRoot, context.cwd),
       stdio: ["ignore", "pipe", "pipe"],
       detached: true,
     });
@@ -608,15 +604,16 @@ async function findPython3(env: NodeJS.ProcessEnv | undefined): Promise<string |
   return undefined;
 }
 
-function buildChildEnv(source: NodeJS.ProcessEnv, transport: RpcTransport): NodeJS.ProcessEnv {
-  const env: NodeJS.ProcessEnv = {};
-  for (const [key, value] of Object.entries(source)) {
-    if (value === undefined) continue;
-    if (SECRET_ENV_SUBSTRINGS.some((part) => key.toUpperCase().includes(part))) continue;
-    if (SAFE_ENV_PREFIXES.some((prefix) => key === prefix || key.startsWith(prefix))) {
-      env[key] = value;
-    }
-  }
+function buildChildEnv(
+  source: NodeJS.ProcessEnv,
+  transport: RpcTransport,
+  tempRoot: string,
+  workspaceCwd: string,
+): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = { ...source };
+  env.PYTHONPATH = source.PYTHONPATH ? `${tempRoot}${path.delimiter}${source.PYTHONPATH}` : tempRoot;
+  env.PILOTDECK_WORKSPACE_CWD = workspaceCwd;
+  env.PILOTDECK_EXECUTE_CODE_TEMP_ROOT = tempRoot;
   if (transport.kind === "uds") {
     env.PILOTDECK_RPC_SOCKET = transport.socketPath;
   } else {

--- a/src/tool/builtin/executeCode.ts
+++ b/src/tool/builtin/executeCode.ts
@@ -467,7 +467,7 @@ function generatePilotDeckToolsModule(kind: RpcTransport["kind"]): string {
 def web_search(query, country=None):
     args = {"query": query}
     if country is not None:
-        args["country"] = country
+        args["gl"] = country
     return _call("web_search", args)
 
 

--- a/src/tool/builtin/executeCode.ts
+++ b/src/tool/builtin/executeCode.ts
@@ -8,6 +8,7 @@ import type { Readable } from "node:stream";
 import type { PilotDeckToolDefinition, PilotDeckToolRuntimeContext } from "../protocol/types.js";
 import { contentToText, type PilotDeckToolResult } from "../protocol/result.js";
 import type { PilotDeckToolValidationIssue } from "../protocol/schema.js";
+import { isReadOnlyShellCommand } from "./bash/permissions.js";
 import { collectPythonSyntaxDiagnostics } from "./filesystem/syntaxDiagnostics.js";
 
 type ExecuteCodeInput = {
@@ -154,7 +155,7 @@ export function createExecuteCodeTool(): PilotDeckToolDefinition<ExecuteCodeInpu
         tool_call_log: { type: "array" },
       },
     },
-    isReadOnly: () => false,
+    isReadOnly: (input) => isExecuteCodeReadOnly(input),
     isConcurrencySafe: () => false,
     validateInput: async (input) => validateExecuteCodeInput(input as ExecuteCodeInput),
     execute: async (input, context) => {
@@ -206,6 +207,93 @@ async function validateExecuteCodeInput(input: ExecuteCodeInput) {
     }
   }
   return issues.length === 0 ? { ok: true as const, input } : { ok: false as const, issues };
+}
+
+function isExecuteCodeReadOnly(input: ExecuteCodeInput): boolean {
+  return !containsWriteCapableHelper(input.code) && readOnlyBashCallsOnly(input.code);
+}
+
+function containsWriteCapableHelper(code: string): boolean {
+  return /\b(?:write_file|edit_file)\s*\(/u.test(stripPythonCommentsAndStrings(code));
+}
+
+function readOnlyBashCallsOnly(code: string): boolean {
+  const searchable = stripPythonCommentsAndStrings(code);
+  const bashCallPattern = /\bbash\s*\(/gu;
+  let match: RegExpExecArray | null;
+  while ((match = bashCallPattern.exec(searchable)) !== null) {
+    const command = readFirstPythonStringArgument(code, bashCallPattern.lastIndex);
+    if (!command || !isReadOnlyShellCommand(command)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function readFirstPythonStringArgument(code: string, offset: number): string | undefined {
+  let index = offset;
+  while (index < code.length && /\s/u.test(code[index]!)) index += 1;
+  const quote = code[index];
+  if (quote !== '"' && quote !== "'") return undefined;
+  const isTriple = code.slice(index, index + 3) === quote.repeat(3);
+  const delimiterLength = isTriple ? 3 : 1;
+  index += delimiterLength;
+  let value = "";
+  while (index < code.length) {
+    if (code[index] === "\\") {
+      const escaped = code[index + 1];
+      if (escaped === undefined) return undefined;
+      value += escaped === "n" ? "\n" : escaped === "t" ? "\t" : escaped;
+      index += 2;
+      continue;
+    }
+    if (code.slice(index, index + delimiterLength) === quote.repeat(delimiterLength)) {
+      return value;
+    }
+    value += code[index]!;
+    index += 1;
+  }
+  return undefined;
+}
+
+function stripPythonCommentsAndStrings(code: string): string {
+  let output = "";
+  let index = 0;
+  while (index < code.length) {
+    const char = code[index]!;
+    if (char === "#") {
+      while (index < code.length && code[index] !== "\n") {
+        output += " ";
+        index += 1;
+      }
+      continue;
+    }
+    if (char === '"' || char === "'") {
+      const quote = char;
+      const isTriple = code.slice(index, index + 3) === quote.repeat(3);
+      const length = isTriple ? 3 : 1;
+      output += " ".repeat(length);
+      index += length;
+      while (index < code.length) {
+        if (code[index] === "\\") {
+          output += "  ";
+          index += 2;
+          continue;
+        }
+        if (code.slice(index, index + length) === quote.repeat(length)) {
+          output += " ".repeat(length);
+          index += length;
+          break;
+        }
+        output += code[index] === "\n" ? "\n" : " ";
+        index += 1;
+      }
+      continue;
+    }
+    output += char;
+    index += 1;
+  }
+  return output;
 }
 
 function createRpcTransport(): RpcTransport {
@@ -471,9 +559,13 @@ def web_search(query, country=None):
     return _call("web_search", args)
 
 
-def web_fetch(url, extract="markdown"):
-    mode = "raw" if extract == "markdown" else extract
-    return _call("web_fetch", {"url": url, "mode": mode})
+def web_fetch(url, mode=None, prompt=None):
+    args = {"url": url}
+    if mode is not None:
+        args["mode"] = mode
+    if prompt is not None:
+        args["prompt"] = prompt
+    return _call("web_fetch", args)
 
 
 def read_file(file_path, offset=0, limit=None):

--- a/src/tool/builtin/filesystem/syntaxDiagnostics.ts
+++ b/src/tool/builtin/filesystem/syntaxDiagnostics.ts
@@ -4,7 +4,7 @@ import { parse as parseCsv } from "csv-parse/sync";
 import { parseFragment as parseHtmlFragment, type ParserError } from "parse5";
 import { LineCounter, parseDocument } from "yaml";
 
-type SyntaxDiagnostic = {
+export type SyntaxDiagnostic = {
   line: number;
   column: number;
   message: string;
@@ -169,7 +169,7 @@ async function collectTypeScriptDiagnostics(
   });
 }
 
-async function collectPythonDiagnostics(
+export async function collectPythonSyntaxDiagnostics(
   filePath: string,
   content: string,
 ): Promise<SyntaxDiagnostic[]> {
@@ -186,6 +186,13 @@ async function collectPythonDiagnostics(
     column: positiveInteger(parsed.column) ?? 1,
     message: trimDiagnosticMessage(stringValue(parsed.message) ?? "Invalid Python syntax."),
   }];
+}
+
+async function collectPythonDiagnostics(
+  filePath: string,
+  content: string,
+): Promise<SyntaxDiagnostic[]> {
+  return collectPythonSyntaxDiagnostics(filePath, content);
 }
 
 async function collectBashDiagnostics(content: string): Promise<SyntaxDiagnostic[]> {

--- a/src/tool/builtin/todoWrite.ts
+++ b/src/tool/builtin/todoWrite.ts
@@ -1,4 +1,5 @@
 import type {
+  PilotDeckTodoDiagnostics,
   PilotDeckTodoItem,
   PilotDeckToolDefinition,
   PilotDeckToolExecutionOutput,
@@ -17,6 +18,7 @@ export type TodoWriteOutput = {
   mode: "read" | "markdown" | "structured";
   merge: boolean;
   reason?: string;
+  diagnostics?: PilotDeckTodoDiagnostics;
 };
 
 const TODO_LINE_PATTERN = /^\s*[-*]\s+\[( |x|X)\]\s+(.*?)\s*$/u;
@@ -60,12 +62,16 @@ export function createTodoWriteTool(): PilotDeckToolDefinition<TodoWriteInput, T
     aliases: ["TodoWrite"],
     description:
       [
-        "Read or update the execution todo list for the current session.",
+        "Read or update a lightweight session checklist for complex work.",
         "Call with no arguments to read the current todo list.",
         "For editable todos, provide `todos` with stable ids and optional `merge=true` to update by id and append new items.",
         "For legacy checklist updates, provide `markdown` using `- [x]` for completed items and `- [ ]` for remaining items.",
+        "Use for complex 3+ step tasks, multi-deliverable work, codebase exploration, batch processing, information gathering, or generation work.",
+        "Do a small amount of exploration before writing a detailed list; use todos as checkable checkpoints, not a rigid plan lock.",
         "Use status pending, in_progress, completed, or cancelled. Keep only one item in_progress when possible.",
+        "Mark an item completed only after checking relevant evidence. If an approach fails or assumptions change, mark the old item cancelled and add a revised item instead of silently rewriting it as completed.",
         "When changing the todo structure mid-task, include `reason` so the change is auditable in the tool result.",
+        "Prefer a final verification checkpoint that checks outputs, format, counts, extra artifacts, and key constraints when applicable.",
         "This tool only updates a checklist; it does not write files, submit, or replace a final plan.",
         "In plan mode, do not use todo_write to write the plan itself, and do not treat a todo list as the final plan.",
         "You may use todo_write in plan mode only to organize planning work such as exploration, analysis, writing a markdown plan under `.pilotdeck/plans/`, and submitting that plan with `exit_plan_mode`.",
@@ -122,17 +128,21 @@ export function createTodoWriteTool(): PilotDeckToolDefinition<TodoWriteInput, T
     isConcurrencySafe: () => true,
     execute: async (input, context): Promise<PilotDeckToolExecutionOutput<TodoWriteOutput>> => {
       let mode: TodoWriteOutput["mode"] = "read";
-      let todos = context.planTodo?.getSnapshot().todos ?? [];
+      let snapshot = context.planTodo?.getSnapshot();
+      let todos = snapshot?.todos ?? [];
       const merge = Boolean(input.merge);
+      const reason = input.reason?.trim();
 
       if (Array.isArray(input.todos)) {
         mode = "structured";
-        todos = context.planTodo?.writeTodos(input.todos, { merge }) ?? input.todos;
+        todos = context.planTodo?.writeTodos(input.todos, { merge, reason }) ?? input.todos;
       } else if (typeof input.markdown === "string") {
         mode = "markdown";
         todos = parseTodoMarkdown(input.markdown);
-        context.planTodo?.recordTodoWrite(input.markdown, todos);
+        todos = context.planTodo?.recordTodoWrite(input.markdown, todos, { reason }) ?? todos;
       }
+      snapshot = context.planTodo?.getSnapshot();
+      const diagnostics = snapshot?.todoDiagnostics;
 
       return {
         content: [{ type: "text", text: mode === "read" ? "Todo list read" : "Todo list updated" }],
@@ -141,11 +151,13 @@ export function createTodoWriteTool(): PilotDeckToolDefinition<TodoWriteInput, T
           todos,
           mode,
           merge,
-          ...(input.reason?.trim() ? { reason: input.reason.trim() } : {}),
+          ...(reason ? { reason } : {}),
+          ...(diagnostics ? { diagnostics } : {}),
         },
         metadata: {
           todoCount: todos.length,
           mode,
+          ...(diagnostics ? { diagnostics } : {}),
         },
       };
     },

--- a/src/tool/builtin/todoWrite.ts
+++ b/src/tool/builtin/todoWrite.ts
@@ -1,13 +1,14 @@
 import type {
   PilotDeckTodoDiagnostics,
   PilotDeckTodoItem,
+  PilotDeckTodoUpdate,
   PilotDeckToolDefinition,
   PilotDeckToolExecutionOutput,
 } from "../protocol/types.js";
 
 export type TodoWriteInput = {
   markdown?: string;
-  todos?: PilotDeckTodoItem[];
+  todos?: PilotDeckTodoUpdate[];
   merge?: boolean;
   reason?: string;
 };
@@ -22,6 +23,15 @@ export type TodoWriteOutput = {
 };
 
 const TODO_LINE_PATTERN = /^\s*[-*]\s+\[( |x|X)\]\s+(.*?)\s*$/u;
+
+function normalizeTodoUpdatesForFallback(todos: PilotDeckTodoUpdate[]): PilotDeckTodoItem[] {
+  return todos.map((todo, index) => ({
+    id: todo.id?.trim() || `todo-${index + 1}`,
+    content: todo.content?.trim() || "(no description)",
+    status: todo.status ?? "pending",
+    ...(todo.priority?.trim() ? { priority: todo.priority.trim() } : {}),
+  }));
+}
 
 export function parseTodoMarkdown(markdown: string): PilotDeckTodoItem[] {
   const lines = markdown.split(/\r?\n/u);
@@ -64,7 +74,7 @@ export function createTodoWriteTool(): PilotDeckToolDefinition<TodoWriteInput, T
       [
         "Read or update a lightweight session checklist for complex work.",
         "Call with no arguments to read the current todo list.",
-        "For editable todos, provide `todos` with stable ids and optional `merge=true` to update by id and append new items.",
+        "For editable todos, provide `todos` with stable ids and optional `merge=true` to update existing items by id or append new items.",
         "For legacy checklist updates, provide `markdown` using `- [x]` for completed items and `- [ ]` for remaining items.",
         "Use for complex 3+ step tasks, multi-deliverable work, codebase exploration, batch processing, information gathering, or generation work.",
         "Do a small amount of exploration before writing a detailed list; use todos as checkable checkpoints, not a rigid plan lock.",
@@ -87,15 +97,14 @@ export function createTodoWriteTool(): PilotDeckToolDefinition<TodoWriteInput, T
         },
         todos: {
           type: "array",
-          description: "Editable todo items. Omit to read current list, or provide with merge=true to update by id.",
+          description: "Editable todo items. Omit to read current list. With merge=true, items may include only id plus the fields to update.",
           items: {
             type: "object",
             additionalProperties: false,
-            required: ["content", "status"],
             properties: {
               id: {
                 type: "string",
-                description: "Stable todo identifier. Required for reliable merge updates.",
+                description: "Stable todo identifier. Required for reliable merge updates to existing items.",
               },
               content: {
                 type: "string",
@@ -135,7 +144,7 @@ export function createTodoWriteTool(): PilotDeckToolDefinition<TodoWriteInput, T
 
       if (Array.isArray(input.todos)) {
         mode = "structured";
-        todos = context.planTodo?.writeTodos(input.todos, { merge, reason }) ?? input.todos;
+        todos = context.planTodo?.writeTodos(input.todos, { merge, reason }) ?? normalizeTodoUpdatesForFallback(input.todos);
       } else if (typeof input.markdown === "string") {
         mode = "markdown";
         todos = parseTodoMarkdown(input.markdown);

--- a/src/tool/builtin/todoWrite.ts
+++ b/src/tool/builtin/todoWrite.ts
@@ -5,12 +5,18 @@ import type {
 } from "../protocol/types.js";
 
 export type TodoWriteInput = {
-  markdown: string;
+  markdown?: string;
+  todos?: PilotDeckTodoItem[];
+  merge?: boolean;
+  reason?: string;
 };
 
 export type TodoWriteOutput = {
-  markdown: string;
+  markdown?: string;
   todos: PilotDeckTodoItem[];
+  mode: "read" | "markdown" | "structured";
+  merge: boolean;
+  reason?: string;
 };
 
 const TODO_LINE_PATTERN = /^\s*[-*]\s+\[( |x|X)\]\s+(.*?)\s*$/u;
@@ -54,36 +60,92 @@ export function createTodoWriteTool(): PilotDeckToolDefinition<TodoWriteInput, T
     aliases: ["TodoWrite"],
     description:
       [
-        "Update the execution todo list from a markdown checklist. Use `- [x]` for completed items and `- [ ]` for remaining items.",
-        "This tool only updates a checklist; it does not write, submit, or replace a final plan.",
+        "Read or update the execution todo list for the current session.",
+        "Call with no arguments to read the current todo list.",
+        "For editable todos, provide `todos` with stable ids and optional `merge=true` to update by id and append new items.",
+        "For legacy checklist updates, provide `markdown` using `- [x]` for completed items and `- [ ]` for remaining items.",
+        "Use status pending, in_progress, completed, or cancelled. Keep only one item in_progress when possible.",
+        "When changing the todo structure mid-task, include `reason` so the change is auditable in the tool result.",
+        "This tool only updates a checklist; it does not write files, submit, or replace a final plan.",
         "In plan mode, do not use todo_write to write the plan itself, and do not treat a todo list as the final plan.",
         "You may use todo_write in plan mode only to organize planning work such as exploration, analysis, writing a markdown plan under `.pilotdeck/plans/`, and submitting that plan with `exit_plan_mode`.",
       ].join(" "),
     kind: "session",
     inputSchema: {
       type: "object",
-      required: ["markdown"],
       additionalProperties: false,
       properties: {
         markdown: {
           type: "string",
-          description: "Markdown checklist content using `- [ ]` and `- [x]` items.",
+          description: "Legacy markdown checklist content using `- [ ]` and `- [x]` items. Replaces the current list.",
+        },
+        todos: {
+          type: "array",
+          description: "Editable todo items. Omit to read current list, or provide with merge=true to update by id.",
+          items: {
+            type: "object",
+            additionalProperties: false,
+            required: ["content", "status"],
+            properties: {
+              id: {
+                type: "string",
+                description: "Stable todo identifier. Required for reliable merge updates.",
+              },
+              content: {
+                type: "string",
+                description: "Todo item description.",
+              },
+              status: {
+                type: "string",
+                enum: ["pending", "in_progress", "completed", "cancelled"],
+                description: "Current todo status.",
+              },
+              priority: {
+                type: "string",
+                description: "Optional priority label such as high, medium, or low.",
+              },
+            },
+          },
+        },
+        merge: {
+          type: "boolean",
+          description: "When todos are provided, true updates existing items by id and appends new items; false replaces the list.",
+          default: false,
+        },
+        reason: {
+          type: "string",
+          description: "Optional reason for structural todo changes, especially added/cancelled/reordered items.",
         },
       },
     },
     isReadOnly: () => true,
     isConcurrencySafe: () => true,
     execute: async (input, context): Promise<PilotDeckToolExecutionOutput<TodoWriteOutput>> => {
-      const todos = parseTodoMarkdown(input.markdown);
-      context.planTodo?.recordTodoWrite(input.markdown, todos);
+      let mode: TodoWriteOutput["mode"] = "read";
+      let todos = context.planTodo?.getSnapshot().todos ?? [];
+      const merge = Boolean(input.merge);
+
+      if (Array.isArray(input.todos)) {
+        mode = "structured";
+        todos = context.planTodo?.writeTodos(input.todos, { merge }) ?? input.todos;
+      } else if (typeof input.markdown === "string") {
+        mode = "markdown";
+        todos = parseTodoMarkdown(input.markdown);
+        context.planTodo?.recordTodoWrite(input.markdown, todos);
+      }
+
       return {
-        content: [{ type: "text", text: "Todo list updated" }],
+        content: [{ type: "text", text: mode === "read" ? "Todo list read" : "Todo list updated" }],
         data: {
-          markdown: input.markdown,
+          ...(typeof input.markdown === "string" ? { markdown: input.markdown } : {}),
           todos,
+          mode,
+          merge,
+          ...(input.reason?.trim() ? { reason: input.reason.trim() } : {}),
         },
         metadata: {
           todoCount: todos.length,
+          mode,
         },
       };
     },

--- a/src/tool/execution/ToolRuntime.ts
+++ b/src/tool/execution/ToolRuntime.ts
@@ -36,6 +36,24 @@ export class ToolRuntime {
 
   async execute(call: PilotDeckToolCall, context: PilotDeckToolRuntimeContext): Promise<PilotDeckToolResult> {
     const startedAtDate = now(context);
+    const runtimeContext: PilotDeckToolRuntimeContext = context.executeTool
+      ? context
+      : {
+          ...context,
+          executeTool: (nestedCall, contextPatch) =>
+            {
+              runtimeContext.readFileState ??= new Map();
+              runtimeContext.writeSnapshots ??= new Map();
+              return this.execute(nestedCall, {
+                ...runtimeContext,
+                ...contextPatch,
+                readFileState: runtimeContext.readFileState,
+                writeSnapshots: runtimeContext.writeSnapshots,
+                executeTool: runtimeContext.executeTool,
+              });
+            },
+        };
+    context = runtimeContext;
     const startedAt = startedAtDate.toISOString();
     let tool = this.registry.get(call.name);
     if (!tool) {
@@ -46,8 +64,8 @@ export class ToolRuntime {
     }
     const toolName = tool?.name ?? call.name;
 
-    if (context.abortSignal?.aborted) {
-      return this.errorResult(call.id, toolName, "tool_aborted", "Tool execution was aborted.", startedAt, context);
+    if (runtimeContext.abortSignal?.aborted) {
+      return this.errorResult(call.id, toolName, "tool_aborted", "Tool execution was aborted.", startedAt, runtimeContext);
     }
 
     if (!tool) {
@@ -57,11 +75,11 @@ export class ToolRuntime {
         "tool_not_found",
         `Tool ${call.name} does not exist.`,
         startedAt,
-        context,
+        runtimeContext,
       );
     }
 
-    const planModeViolation = getPlanModeViolation(tool.name, call.input, context);
+    const planModeViolation = getPlanModeViolation(tool.name, call.input, runtimeContext);
     if (planModeViolation) {
       return this.errorResult(
         call.id,
@@ -69,11 +87,11 @@ export class ToolRuntime {
         "plan_mode_violation",
         planModeViolation,
         startedAt,
-        context,
+        runtimeContext,
       );
     }
 
-    const askModeViolation = context.runMode === "ask"
+    const askModeViolation = runtimeContext.runMode === "ask"
       ? getAskModeViolation(tool, call.input)
       : undefined;
     if (askModeViolation) {
@@ -83,7 +101,7 @@ export class ToolRuntime {
         "ask_mode_violation",
         askModeViolation,
         startedAt,
-        context,
+        runtimeContext,
       );
     }
 
@@ -94,23 +112,23 @@ export class ToolRuntime {
         tool.name,
         "invalid_tool_input",
         formatValidationError(tool.name, validation.issues, {
-          maxOutputTokens: context.maxOutputTokens,
-          outputTruncated: context.outputTruncated,
+          maxOutputTokens: runtimeContext.maxOutputTokens,
+          outputTruncated: runtimeContext.outputTruncated,
         }),
         startedAt,
-        context,
+        runtimeContext,
         { issues: validation.issues },
       );
     }
 
-    if (context.permissionContext.canPrompt === false && requiresPromptCapability(tool, call.input)) {
+    if (runtimeContext.permissionContext.canPrompt === false && requiresPromptCapability(tool, call.input)) {
       return this.errorResult(
         call.id,
         tool.name,
         "unsupported_tool",
         `${tool.name} requires user interaction, but this session is running with prompts disabled.`,
         startedAt,
-        context,
+        runtimeContext,
       );
     }
 

--- a/src/tool/index.ts
+++ b/src/tool/index.ts
@@ -70,6 +70,12 @@ export { createReadSkillTool, type ReadSkillDeps, type ReadSkillInput } from "./
 export { createGlobTool, extractGlobBaseDirectory, type GlobInput } from "./builtin/glob.js";
 export { createGrepTool, type GrepInput } from "./builtin/grep.js";
 export {
+  createExecuteCodeTool,
+  type ExecuteCodeOutput,
+  type ExecuteCodeStatus,
+  type ExecuteCodeToolCallLogEntry,
+} from "./builtin/executeCode.js";
+export {
   createGetCurrentTimeTool,
   type GetCurrentTimeInput,
   type GetCurrentTimeOutput,

--- a/src/tool/protocol/types.ts
+++ b/src/tool/protocol/types.ts
@@ -161,19 +161,54 @@ export type PilotDeckTodoItem = {
   priority?: string;
 };
 
+export type PilotDeckTodoDiagnostics = {
+  writeCount: number;
+  todoCount: number;
+  activeCount: number;
+  completedCount: number;
+  cancelledCount: number;
+  largeRewriteCount: number;
+  deletedOpenItemCount: number;
+  completedWithoutActiveCount: number;
+  lastWrite?: {
+    mode: "markdown" | "structured";
+    merge: boolean;
+    reason?: string;
+    addedCount: number;
+    removedCount: number;
+    changedCount: number;
+    deletedOpenItemCount: number;
+    largeRewrite: boolean;
+    allCompleted: boolean;
+  };
+};
+
+export type PilotDeckTodoWriteHistoryEntry = {
+  createdAt: string;
+  mode: "markdown" | "structured";
+  merge: boolean;
+  reason?: string;
+  markdown?: string;
+  todos: PilotDeckTodoItem[];
+  diagnostics: PilotDeckTodoDiagnostics;
+};
+
 export type PilotDeckPlanTodoStateSnapshot = {
   approvedPlan?: string;
   requiresInitialization: boolean;
   toolCallsSinceLastTodoWrite: number;
   lastMarkdown?: string;
   todos: PilotDeckTodoItem[];
+  activeTodos: PilotDeckTodoItem[];
+  todoHistory: PilotDeckTodoWriteHistoryEntry[];
+  todoDiagnostics: PilotDeckTodoDiagnostics;
 };
 
 export type PilotDeckPlanTodoStateHandle = {
   getSnapshot(): PilotDeckPlanTodoStateSnapshot;
   markPlanApproved(plan: string): void;
-  recordTodoWrite(markdown: string, todos: PilotDeckTodoItem[]): void;
-  writeTodos(todos: PilotDeckTodoItem[], options?: { markdown?: string; merge?: boolean }): PilotDeckTodoItem[];
+  recordTodoWrite(markdown: string, todos: PilotDeckTodoItem[], options?: { reason?: string }): PilotDeckTodoItem[];
+  writeTodos(todos: PilotDeckTodoItem[], options?: { markdown?: string; merge?: boolean; reason?: string }): PilotDeckTodoItem[];
   markToolProgressChanged(toolName: string): void;
   buildPromptAddendum(): string | undefined;
   blockingMessageFor(toolName: string, isReadOnly: boolean): string | undefined;

--- a/src/tool/protocol/types.ts
+++ b/src/tool/protocol/types.ts
@@ -295,6 +295,17 @@ export type PilotDeckToolRuntimeContext = {
    */
   outputTruncated?: boolean;
   /**
+   * Optional recursive tool executor used by higher-level tools such as
+   * `execute_code` to dispatch nested tool calls through the same ToolRuntime
+   * permission, lifecycle, audit, and result-limiting path as normal model
+   * tool calls. Hosts that execute tools directly may omit this; dependent
+   * tools report `unsupported_tool` instead of bypassing safety checks.
+   */
+  executeTool?: (
+    call: PilotDeckToolCall,
+    contextPatch?: Partial<PilotDeckToolRuntimeContext>,
+  ) => Promise<import("./result.js").PilotDeckToolResult>;
+  /**
    * Optional session-scoped cache for read_file de-duplication. The agent loop
    * keeps the map stable across turns so repeated reads of an unchanged file
    * can return a lightweight stub instead of re-injecting the full payload.

--- a/src/tool/protocol/types.ts
+++ b/src/tool/protocol/types.ts
@@ -157,7 +157,7 @@ export type PilotDeckToolProgressSink = (event: PilotDeckToolProgressEvent) => v
 export type PilotDeckTodoItem = {
   id?: string;
   content: string;
-  status: "pending" | "in_progress" | "completed";
+  status: "pending" | "in_progress" | "completed" | "cancelled";
   priority?: string;
 };
 
@@ -173,6 +173,7 @@ export type PilotDeckPlanTodoStateHandle = {
   getSnapshot(): PilotDeckPlanTodoStateSnapshot;
   markPlanApproved(plan: string): void;
   recordTodoWrite(markdown: string, todos: PilotDeckTodoItem[]): void;
+  writeTodos(todos: PilotDeckTodoItem[], options?: { markdown?: string; merge?: boolean }): PilotDeckTodoItem[];
   markToolProgressChanged(toolName: string): void;
   buildPromptAddendum(): string | undefined;
   blockingMessageFor(toolName: string, isReadOnly: boolean): string | undefined;

--- a/src/tool/protocol/types.ts
+++ b/src/tool/protocol/types.ts
@@ -161,6 +161,13 @@ export type PilotDeckTodoItem = {
   priority?: string;
 };
 
+export type PilotDeckTodoUpdate = {
+  id?: string;
+  content?: string;
+  status?: PilotDeckTodoItem["status"];
+  priority?: string;
+};
+
 export type PilotDeckTodoDiagnostics = {
   writeCount: number;
   todoCount: number;
@@ -208,7 +215,7 @@ export type PilotDeckPlanTodoStateHandle = {
   getSnapshot(): PilotDeckPlanTodoStateSnapshot;
   markPlanApproved(plan: string): void;
   recordTodoWrite(markdown: string, todos: PilotDeckTodoItem[], options?: { reason?: string }): PilotDeckTodoItem[];
-  writeTodos(todos: PilotDeckTodoItem[], options?: { markdown?: string; merge?: boolean; reason?: string }): PilotDeckTodoItem[];
+  writeTodos(todos: PilotDeckTodoUpdate[], options?: { markdown?: string; merge?: boolean; reason?: string }): PilotDeckTodoItem[];
   markToolProgressChanged(toolName: string): void;
   buildPromptAddendum(): string | undefined;
   blockingMessageFor(toolName: string, isReadOnly: boolean): string | undefined;

--- a/src/tool/registry/createBuiltinRegistry.ts
+++ b/src/tool/registry/createBuiltinRegistry.ts
@@ -4,6 +4,7 @@ import { createAskUserQuestionTool } from "../builtin/askUserQuestion.js";
 import { createBashTool, type CreateBashToolOptions } from "../builtin/bash.js";
 import { createEditFileTool } from "../builtin/editFile.js";
 import { createEditNotebookTool } from "../builtin/editNotebook.js";
+import { createExecuteCodeTool } from "../builtin/executeCode.js";
 import { createGlobTool } from "../builtin/glob.js";
 import { createGrepTool } from "../builtin/grep.js";
 import { createGetCurrentTimeTool } from "../builtin/getCurrentTime.js";
@@ -95,6 +96,7 @@ export function createBuiltinRegistry(options?: CreateBuiltinRegistryOptions): T
   registry.register(createEditNotebookTool());
   registry.register(createWriteFileTool());
   registry.register(createBashTool(options?.bash));
+  registry.register(createExecuteCodeTool());
   if (options?.webSearch !== false) {
     registry.register(createWebSearchTool(options?.webSearch));
   }

--- a/tests/agent/executeCodeAgent.spec.ts
+++ b/tests/agent/executeCodeAgent.spec.ts
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { createAgentSession } from "../../src/agent/index.js";
+import type { AgentEvent } from "../../src/agent/protocol/events.js";
+import type { AgentRouterRuntime } from "../../src/agent/runtime/AgentRuntimeDependencies.js";
+import type { CanonicalModelEvent, CanonicalModelRequest } from "../../src/model/index.js";
+import { contentToText } from "../../src/tool/index.js";
+import { createDefaultPermissionContext } from "../../src/permission/index.js";
+import type { RouterDecision } from "../../src/router/index.js";
+import { createBuiltinRegistry } from "../../src/tool/registry/createBuiltinRegistry.js";
+
+function createExecuteCodeRouter(): AgentRouterRuntime {
+  let executeCount = 0;
+  return {
+    decide: async ({ request }) => ({
+      provider: request.provider,
+      model: request.model,
+      scenarioType: "default",
+      isSubagent: false,
+      orchestrating: false,
+      resolvedFrom: "explicit",
+      mutations: {},
+    } satisfies RouterDecision),
+    execute: async function* (_decision: RouterDecision, _request: CanonicalModelRequest): AsyncIterable<CanonicalModelEvent> {
+      executeCount += 1;
+      yield { type: "message_start", role: "assistant" };
+      if (executeCount === 1) {
+        const toolCall = {
+          id: "agent-execute-code-call",
+          name: "execute_code",
+          input: { code: 'print("agent execute_code ok")' },
+        };
+        yield { type: "tool_call_start", id: toolCall.id, name: toolCall.name };
+        yield { type: "tool_call_end", toolCall };
+        yield { type: "message_end", finishReason: "tool_call" };
+        return;
+      }
+      yield { type: "text_delta", text: "done" };
+      yield { type: "message_end", finishReason: "stop" };
+    },
+    stream: async function* (): AsyncIterable<CanonicalModelEvent> {
+      yield { type: "message_start", role: "assistant" };
+      yield { type: "message_end", finishReason: "stop" };
+    },
+  };
+}
+
+test("agent loop can execute the execute_code tool", async () => {
+  const cwd = await mkdtemp(path.join(tmpdir(), "pilotdeck-agent-execute-code-"));
+  try {
+    const registry = createBuiltinRegistry({ webSearch: false, webFetch: false, agent: false, askUserQuestion: false });
+    const session = createAgentSession({
+      sessionId: "agent-execute-code-session",
+      config: {
+        provider: "test",
+        model: "fake-model",
+        cwd,
+        permissionMode: "bypassPermissions",
+        permissionContext: createDefaultPermissionContext({ cwd, mode: "bypassPermissions", canPrompt: false }),
+      },
+      dependencies: {
+        router: createExecuteCodeRouter(),
+        tools: { registry },
+        now: () => new Date("2026-07-02T00:00:00.000Z"),
+        uuid: (() => {
+          let id = 0;
+          return () => `test-id-${++id}`;
+        })(),
+      },
+    });
+
+    const events: AgentEvent[] = [];
+    for await (const event of session.submit({ type: "text", text: "run execute_code" }, { maxTurns: 3 })) {
+      events.push(event);
+    }
+
+    const toolResult = events.find((event): event is Extract<AgentEvent, { type: "tool_result" }> =>
+      event.type === "tool_result" && event.result.toolName === "execute_code");
+    assert.ok(toolResult, "expected execute_code tool_result event");
+    assert.equal(toolResult.result.type, "success");
+    assert.match(toolResult.result.content.map(contentToText).join("\n"), /agent execute_code ok/);
+    assert.ok(events.some((event) => event.type === "tool_calls_detected" && event.calls.some((call) => call.name === "execute_code")));
+    assert.ok(events.some((event) => event.type === "turn_completed" && event.result.type === "success"));
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+});

--- a/tests/agent/invalidToolLoopRecovery.spec.ts
+++ b/tests/agent/invalidToolLoopRecovery.spec.ts
@@ -1,0 +1,133 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { createAgentSession } from "../../src/agent/index.js";
+import type { AgentEvent } from "../../src/agent/protocol/events.js";
+import type { AgentRouterRuntime } from "../../src/agent/runtime/AgentRuntimeDependencies.js";
+import type { CanonicalModelEvent, CanonicalModelRequest } from "../../src/model/index.js";
+import { createDefaultPermissionContext } from "../../src/permission/index.js";
+import type { RouterDecision } from "../../src/router/index.js";
+import { createBuiltinRegistry } from "../../src/tool/registry/createBuiltinRegistry.js";
+
+type ScriptedResponse =
+  | { type: "tool"; input: Record<string, unknown>; id?: string }
+  | { type: "text"; text: string };
+
+function createScriptedRouter(responses: ScriptedResponse[], requests: CanonicalModelRequest[]): AgentRouterRuntime {
+  let responseIndex = 0;
+  return {
+    decide: async ({ request }) => ({
+      provider: request.provider,
+      model: request.model,
+      scenarioType: "default",
+      isSubagent: false,
+      orchestrating: false,
+      resolvedFrom: "explicit",
+      mutations: {},
+    } satisfies RouterDecision),
+    execute: async function* (_decision: RouterDecision, request: CanonicalModelRequest): AsyncIterable<CanonicalModelEvent> {
+      requests.push(request);
+      const response = responses[Math.min(responseIndex, responses.length - 1)]!;
+      responseIndex += 1;
+      yield { type: "message_start", role: "assistant" };
+      if (response.type === "text") {
+        yield { type: "text_delta", text: response.text };
+        yield { type: "message_end", finishReason: "stop" };
+        return;
+      }
+      const id = response.id ?? `invalid-execute-code-${responseIndex}`;
+      const toolCall = { id, name: "execute_code", input: response.input };
+      yield { type: "tool_call_start", id: toolCall.id, name: toolCall.name };
+      yield { type: "tool_call_end", toolCall };
+      yield { type: "message_end", finishReason: "tool_call" };
+    },
+    stream: async function* (): AsyncIterable<CanonicalModelEvent> {
+      yield { type: "message_start", role: "assistant" };
+      yield { type: "message_end", finishReason: "stop" };
+    },
+  };
+}
+
+async function runScriptedAgent(responses: ScriptedResponse[], maxTurns: number): Promise<{
+  events: AgentEvent[];
+  requests: CanonicalModelRequest[];
+}> {
+  const cwd = await mkdtemp(path.join(tmpdir(), "pilotdeck-invalid-loop-"));
+  const requests: CanonicalModelRequest[] = [];
+  try {
+    const registry = createBuiltinRegistry({ webSearch: false, webFetch: false, agent: false, askUserQuestion: false });
+    const session = createAgentSession({
+      sessionId: "invalid-tool-loop-session",
+      config: {
+        provider: "test",
+        model: "fake-model",
+        cwd,
+        permissionMode: "bypassPermissions",
+        permissionContext: createDefaultPermissionContext({ cwd, mode: "bypassPermissions", canPrompt: false }),
+      },
+      dependencies: {
+        router: createScriptedRouter(responses, requests),
+        tools: { registry },
+        now: () => new Date("2026-07-04T00:00:00.000Z"),
+        uuid: (() => {
+          let id = 0;
+          return () => `test-id-${++id}`;
+        })(),
+      },
+    });
+
+    const events: AgentEvent[] = [];
+    for await (const event of session.submit({ type: "text", text: "exercise invalid tool recovery" }, { maxTurns })) {
+      events.push(event);
+    }
+    return { events, requests };
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+}
+
+function requestText(request: CanonicalModelRequest): string {
+  return request.messages
+    .flatMap((message) => message.content)
+    .filter((block) => block.type === "text")
+    .map((block) => block.text)
+    .join("\n");
+}
+
+test("repeated identical invalid tool inputs receive one grace prompt before circuit-breaking", async () => {
+  const invalidMissingCode = { description: "missing required code" };
+  const { events, requests } = await runScriptedAgent([
+    { type: "tool", input: invalidMissingCode },
+    { type: "tool", input: invalidMissingCode },
+    { type: "tool", input: invalidMissingCode },
+    { type: "tool", input: invalidMissingCode },
+  ], 8);
+
+  assert.equal(events.filter((event) => event.type === "tool_result" && event.result.type === "error").length, 4);
+  assert.equal(events.filter((event) => event.type === "turn_continued" && event.reason === "model_error").length, 1);
+  assert.ok(
+    requests.some((request) => requestText(request).includes("Your last several tool calls all failed input validation with the same error.")),
+    "expected the follow-up model request to include the invalid-input grace prompt",
+  );
+  const failed = events.find((event): event is Extract<AgentEvent, { type: "turn_failed" }> => event.type === "turn_failed");
+  assert.ok(failed, "expected repeated identical invalid inputs to eventually fail");
+  assert.equal(failed.error.code, "agent_tool_error_loop");
+  assert.match(failed.error.message, /identical tool input validation failures/);
+});
+
+test("changed invalid fingerprints do not consume the repeated-invalid grace period", async () => {
+  const { events, requests } = await runScriptedAgent([
+    { type: "tool", input: { description: "missing required code" } },
+    { type: "tool", input: { code: 123 } },
+    { type: "tool", input: { description: "missing required code" } },
+    { type: "text", text: "I changed strategy instead of repeating the invalid call." },
+  ], 8);
+
+  assert.equal(events.filter((event) => event.type === "turn_continued" && event.reason === "model_error").length, 0);
+  assert.ok(!requests.some((request) => requestText(request).includes("Your last several tool calls all failed input validation")));
+  assert.ok(!events.some((event) => event.type === "turn_failed"));
+  assert.ok(events.some((event) => event.type === "turn_completed" && event.result.type === "success"));
+});
+

--- a/tests/model/streaming/parseTextToolCalls.spec.ts
+++ b/tests/model/streaming/parseTextToolCalls.spec.ts
@@ -1,0 +1,104 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { extractTextToolCalls } from "../../../src/model/streaming/parseTextToolCalls.js";
+
+test("Qwen XML fallback extracts complete function calls", () => {
+  const parsed = extractTextToolCalls(
+    "<function=bash><parameter=command>echo hi</parameter></function>",
+  );
+
+  assert.equal(parsed.toolCalls.length, 1);
+  assert.equal(parsed.toolCalls[0]?.name, "bash");
+  assert.deepEqual(parsed.toolCalls[0]?.input, { command: "echo hi" });
+  assert.equal(parsed.partialToolCall, undefined);
+});
+
+test("orphan Qwen XML closing tags are partial, not executable", () => {
+  const parsed = extractTextToolCalls("</parameter>\n</function>");
+
+  assert.equal(parsed.toolCalls.length, 0);
+  assert.equal(parsed.partialToolCall?.format, "qwen_xml");
+  assert.equal(parsed.partialToolCall?.reason, "orphan_qwen_function_close");
+});
+
+test("orphan Qwen XML parameters are partial, not executable", () => {
+  const parsed = extractTextToolCalls("<parameter=description>x</parameter>\n</function>");
+
+  assert.equal(parsed.toolCalls.length, 0);
+  assert.equal(parsed.partialToolCall?.format, "qwen_xml");
+  assert.equal(parsed.partialToolCall?.reason, "orphan_qwen_parameter");
+});
+
+test("Qwen XML fallback records dangling fragments after complete calls", () => {
+  const parsed = extractTextToolCalls(
+    "<function=bash><parameter=command>echo hi</parameter></function>\n</parameter>\n</function>",
+  );
+
+  assert.equal(parsed.toolCalls.length, 1);
+  assert.equal(parsed.toolCalls[0]?.name, "bash");
+  assert.equal(parsed.partialToolCall?.format, "qwen_xml");
+  assert.equal(parsed.partialToolCall?.reason, "orphan_qwen_function_close");
+});
+
+test("better0626 isolated Qwen XML fragments are all classified as partial", () => {
+  const samples = [
+    { text: "\n\n\n</parameter>\n</function>\n", reason: "orphan_qwen_function_close" },
+    { text: "\n\n</parameter>\n</function>\n", reason: "orphan_qwen_function_close" },
+    { text: "\n</parameter>\n</function>\n", reason: "orphan_qwen_function_close" },
+    {
+      text: "\n\n</parameter>\n<parameter=timeout>\n30000\n</parameter>\n<parameter=description>\nWrite improved solve script v2\n</parameter>\n</parameter>\n</function>\n",
+      reason: "orphan_qwen_parameter",
+    },
+    {
+      text: "</parameter>\n<parameter=description>\nRun solve3 to see the error\n</parameter>\n<parameter=description>\nCheck solve3 error\n</parameter>\n</function>",
+      reason: "orphan_qwen_parameter",
+    },
+    {
+      text: "\n</parameter>\n<parameter=description>\nExtract metadata from video container\n</parameter>\n</function>\n",
+      reason: "orphan_qwen_parameter",
+    },
+  ];
+
+  for (const sample of samples) {
+    const parsed = extractTextToolCalls(sample.text);
+    assert.equal(parsed.toolCalls.length, 0);
+    assert.equal(parsed.partialToolCall?.format, "qwen_xml");
+    assert.equal(parsed.partialToolCall?.reason, sample.reason);
+  }
+});
+
+test("orphan Hermes XML closing tags are partial, not executable", () => {
+  const parsed = extractTextToolCalls("</tool_call>");
+
+  assert.equal(parsed.toolCalls.length, 0);
+  assert.equal(parsed.partialToolCall?.format, "hermes_json");
+  assert.equal(parsed.partialToolCall?.reason, "orphan_hermes_tool_call_close");
+});
+
+test("Hermes XML fallback records dangling fragments after complete calls", () => {
+  const parsed = extractTextToolCalls(
+    '<tool_call>{"name":"read","arguments":{"path":"a.txt"}}</tool_call>\n</tool_call>',
+  );
+
+  assert.equal(parsed.toolCalls.length, 1);
+  assert.equal(parsed.toolCalls[0]?.name, "read");
+  assert.equal(parsed.partialToolCall?.format, "hermes_json");
+  assert.equal(parsed.partialToolCall?.reason, "orphan_hermes_tool_call_close");
+});
+
+test("orphan DSML XML fragments are partial, not executable", () => {
+  const parsed = extractTextToolCalls("</｜DSML｜invoke>\n</｜DSML｜tool_calls>");
+
+  assert.equal(parsed.toolCalls.length, 0);
+  assert.equal(parsed.partialToolCall?.format, "deepseek_dsml");
+  assert.equal(parsed.partialToolCall?.reason, "orphan_dsml_tool_call_close");
+});
+
+test("orphan DSML parameters are partial, not executable", () => {
+  const parsed = extractTextToolCalls('<｜DSML｜parameter name="path">a.txt</content>\n</｜DSML｜invoke>');
+
+  assert.equal(parsed.toolCalls.length, 0);
+  assert.equal(parsed.partialToolCall?.format, "deepseek_dsml");
+  assert.equal(parsed.partialToolCall?.reason, "orphan_dsml_parameter");
+});

--- a/tests/tool/executeCode.spec.ts
+++ b/tests/tool/executeCode.spec.ts
@@ -1,0 +1,379 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { PermissionRuntime, createDefaultPermissionContext } from "../../src/permission/index.js";
+import {
+  handleExecuteCodeRpcLineForTests,
+  setExecuteCodeTransportOverrideForTests,
+} from "../../src/tool/builtin/executeCode.js";
+import { ToolRuntime } from "../../src/tool/execution/ToolRuntime.js";
+import { createBuiltinRegistry } from "../../src/tool/registry/createBuiltinRegistry.js";
+import { ToolRegistry } from "../../src/tool/registry/ToolRegistry.js";
+import type { PilotDeckToolCall, PilotDeckToolDefinition, PilotDeckToolRuntimeContext } from "../../src/tool/index.js";
+
+function createContext(cwd: string, overrides: Partial<PilotDeckToolRuntimeContext> = {}): PilotDeckToolRuntimeContext {
+  return {
+    sessionId: "test-session",
+    turnId: "test-turn",
+    cwd,
+    permissionMode: "bypassPermissions",
+    permissionContext: createDefaultPermissionContext({ cwd, mode: "bypassPermissions", canPrompt: false }),
+    ...overrides,
+  };
+}
+
+async function execute(call: PilotDeckToolCall, context: PilotDeckToolRuntimeContext) {
+  const runtime = new ToolRuntime(createBuiltinRegistry({ webSearch: false, webFetch: false, agent: false, askUserQuestion: false }), new PermissionRuntime());
+  return runtime.execute(call, context);
+}
+
+function data(result: Awaited<ReturnType<typeof execute>>) {
+  assert.equal(result.type, "success");
+  return result.data as { status: string; output: string; error?: string; tool_calls_made: number; tool_call_log: Array<{ tool: string; ok: boolean }> };
+}
+
+async function withTransportOverride<T>(kind: "uds" | "tcp", run: () => Promise<T>): Promise<T> {
+  setExecuteCodeTransportOverrideForTests(kind);
+  try {
+    return await run();
+  } finally {
+    setExecuteCodeTransportOverrideForTests(undefined);
+  }
+}
+
+test("execute_code returns stdout from Python", async () => {
+  const cwd = await mkdtemp(path.join(tmpdir(), "pilotdeck-execute-code-hello-"));
+  try {
+    const result = await execute({ id: "call-1", name: "execute_code", input: { code: 'print("hello")' } }, createContext(cwd));
+    const output = data(result);
+    assert.equal(output.status, "success");
+    assert.match(output.output, /hello/);
+    assert.equal(output.tool_calls_made, 0);
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+});
+
+test("execute_code can call read_file through PilotDeck RPC", async () => {
+  const cwd = await mkdtemp(path.join(tmpdir(), "pilotdeck-execute-code-read-"));
+  try {
+    await writeFile(path.join(cwd, "note.txt"), "alpha\nbeta\n", "utf8");
+    const code = `from pilotdeck_tools import read_file\nresult = read_file("note.txt", offset=1, limit=1)\nprint(result["content"] if isinstance(result, dict) and "content" in result else result)`;
+    const result = await execute({ id: "call-2", name: "execute_code", input: { code } }, createContext(cwd));
+    const output = data(result);
+    assert.equal(output.status, "success");
+    assert.match(output.output, /alpha/);
+    assert.equal(output.tool_calls_made, 1);
+    assert.equal(output.tool_call_log[0]?.tool, "read_file");
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+});
+
+test("execute_code exposes write helpers but keeps unsafe helpers unavailable", async () => {
+  const cwd = await mkdtemp(path.join(tmpdir(), "pilotdeck-execute-code-blocked-"));
+  try {
+    const code = `import pilotdeck_tools
+print(hasattr(pilotdeck_tools, "write_file"))
+print(hasattr(pilotdeck_tools, "edit_file"))
+print(hasattr(pilotdeck_tools, "agent"))
+print(hasattr(pilotdeck_tools, "execute_code"))
+print(hasattr(pilotdeck_tools, "task_create"))`;
+    const result = await execute({ id: "call-3", name: "execute_code", input: { code } }, createContext(cwd));
+    const output = data(result);
+    assert.equal(output.status, "success");
+    assert.match(output.output, /True\s+True\s+False\s+False\s+False/s);
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+});
+
+test("execute_code can create a file with write_file", async () => {
+  const cwd = await mkdtemp(path.join(tmpdir(), "pilotdeck-execute-code-write-new-"));
+  try {
+    const code = `from pilotdeck_tools import write_file
+write_file("new.txt", "hello from python\\n")
+print("created")`;
+    const result = await execute({ id: "call-write-new", name: "execute_code", input: { code } }, createContext(cwd));
+    const output = data(result);
+    assert.equal(output.status, "success");
+    assert.match(output.output, /created/);
+    assert.equal(output.tool_calls_made, 1);
+    assert.equal(output.tool_call_log[0]?.tool, "write_file");
+    assert.equal(await readFile(path.join(cwd, "new.txt"), "utf8"), "hello from python\n");
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+});
+
+test("execute_code requires read_file before overwriting an existing file", async () => {
+  const cwd = await mkdtemp(path.join(tmpdir(), "pilotdeck-execute-code-write-existing-"));
+  try {
+    await writeFile(path.join(cwd, "note.txt"), "old\n", "utf8");
+    const rejectedCode = `from pilotdeck_tools import write_file
+try:
+    write_file("note.txt", "new\\n")
+except Exception as exc:
+    print(str(exc))`;
+    const rejected = await execute({ id: "call-write-existing-reject", name: "execute_code", input: { code: rejectedCode } }, createContext(cwd));
+    const rejectedOutput = data(rejected);
+    assert.equal(rejectedOutput.status, "success");
+    assert.match(rejectedOutput.output, /File has not been read yet/);
+    assert.equal(await readFile(path.join(cwd, "note.txt"), "utf8"), "old\n");
+
+    const acceptedCode = `from pilotdeck_tools import read_file, write_file
+read_file("note.txt")
+write_file("note.txt", "new\\n")
+print("updated")`;
+    const accepted = await execute({ id: "call-write-existing-accept", name: "execute_code", input: { code: acceptedCode } }, createContext(cwd));
+    const acceptedOutput = data(accepted);
+    assert.equal(acceptedOutput.status, "success");
+    assert.match(acceptedOutput.output, /updated/);
+    assert.equal(acceptedOutput.tool_calls_made, 2);
+    assert.deepEqual(acceptedOutput.tool_call_log.map((entry) => entry.tool), ["read_file", "write_file"]);
+    assert.equal(await readFile(path.join(cwd, "note.txt"), "utf8"), "new\n");
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+});
+
+test("execute_code can edit an existing file after read_file", async () => {
+  const cwd = await mkdtemp(path.join(tmpdir(), "pilotdeck-execute-code-edit-"));
+  try {
+    await writeFile(path.join(cwd, "note.txt"), "alpha\nbeta\n", "utf8");
+    const code = `from pilotdeck_tools import read_file, edit_file
+read_file("note.txt")
+edit_file("note.txt", "beta", "gamma")
+print("edited")`;
+    const result = await execute({ id: "call-edit", name: "execute_code", input: { code } }, createContext(cwd));
+    const output = data(result);
+    assert.equal(output.status, "success");
+    assert.match(output.output, /edited/);
+    assert.equal(output.tool_calls_made, 2);
+    assert.deepEqual(output.tool_call_log.map((entry) => entry.tool), ["read_file", "edit_file"]);
+    assert.equal(await readFile(path.join(cwd, "note.txt"), "utf8"), "alpha\ngamma\n");
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+});
+
+test("execute_code enforces max_tool_calls", async () => {
+  const cwd = await mkdtemp(path.join(tmpdir(), "pilotdeck-execute-code-limit-"));
+  try {
+    await writeFile(path.join(cwd, "note.txt"), "alpha\n", "utf8");
+    const code = `from pilotdeck_tools import read_file\nprint(read_file("note.txt")["content"])\ntry:\n    read_file("note.txt")\nexcept Exception as exc:\n    print(str(exc))`;
+    const result = await execute({ id: "call-4", name: "execute_code", input: { code, max_tool_calls: 1 } }, createContext(cwd));
+    const output = data(result);
+    assert.equal(output.status, "success");
+    assert.match(output.output, /Tool call limit reached/);
+    assert.equal(output.tool_calls_made, 1);
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+});
+
+test("execute_code kills timed out scripts", async () => {
+  const cwd = await mkdtemp(path.join(tmpdir(), "pilotdeck-execute-code-timeout-"));
+  try {
+    const result = await execute(
+      { id: "call-5", name: "execute_code", input: { code: "import time\ntime.sleep(5)", timeout_seconds: 1 } },
+      createContext(cwd),
+    );
+    const output = data(result);
+    assert.equal(output.status, "timeout");
+    assert.match(output.error ?? "", /timed out/);
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+});
+
+test("execute_code filters secret-like environment variables", async () => {
+  const cwd = await mkdtemp(path.join(tmpdir(), "pilotdeck-execute-code-env-"));
+  try {
+    const result = await execute(
+      { id: "call-6", name: "execute_code", input: { code: 'import os\nprint(os.environ.get("OPENAI_API_KEY"))' } },
+      createContext(cwd, { env: { ...process.env, OPENAI_API_KEY: "secret-value" } }),
+    );
+    const output = data(result);
+    assert.equal(output.status, "success");
+    assert.match(output.output, /None/);
+    assert.doesNotMatch(output.output, /secret-value/);
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+});
+
+test("execute_code nested bash still goes through permission runtime", async () => {
+  const registry = new ToolRegistry();
+  registry.register(createBuiltinRegistry({ webSearch: false, webFetch: false, agent: false, askUserQuestion: false }).get("execute_code")!);
+  registry.register({
+    name: "bash",
+    description: "test bash",
+    kind: "shell",
+    inputSchema: { type: "object", required: ["command"], additionalProperties: false, properties: { command: { type: "string" } } },
+    isReadOnly: () => false,
+    isConcurrencySafe: () => false,
+    checkPermissions: async () => ({
+      type: "deny",
+      reason: { type: "runtime", message: "blocked in test" },
+      message: "blocked in test",
+    }),
+    execute: async () => ({ content: [{ type: "text", text: "should not run" }] }),
+  } satisfies PilotDeckToolDefinition);
+  const runtime = new ToolRuntime(registry, new PermissionRuntime());
+  const cwd = await mkdtemp(path.join(tmpdir(), "pilotdeck-execute-code-perm-"));
+  try {
+    const result = await runtime.execute(
+      {
+        id: "call-7",
+        name: "execute_code",
+        input: { code: 'from pilotdeck_tools import bash\ntry:\n    bash("echo no")\nexcept Exception as exc:\n    print(str(exc))' },
+      },
+      createContext(cwd),
+    );
+    const output = data(result);
+    assert.equal(output.status, "success");
+    assert.match(output.output, /blocked in test/);
+    assert.equal(output.tool_calls_made, 1);
+    assert.equal(output.tool_call_log[0]?.ok, false);
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+});
+
+test("execute_code nested write_file still goes through permission runtime", async () => {
+  let executed = false;
+  const registry = new ToolRegistry();
+  registry.register(createBuiltinRegistry({ webSearch: false, webFetch: false, agent: false, askUserQuestion: false }).get("execute_code")!);
+  registry.register({
+    name: "write_file",
+    description: "test write_file",
+    kind: "filesystem",
+    inputSchema: {
+      type: "object",
+      required: ["file_path", "content"],
+      additionalProperties: false,
+      properties: { file_path: { type: "string" }, content: { type: "string" } },
+    },
+    isReadOnly: () => false,
+    isConcurrencySafe: () => false,
+    checkPermissions: async () => ({
+      type: "deny",
+      reason: { type: "runtime", message: "write blocked in test" },
+      message: "write blocked in test",
+    }),
+    execute: async () => {
+      executed = true;
+      return { content: [{ type: "text", text: "should not write" }] };
+    },
+  } satisfies PilotDeckToolDefinition);
+  const runtime = new ToolRuntime(registry, new PermissionRuntime());
+  const cwd = await mkdtemp(path.join(tmpdir(), "pilotdeck-execute-code-write-perm-"));
+  try {
+    const result = await runtime.execute(
+      {
+        id: "call-write-perm",
+        name: "execute_code",
+        input: { code: 'from pilotdeck_tools import write_file\ntry:\n    write_file("no.txt", "no")\nexcept Exception as exc:\n    print(str(exc))' },
+      },
+      createContext(cwd),
+    );
+    const output = data(result);
+    assert.equal(output.status, "success");
+    assert.match(output.output, /write blocked in test/);
+    assert.equal(output.tool_calls_made, 1);
+    assert.equal(output.tool_call_log[0]?.tool, "write_file");
+    assert.equal(output.tool_call_log[0]?.ok, false);
+    assert.equal(executed, false);
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+});
+
+test("execute_code TCP transport returns stdout", async () => {
+  await withTransportOverride("tcp", async () => {
+    const cwd = await mkdtemp(path.join(tmpdir(), "pilotdeck-execute-code-tcp-stdout-"));
+    try {
+      const result = await execute({ id: "call-tcp-stdout", name: "execute_code", input: { code: 'print("tcp hello")' } }, createContext(cwd));
+      const output = data(result);
+      assert.equal(output.status, "success");
+      assert.match(output.output, /tcp hello/);
+      assert.equal(output.tool_calls_made, 0);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+});
+
+test("execute_code TCP transport can call read_file", async () => {
+  await withTransportOverride("tcp", async () => {
+    const cwd = await mkdtemp(path.join(tmpdir(), "pilotdeck-execute-code-tcp-read-"));
+    try {
+      await writeFile(path.join(cwd, "note.txt"), "tcp alpha\n", "utf8");
+      const code = `from pilotdeck_tools import read_file\nprint(read_file("note.txt")["content"])`;
+      const result = await execute({ id: "call-tcp-read", name: "execute_code", input: { code } }, createContext(cwd));
+      const output = data(result);
+      assert.equal(output.status, "success");
+      assert.match(output.output, /tcp alpha/);
+      assert.equal(output.tool_calls_made, 1);
+      assert.equal(output.tool_call_log[0]?.tool, "read_file");
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+});
+
+test("execute_code TCP transport injects loopback env", async () => {
+  await withTransportOverride("tcp", async () => {
+    const cwd = await mkdtemp(path.join(tmpdir(), "pilotdeck-execute-code-tcp-env-"));
+    try {
+      const code = 'import os\nprint(os.environ.get("PILOTDECK_RPC_HOST"))\nprint(os.environ.get("PILOTDECK_RPC_PORT", "").isdigit())\nprint(len(os.environ.get("PILOTDECK_RPC_TOKEN", "")) > 20)\nprint(os.environ.get("PILOTDECK_RPC_SOCKET"))';
+      const result = await execute({ id: "call-tcp-env", name: "execute_code", input: { code } }, createContext(cwd));
+      const output = data(result);
+      assert.equal(output.status, "success");
+      assert.match(output.output, /127\.0\.0\.1\s+True\s+True\s+None/s);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+});
+
+test("execute_code UDS transport injects socket env", async () => {
+  await withTransportOverride("uds", async () => {
+    const cwd = await mkdtemp(path.join(tmpdir(), "pilotdeck-execute-code-uds-env-"));
+    try {
+      const code = 'import os\nprint(bool(os.environ.get("PILOTDECK_RPC_SOCKET")))\nprint(os.environ.get("PILOTDECK_RPC_HOST"))\nprint(os.environ.get("PILOTDECK_RPC_TOKEN"))';
+      const result = await execute({ id: "call-uds-env", name: "execute_code", input: { code } }, createContext(cwd));
+      const output = data(result);
+      assert.equal(output.status, "success");
+      assert.match(output.output, /True\s+None\s+None/s);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+});
+
+test("execute_code TCP RPC rejects invalid token before executing tools", async () => {
+  let executed = false;
+  const response = await handleExecuteCodeRpcLineForTests(
+    JSON.stringify({ token: "wrong", tool: "read_file", args: { file_path: "note.txt" } }),
+    {
+      expectedToken: "correct",
+      executeTool: async () => {
+        executed = true;
+        return {
+          type: "success",
+          toolCallId: "nested",
+          toolName: "read_file",
+          content: [{ type: "text", text: "should not run" }],
+          startedAt: new Date().toISOString(),
+          completedAt: new Date().toISOString(),
+        };
+      },
+    },
+  );
+  assert.equal(response.code, "invalid_rpc_token");
+  assert.equal(executed, false);
+});

--- a/tests/tool/executeCode.spec.ts
+++ b/tests/tool/executeCode.spec.ts
@@ -107,6 +107,29 @@ print(os.environ.get("OPENROUTER_API_KEY") == "test-openrouter-secret")`;
   }
 });
 
+test("execute_code accepts optional description and ignores it", async () => {
+  const cwd = await mkdtemp(path.join(tmpdir(), "pilotdeck-execute-code-description-"));
+  try {
+    const result = await execute(
+      {
+        id: "call-description",
+        name: "execute_code",
+        input: {
+          code: 'print("description ignored")',
+          description: "This field should not affect execution or leak into metadata.",
+        },
+      },
+      createContext(cwd),
+    );
+    const output = data(result);
+    assert.equal(output.status, "success");
+    assert.match(output.output, /description ignored/);
+    assert.doesNotMatch(JSON.stringify(result.metadata), /This field should not affect execution/);
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+});
+
 test("execute_code rejects invalid Python syntax before execution", async () => {
   const cwd = await mkdtemp(path.join(tmpdir(), "pilotdeck-execute-code-syntax-"));
   try {

--- a/tests/tool/executeCode.spec.ts
+++ b/tests/tool/executeCode.spec.ts
@@ -56,6 +56,69 @@ test("execute_code returns stdout from Python", async () => {
   }
 });
 
+test("execute_code runs from workspace cwd and preserves helper imports", async () => {
+  const cwd = await mkdtemp(path.join(tmpdir(), "pilotdeck-execute-code-cwd-"));
+  try {
+    const code = `import os
+import pilotdeck_tools
+print(os.getcwd())
+print(os.environ.get("PILOTDECK_WORKSPACE_CWD"))
+print(os.environ.get("PILOTDECK_EXECUTE_CODE_TEMP_ROOT") in os.environ.get("PYTHONPATH", "").split(os.pathsep))
+print(hasattr(pilotdeck_tools, "read_file"))`;
+    const result = await execute({ id: "call-cwd", name: "execute_code", input: { code } }, createContext(cwd));
+    const output = data(result);
+    assert.equal(output.status, "success");
+    assert.match(output.output, new RegExp(`${cwd.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\s+${cwd.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\s+True\\s+True`, "s"));
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+});
+
+test("execute_code fully inherits runtime env including API and proxy variables", async () => {
+  const cwd = await mkdtemp(path.join(tmpdir(), "pilotdeck-execute-code-env-"));
+  try {
+    const inheritedEnv: NodeJS.ProcessEnv = {
+      ...process.env,
+      OPENROUTER_API_KEY: "test-openrouter-secret",
+      DASHSCOPE_API_KEY: "test-dashscope-secret",
+      TAVILY_API_KEY: "test-tavily-secret",
+      HTTP_PROXY: "http://127.0.0.1:17890",
+      HTTPS_PROXY: "http://127.0.0.1:17890",
+      NO_PROXY: "localhost,127.0.0.1",
+      PYTHONPATH: "/existing/pythonpath",
+    };
+    const code = `import os
+names = ["OPENROUTER_API_KEY", "DASHSCOPE_API_KEY", "TAVILY_API_KEY", "HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY"]
+print(" ".join("present" if os.environ.get(name) else "missing" for name in names))
+parts = os.environ.get("PYTHONPATH", "").split(os.pathsep)
+print(parts[0] == os.environ.get("PILOTDECK_EXECUTE_CODE_TEMP_ROOT"))
+print("/existing/pythonpath" in parts)
+print(os.environ.get("OPENROUTER_API_KEY") == "test-openrouter-secret")`;
+    const result = await execute(
+      { id: "call-env", name: "execute_code", input: { code } },
+      createContext(cwd, { env: inheritedEnv }),
+    );
+    const output = data(result);
+    assert.equal(output.status, "success");
+    assert.match(output.output, /present present present present present present\s+True\s+True\s+True/s);
+    assert.doesNotMatch(output.output, /test-(openrouter|dashscope|tavily)-secret/);
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+});
+
+test("execute_code rejects invalid Python syntax before execution", async () => {
+  const cwd = await mkdtemp(path.join(tmpdir(), "pilotdeck-execute-code-syntax-"));
+  try {
+    const result = await execute({ id: "call-syntax", name: "execute_code", input: { code: "def broken(:\n    pass" } }, createContext(cwd));
+    assert.equal(result.type, "error");
+    assert.equal(result.error.code, "invalid_tool_input");
+    assert.match(result.error.details?.issues ? JSON.stringify(result.error.details.issues) : "", /Python syntax error/);
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+});
+
 test("execute_code can call read_file through PilotDeck RPC", async () => {
   const cwd = await mkdtemp(path.join(tmpdir(), "pilotdeck-execute-code-read-"));
   try {
@@ -189,17 +252,21 @@ test("execute_code kills timed out scripts", async () => {
   }
 });
 
-test("execute_code filters secret-like environment variables", async () => {
-  const cwd = await mkdtemp(path.join(tmpdir(), "pilotdeck-execute-code-env-"));
+test("execute_code inherits secret-like environment variables without exposing them in metadata", async () => {
+  const cwd = await mkdtemp(path.join(tmpdir(), "pilotdeck-execute-code-secret-env-"));
   try {
     const result = await execute(
-      { id: "call-6", name: "execute_code", input: { code: 'import os\nprint(os.environ.get("OPENAI_API_KEY"))' } },
+      { id: "call-6", name: "execute_code", input: { code: 'import os\nprint(os.environ.get("OPENAI_API_KEY") == "secret-value")' } },
       createContext(cwd, { env: { ...process.env, OPENAI_API_KEY: "secret-value" } }),
     );
     const output = data(result);
     assert.equal(output.status, "success");
-    assert.match(output.output, /None/);
+    assert.match(output.output, /True/);
     assert.doesNotMatch(output.output, /secret-value/);
+    assert.equal(result.metadata?.env_inheritance, "full");
+    assert.equal(result.metadata?.cwd, cwd);
+    assert.equal(result.metadata?.python_path_augmented, true);
+    assert.doesNotMatch(JSON.stringify(result.metadata), /secret-value/);
   } finally {
     await rm(cwd, { recursive: true, force: true });
   }

--- a/tests/tool/executeCode.spec.ts
+++ b/tests/tool/executeCode.spec.ts
@@ -158,6 +158,45 @@ test("execute_code can call read_file through PilotDeck RPC", async () => {
   }
 });
 
+test("execute_code maps web_search country helper argument to gl", async () => {
+  let capturedInput: unknown;
+  const registry = new ToolRegistry();
+  registry.register(createBuiltinRegistry({ webSearch: false, webFetch: false, agent: false, askUserQuestion: false }).get("execute_code")!);
+  registry.register({
+    name: "web_search",
+    description: "test web search",
+    kind: "network",
+    inputSchema: {
+      type: "object",
+      required: ["query"],
+      additionalProperties: false,
+      properties: {
+        query: { type: "string" },
+        gl: { type: "string" },
+      },
+    },
+    isReadOnly: () => true,
+    isConcurrencySafe: () => true,
+    execute: async (input) => {
+      capturedInput = input;
+      return { content: [{ type: "text", text: "search ok" }], data: { organic: [] } };
+    },
+  } satisfies PilotDeckToolDefinition);
+  const runtime = new ToolRuntime(registry, new PermissionRuntime());
+  const cwd = await mkdtemp(path.join(tmpdir(), "pilotdeck-execute-code-web-search-"));
+  try {
+    const code = 'from pilotdeck_tools import web_search\nprint(web_search("docs", country="cn")["content"])';
+    const result = await runtime.execute({ id: "call-web-search", name: "execute_code", input: { code } }, createContext(cwd));
+    const output = data(result);
+    assert.equal(output.status, "success");
+    assert.deepEqual(capturedInput, { query: "docs", gl: "cn" });
+    assert.equal(output.tool_call_log[0]?.tool, "web_search");
+    assert.equal(output.tool_call_log[0]?.ok, true);
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+});
+
 test("execute_code exposes write helpers but keeps unsafe helpers unavailable", async () => {
   const cwd = await mkdtemp(path.join(tmpdir(), "pilotdeck-execute-code-blocked-"));
   try {

--- a/tests/tool/executeCode.spec.ts
+++ b/tests/tool/executeCode.spec.ts
@@ -24,6 +24,15 @@ function createContext(cwd: string, overrides: Partial<PilotDeckToolRuntimeConte
   };
 }
 
+function createAskContext(cwd: string, overrides: Partial<PilotDeckToolRuntimeContext> = {}): PilotDeckToolRuntimeContext {
+  return createContext(cwd, {
+    permissionMode: "default",
+    permissionContext: createDefaultPermissionContext({ cwd, mode: "default", canPrompt: false }),
+    runMode: "ask",
+    ...overrides,
+  });
+}
+
 async function execute(call: PilotDeckToolCall, context: PilotDeckToolRuntimeContext) {
   const runtime = new ToolRuntime(createBuiltinRegistry({ webSearch: false, webFetch: false, agent: false, askUserQuestion: false }), new PermissionRuntime());
   return runtime.execute(call, context);
@@ -195,6 +204,87 @@ test("execute_code maps web_search country helper argument to gl", async () => {
   } finally {
     await rm(cwd, { recursive: true, force: true });
   }
+});
+
+test("execute_code allows read-only scripts in ask mode", async () => {
+  const cwd = await mkdtemp(path.join(tmpdir(), "pilotdeck-execute-code-ask-read-"));
+  try {
+    await writeFile(path.join(cwd, "note.txt"), "ask alpha\n", "utf8");
+    const code = `from pilotdeck_tools import read_file, grep, bash
+print(read_file("note.txt")["content"])
+print(grep("alpha", path="note.txt")["content"])
+print(bash("pwd")["content"])`;
+    const result = await execute({ id: "call-ask-read", name: "execute_code", input: { code } }, createAskContext(cwd));
+    const output = data(result);
+    assert.equal(output.status, "success");
+    assert.match(output.output, /ask alpha/);
+    assert.deepEqual(output.tool_call_log.map((entry) => entry.tool), ["read_file", "grep", "bash"]);
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+});
+
+test("execute_code blocks write-capable scripts in ask mode", async () => {
+  const cwd = await mkdtemp(path.join(tmpdir(), "pilotdeck-execute-code-ask-write-"));
+  try {
+    const result = await execute(
+      { id: "call-ask-write", name: "execute_code", input: { code: 'from pilotdeck_tools import write_file\nwrite_file("note.txt", "no")' } },
+      createAskContext(cwd),
+    );
+    assert.equal(result.type, "error");
+    assert.equal(result.error.code, "ask_mode_violation");
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+});
+
+test("execute_code web_fetch helper preserves web_fetch default mode", async () => {
+  const registry = new ToolRegistry();
+  registry.register(createBuiltinRegistry({ webSearch: false, webFetch: false, agent: false, askUserQuestion: false }).get("execute_code")!);
+  registry.register({
+    name: "web_fetch",
+    description: "test web_fetch",
+    kind: "network",
+    inputSchema: { type: "object", required: ["url"], additionalProperties: false, properties: { url: { type: "string" }, mode: { type: "string" }, prompt: { type: "string" } } },
+    isReadOnly: () => true,
+    isConcurrencySafe: () => true,
+    execute: async (input: { url: string; mode?: string; prompt?: string }) => ({
+      content: [{ type: "text", text: JSON.stringify(input) }],
+      data: input,
+    }),
+  } satisfies PilotDeckToolDefinition<{ url: string; mode?: string; prompt?: string }, { url: string; mode?: string; prompt?: string }>);
+  const runtime = new ToolRuntime(registry, new PermissionRuntime());
+  const cwd = await mkdtemp(path.join(tmpdir(), "pilotdeck-execute-code-web-fetch-default-"));
+  try {
+    const result = await runtime.execute(
+      { id: "call-web-fetch-default", name: "execute_code", input: { code: 'from pilotdeck_tools import web_fetch\nprint(web_fetch("https://example.com")["data"])' } },
+      createContext(cwd),
+    );
+    const output = data(result);
+    assert.equal(output.status, "success");
+    assert.match(output.output, /'url': 'https:\/\/example\.com'/);
+    assert.doesNotMatch(output.output, /'mode': 'raw'/);
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+});
+
+test("execute_code web_fetch helper forwards explicit mode and prompt", async () => {
+  const response = await handleExecuteCodeRpcLineForTests(
+    JSON.stringify({ tool: "web_fetch", args: { url: "https://example.com", mode: "raw", prompt: "summarize" } }),
+    {
+      executeTool: async (call) => ({
+        type: "success",
+        toolCallId: call.id,
+        toolName: call.name,
+        content: [{ type: "text", text: "ok" }],
+        data: call.input,
+        startedAt: new Date().toISOString(),
+        completedAt: new Date().toISOString(),
+      }),
+    },
+  );
+  assert.deepEqual(response.data, { url: "https://example.com", mode: "raw", prompt: "summarize" });
 });
 
 test("execute_code exposes write helpers but keeps unsafe helpers unavailable", async () => {

--- a/tests/tool/todoWrite.spec.ts
+++ b/tests/tool/todoWrite.spec.ts
@@ -105,4 +105,87 @@ describe("todo_write", () => {
     assert.equal(result.data.todos[0]?.status, "cancelled");
     assert.equal(context.planTodo?.getSnapshot().todos[0]?.status, "cancelled");
   });
+
+  it("records todo history and diagnostics for structural changes", async () => {
+    const tool = createTodoWriteTool();
+    const context = createContext();
+
+    await tool.execute({
+      todos: [
+        { id: "inspect", content: "Inspect implementation", status: "completed" },
+        { id: "patch", content: "Patch implementation", status: "in_progress" },
+        { id: "verify", content: "Verify behavior", status: "pending" },
+      ],
+    }, context);
+
+    const rewrite = await tool.execute({
+      reason: "evidence changed the implementation route",
+      todos: [
+        { id: "new-route", content: "Use revised implementation route", status: "in_progress" },
+      ],
+    }, context);
+
+    assert.ok(rewrite.data?.diagnostics);
+    assert.equal(rewrite.data.diagnostics.writeCount, 2);
+    assert.equal(rewrite.data.diagnostics.largeRewriteCount, 1);
+    assert.equal(rewrite.data.diagnostics.deletedOpenItemCount, 2);
+    assert.equal(rewrite.data.diagnostics.lastWrite?.reason, "evidence changed the implementation route");
+    assert.equal(context.planTodo?.getSnapshot().todoHistory.length, 2);
+  });
+
+  it("exposes active todos separately from completed and cancelled todos", async () => {
+    const tool = createTodoWriteTool();
+    const context = createContext();
+
+    await tool.execute({
+      todos: [
+        { id: "done", content: "Already checked", status: "completed" },
+        { id: "skip", content: "Abandoned route", status: "cancelled" },
+        { id: "next", content: "Continue useful work", status: "pending" },
+      ],
+    }, context);
+
+    assert.deepEqual(context.planTodo?.getSnapshot().activeTodos, [
+      { id: "next", content: "Continue useful work", status: "pending" },
+    ]);
+  });
+
+  it("does not put completed or cancelled todos in active todo context", async () => {
+    const planTodo = createPlanTodoStateManager().forSession("plan-session");
+    planTodo.markPlanApproved("approved plan");
+    planTodo.writeTodos([
+      { id: "done", content: "Completed work", status: "completed" },
+      { id: "old", content: "Cancelled route", status: "cancelled" },
+      { id: "now", content: "Current work", status: "in_progress" },
+    ]);
+
+    const snapshot = planTodo.getSnapshot();
+    assert.deepEqual(snapshot.activeTodos, [
+      { id: "now", content: "Current work", status: "in_progress" },
+    ]);
+    assert.equal(snapshot.todoHistory.length, 1);
+    assert.equal(snapshot.todoDiagnostics.cancelledCount, 1);
+  });
+
+  it("flags all-completed updates after active work", async () => {
+    const tool = createTodoWriteTool();
+    const context = createContext();
+
+    await tool.execute({
+      todos: [
+        { id: "build", content: "Build output", status: "in_progress" },
+        { id: "verify", content: "Verify output", status: "pending" },
+      ],
+    }, context);
+    const done = await tool.execute({
+      merge: true,
+      todos: [
+        { id: "build", content: "Build output", status: "completed" },
+        { id: "verify", content: "Verify output", status: "completed" },
+      ],
+    }, context);
+
+    assert.equal(done.data?.diagnostics?.completedWithoutActiveCount, 1);
+    assert.equal(done.data?.diagnostics?.lastWrite?.allCompleted, true);
+  });
 });

--- a/tests/tool/todoWrite.spec.ts
+++ b/tests/tool/todoWrite.spec.ts
@@ -90,6 +90,27 @@ describe("todo_write", () => {
     ]);
   });
 
+  it("allows merge updates to include only the fields that changed", async () => {
+    const tool = createTodoWriteTool();
+    const context = createContext();
+
+    await tool.execute({
+      todos: [
+        { id: "inspect", content: "Inspect current implementation", status: "in_progress", priority: "high" },
+      ],
+    }, context);
+
+    const merged = await tool.execute({
+      merge: true,
+      todos: [{ id: "inspect", status: "completed" }],
+    }, context);
+
+    assert.ok(merged.data);
+    assert.deepEqual(merged.data.todos, [
+      { id: "inspect", content: "Inspect current implementation", status: "completed", priority: "high" },
+    ]);
+  });
+
   it("supports cancelled structured todos", async () => {
     const tool = createTodoWriteTool();
     const context = createContext();

--- a/tests/tool/todoWrite.spec.ts
+++ b/tests/tool/todoWrite.spec.ts
@@ -1,0 +1,108 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { createPlanTodoStateManager } from "../../src/agent/runtime/PlanTodoState.js";
+import { createTodoWriteTool, parseTodoMarkdown } from "../../src/tool/builtin/todoWrite.js";
+import type { PilotDeckToolRuntimeContext } from "../../src/tool/protocol/types.js";
+
+function createContext(sessionId = "session-1"): PilotDeckToolRuntimeContext {
+  const planTodo = createPlanTodoStateManager().forSession(sessionId);
+  return {
+    sessionId,
+    turnId: "turn-1",
+    cwd: "/tmp/workspace",
+    permissionMode: "default",
+    permissionContext: {
+      cwd: "/tmp/workspace",
+      mode: "default",
+      additionalWorkingDirectories: [],
+      bypassAvailable: false,
+      canPrompt: false,
+      rules: { allow: [], ask: [], deny: [] },
+    },
+    planTodo,
+  };
+}
+
+describe("todo_write", () => {
+  it("keeps markdown checklist parsing compatible", () => {
+    assert.deepEqual(parseTodoMarkdown("- [x] Done\n- [ ] Next\n- [ ] Later"), [
+      { id: "todo-1", content: "Done", status: "completed" },
+      { id: "todo-2", content: "Next", status: "in_progress" },
+      { id: "todo-3", content: "Later", status: "pending" },
+    ]);
+  });
+
+  it("writes and reads structured todos", async () => {
+    const tool = createTodoWriteTool();
+    const context = createContext();
+
+    const write = await tool.execute({
+      todos: [
+        { id: "inspect", content: "Inspect current implementation", status: "completed" },
+        { id: "patch", content: "Patch editable todo support", status: "in_progress", priority: "high" },
+      ],
+      reason: "initial editable plan",
+    }, context);
+
+    assert.ok(write.data);
+    assert.equal(write.data.mode, "structured");
+    assert.equal(write.data.merge, false);
+    assert.equal(write.data.reason, "initial editable plan");
+    assert.deepEqual(write.data.todos, [
+      { id: "inspect", content: "Inspect current implementation", status: "completed" },
+      { id: "patch", content: "Patch editable todo support", status: "in_progress", priority: "high" },
+    ]);
+
+    const read = await tool.execute({}, context);
+    assert.ok(read.data);
+    assert.equal(read.data.mode, "read");
+    assert.deepEqual(read.data.todos, write.data.todos);
+  });
+
+  it("merges structured todo updates by id and appends discovered work", async () => {
+    const tool = createTodoWriteTool();
+    const context = createContext();
+
+    await tool.execute({
+      todos: [
+        { id: "inspect", content: "Inspect current implementation", status: "completed" },
+        { id: "patch", content: "Patch editable todo support", status: "in_progress" },
+      ],
+    }, context);
+
+    const merged = await tool.execute({
+      merge: true,
+      reason: "found verification gap",
+      todos: [
+        { id: "patch", content: "Patch editable todo support", status: "completed" },
+        { id: "verify", content: "Run todo workflow tests", status: "in_progress" },
+      ],
+    }, context);
+
+    assert.ok(merged.data);
+    assert.equal(merged.data.mode, "structured");
+    assert.equal(merged.data.merge, true);
+    assert.deepEqual(merged.data.todos, [
+      { id: "inspect", content: "Inspect current implementation", status: "completed" },
+      { id: "patch", content: "Patch editable todo support", status: "completed" },
+      { id: "verify", content: "Run todo workflow tests", status: "in_progress" },
+    ]);
+  });
+
+  it("supports cancelled structured todos", async () => {
+    const tool = createTodoWriteTool();
+    const context = createContext();
+
+    const result = await tool.execute({
+      todos: [
+        { id: "obsolete", content: "Use markdown-only updates", status: "cancelled" },
+        { id: "structured", content: "Use structured updates", status: "in_progress" },
+      ],
+    }, context);
+
+    assert.ok(result.data);
+    assert.equal(result.data.todos[0]?.status, "cancelled");
+    assert.equal(context.planTodo?.getSnapshot().todos[0]?.status, "cancelled");
+  });
+});


### PR DESCRIPTION
## Summary

This PR proposes the `feat/better_tool_0704` tool/runtime improvements for upstream review.

Main changes:
- Add the `execute_code` built-in tool and related runtime environment inheritance.
- Improve text/XML tool-call parsing and recovery for malformed or orphan tool-call fragments.
- Add filesystem syntax diagnostics support updates.
- Make `todo_write` a more editable, generic session checklist:
  - no-argument read support
  - structured `todos: [{ id, content, status }]`
  - `pending` / `in_progress` / `completed` / `cancelled` statuses
  - `merge=true` partial updates by id
  - todo history, active todos, and diagnostics snapshots
  - generic guidance for exploration, revised routes, and final verification checkpoints
- Add/update unit tests for execute_code, streaming tool-call parsing, and todo behavior.

## Notes

The todo changes are intentionally generic. They do not include benchmark-specific prompts, task-specific logic, grader behavior, fixture details, or hidden evaluation information.

## Validation

Validated in the downstream runtime image before opening this PR:

```bash
npm run build
node --test --test-force-exit --test-timeout 60000 dist/tests/tool/todoWrite.spec.js
```

The targeted todo test suite passed with 8/8 tests.
