### PR TITLE
fix(ui): unify run mode menu colors and update Ask mode description

### DIFF
--- a/ui/src/components/chat-v2/ComposerV2.tsx
+++ b/ui/src/components/chat-v2/ComposerV2.tsx
@@ -503,14 +503,7 @@ export default function ComposerV2({
                       <button
                         type="button"
                         onClick={() => setIsRunModeMenuOpen((open) => !open)}
-                        className={cn(
-                          'inline-flex h-7 max-w-[108px] items-center justify-center gap-1.5 rounded-md px-2 text-[12px] font-medium transition sm:max-w-[140px]',
-                          runMode === 'plan'
-                            ? 'text-blue-600 hover:bg-blue-50 dark:text-blue-300 dark:hover:bg-blue-950/30'
-                            : runMode === 'ask'
-                              ? 'text-emerald-600 hover:bg-emerald-50 dark:text-emerald-300 dark:hover:bg-emerald-950/30'
-                            : 'text-neutral-600 hover:bg-neutral-100 dark:text-neutral-300 dark:hover:bg-neutral-800',
-                        )}
+                        className="inline-flex h-7 max-w-[108px] items-center justify-center gap-1.5 rounded-md px-2 text-[12px] font-medium transition sm:max-w-[140px] text-neutral-600 hover:bg-neutral-100 dark:text-neutral-300 dark:hover:bg-neutral-800"
                         title={t('input.runModes.change', {
                           defaultValue: 'Select run mode',
                         }) as string}
@@ -547,7 +540,7 @@ export default function ComposerV2({
                                 }) as string)
                               : isAsk
                                 ? (t('input.runModes.askDescription', {
-                                    defaultValue: 'Read-only analysis with optional subagents',
+                                    defaultValue: 'Only answers questions without modifying files',
                                   }) as string)
                               : (t('input.runModes.agentDescription', {
                                   defaultValue: 'Directly process and execute the task',
@@ -575,25 +568,16 @@ export default function ComposerV2({
                                 )}
                               >
                                 <Icon
-                                  className={cn(
-                                    'h-4 w-4 shrink-0',
-                                    isPlan
-                                      ? 'text-blue-600 dark:text-blue-300'
-                                      : isAsk
-                                        ? 'text-emerald-600 dark:text-emerald-300'
-                                      : 'text-neutral-500 dark:text-neutral-400',
-                                  )}
+                                  className="h-4 w-4 shrink-0 text-neutral-500 dark:text-neutral-400"
                                   strokeWidth={1.9}
                                 />
                                 <span className="min-w-0 flex-1">
                                   <span
                                     className={cn(
-                                      'block truncate text-[13px] font-medium',
-                                      isPlan
-                                        ? 'text-blue-700 dark:text-blue-300'
-                                        : isAsk
-                                          ? 'text-emerald-700 dark:text-emerald-300'
-                                        : 'text-neutral-900 dark:text-neutral-100',
+                                      'block truncate text-[13px]',
+                                      isSelected
+                                        ? 'font-bold text-neutral-900 dark:text-neutral-100'
+                                        : 'font-medium text-neutral-700 dark:text-neutral-300',
                                     )}
                                   >
                                     {label}

--- a/ui/src/i18n/locales/en/chat.json
+++ b/ui/src/i18n/locales/en/chat.json
@@ -267,7 +267,7 @@
       "change": "Select run mode",
       "agentDescription": "Directly process and execute the task",
       "planDescription": "Generate a plan first, then execute after confirmation",
-      "askDescription": "Read-only analysis with optional subagents"
+      "askDescription": "Only answers questions without modifying files"
     }
   },
   "commandMenu": {

--- a/ui/src/i18n/locales/zh-CN/chat.json
+++ b/ui/src/i18n/locales/zh-CN/chat.json
@@ -250,7 +250,7 @@
       "change": "选择运行模式",
       "agentDescription": "直接处理并执行任务",
       "planDescription": "先产出计划，确认后再执行",
-      "askDescription": "只读分析，可使用只读子智能体"
+      "askDescription": "仅回答问题，不修改文件"
     }
   },
   "commandMenu": {


### PR DESCRIPTION
## Summary
- Remove blue/green color distinction for Plan/Ask modes in the run mode selector menu, using neutral black/gray uniformly across all mode options.
- Bold the selected mode name for clear visual emphasis while retaining the checkmark icon.
- Update Ask mode description: "仅回答问题，不修改文件" (zh-CN) / "Only answers questions without modifying files" (en).

## Test plan
- [ ] Open chat composer, click the run mode selector button
- [ ] Verify all three modes (Agent/Plan/Ask) use black/gray text and icons (no blue or green)
- [ ] Verify the selected mode name is bolded and darker
- [ ] Verify the checkmark icon still appears next to the selected mode
- [ ] Switch language to zh-CN/en and verify Ask mode description text is correct

Made with [Cursor](https://cursor.com)