### PR TITLE
Add Ollama provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,6 +355,27 @@ model:
         gemini-3.1-pro-preview: {}
 ```
 
+Local Ollama models can be configured without an API key. PilotDeck uses
+Ollama's OpenAI-compatible `/v1/chat/completions` endpoint:
+
+```bash
+ollama serve
+ollama pull qwen3:0.6b
+```
+
+```yaml
+schemaVersion: 1
+agent:
+  model: ollama/qwen3:0.6b
+model:
+  providers:
+    ollama:
+      protocol: openai
+      url: http://localhost:11434/v1
+      models:
+        qwen3:0.6b: {}
+```
+
 **3. Start the services**
 
 ```bash

--- a/src/model/catalog/providers.ts
+++ b/src/model/catalog/providers.ts
@@ -1078,4 +1078,60 @@ export const PROVIDER_CATALOG: ProviderCatalog = {
     models: {},
   },
 
+  ollama: {
+    displayName: "Ollama",
+    protocol: "openai",
+    defaultUrl: "http://localhost:11434/v1",
+    models: {
+      "qwen3:0.6b": {
+        displayName: "Qwen3 0.6B (Ollama)",
+        capabilities: {
+          supportsToolUse: true,
+          supportsStreaming: true,
+          supportsParallelToolCalls: false,
+          supportsThinking: false,
+          supportsJsonSchema: false,
+          supportsSystemPrompt: true,
+          supportsPromptCache: false,
+          maxContextTokens: 40_960,
+          maxOutputTokens: 8_192,
+        },
+        multimodal: { input: ["text"] },
+        aliases: [],
+      },
+      "qwen3:8b": {
+        displayName: "Qwen3 8B (Ollama)",
+        capabilities: {
+          supportsToolUse: false,
+          supportsStreaming: true,
+          supportsParallelToolCalls: false,
+          supportsThinking: false,
+          supportsJsonSchema: false,
+          supportsSystemPrompt: true,
+          supportsPromptCache: false,
+          maxContextTokens: 40_960,
+          maxOutputTokens: 8_192,
+        },
+        multimodal: { input: ["text"] },
+        aliases: [],
+      },
+      "llama3.1:8b": {
+        displayName: "Llama 3.1 8B (Ollama)",
+        capabilities: {
+          supportsToolUse: false,
+          supportsStreaming: true,
+          supportsParallelToolCalls: false,
+          supportsThinking: false,
+          supportsJsonSchema: false,
+          supportsSystemPrompt: true,
+          supportsPromptCache: false,
+          maxContextTokens: 131_072,
+          maxOutputTokens: 8_192,
+        },
+        multimodal: { input: ["text"] },
+        aliases: [],
+      },
+    },
+  },
+
 };

--- a/src/model/config/parseModelConfig.ts
+++ b/src/model/config/parseModelConfig.ts
@@ -104,13 +104,20 @@ function parseProvider(providerId: string, rawProvider: unknown, env?: Credentia
     id: providerId,
     protocol,
     url: rawUrl,
-    apiKey: resolveApiKey(provider.apiKey, env),
+    apiKey: resolveProviderApiKey(providerId, provider.apiKey, env),
     timeoutMs: readOptionalPositiveNumber(provider.timeoutMs, "timeoutMs"),
     headers: readStringRecord(provider.headers, "headers"),
     extraBody: isRecord(provider.extraBody) ? (provider.extraBody as Record<string, unknown>) : undefined,
     retry: parseRetryConfig(provider.retry),
     models,
   };
+}
+
+function resolveProviderApiKey(providerId: string, value: unknown, env?: CredentialEnv): string {
+  if (providerId === "ollama" && value === undefined) {
+    return "ollama";
+  }
+  return resolveApiKey(value, env);
 }
 
 function resolveDefaultProviderUrl(

--- a/tests/model/ollamaConfig.spec.ts
+++ b/tests/model/ollamaConfig.spec.ts
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { buildModelRequest, parseModelConfig } from "../../src/model/index.js";
+import type { CanonicalModelRequest } from "../../src/model/index.js";
+
+test("Ollama provider uses catalog defaults and does not require apiKey", () => {
+  const config = parseModelConfig({
+    providers: {
+      ollama: {
+        models: {
+          "qwen3:0.6b": {},
+        },
+      },
+    },
+  });
+
+  const provider = config.providers.ollama;
+  assert.equal(provider.protocol, "openai");
+  assert.equal(provider.url, "http://localhost:11434/v1");
+  assert.equal(provider.apiKey, "ollama");
+  assert.equal(provider.models["qwen3:0.6b"].displayName, "Qwen3 0.6B (Ollama)");
+  assert.equal(provider.models["qwen3:0.6b"].capabilities.supportsStreaming, true);
+  assert.equal(provider.models["qwen3:0.6b"].capabilities.supportsToolUse, true);
+});
+
+test("Ollama provider builds OpenAI-compatible chat completions body", () => {
+  const config = parseModelConfig({
+    providers: {
+      ollama: {
+        models: {
+          "llama3.1:8b": {},
+        },
+      },
+    },
+  });
+
+  const request: CanonicalModelRequest = {
+    provider: "ollama",
+    model: "llama3.1:8b",
+    stream: true,
+    systemPrompt: "You are concise.",
+    messages: [
+      { role: "user", content: [{ type: "text", text: "hello" }] },
+    ],
+  };
+
+  const body = buildModelRequest(request, config) as Record<string, unknown>;
+
+  assert.equal(body.model, "llama3.1:8b");
+  assert.equal(body.stream, true);
+  assert.equal(body.max_tokens, 8192);
+  assert.deepEqual(body.messages, [
+    { role: "system", content: "You are concise." },
+    { role: "user", content: "hello" },
+  ]);
+});

--- a/ui/server/services/pilotdeckConfig.js
+++ b/ui/server/services/pilotdeckConfig.js
@@ -114,10 +114,13 @@ export function sanitizeProviderCredentials(config) {
   if (!isRecord(config)) return config;
   const providers = config?.model?.providers;
   if (!isRecord(providers)) return config;
-  for (const provider of Object.values(providers)) {
+  for (const [providerId, provider] of Object.entries(providers)) {
     if (!isRecord(provider)) continue;
     if (typeof provider.apiKey === 'string') {
       provider.apiKey = provider.apiKey.trim();
+      if (allowsMissingApiKey(providerId) && provider.apiKey.length === 0) {
+        delete provider.apiKey;
+      }
     }
     if (typeof provider.url === 'string') {
       provider.url = provider.url.trim();
@@ -167,6 +170,10 @@ export function resolveModel(config, ref, options = {}) {
 
 // ─── Validation ──────────────────────────────────────────────────────────────
 
+function allowsMissingApiKey(providerId) {
+  return providerId === 'ollama';
+}
+
 function validateProvider(id, provider, errors) {
   if (!isRecord(provider)) {
     errors.push(`model.providers.${id} must be an object`);
@@ -178,7 +185,9 @@ function validateProvider(id, provider, errors) {
     errors.push(`model.providers.${id}.protocol must be "openai", "openai-responses", "anthropic", or "google"`);
   }
   if (!normalizeString(provider.url)) errors.push(`model.providers.${id}.url is required`);
-  if (!normalizeString(provider.apiKey)) errors.push(`model.providers.${id}.apiKey is required`);
+  if (!allowsMissingApiKey(id) && !normalizeString(provider.apiKey)) {
+    errors.push(`model.providers.${id}.apiKey is required`);
+  }
 }
 
 function validateModelRef(config, ref, label, errors) {

--- a/ui/server/services/pilotdeckConfig.test.js
+++ b/ui/server/services/pilotdeckConfig.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { validatePilotDeckConfig } from './pilotdeckConfig.js';
+import { sanitizeProviderCredentials, validatePilotDeckConfig } from './pilotdeckConfig.js';
 
 describe('validatePilotDeckConfig gateway validation', () => {
     it('rejects non-object gateway config', () => {
@@ -42,5 +42,45 @@ describe('validatePilotDeckConfig gateway validation', () => {
 
         expect(validation.valid).toBe(true);
         expect(validation.errors).toEqual([]);
+    });
+
+    it('accepts Ollama providers without an apiKey', () => {
+        const validation = validatePilotDeckConfig({
+            agent: { model: 'ollama/qwen3:0.6b' },
+            model: {
+                providers: {
+                    ollama: {
+                        protocol: 'openai',
+                        url: 'http://localhost:11434/v1',
+                        models: {
+                            'qwen3:0.6b': {},
+                        },
+                    },
+                },
+            },
+        });
+
+        expect(validation.valid).toBe(true);
+        expect(validation.errors).toEqual([]);
+    });
+
+    it('removes blank Ollama apiKeys during sanitization', () => {
+        const config = sanitizeProviderCredentials({
+            model: {
+                providers: {
+                    ollama: {
+                        protocol: 'openai',
+                        url: ' http://localhost:11434/v1 ',
+                        apiKey: '   ',
+                        models: {
+                            'qwen3:0.6b': {},
+                        },
+                    },
+                },
+            },
+        });
+
+        expect(config.model.providers.ollama).not.toHaveProperty('apiKey');
+        expect(config.model.providers.ollama.url).toBe('http://localhost:11434/v1');
     });
 });


### PR DESCRIPTION
## Summary
- add an Ollama provider catalog entry using the OpenAI-compatible local endpoint
- allow Ollama provider config without an API key
- document local Ollama setup with qwen3:0.6b and add focused model config tests

## Tests
- npm test
- npm run build && node --test --test-timeout 60000 dist/tests/model/ollamaConfig.spec.js