### PR TITLE
Align streaming recovery with LiteLLM

### DIFF
--- a/src/cli/proxy.ts
+++ b/src/cli/proxy.ts
@@ -1,6 +1,12 @@
+import {
+  LITELLM_COMPLETION_HTTP_FALLBACK_MS,
+  LITELLM_HTTP_CONNECTOR_LIMIT,
+  LITELLM_HTTP_KEEPALIVE_TIMEOUT_MS,
+} from "../model/streaming/streamModel.js";
+
 type EnvLike = Record<string, string | undefined>;
 
-export const UNDICI_TRANSPORT_TIMEOUT_MS = 600_000;
+export const UNDICI_TRANSPORT_TIMEOUT_MS = LITELLM_COMPLETION_HTTP_FALLBACK_MS;
 
 type ProxyInstallSource = "env" | "config";
 type DispatcherState =
@@ -140,10 +146,17 @@ async function applyGlobalProxy(
   }
 }
 
-function createLongTimeoutOptions(): { headersTimeout: number; bodyTimeout: number } {
+export function createLongTimeoutOptions(): {
+  headersTimeout: number;
+  bodyTimeout: number;
+  connections: number;
+  keepAliveTimeout: number;
+} {
   return {
     headersTimeout: UNDICI_TRANSPORT_TIMEOUT_MS,
     bodyTimeout: UNDICI_TRANSPORT_TIMEOUT_MS,
+    connections: LITELLM_HTTP_CONNECTOR_LIMIT,
+    keepAliveTimeout: LITELLM_HTTP_KEEPALIVE_TIMEOUT_MS,
   };
 }
 

--- a/src/model/config/parseModelConfig.ts
+++ b/src/model/config/parseModelConfig.ts
@@ -130,7 +130,8 @@ function parseRetryConfig(raw: unknown): ProviderRetryConfig | undefined {
   const result: ProviderRetryConfig = {};
   const numFields = [
     "requestMaxRetries", "streamMaxRetries", "streamIdleTimeoutMs",
-    "baseDelayMs", "maxDelayMs",
+    "maxStreamingDurationMs", "repeatedChunkLimit",
+    "baseDelayMs", "maxDelayMs", "jitter",
   ] as const;
   for (const key of numFields) {
     const value = raw[key];

--- a/src/model/index.ts
+++ b/src/model/index.ts
@@ -11,7 +11,34 @@ export {
 } from "./request/materializeMediaReferences.js";
 export { validateModelRequest, type ResolvedModelRequest } from "./request/validateModelRequest.js";
 export { parseModelResponse } from "./response/parseModelResponse.js";
-export { complete, streamModel, type ModelRuntimeOptions, type ModelTransport } from "./streaming/streamModel.js";
+export {
+  complete,
+  streamModel,
+  LITELLM_COMPLETION_HTTP_FALLBACK_MS,
+  LITELLM_DEFAULT_MAX_RETRIES,
+  LITELLM_DEFAULT_REQUEST_TIMEOUT_MS,
+  LITELLM_INITIAL_RETRY_DELAY_MS,
+  LITELLM_HTTP_CONNECTOR_LIMIT,
+  LITELLM_HTTP_CONNECTOR_LIMIT_PER_HOST,
+  LITELLM_HTTP_KEEPALIVE_TIMEOUT_MS,
+  LITELLM_HTTP_SO_KEEPALIVE,
+  LITELLM_HTTP_TCP_KEEPCNT,
+  LITELLM_HTTP_TCP_KEEPIDLE_SECONDS,
+  LITELLM_HTTP_TCP_KEEPINTVL_SECONDS,
+  LITELLM_HTTP_TTL_DNS_CACHE_MS,
+  LITELLM_MAX_RETRY_DELAY_MS,
+  LITELLM_REPEATED_STREAMING_CHUNK_LIMIT,
+  LITELLM_RETRY_JITTER,
+  LITELLM_STREAM_MAX_DURATION_MS,
+  type ModelRuntimeOptions,
+  type ModelStreamRetryProgress,
+  type ModelTransport,
+} from "./streaming/streamModel.js";
+export {
+  buildLiteLLMContinuationRequest,
+  LITELLM_CONTINUATION_INSTRUCTION,
+  stripLiteLLMContinuationMessages,
+} from "./streaming/continuationRequest.js";
 export {
   normalizeStreamEvent,
   createStreamNormalizerState,

--- a/src/model/protocol/canonical.ts
+++ b/src/model/protocol/canonical.ts
@@ -277,12 +277,18 @@ export type ProviderRetryConfig = {
   requestMaxRetries?: number;
   /** Max retries for dropped SSE streams. Default 2. */
   streamMaxRetries?: number;
-  /** Idle timeout (ms) for streaming responses before treating as lost. Default 300000 (5 min). */
+  /** First-token / idle timeout (ms) for streaming responses. Defaults through request timeout when omitted. */
   streamIdleTimeoutMs?: number;
-  /** Base delay (ms) for exponential backoff. Default 1000. */
+  /** Maximum streaming duration (ms). Default disabled. */
+  maxStreamingDurationMs?: number;
+  /** Repeated non-empty text chunk limit before treating a stream as looping. Default 100. */
+  repeatedChunkLimit?: number;
+  /** Base delay (ms) for retry backoff. Default 500. */
   baseDelayMs?: number;
-  /** Max delay cap (ms) for backoff. Default 30000. */
+  /** Max delay cap (ms) for backoff. Default 8000. */
   maxDelayMs?: number;
+  /** Jitter multiplier for retry backoff. Default 0.75. */
+  jitter?: number;
 };
 
 export type ProviderConfig = {

--- a/src/model/providers/openai/stream.ts
+++ b/src/model/providers/openai/stream.ts
@@ -130,6 +130,21 @@ export function normalizeOpenAIStreamEvent(
 ): CanonicalModelEvent[] {
   const chunk = asRecord(raw);
   const events: CanonicalModelEvent[] = [];
+  const error = asRecord(chunk.error);
+  if (Object.keys(error).length > 0) {
+    const code = readNonEmptyString(error.type) ?? readNonEmptyString(error.code) ?? "provider_error";
+    return [{
+      type: "error",
+      error: {
+        provider: "openai",
+        protocol: "openai",
+        code,
+        message: readNonEmptyString(error.message) ?? "OpenAI stream request failed.",
+        retryable: code === "rate_limit_error" || code === "overloaded_error" || code === "server_error" || code === "timeout_error",
+        raw,
+      },
+    }];
+  }
   const responseId = readNonEmptyString(chunk.id);
   if (responseId !== undefined && state.streamResponseId === undefined) {
     state.streamResponseId = responseId;

--- a/src/model/streaming/StreamingCheckpoint.ts
+++ b/src/model/streaming/StreamingCheckpoint.ts
@@ -42,7 +42,7 @@ export class StreamingCheckpointManager {
   }
 
   hasSubstantialContent(): boolean {
-    return this.checkpoint.tokensReceived > 50 && this.checkpoint.partialText.length > 100;
+    return this.checkpoint.partialText.trim().length > 0;
   }
 
   reset(): void {

--- a/src/model/streaming/continuationRequest.ts
+++ b/src/model/streaming/continuationRequest.ts
@@ -1,0 +1,44 @@
+import type { CanonicalModelRequest } from "../protocol/canonical.js";
+
+export const LITELLM_CONTINUATION_INSTRUCTION =
+  "You are a helpful assistant. You are given a message and you need to respond to it. " +
+  "You are also given a generated content. You need to respond to the message in continuation of the generated content. " +
+  "Do not repeat the same content. Your response should be in continuation of this text:";
+
+export function buildLiteLLMContinuationRequest<T extends CanonicalModelRequest>(
+  original: T,
+  partialText: string,
+): T {
+  return {
+    ...original,
+    messages: [
+      ...stripLiteLLMContinuationMessages(original.messages),
+      {
+        role: "assistant" as const,
+        content: [{ type: "text" as const, text: partialText }],
+      },
+      {
+        role: "user" as const,
+        content: [{ type: "text" as const, text: LITELLM_CONTINUATION_INSTRUCTION }],
+      },
+    ],
+  };
+}
+
+export function stripLiteLLMContinuationMessages(
+  messages: CanonicalModelRequest["messages"],
+): CanonicalModelRequest["messages"] {
+  if (messages.length < 2) return messages;
+  const last = messages[messages.length - 1];
+  const secondLast = messages[messages.length - 2];
+  if (
+    last.role === "user" &&
+    secondLast.role === "assistant" &&
+    last.content.length === 1 &&
+    last.content[0].type === "text" &&
+    last.content[0].text === LITELLM_CONTINUATION_INSTRUCTION
+  ) {
+    return messages.slice(0, -2);
+  }
+  return messages;
+}

--- a/src/model/streaming/streamModel.ts
+++ b/src/model/streaming/streamModel.ts
@@ -17,6 +17,7 @@ import { createStreamNormalizerState, normalizeStreamEvent } from "./normalizeSt
 import { createGoogleStreamState, normalizeGoogleStreamEvent } from "../providers/google/stream.js";
 import { normalizeProviderBaseUrl } from "../normalizeProviderBaseUrl.js";
 import { StreamingCheckpointManager } from "./StreamingCheckpoint.js";
+import { buildLiteLLMContinuationRequest } from "./continuationRequest.js";
 
 export type ModelTransport = typeof fetch;
 
@@ -24,9 +25,40 @@ export type ModelRuntimeOptions = {
   fetch?: ModelTransport;
   googleClientFactory?: GoogleClientFactory;
   signal?: AbortSignal;
+  streamTimeoutMs?: number;
+  onRetryProgress?: (progress: ModelStreamRetryProgress) => void;
 };
 
-const DEFAULT_REQUEST_MAX_RETRIES = 2;
+export type ModelStreamRetryProgress = {
+  reason: "network_error" | "server_error" | "continuation";
+  attempt: number;
+  maxAttempts: number;
+  delayMs: number;
+  provider: string;
+  model: string;
+};
+
+export const LITELLM_DEFAULT_MAX_RETRIES = 2;
+export const LITELLM_DEFAULT_REQUEST_TIMEOUT_MS = 6_000_000;
+export const LITELLM_COMPLETION_HTTP_FALLBACK_MS = 600_000;
+export const LITELLM_REPEATED_STREAMING_CHUNK_LIMIT = 100;
+export const LITELLM_INITIAL_RETRY_DELAY_MS = 500;
+export const LITELLM_MAX_RETRY_DELAY_MS = 8_000;
+export const LITELLM_RETRY_JITTER = 0.75;
+export const LITELLM_HTTP_CONNECTOR_LIMIT = 1000;
+export const LITELLM_HTTP_CONNECTOR_LIMIT_PER_HOST = 500;
+export const LITELLM_HTTP_KEEPALIVE_TIMEOUT_MS = 120_000;
+export const LITELLM_HTTP_TTL_DNS_CACHE_MS = 300_000;
+export const LITELLM_HTTP_SO_KEEPALIVE = false;
+export const LITELLM_HTTP_TCP_KEEPIDLE_SECONDS = 60;
+export const LITELLM_HTTP_TCP_KEEPINTVL_SECONDS = 30;
+export const LITELLM_HTTP_TCP_KEEPCNT = 5;
+export const LITELLM_STREAM_MAX_DURATION_MS: number | undefined = readOptionalPositiveEnvMs(
+  "LITELLM_MAX_STREAMING_DURATION_SECONDS",
+  1000,
+);
+
+const DEFAULT_REQUEST_MAX_RETRIES = LITELLM_DEFAULT_MAX_RETRIES;
 
 export async function complete(
   request: CanonicalModelRequest,
@@ -36,7 +68,7 @@ export async function complete(
   const nonStreamingRequest = { ...request, stream: false };
   const { provider } = validateModelRequest(nonStreamingRequest, config);
   const maxRetries = provider.retry?.requestMaxRetries ?? DEFAULT_REQUEST_MAX_RETRIES;
-  const retryBaseDelay = provider.retry?.baseDelayMs ?? DEFAULT_RETRY_BASE_DELAY_MS;
+  const retryBaseDelay = provider.retry?.baseDelayMs ?? LITELLM_INITIAL_RETRY_DELAY_MS;
 
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
     throwIfAborted(options.signal);
@@ -93,8 +125,7 @@ export async function complete(
   throw new Error("complete() exhausted all retry attempts without a result.");
 }
 
-const DEFAULT_STREAM_MAX_RETRIES = 2;
-const DEFAULT_RETRY_BASE_DELAY_MS = 1000;
+const DEFAULT_STREAM_MAX_RETRIES = LITELLM_DEFAULT_MAX_RETRIES;
 
 export async function* streamModel(
   request: CanonicalModelRequest,
@@ -104,7 +135,7 @@ export async function* streamModel(
   const streamingRequest = { ...request, stream: true };
   const { provider } = validateModelRequest(streamingRequest, config);
   const maxRetries = provider.retry?.streamMaxRetries ?? DEFAULT_STREAM_MAX_RETRIES;
-  const retryBaseDelay = provider.retry?.baseDelayMs ?? DEFAULT_RETRY_BASE_DELAY_MS;
+  const retryBaseDelay = provider.retry?.baseDelayMs ?? LITELLM_INITIAL_RETRY_DELAY_MS;
 
   yield {
     type: "request_started",
@@ -145,7 +176,9 @@ export async function* streamModel(
       response = await sendProviderRequest(provider, body, true, options.fetch ?? fetch, options.signal);
     } catch (error) {
       if (attempt < maxRetries && isRetryableStreamError(error)) {
-        await delay(retryBaseDelay * (attempt + 1));
+        const delayMs = calculateRetryDelay(provider, attempt);
+        emitModelRetryProgress(options, "network_error", attempt, maxRetries, delayMs, provider, currentRequest.model);
+        await delay(delayMs, options.signal);
         continue;
       }
       throw error;
@@ -176,10 +209,12 @@ export async function* streamModel(
     let streamCompleted = false;
     let sawCompletionSentinel = false;
 
-    const streamIdleTimeoutMs = resolveStreamIdleTimeout(provider);
+    const streamIdleTimeoutMs = resolveStreamIdleTimeout(provider, options);
+    const streamGuard = createStreamGuard(provider);
 
     try {
       for await (const sseEvent of readServerSentEvents(response.body, options.signal, streamIdleTimeoutMs)) {
+        streamGuard.checkDuration();
         if (sseEvent.type === "done") {
           sawCompletionSentinel = true;
           continue;
@@ -188,10 +223,15 @@ export async function* streamModel(
           if (event.type === "message_end") {
             sawCompletionSentinel = true;
           }
+          if (event.type === "error") {
+            throw new ModelProviderError(event.error);
+          }
+          streamGuard.observe(event);
           checkpoint.onEvent(event);
           yield event;
         }
       }
+      streamGuard.checkDuration();
       if (!sawCompletionSentinel) {
         throw new IncompleteStreamError();
       }
@@ -202,14 +242,18 @@ export async function* streamModel(
         isRetryableStreamError(error) &&
         checkpoint.hasSubstantialContent()
       ) {
-        currentRequest = buildContinuationRequest(currentRequest, checkpoint.get().partialText);
+        currentRequest = buildLiteLLMContinuationRequest(currentRequest, checkpoint.get().partialText);
         checkpoint.reset();
-        await delay(retryBaseDelay * (attempt + 1), options.signal);
+        const delayMs = calculateRetryDelay(provider, attempt);
+        emitModelRetryProgress(options, "continuation", attempt, maxRetries, delayMs, provider, currentRequest.model);
+        await delay(delayMs, options.signal);
         continue;
       }
 
       if (isRetryableStreamError(error) && attempt < maxRetries) {
-        await delay(retryBaseDelay * (attempt + 1), options.signal);
+        const delayMs = calculateRetryDelay(provider, attempt);
+        emitModelRetryProgress(options, "network_error", attempt, maxRetries, delayMs, provider, currentRequest.model);
+        await delay(delayMs, options.signal);
         continue;
       }
 
@@ -268,17 +312,24 @@ async function* streamGoogleProviderRequest(params: {
       const stream = await client.models.generateContentStream(body as unknown as GoogleRequestBody);
       const state = createGoogleStreamState();
       let sawTerminalEvent = false;
+      const streamGuard = createStreamGuard(params.provider);
 
       for await (const chunk of stream) {
         throwIfAborted(params.options.signal);
+        streamGuard.checkDuration();
         for (const event of normalizeGoogleStreamEvent(chunk, state)) {
           if (event.type === "message_end" || event.type === "error") {
             sawTerminalEvent = true;
           }
+          if (event.type === "error") {
+            throw new ModelProviderError(event.error);
+          }
+          streamGuard.observe(event);
           params.checkpoint.onEvent(event);
           yield event;
         }
       }
+      streamGuard.checkDuration();
 
       if (!sawTerminalEvent && !state.ended) {
         yield { type: "message_end", finishReason: "unknown", raw: undefined };
@@ -292,14 +343,18 @@ async function* streamGoogleProviderRequest(params: {
         isRetryableGoogleStreamError(providerError, error) &&
         params.checkpoint.hasSubstantialContent()
       ) {
-        currentRequest = buildContinuationRequest(currentRequest, params.checkpoint.get().partialText);
+        currentRequest = buildLiteLLMContinuationRequest(currentRequest, params.checkpoint.get().partialText);
         params.checkpoint.reset();
-        await delay(params.retryBaseDelay * (attempt + 1), params.options.signal);
+        const delayMs = calculateRetryDelay(params.provider, attempt);
+        emitModelRetryProgress(params.options, "continuation", attempt, params.maxRetries, delayMs, params.provider, currentRequest.model);
+        await delay(delayMs, params.options.signal);
         continue;
       }
 
       if (isRetryableGoogleStreamError(providerError, error) && attempt < params.maxRetries) {
-        await delay(params.retryBaseDelay * (attempt + 1), params.options.signal);
+        const delayMs = calculateRetryDelay(params.provider, attempt);
+        emitModelRetryProgress(params.options, "network_error", attempt, params.maxRetries, delayMs, params.provider, currentRequest.model);
+        await delay(delayMs, params.options.signal);
         continue;
       }
 
@@ -386,12 +441,18 @@ function isRetryableStreamError(error: unknown): boolean {
     return false;
   }
   if (error instanceof ModelProviderError) {
-    return false;
+    return error.error.retryable;
   }
   if (error instanceof StreamIdleTimeoutError) {
     return true;
   }
   if (error instanceof IncompleteStreamError) {
+    return true;
+  }
+  if (error instanceof MaxStreamingDurationError) {
+    return true;
+  }
+  if (error instanceof RepeatedStreamingChunkError) {
     return true;
   }
   if (error instanceof Error) {
@@ -410,23 +471,69 @@ function isRetryableStreamError(error: unknown): boolean {
   return false;
 }
 
-function buildContinuationRequest(
-  original: CanonicalModelRequest & { stream: boolean },
-  partialText: string,
-): CanonicalModelRequest & { stream: boolean } {
+function calculateRetryDelay(provider: ProviderConfig, attempt: number): number {
+  const baseDelayMs = provider.retry?.baseDelayMs ?? LITELLM_INITIAL_RETRY_DELAY_MS;
+  const maxDelayMs = provider.retry?.maxDelayMs ?? LITELLM_MAX_RETRY_DELAY_MS;
+  const jitter = provider.retry?.jitter ?? LITELLM_RETRY_JITTER;
+  const deterministicDelay = baseDelayMs * (attempt + 1);
+  const jitterDelay = deterministicDelay * jitter * Math.random();
+  return Math.min(deterministicDelay + jitterDelay, maxDelayMs);
+}
+
+function emitModelRetryProgress(
+  options: ModelRuntimeOptions,
+  reason: ModelStreamRetryProgress["reason"],
+  attempt: number,
+  maxAttempts: number,
+  delayMs: number,
+  provider: ProviderConfig,
+  model: string,
+): void {
+  options.onRetryProgress?.({
+    reason,
+    attempt: attempt + 1,
+    maxAttempts,
+    delayMs: Math.round(delayMs),
+    provider: provider.id,
+    model,
+  });
+}
+
+type StreamGuard = {
+  checkDuration: () => void;
+  observe: (event: CanonicalModelEvent) => void;
+};
+
+function createStreamGuard(provider: ProviderConfig): StreamGuard {
+  const startedAt = Date.now();
+  const maxDurationMs = provider.retry?.maxStreamingDurationMs ?? LITELLM_STREAM_MAX_DURATION_MS;
+  const repeatedChunkLimit = provider.retry?.repeatedChunkLimit ?? LITELLM_REPEATED_STREAMING_CHUNK_LIMIT;
+  let lastText: string | undefined;
+  let repeatedCount = 1;
+
   return {
-    ...original,
-    messages: [
-      ...original.messages,
-      {
-        role: "assistant" as const,
-        content: [{ type: "text" as const, text: partialText }],
-      },
-      {
-        role: "user" as const,
-        content: [{ type: "text" as const, text: "Continue from where you left off." }],
-      },
-    ],
+    checkDuration() {
+      if (maxDurationMs !== undefined && Date.now() - startedAt > maxDurationMs) {
+        throw new MaxStreamingDurationError(maxDurationMs);
+      }
+    },
+    observe(event) {
+      this.checkDuration();
+      if (event.type !== "text_delta" || typeof event.text !== "string" || event.text.length <= 2) {
+        repeatedCount = 1;
+        lastText = undefined;
+        return;
+      }
+      if (event.text === lastText) {
+        repeatedCount += 1;
+      } else {
+        lastText = event.text;
+        repeatedCount = 1;
+      }
+      if (repeatedCount >= repeatedChunkLimit) {
+        throw new RepeatedStreamingChunkError(event.text);
+      }
+    },
   };
 }
 
@@ -448,7 +555,7 @@ function delay(ms: number, signal?: AbortSignal): Promise<void> {
   });
 }
 
-const DEFAULT_REQUEST_TIMEOUT_MS = 300_000; // 5 minutes
+const DEFAULT_REQUEST_TIMEOUT_MS = LITELLM_COMPLETION_HTTP_FALLBACK_MS;
 
 async function sendProviderRequest(
   provider: ProviderConfig,
@@ -459,7 +566,7 @@ async function sendProviderRequest(
 ): Promise<Response> {
   const controller = new AbortController();
   const detachAbort = signal ? forwardAbort(signal, controller) : undefined;
-  const effectiveTimeoutMs = stream ? provider.timeoutMs : (provider.timeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS);
+  const effectiveTimeoutMs = provider.timeoutMs ?? (stream ? undefined : DEFAULT_REQUEST_TIMEOUT_MS);
   const timeout = effectiveTimeoutMs
     ? setTimeout(() => controller.abort("request_timeout"), effectiveTimeoutMs)
     : undefined;
@@ -543,7 +650,7 @@ async function safeReadJson(response: Response): Promise<unknown> {
   }
 }
 
-const DEFAULT_STREAM_IDLE_TIMEOUT_MS = 300_000; // 5 minutes
+const DEFAULT_STREAM_IDLE_TIMEOUT_MS = LITELLM_DEFAULT_REQUEST_TIMEOUT_MS;
 
 class StreamIdleTimeoutError extends Error {
   constructor(idleMs: number) {
@@ -556,6 +663,20 @@ class IncompleteStreamError extends Error {
   constructor() {
     super("Network stream ended before provider completion sentinel.");
     this.name = "IncompleteStreamError";
+  }
+}
+
+class MaxStreamingDurationError extends Error {
+  constructor(durationMs: number) {
+    super(`Stream exceeded max streaming duration of ${durationMs}ms`);
+    this.name = "MaxStreamingDurationError";
+  }
+}
+
+class RepeatedStreamingChunkError extends Error {
+  constructor(chunk: string) {
+    super(`The model is repeating the same chunk = ${chunk}.`);
+    this.name = "RepeatedStreamingChunkError";
   }
 }
 
@@ -609,6 +730,7 @@ async function* readServerSentEvents(
     }
   } finally {
     signal?.removeEventListener("abort", cancelReader);
+    await reader.cancel().catch(() => undefined);
   }
 }
 
@@ -677,12 +799,30 @@ function readWithIdleTimeout(
   });
 }
 
-function resolveStreamIdleTimeout(provider: ProviderConfig): number {
+function resolveStreamIdleTimeout(provider: ProviderConfig, options?: ModelRuntimeOptions): number {
+  if (typeof options?.streamTimeoutMs === "number" && options.streamTimeoutMs > 0) {
+    return options.streamTimeoutMs;
+  }
   const retry = provider.retry;
   if (retry && typeof retry.streamIdleTimeoutMs === "number" && retry.streamIdleTimeoutMs > 0) {
     return retry.streamIdleTimeoutMs;
   }
+  if (typeof provider.timeoutMs === "number" && provider.timeoutMs > 0) {
+    return provider.timeoutMs;
+  }
   return DEFAULT_STREAM_IDLE_TIMEOUT_MS;
+}
+
+function readOptionalPositiveEnvMs(name: string, multiplier: number): number | undefined {
+  const raw = process.env[name];
+  if (raw === undefined || raw.trim() === "") {
+    return undefined;
+  }
+  const value = Number(raw);
+  if (!Number.isFinite(value) || value <= 0) {
+    return undefined;
+  }
+  return value * multiplier;
 }
 
 function throwIfAborted(signal?: AbortSignal): void {

--- a/src/model/streaming/streamModel.ts
+++ b/src/model/streaming/streamModel.ts
@@ -173,7 +173,7 @@ export async function* streamModel(
     }
     let response: Response;
     try {
-      response = await sendProviderRequest(provider, body, true, options.fetch ?? fetch, options.signal);
+      response = await sendProviderRequest(provider, body, true, options.fetch ?? fetch, options.signal, options);
     } catch (error) {
       if (attempt < maxRetries && isRetryableStreamError(error)) {
         const delayMs = calculateRetryDelay(provider, attempt);
@@ -192,6 +192,12 @@ export async function* streamModel(
         if (headerMs !== undefined) {
           error.retryAfterMs = headerMs;
         }
+      }
+      if (error.retryable && attempt < maxRetries) {
+        const delayMs = calculateRetryDelay(provider, attempt, error.retryAfterMs);
+        emitModelRetryProgress(options, retryReasonForError(error.code), attempt, maxRetries, delayMs, provider, currentRequest.model);
+        await delay(delayMs, options.signal);
+        continue;
       }
       yield { type: "error", error };
       return;
@@ -244,15 +250,15 @@ export async function* streamModel(
       ) {
         currentRequest = buildLiteLLMContinuationRequest(currentRequest, checkpoint.get().partialText);
         checkpoint.reset();
-        const delayMs = calculateRetryDelay(provider, attempt);
+        const delayMs = calculateRetryDelay(provider, attempt, retryAfterMsForError(error));
         emitModelRetryProgress(options, "continuation", attempt, maxRetries, delayMs, provider, currentRequest.model);
         await delay(delayMs, options.signal);
         continue;
       }
 
       if (isRetryableStreamError(error) && attempt < maxRetries) {
-        const delayMs = calculateRetryDelay(provider, attempt);
-        emitModelRetryProgress(options, "network_error", attempt, maxRetries, delayMs, provider, currentRequest.model);
+        const delayMs = calculateRetryDelay(provider, attempt, retryAfterMsForError(error));
+        emitModelRetryProgress(options, retryReasonForThrownError(error), attempt, maxRetries, delayMs, provider, currentRequest.model);
         await delay(delayMs, options.signal);
         continue;
       }
@@ -471,13 +477,32 @@ function isRetryableStreamError(error: unknown): boolean {
   return false;
 }
 
-function calculateRetryDelay(provider: ProviderConfig, attempt: number): number {
+function calculateRetryDelay(provider: ProviderConfig, attempt: number, retryAfterMs?: number): number {
+  if (retryAfterMs !== undefined) {
+    const maxDelayMs = provider.retry?.maxDelayMs ?? LITELLM_MAX_RETRY_DELAY_MS;
+    return Math.min(retryAfterMs, maxDelayMs);
+  }
   const baseDelayMs = provider.retry?.baseDelayMs ?? LITELLM_INITIAL_RETRY_DELAY_MS;
   const maxDelayMs = provider.retry?.maxDelayMs ?? LITELLM_MAX_RETRY_DELAY_MS;
   const jitter = provider.retry?.jitter ?? LITELLM_RETRY_JITTER;
   const deterministicDelay = baseDelayMs * (attempt + 1);
   const jitterDelay = deterministicDelay * jitter * Math.random();
   return Math.min(deterministicDelay + jitterDelay, maxDelayMs);
+}
+
+function retryAfterMsForError(error: unknown): number | undefined {
+  return error instanceof ModelProviderError ? error.error.retryAfterMs : undefined;
+}
+
+function retryReasonForThrownError(error: unknown): ModelStreamRetryProgress["reason"] {
+  if (error instanceof ModelProviderError) {
+    return retryReasonForError(error.error.code);
+  }
+  return "network_error";
+}
+
+function retryReasonForError(code: string): ModelStreamRetryProgress["reason"] {
+  return code === "server_error" ? "server_error" : "network_error";
 }
 
 function emitModelRetryProgress(
@@ -563,10 +588,11 @@ async function sendProviderRequest(
   stream: boolean,
   transport: ModelTransport,
   signal?: AbortSignal,
+  options?: ModelRuntimeOptions,
 ): Promise<Response> {
   const controller = new AbortController();
   const detachAbort = signal ? forwardAbort(signal, controller) : undefined;
-  const effectiveTimeoutMs = provider.timeoutMs ?? (stream ? undefined : DEFAULT_REQUEST_TIMEOUT_MS);
+  const effectiveTimeoutMs = stream ? resolveStreamIdleTimeout(provider, options) : provider.timeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
   const timeout = effectiveTimeoutMs
     ? setTimeout(() => controller.abort("request_timeout"), effectiveTimeoutMs)
     : undefined;

--- a/src/router/RouterRuntime.ts
+++ b/src/router/RouterRuntime.ts
@@ -7,6 +7,13 @@ import type {
 import { cloneMessages, downgradeUnsupportedContent, ModelRequestError } from "../model/index.js";
 import type { InputModality } from "../model/index.js";
 import {
+  LITELLM_DEFAULT_MAX_RETRIES,
+  LITELLM_INITIAL_RETRY_DELAY_MS,
+  LITELLM_MAX_RETRY_DELAY_MS,
+  LITELLM_RETRY_JITTER,
+} from "../model/streaming/streamModel.js";
+import { buildLiteLLMContinuationRequest } from "../model/streaming/continuationRequest.js";
+import {
   DEFAULT_SUBAGENT_POLICY,
   type RouterConfig,
   type RouterModelRef,
@@ -577,7 +584,7 @@ export function createRouterRuntime(
       };
       const cappedPassthroughRequest = clampMaxOutputTokensToModelCap(passthroughRequest, deps.modelRuntime);
       let sawErrorEvent = false;
-      for await (const item of streamAttempt(cappedPassthroughRequest, deps.modelRuntime, ctx.abortSignal)) {
+      for await (const item of streamAttempt(cappedPassthroughRequest, deps.modelRuntime, ctx, events)) {
         if (item.kind === "event") {
           if (item.event.type === "error") {
             sawErrorEvent = true;
@@ -621,9 +628,9 @@ export function createRouterRuntime(
     const zeroUsageMax = Math.max(1, config.zeroUsageRetry?.maxAttempts ?? 5);
     const zeroUsageEnabled = config.zeroUsageRetry?.enabled ?? true;
     const transientRetryEnabled = config.transientRetry?.enabled ?? true;
-    const transientRetryMax = Math.max(1, config.transientRetry?.maxAttempts ?? 5);
-    const transientBaseDelayMs = config.transientRetry?.baseDelayMs ?? 1000;
-    const transientMaxDelayMs = config.transientRetry?.maxDelayMs ?? 30000;
+    const transientRetryMax = Math.max(1, config.transientRetry?.maxAttempts ?? LITELLM_DEFAULT_MAX_RETRIES);
+    const transientBaseDelayMs = config.transientRetry?.baseDelayMs ?? LITELLM_INITIAL_RETRY_DELAY_MS;
+    const transientMaxDelayMs = config.transientRetry?.maxDelayMs ?? LITELLM_MAX_RETRY_DELAY_MS;
 
     let lastBuffered: CanonicalModelEvent[] = [];
     let lastError: import("../model/index.js").CanonicalModelError | undefined;
@@ -703,7 +710,7 @@ export function createRouterRuntime(
         const pending: CanonicalModelEvent[] = [];
         let outcome: AttemptOutcome | undefined;
 
-        for await (const item of streamAttempt(attemptRequest, deps.modelRuntime, ctx.abortSignal)) {
+        for await (const item of streamAttempt(attemptRequest, deps.modelRuntime, ctx, events)) {
           if (item.kind === "outcome") {
             outcome = item.outcome;
             break;
@@ -755,6 +762,19 @@ export function createRouterRuntime(
                 toModel: next.model,
                 error: outcome.error,
               });
+              if (outcome.error.retryAfterMs != null) {
+                events.emit({
+                  type: "pilotdeck_router_retry_progress",
+                  sessionId: ctx.sessionId,
+                  turnId: ctx.turnId,
+                  attempt: attemptIndex + 1,
+                  maxAttempts: attemptPlans.length - 1,
+                  delayMs: outcome.error.retryAfterMs,
+                  reason: classifyRetryReason(outcome.error.code),
+                  provider: attempt.provider,
+                  model: attempt.model,
+                });
+              }
               telemetry?.trackFeatureLoopStage({
                 module: "router",
                 ownerModule: "router",
@@ -784,10 +804,7 @@ export function createRouterRuntime(
           ) {
             const delay = outcome.error.retryAfterMs != null
               ? Math.min(outcome.error.retryAfterMs, transientMaxDelayMs)
-              : Math.min(
-                  transientBaseDelayMs * Math.pow(2, transientRetryCount) + Math.random() * 500,
-                  transientMaxDelayMs,
-                );
+              : calculateLiteLLMRetryDelay(transientRetryCount, transientBaseDelayMs, transientMaxDelayMs);
             console.warn(
               `[PilotDeck] transientRetry: ${outcome.error.code} (attempt ${transientRetryCount + 1}/${transientRetryMax}, delay=${Math.round(delay)}ms)`,
             );
@@ -838,13 +855,10 @@ export function createRouterRuntime(
             transientRetryCount < transientRetryMax
           ) {
             const partialText = extractPartialText(outcome.buffered);
-            if (partialText.length > 100) {
+            if (partialText.length > 0) {
               const midDelay = outcome.error.retryAfterMs != null
                 ? Math.min(outcome.error.retryAfterMs, transientMaxDelayMs)
-                : Math.min(
-                    transientBaseDelayMs * Math.pow(2, transientRetryCount) + Math.random() * 500,
-                    transientMaxDelayMs,
-                  );
+                : calculateLiteLLMRetryDelay(transientRetryCount, transientBaseDelayMs, transientMaxDelayMs);
               console.warn(
                 `[PilotDeck] midStreamRetry: ${outcome.error.code} after partial content ` +
                 `(attempt ${transientRetryCount + 1}/${transientRetryMax}, delay=${Math.round(midDelay)}ms)`,
@@ -861,7 +875,7 @@ export function createRouterRuntime(
                 model: attempt.model,
               });
               await abortableDelay(midDelay, ctx.abortSignal);
-              attemptRequest = buildMidStreamContinuationRequest(attemptRequest, partialText);
+              attemptRequest = buildLiteLLMContinuationRequest(attemptRequest, partialText);
               transientRetryCount++;
               continue;
             }
@@ -1143,7 +1157,8 @@ function downgradeRequestForAttempt(
 async function* streamAttempt(
   request: CanonicalModelRequest,
   modelRuntime: ModelRuntime,
-  abortSignal?: AbortSignal,
+  ctx: RouterExecuteContext,
+  events: RouterEventBus,
 ): AsyncGenerator<
   | { kind: "event"; event: CanonicalModelEvent }
   | { kind: "outcome"; outcome: AttemptOutcome }
@@ -1151,9 +1166,25 @@ async function* streamAttempt(
   const buffered: CanonicalModelEvent[] = [];
   const state = createZeroUsageState();
   let providerError: import("../model/index.js").CanonicalModelError | undefined;
+  const abortSignal = ctx.abortSignal;
 
   try {
-    for await (const event of modelRuntime.stream(request, { signal: abortSignal })) {
+    for await (const event of modelRuntime.stream(request, {
+      signal: abortSignal,
+      onRetryProgress(progress) {
+        events.emit({
+          type: "pilotdeck_router_retry_progress",
+          sessionId: ctx.sessionId,
+          turnId: ctx.turnId,
+          attempt: progress.attempt,
+          maxAttempts: progress.maxAttempts,
+          delayMs: progress.delayMs,
+          reason: progress.reason,
+          provider: progress.provider,
+          model: progress.model,
+        });
+      },
+    })) {
       if (abortSignal?.aborted) {
         throwAbortError(abortSignal.reason);
       }
@@ -1285,6 +1316,12 @@ function classifyRetryReason(errorCode: string): "rate_limit" | "server_error" |
   return "server_error";
 }
 
+function calculateLiteLLMRetryDelay(attempt: number, baseDelayMs: number, maxDelayMs: number): number {
+  const deterministicDelay = baseDelayMs * (attempt + 1);
+  const jitterDelay = deterministicDelay * LITELLM_RETRY_JITTER * Math.random();
+  return Math.min(deterministicDelay + jitterDelay, maxDelayMs);
+}
+
 function createUnsupportedMediaError(
   attempt: RouterModelRef,
   required: readonly InputModality[],
@@ -1312,43 +1349,4 @@ function extractPartialText(buffered: CanonicalModelEvent[]): string {
     }
   }
   return text;
-}
-
-const MID_STREAM_CONTINUATION_MARKER = "Continue from where you left off.";
-
-function buildMidStreamContinuationRequest(
-  original: CanonicalModelRequest,
-  partialText: string,
-): CanonicalModelRequest {
-  const baseMessages = stripPriorContinuation(original.messages);
-  return {
-    ...original,
-    messages: [
-      ...baseMessages,
-      {
-        role: "assistant" as const,
-        content: [{ type: "text" as const, text: partialText }],
-      },
-      {
-        role: "user" as const,
-        content: [{ type: "text" as const, text: MID_STREAM_CONTINUATION_MARKER }],
-      },
-    ],
-  };
-}
-
-function stripPriorContinuation(messages: CanonicalModelRequest["messages"]): CanonicalModelRequest["messages"] {
-  if (messages.length < 2) return messages;
-  const last = messages[messages.length - 1];
-  const secondLast = messages[messages.length - 2];
-  if (
-    last.role === "user" &&
-    secondLast.role === "assistant" &&
-    last.content.length === 1 &&
-    last.content[0].type === "text" &&
-    (last.content[0] as { type: "text"; text: string }).text === MID_STREAM_CONTINUATION_MARKER
-  ) {
-    return messages.slice(0, -2);
-  }
-  return messages;
 }

--- a/src/router/RouterRuntime.ts
+++ b/src/router/RouterRuntime.ts
@@ -762,19 +762,6 @@ export function createRouterRuntime(
                 toModel: next.model,
                 error: outcome.error,
               });
-              if (outcome.error.retryAfterMs != null) {
-                events.emit({
-                  type: "pilotdeck_router_retry_progress",
-                  sessionId: ctx.sessionId,
-                  turnId: ctx.turnId,
-                  attempt: attemptIndex + 1,
-                  maxAttempts: attemptPlans.length - 1,
-                  delayMs: outcome.error.retryAfterMs,
-                  reason: classifyRetryReason(outcome.error.code),
-                  provider: attempt.provider,
-                  model: attempt.model,
-                });
-              }
               telemetry?.trackFeatureLoopStage({
                 module: "router",
                 ownerModule: "router",

--- a/src/router/config/parseRouterConfig.ts
+++ b/src/router/config/parseRouterConfig.ts
@@ -8,6 +8,7 @@ import {
   DEFAULT_TIER_RULES,
   DEFAULT_TRIGGER_TIERS,
   DEFAULT_ZERO_USAGE_MAX_ATTEMPTS,
+  LITELLM_ROUTER_MAX_FALLBACKS,
   resolveProviderRef,
   type RouterAutoOrchestrateConfig,
   type RouterConfig,
@@ -164,6 +165,19 @@ function parseFallback(
 
   const fallback: RouterFallbackConfig = {};
   for (const [key, value] of Object.entries(raw)) {
+    if (key === "maxFallbacks") {
+      if (typeof value === "number" && Number.isInteger(value) && value >= 0) {
+        fallback.maxFallbacks = value;
+      } else {
+        diagnostics.push({
+          code: "ROUTER_FALLBACK_MAX_FALLBACKS_INVALID",
+          severity: "fatal",
+          path: "router.fallback.maxFallbacks",
+          message: "router.fallback.maxFallbacks must be a non-negative integer.",
+        });
+      }
+      continue;
+    }
     if (!SCENARIO_KEYS.includes(key as RouterScenarioType)) {
       diagnostics.push({
         code: "ROUTER_FALLBACK_UNKNOWN_SCENARIO",
@@ -193,6 +207,9 @@ function parseFallback(
     if (refs.length > 0) {
       fallback[key as RouterScenarioType] = refs;
     }
+  }
+  if (fallback.maxFallbacks === undefined) {
+    fallback.maxFallbacks = LITELLM_ROUTER_MAX_FALLBACKS;
   }
   return Object.keys(fallback).length > 0 ? fallback : undefined;
 }

--- a/src/router/config/schema.ts
+++ b/src/router/config/schema.ts
@@ -65,7 +65,12 @@ export type RouterStatsConfig = {
   baselineModel?: { provider: string; model: string };
 };
 
-export type RouterFallbackConfig = Partial<Record<RouterScenarioType, RouterModelRef[]>>;
+export type RouterFallbackConfig = Partial<Record<RouterScenarioType, RouterModelRef[]>> & {
+  /** LiteLLM-compatible max fallback model groups to try after the primary model. Default 5. */
+  maxFallbacks?: number;
+};
+
+export const LITELLM_ROUTER_MAX_FALLBACKS = 5;
 
 export type RouterCustomRouterConfig = {
   extensionId: string;

--- a/src/router/fallback/runFallbackChain.ts
+++ b/src/router/fallback/runFallbackChain.ts
@@ -1,6 +1,7 @@
 import type { CanonicalModelError } from "../../model/index.js";
 import type { RouterFallbackConfig, RouterModelRef } from "../config/schema.js";
 import type { RouterScenarioType } from "../protocol/decision.js";
+import { LITELLM_ROUTER_MAX_FALLBACKS } from "../config/schema.js";
 
 export type FallbackPlan = {
   /** Provider/model pairs to try in order, after the initial decision. */
@@ -16,10 +17,21 @@ export function planFallback(
   }
 
   if (scenarioType === "explicit") {
-    return { attempts: fallback.default ?? [] };
+    return { attempts: capFallbackAttempts(fallback.default ?? [], fallback.maxFallbacks) };
   }
 
-  return { attempts: (fallback as Record<string, RouterModelRef[] | undefined>)[scenarioType] ?? fallback.default ?? [] };
+  return {
+    attempts: capFallbackAttempts(
+      (fallback as Record<string, RouterModelRef[] | undefined>)[scenarioType] ?? fallback.default ?? [],
+      fallback.maxFallbacks,
+    ),
+  };
+}
+
+function capFallbackAttempts(attempts: RouterModelRef[], maxFallbacks: number | undefined): RouterModelRef[] {
+  const cap = maxFallbacks ?? LITELLM_ROUTER_MAX_FALLBACKS;
+  if (cap <= 0) return [];
+  return attempts.slice(0, cap);
 }
 
 /**

--- a/src/router/protocol/events.ts
+++ b/src/router/protocol/events.ts
@@ -74,7 +74,7 @@ export type RouterRetryProgressEvent = {
   attempt: number;
   maxAttempts: number;
   delayMs: number;
-  reason: "rate_limit" | "server_error" | "network_error" | "zero_usage" | "overloaded";
+  reason: "rate_limit" | "server_error" | "network_error" | "zero_usage" | "overloaded" | "continuation";
   provider: string;
   model: string;
 };

--- a/tests/cli/proxyDefaults.spec.ts
+++ b/tests/cli/proxyDefaults.spec.ts
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  LITELLM_COMPLETION_HTTP_FALLBACK_MS,
+  LITELLM_HTTP_CONNECTOR_LIMIT,
+  LITELLM_HTTP_KEEPALIVE_TIMEOUT_MS,
+} from "../../src/model/index.js";
+import { createLongTimeoutOptions, UNDICI_TRANSPORT_TIMEOUT_MS } from "../../src/cli/proxy.js";
+
+test("undici transport options use LiteLLM-compatible defaults", () => {
+  assert.equal(UNDICI_TRANSPORT_TIMEOUT_MS, LITELLM_COMPLETION_HTTP_FALLBACK_MS);
+  assert.deepEqual(createLongTimeoutOptions(), {
+    headersTimeout: LITELLM_COMPLETION_HTTP_FALLBACK_MS,
+    bodyTimeout: LITELLM_COMPLETION_HTTP_FALLBACK_MS,
+    connections: LITELLM_HTTP_CONNECTOR_LIMIT,
+    keepAliveTimeout: LITELLM_HTTP_KEEPALIVE_TIMEOUT_MS,
+  });
+});

--- a/tests/model/litellmStreamingDefaults.spec.ts
+++ b/tests/model/litellmStreamingDefaults.spec.ts
@@ -1,0 +1,454 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  LITELLM_CONTINUATION_INSTRUCTION,
+  LITELLM_COMPLETION_HTTP_FALLBACK_MS,
+  LITELLM_DEFAULT_MAX_RETRIES,
+  LITELLM_DEFAULT_REQUEST_TIMEOUT_MS,
+  LITELLM_HTTP_CONNECTOR_LIMIT,
+  LITELLM_HTTP_CONNECTOR_LIMIT_PER_HOST,
+  LITELLM_HTTP_KEEPALIVE_TIMEOUT_MS,
+  LITELLM_HTTP_SO_KEEPALIVE,
+  LITELLM_HTTP_TCP_KEEPCNT,
+  LITELLM_HTTP_TCP_KEEPIDLE_SECONDS,
+  LITELLM_HTTP_TCP_KEEPINTVL_SECONDS,
+  LITELLM_HTTP_TTL_DNS_CACHE_MS,
+  LITELLM_INITIAL_RETRY_DELAY_MS,
+  LITELLM_MAX_RETRY_DELAY_MS,
+  LITELLM_REPEATED_STREAMING_CHUNK_LIMIT,
+  LITELLM_RETRY_JITTER,
+  LITELLM_STREAM_MAX_DURATION_MS,
+  buildLiteLLMContinuationRequest,
+  parseModelConfig,
+  streamModel,
+} from "../../src/model/index.js";
+import type { CanonicalModelRequest, ModelConfig, ModelProtocol } from "../../src/model/index.js";
+
+const request: CanonicalModelRequest = {
+  provider: "openai",
+  model: "test-model",
+  messages: [{ role: "user", content: [{ type: "text", text: "hello" }] }],
+};
+
+function modelConfig(retry?: Record<string, unknown>): ModelConfig {
+  return parseModelConfig({
+    providers: {
+      openai: {
+        protocol: "openai",
+        url: "https://example.test/v1",
+        apiKey: "test-key",
+        ...(retry ? { retry } : {}),
+        models: { "test-model": {} },
+      },
+    },
+  });
+}
+
+function protocolModelConfig(protocol: ModelProtocol, retry?: Record<string, unknown>): ModelConfig {
+  return parseModelConfig({
+    providers: {
+      provider: {
+        protocol,
+        url: "https://example.test/v1",
+        apiKey: "test-key",
+        ...(retry ? { retry } : {}),
+        models: { "test-model": {} },
+      },
+    },
+  });
+}
+
+function protocolRequest(protocol: ModelProtocol): CanonicalModelRequest {
+  return {
+    ...request,
+    provider: "provider",
+    model: "test-model",
+    ...(protocol === "openai-responses" ? { maxOutputTokens: 64 } : {}),
+  };
+}
+
+function sseFrame(data: unknown): Uint8Array {
+  return new TextEncoder().encode(`data: ${JSON.stringify(data)}\n\n`);
+}
+
+function openAITextChunk(text: string): unknown {
+  return {
+    id: "chatcmpl-test",
+    object: "chat.completion.chunk",
+    choices: [{ index: 0, delta: { content: text }, finish_reason: null }],
+  };
+}
+
+function openAIResponsesEvent(type: string, extra: Record<string, unknown> = {}): Uint8Array {
+  return new TextEncoder().encode(`event: ${type}\ndata: ${JSON.stringify({ type, ...extra })}\n\n`);
+}
+
+function anthropicEvent(type: string, data: Record<string, unknown>): Uint8Array {
+  return new TextEncoder().encode(`event: ${type}\ndata: ${JSON.stringify({ type, ...data })}\n\n`);
+}
+
+test("LiteLLM-compatible streaming defaults are exposed", () => {
+  assert.equal(LITELLM_DEFAULT_MAX_RETRIES, 2);
+  assert.equal(LITELLM_DEFAULT_REQUEST_TIMEOUT_MS, 6_000_000);
+  assert.equal(LITELLM_COMPLETION_HTTP_FALLBACK_MS, 600_000);
+  assert.equal(LITELLM_REPEATED_STREAMING_CHUNK_LIMIT, 100);
+  assert.equal(LITELLM_INITIAL_RETRY_DELAY_MS, 500);
+  assert.equal(LITELLM_MAX_RETRY_DELAY_MS, 8_000);
+  assert.equal(LITELLM_RETRY_JITTER, 0.75);
+  assert.equal(LITELLM_STREAM_MAX_DURATION_MS, undefined);
+  assert.equal(LITELLM_HTTP_CONNECTOR_LIMIT, 1000);
+  assert.equal(LITELLM_HTTP_CONNECTOR_LIMIT_PER_HOST, 500);
+  assert.equal(LITELLM_HTTP_KEEPALIVE_TIMEOUT_MS, 120_000);
+  assert.equal(LITELLM_HTTP_TTL_DNS_CACHE_MS, 300_000);
+  assert.equal(LITELLM_HTTP_SO_KEEPALIVE, false);
+  assert.equal(LITELLM_HTTP_TCP_KEEPIDLE_SECONDS, 60);
+  assert.equal(LITELLM_HTTP_TCP_KEEPINTVL_SECONDS, 30);
+  assert.equal(LITELLM_HTTP_TCP_KEEPCNT, 5);
+});
+
+test("parseModelConfig accepts LiteLLM-compatible retry fields", () => {
+  const config = modelConfig({
+    maxStreamingDurationMs: 1234,
+    repeatedChunkLimit: 99,
+    baseDelayMs: 500,
+    maxDelayMs: 8000,
+    jitter: 0.75,
+  });
+  assert.deepEqual(config.providers.openai.retry, {
+    maxStreamingDurationMs: 1234,
+    repeatedChunkLimit: 99,
+    baseDelayMs: 500,
+    maxDelayMs: 8000,
+    jitter: 0.75,
+  });
+});
+
+test("streamModel retries after repeated chunks reach configured LiteLLM guard", async () => {
+  let calls = 0;
+  const fetchImpl = async () => {
+    calls += 1;
+    const chunks = calls === 1
+      ? [sseFrame(openAITextChunk("repeat")), sseFrame(openAITextChunk("repeat"))]
+      : [sseFrame(openAITextChunk("ok")), new TextEncoder().encode("data: [DONE]\n\n")];
+    return new Response(new ReadableStream<Uint8Array>({
+      start(controller) {
+        for (const chunk of chunks) controller.enqueue(chunk);
+        controller.close();
+      },
+    }), { status: 200 });
+  };
+
+  const events = [];
+  for await (const event of streamModel(request, modelConfig({ repeatedChunkLimit: 2, streamMaxRetries: 1 }), { fetch: fetchImpl })) {
+    events.push(event);
+  }
+
+  assert.equal(calls, 2);
+  assert.equal(events.some((event) => event.type === "text_delta" && event.text === "ok"), true);
+});
+
+test("streamModel max streaming duration is disabled by default and enforced when configured", async () => {
+  const fetchImpl = async () => new Response(new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(sseFrame(openAITextChunk("ok")));
+      controller.enqueue(new TextEncoder().encode("data: [DONE]\n\n"));
+      controller.close();
+    },
+  }), { status: 200 });
+
+  const defaultEvents = [];
+  for await (const event of streamModel(request, modelConfig(), { fetch: fetchImpl })) {
+    defaultEvents.push(event);
+  }
+  assert.equal(defaultEvents.some((event) => event.type === "text_delta"), true);
+
+  const slowFetch = async () => new Response(new ReadableStream<Uint8Array>({
+    async start(controller) {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      controller.enqueue(sseFrame(openAITextChunk("late")));
+      controller.enqueue(new TextEncoder().encode("data: [DONE]\n\n"));
+      controller.close();
+    },
+  }), { status: 200 });
+
+  await assert.rejects(async () => {
+    for await (const _event of streamModel(request, modelConfig({ maxStreamingDurationMs: 1, streamMaxRetries: 0 }), { fetch: slowFetch })) {
+      // consume
+    }
+  }, /max streaming duration|exceeded/i);
+});
+
+test("request streamTimeoutMs overrides provider stream idle timeout", async () => {
+  const fetchImpl = async () => new Response(new ReadableStream<Uint8Array>({
+    async start(controller) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      controller.enqueue(sseFrame(openAITextChunk("late")));
+      controller.close();
+    },
+  }), { status: 200 });
+
+  await assert.rejects(async () => {
+    for await (const _event of streamModel(
+      request,
+      modelConfig({ streamIdleTimeoutMs: 60_000, streamMaxRetries: 0 }),
+      { fetch: fetchImpl, streamTimeoutMs: 1 },
+    )) {
+      // consume
+    }
+  }, /Stream idle timeout/);
+});
+
+test("LiteLLM continuation request includes partial content and no-repeat instruction", () => {
+  const continuation = buildLiteLLMContinuationRequest(request, "partial answer");
+  assert.equal(continuation.messages.length, request.messages.length + 2);
+  assert.deepEqual(continuation.messages.at(-2), {
+    role: "assistant",
+    content: [{ type: "text", text: "partial answer" }],
+  });
+  assert.deepEqual(continuation.messages.at(-1), {
+    role: "user",
+    content: [{ type: "text", text: LITELLM_CONTINUATION_INSTRUCTION }],
+  });
+  assert.equal(JSON.stringify(continuation).includes("Continue from where you left off."), false);
+});
+
+test("LiteLLM continuation builder strips prior continuation pair before appending", () => {
+  const first = buildLiteLLMContinuationRequest(request, "first partial");
+  const second = buildLiteLLMContinuationRequest(first, "second partial");
+  assert.equal(second.messages.length, request.messages.length + 2);
+  assert.equal(JSON.stringify(second).includes("first partial"), false);
+  assert.equal(JSON.stringify(second).includes("second partial"), true);
+  assert.equal(JSON.stringify(second).match(new RegExp(LITELLM_CONTINUATION_INSTRUCTION, "g"))?.length, 1);
+});
+
+test("pre-first-content retry keeps original request messages", async () => {
+  const requestBodies: unknown[] = [];
+  let calls = 0;
+  const fetchImpl = async (_url: string | URL | Request, init?: RequestInit) => {
+    calls += 1;
+    requestBodies.push(JSON.parse(String(init?.body)));
+    if (calls === 1) {
+      throw new Error("fetch failed");
+    }
+    return new Response(new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(sseFrame(openAITextChunk("ok")));
+        controller.enqueue(new TextEncoder().encode("data: [DONE]\n\n"));
+        controller.close();
+      },
+    }), { status: 200 });
+  };
+
+  for await (const _event of streamModel(request, modelConfig({ streamMaxRetries: 1 }), { fetch: fetchImpl })) {
+    // consume
+  }
+
+  assert.equal(calls, 2);
+  assert.equal(JSON.stringify(requestBodies[1]).includes(LITELLM_CONTINUATION_INSTRUCTION), false);
+  assert.equal(JSON.stringify(requestBodies[1]).includes("Continue from where you left off."), false);
+});
+
+test("post-content retry sends LiteLLM continuation request", async () => {
+  const requestBodies: unknown[] = [];
+  let calls = 0;
+  const fetchImpl = async (_url: string | URL | Request, init?: RequestInit) => {
+    calls += 1;
+    requestBodies.push(JSON.parse(String(init?.body)));
+    const partialChunks = Array.from(
+      { length: 60 },
+      (_, index) => sseFrame(openAITextChunk(`partial content ${index} that is long enough for continuation retry `)),
+    );
+    const chunks = calls === 1
+      ? partialChunks
+      : [sseFrame(openAITextChunk("continued")), new TextEncoder().encode("data: [DONE]\n\n")];
+    return new Response(new ReadableStream<Uint8Array>({
+      start(controller) {
+        for (const chunk of chunks) controller.enqueue(chunk);
+        controller.close();
+      },
+    }), { status: 200 });
+  };
+
+  for await (const _event of streamModel(request, modelConfig({ streamMaxRetries: 1 }), { fetch: fetchImpl })) {
+    // consume
+  }
+
+  assert.equal(calls, 2);
+  const retriedBody = JSON.stringify(requestBodies[1]);
+  assert.equal(retriedBody.includes(LITELLM_CONTINUATION_INSTRUCTION), true);
+  assert.equal(retriedBody.includes("partial content 0 that is long enough"), true);
+  assert.equal(retriedBody.includes("Continue from where you left off."), false);
+});
+
+test("stream retry cancels the failed SSE reader before retrying", async () => {
+  let calls = 0;
+  let cancelCount = 0;
+  const fetchImpl = async () => {
+    calls += 1;
+    const chunks = calls === 1
+      ? [sseFrame(openAITextChunk("repeat")), sseFrame(openAITextChunk("repeat"))]
+      : [sseFrame(openAITextChunk("ok")), new TextEncoder().encode("data: [DONE]\n\n")];
+    return new Response(new ReadableStream<Uint8Array>({
+      start(controller) {
+        for (const chunk of chunks) controller.enqueue(chunk);
+        if (calls !== 1) {
+          controller.close();
+        }
+      },
+      cancel() {
+        cancelCount += 1;
+      },
+    }), { status: 200 });
+  };
+
+  for await (const _event of streamModel(request, modelConfig({ repeatedChunkLimit: 2, streamMaxRetries: 1 }), { fetch: fetchImpl })) {
+    // consume
+  }
+
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.equal(calls, 2);
+  assert.equal(cancelCount >= 1, true);
+});
+
+test("model stream retry progress reports continuation", async () => {
+  const progressReasons: string[] = [];
+  let calls = 0;
+  const fetchImpl = async () => {
+    calls += 1;
+    const chunks = calls === 1
+      ? [sseFrame(openAITextChunk("partial content for continuation"))]
+      : [sseFrame(openAITextChunk("continued")), new TextEncoder().encode("data: [DONE]\n\n")];
+    return new Response(new ReadableStream<Uint8Array>({
+      start(controller) {
+        for (const chunk of chunks) controller.enqueue(chunk);
+        controller.close();
+      },
+    }), { status: 200 });
+  };
+
+  for await (const _event of streamModel(
+    request,
+    modelConfig({ streamMaxRetries: 1 }),
+    { fetch: fetchImpl, onRetryProgress: (progress) => progressReasons.push(progress.reason) },
+  )) {
+    // consume
+  }
+
+  assert.deepEqual(progressReasons, ["continuation"]);
+});
+
+test("non-retryable 4xx surfaces without retry while 429 captures Retry-After", async () => {
+  let badRequestCalls = 0;
+  const badRequestFetch = async () => {
+    badRequestCalls += 1;
+    return Response.json({ error: { message: "bad request", type: "invalid_request" } }, { status: 400 });
+  };
+
+  const badRequestEvents = [];
+  for await (const event of streamModel(request, modelConfig({ streamMaxRetries: 1 }), { fetch: badRequestFetch })) {
+    badRequestEvents.push(event);
+  }
+
+  assert.equal(badRequestCalls, 1);
+  const badRequestError = badRequestEvents.find((event) => event.type === "error")?.error;
+  assert.equal(badRequestError?.retryable, false);
+
+  const rateLimitFetch = async () => Response.json(
+    { error: { message: "rate limit" } },
+    { status: 429, headers: { "retry-after": "3" } },
+  );
+  const rateLimitEvents = [];
+  for await (const event of streamModel(request, modelConfig({ streamMaxRetries: 1 }), { fetch: rateLimitFetch })) {
+    rateLimitEvents.push(event);
+  }
+  const rateLimitError = rateLimitEvents.find((event) => event.type === "error")?.error;
+  assert.equal(rateLimitError?.retryable, true);
+  assert.equal(rateLimitError?.retryAfterMs, 3_000);
+});
+
+test("OpenAI Responses and Anthropic stream drops recover with LiteLLM continuation", async () => {
+  const cases: Array<{ protocol: ModelProtocol; first: Uint8Array[]; second: Uint8Array[]; expectedText: string }> = [
+    {
+      protocol: "openai-responses",
+      first: [openAIResponsesEvent("response.created", { response: { id: "resp_test" } }), openAIResponsesEvent("response.output_text.delta", { delta: "partial response" })],
+      second: [openAIResponsesEvent("response.created", { response: { id: "resp_test_2" } }), openAIResponsesEvent("response.output_text.delta", { delta: "continued response" }), openAIResponsesEvent("response.completed", { response: { id: "resp_test_2", usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 } } })],
+      expectedText: "continued response",
+    },
+    {
+      protocol: "anthropic",
+      first: [
+        anthropicEvent("message_start", { message: { id: "msg_1", type: "message", role: "assistant", content: [], model: "test-model" } }),
+        anthropicEvent("content_block_start", { index: 0, content_block: { type: "text", text: "" } }),
+        anthropicEvent("content_block_delta", { index: 0, delta: { type: "text_delta", text: "partial response" } }),
+      ],
+      second: [
+        anthropicEvent("message_start", { message: { id: "msg_2", type: "message", role: "assistant", content: [], model: "test-model" } }),
+        anthropicEvent("content_block_start", { index: 0, content_block: { type: "text", text: "" } }),
+        anthropicEvent("content_block_delta", { index: 0, delta: { type: "text_delta", text: "continued response" } }),
+        anthropicEvent("message_delta", { delta: { stop_reason: "end_turn" }, usage: { output_tokens: 1 } }),
+        anthropicEvent("message_stop", {}),
+      ],
+      expectedText: "continued response",
+    },
+  ];
+
+  for (const testCase of cases) {
+    const requestBodies: unknown[] = [];
+    let calls = 0;
+    const fetchImpl = async (_url: string | URL | Request, init?: RequestInit) => {
+      calls += 1;
+      requestBodies.push(JSON.parse(String(init?.body)));
+      const chunks = calls === 1 ? testCase.first : testCase.second;
+      return new Response(new ReadableStream<Uint8Array>({
+        start(controller) {
+          for (const chunk of chunks) controller.enqueue(chunk);
+          controller.close();
+        },
+      }), { status: 200 });
+    };
+
+    const events = [];
+    for await (const event of streamModel(
+      protocolRequest(testCase.protocol),
+      protocolModelConfig(testCase.protocol, { streamMaxRetries: 1, baseDelayMs: 1, maxDelayMs: 1, jitter: 0 }),
+      { fetch: fetchImpl },
+    )) {
+      events.push(event);
+    }
+
+    assert.equal(calls, 2, `${testCase.protocol} should retry once`);
+    assert.equal(JSON.stringify(requestBodies[1]).includes(LITELLM_CONTINUATION_INSTRUCTION), true);
+    assert.equal(JSON.stringify(requestBodies[1]).includes("partial response"), true);
+    assert.equal(events.some((event) => event.type === "text_delta" && event.text === testCase.expectedText), true);
+  }
+});
+
+test("Google native stream completion accepts finishReason without OpenAI DONE sentinel", async () => {
+  const googleRequest = protocolRequest("google");
+  const config = protocolModelConfig("google", { streamMaxRetries: 0 });
+  const googleClientFactory = () => ({
+    models: {
+      async generateContent() {
+        throw new Error("not used");
+      },
+      async generateContentStream() {
+        return (async function* () {
+          yield {
+            candidates: [{ content: { role: "model", parts: [{ text: "STREAM_OK" }] }, finishReason: "STOP", index: 0 }],
+            usageMetadata: { promptTokenCount: 1, candidatesTokenCount: 1, totalTokenCount: 2 },
+          };
+        })();
+      },
+    },
+  } as never);
+
+  const events = [];
+  for await (const event of streamModel(googleRequest, config, { googleClientFactory })) {
+    events.push(event);
+  }
+
+  assert.equal(events.some((event) => event.type === "text_delta" && event.text === "STREAM_OK"), true);
+  assert.equal(events.some((event) => event.type === "message_end"), true);
+  assert.equal(events.some((event) => event.type === "error"), false);
+});

--- a/tests/model/litellmStreamingDefaults.spec.ts
+++ b/tests/model/litellmStreamingDefaults.spec.ts
@@ -338,7 +338,7 @@ test("model stream retry progress reports continuation", async () => {
   assert.deepEqual(progressReasons, ["continuation"]);
 });
 
-test("non-retryable 4xx surfaces without retry while 429 captures Retry-After", async () => {
+test("non-retryable 4xx surfaces without retry while 429 retries with Retry-After", async () => {
   let badRequestCalls = 0;
   const badRequestFetch = async () => {
     badRequestCalls += 1;
@@ -354,17 +354,56 @@ test("non-retryable 4xx surfaces without retry while 429 captures Retry-After", 
   const badRequestError = badRequestEvents.find((event) => event.type === "error")?.error;
   assert.equal(badRequestError?.retryable, false);
 
-  const rateLimitFetch = async () => Response.json(
-    { error: { message: "rate limit" } },
-    { status: 429, headers: { "retry-after": "3" } },
-  );
+  let rateLimitCalls = 0;
+  const progressDelays: number[] = [];
+  const rateLimitFetch = async () => {
+    rateLimitCalls += 1;
+    if (rateLimitCalls === 1) {
+      return Response.json(
+        { error: { message: "rate limit" } },
+        { status: 429, headers: { "retry-after": "3" } },
+      );
+    }
+    return new Response(new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(sseFrame(openAITextChunk("ok after 429")));
+        controller.enqueue(new TextEncoder().encode("data: [DONE]\n\n"));
+        controller.close();
+      },
+    }), { status: 200 });
+  };
   const rateLimitEvents = [];
-  for await (const event of streamModel(request, modelConfig({ streamMaxRetries: 1 }), { fetch: rateLimitFetch })) {
+  for await (const event of streamModel(
+    request,
+    modelConfig({ streamMaxRetries: 1, baseDelayMs: 1, maxDelayMs: 5_000, jitter: 0 }),
+    { fetch: rateLimitFetch, onRetryProgress: (progress) => progressDelays.push(progress.delayMs) },
+  )) {
     rateLimitEvents.push(event);
   }
-  const rateLimitError = rateLimitEvents.find((event) => event.type === "error")?.error;
-  assert.equal(rateLimitError?.retryable, true);
-  assert.equal(rateLimitError?.retryAfterMs, 3_000);
+  assert.equal(rateLimitCalls, 2);
+  assert.deepEqual(progressDelays, [3_000]);
+  assert.equal(rateLimitEvents.some((event) => event.type === "text_delta" && event.text === "ok after 429"), true);
+});
+
+test("streamTimeoutMs bounds the pre-response fetch phase", async () => {
+  let abortObserved = false;
+  const hangingFetch = async (_url: string | URL | Request, init?: RequestInit) => new Promise<Response>((_resolve, reject) => {
+    init?.signal?.addEventListener("abort", () => {
+      abortObserved = true;
+      reject(new Error("request timeout"));
+    }, { once: true });
+  });
+
+  await assert.rejects(async () => {
+    for await (const _event of streamModel(
+      request,
+      modelConfig({ streamMaxRetries: 0 }),
+      { fetch: hangingFetch, streamTimeoutMs: 1 },
+    )) {
+      // consume
+    }
+  }, /request timeout|timeout/i);
+  assert.equal(abortObserved, true);
 });
 
 test("OpenAI Responses and Anthropic stream drops recover with LiteLLM continuation", async () => {

--- a/tests/model/modelBestRealStreaming.smoke.spec.ts
+++ b/tests/model/modelBestRealStreaming.smoke.spec.ts
@@ -1,0 +1,221 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+const BASE_URL = "https://llm-center.ali.modelbest.cn/llm";
+const API_KEY = process.env.MODELBEST_API_KEY;
+const RUN_REAL = process.env.PILOTDECK_RUN_MODELBEST_REAL_E2E === "1";
+
+type SmokeResult = {
+  protocol: string;
+  model: string;
+  endpoint: string;
+  ok: boolean;
+  status: number | null;
+  contentType: string | null;
+  firstChunkMs: number | null;
+  chunks: number;
+  bytes: number;
+  completionMarker: string;
+  sample: string;
+  error?: string;
+};
+
+type SmokeCase = {
+  protocol: string;
+  model: string;
+  endpoint: string;
+  headers: Record<string, string>;
+  body: Record<string, unknown>;
+  completionMarker: string;
+  isComplete: (text: string) => boolean;
+};
+
+const prompt = "Reply with exactly: STREAM_OK";
+
+const realSmokeCases: SmokeCase[] = [
+  {
+    protocol: "OpenAI Chat / GPT",
+    model: "GPT_pgikl3",
+    endpoint: "/v1/chat/completions",
+    headers: bearerHeaders(),
+    body: { model: "GPT_pgikl3", stream: true, max_tokens: 24, messages: [{ role: "user", content: prompt }] },
+    completionMarker: "[DONE]",
+    isComplete: (text) => text.includes("[DONE]"),
+  },
+  {
+    protocol: "OpenAI Chat / DeepSeek",
+    model: "DEEPSEEK_rtwgny",
+    endpoint: "/v1/chat/completions",
+    headers: bearerHeaders(),
+    body: { model: "DEEPSEEK_rtwgny", stream: true, max_tokens: 24, messages: [{ role: "user", content: prompt }] },
+    completionMarker: "[DONE]",
+    isComplete: (text) => text.includes("[DONE]"),
+  },
+  {
+    protocol: "OpenAI Chat / Gemini",
+    model: "GEMINI_mo7jqq",
+    endpoint: "/v1/chat/completions",
+    headers: bearerHeaders(),
+    body: { model: "GEMINI_mo7jqq", stream: true, max_tokens: 24, messages: [{ role: "user", content: prompt }] },
+    completionMarker: "[DONE]",
+    isComplete: (text) => text.includes("[DONE]"),
+  },
+  {
+    protocol: "OpenAI Responses / Qwen",
+    model: "QWEN_36ltx6",
+    endpoint: "/v1/responses",
+    headers: bearerHeaders(),
+    body: { model: "QWEN_36ltx6", stream: true, max_output_tokens: 24, input: prompt },
+    completionMarker: "response.completed",
+    isComplete: (text) => text.includes("response.completed"),
+  },
+  {
+    protocol: "Anthropic / Claude",
+    model: "CLAUDE_osm7oh",
+    endpoint: "/v1/messages",
+    headers: anthropicHeaders(),
+    body: { model: "CLAUDE_osm7oh", stream: true, max_tokens: 24, messages: [{ role: "user", content: prompt }] },
+    completionMarker: "message_stop",
+    isComplete: (text) => text.includes("message_stop"),
+  },
+  {
+    protocol: "Anthropic / DeepSeek",
+    model: "DEEPSEEK_rtwgny",
+    endpoint: "/v1/messages",
+    headers: anthropicHeaders(),
+    body: { model: "DEEPSEEK_rtwgny", stream: true, max_tokens: 24, messages: [{ role: "user", content: prompt }] },
+    completionMarker: "message_stop",
+    isComplete: (text) => text.includes("message_stop"),
+  },
+  {
+    protocol: "Gemini Native / Gemini",
+    model: "GEMINI_mo7jqq",
+    endpoint: "/v1beta/models/GEMINI_mo7jqq:streamGenerateContent",
+    headers: googleHeaders(),
+    body: { contents: [{ role: "user", parts: [{ text: prompt }] }], generationConfig: { maxOutputTokens: 24 } },
+    completionMarker: "finishReason",
+    isComplete: (text) => text.includes("finishReason"),
+  },
+];
+
+test("ModelBest real streaming endpoints smoke test", { skip: !RUN_REAL || !API_KEY }, async () => {
+  const results: SmokeResult[] = [];
+  for (const testCase of realSmokeCases) {
+    results.push(await runSmokeCase(testCase));
+  }
+
+  console.table(results.map(({ sample: _sample, ...result }) => result));
+  for (const result of results) {
+    assert.equal(result.ok, true, `${result.protocol} failed: ${JSON.stringify(result)}`);
+    assert.equal(result.status, 200, `${result.protocol} returned unexpected status`);
+    assert.match(result.contentType ?? "", /text\/event-stream/i, `${result.protocol} did not stream SSE`);
+    assert.equal(typeof result.firstChunkMs, "number", `${result.protocol} did not receive a first chunk`);
+    assert.equal(result.chunks > 0, true, `${result.protocol} did not receive chunks`);
+  }
+});
+
+test("ModelBest model list exposes protocol endpoints", { skip: !RUN_REAL || !API_KEY }, async () => {
+  const response = await fetch(`${BASE_URL}/v1/models`, { headers: bearerHeaders() });
+  assert.equal(response.status, 200);
+  const raw = await response.json() as { data?: Array<{ id?: string; supported_protocols?: Array<{ code?: string; endpoint?: string }> }> };
+  const models = raw.data ?? [];
+  assert.equal(models.some((model) => model.supported_protocols?.some((protocol) => protocol.code === "OPENAI_HTTP" && protocol.endpoint === "/v1/chat/completions")), true);
+  assert.equal(models.some((model) => model.supported_protocols?.some((protocol) => protocol.code === "OPENAI_RESPONSE" && protocol.endpoint === "/v1/responses")), true);
+  assert.equal(models.some((model) => model.supported_protocols?.some((protocol) => protocol.code === "ANTHROPIC" && protocol.endpoint === "/v1/messages")), true);
+  assert.equal(models.some((model) => model.supported_protocols?.some((protocol) => protocol.code === "GEMINI" && protocol.endpoint === "/v1beta/models/{model}:generateContent")), true);
+
+  const geminiListResponse = await fetch(`${BASE_URL}/v1beta/models`, { headers: googleHeaders() });
+  assert.equal(geminiListResponse.status, 404);
+});
+
+async function runSmokeCase(testCase: SmokeCase): Promise<SmokeResult> {
+  const startedAt = Date.now();
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 60_000);
+  let status: number | null = null;
+  let contentType: string | null = null;
+  let firstChunkMs: number | null = null;
+  let chunks = 0;
+  let bytes = 0;
+  let sample = "";
+  let completionSeen = false;
+
+  try {
+    const response = await fetch(`${BASE_URL}${testCase.endpoint}`, {
+      method: "POST",
+      headers: { "content-type": "application/json", ...testCase.headers },
+      body: JSON.stringify(testCase.body),
+      signal: controller.signal,
+    });
+    status = response.status;
+    contentType = response.headers.get("content-type");
+    if (!response.body) {
+      throw new Error("Missing response body");
+    }
+
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    try {
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        firstChunkMs ??= Date.now() - startedAt;
+        chunks += 1;
+        bytes += value.byteLength;
+        const text = decoder.decode(value, { stream: true });
+        if (sample.length < 1500) {
+          sample += text.slice(0, 1500 - sample.length);
+        }
+        completionSeen ||= testCase.isComplete(text) || testCase.isComplete(sample);
+        if (completionSeen) {
+          break;
+        }
+      }
+    } finally {
+      await reader.cancel().catch(() => undefined);
+    }
+
+    return {
+      protocol: testCase.protocol,
+      model: testCase.model,
+      endpoint: testCase.endpoint,
+      ok: response.ok && completionSeen,
+      status,
+      contentType,
+      firstChunkMs,
+      chunks,
+      bytes,
+      completionMarker: testCase.completionMarker,
+      sample: sample.replace(/\s+/g, " ").slice(0, 500),
+    };
+  } catch (error) {
+    return {
+      protocol: testCase.protocol,
+      model: testCase.model,
+      endpoint: testCase.endpoint,
+      ok: false,
+      status,
+      contentType,
+      firstChunkMs,
+      chunks,
+      bytes,
+      completionMarker: testCase.completionMarker,
+      sample: sample.replace(/\s+/g, " ").slice(0, 500),
+      error: error instanceof Error ? `${error.name}: ${error.message}` : String(error),
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function bearerHeaders(): Record<string, string> {
+  return { authorization: `Bearer ${API_KEY ?? ""}` };
+}
+
+function anthropicHeaders(): Record<string, string> {
+  return { "x-api-key": API_KEY ?? "", "anthropic-version": "2023-06-01" };
+}
+
+function googleHeaders(): Record<string, string> {
+  return { "x-goog-api-key": API_KEY ?? "" };
+}

--- a/tests/router/fallbackPlan.spec.ts
+++ b/tests/router/fallbackPlan.spec.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { planFallback } from "../../src/router/fallback/runFallbackChain.js";
+import type { RouterFallbackConfig, RouterModelRef } from "../../src/router/config/schema.js";
+
+function ref(index: number): RouterModelRef {
+  return { id: `p${index}/m${index}`, provider: `p${index}`, model: `m${index}` };
+}
+
+test("router fallback caps default attempts at LiteLLM maxFallbacks", () => {
+  const fallback: RouterFallbackConfig = {
+    default: Array.from({ length: 10 }, (_, index) => ref(index)),
+  };
+  const plan = planFallback(fallback, "default");
+  assert.equal(plan.attempts.length, 5);
+  assert.deepEqual(plan.attempts.map((attempt) => attempt.id), ["p0/m0", "p1/m1", "p2/m2", "p3/m3", "p4/m4"]);
+});
+
+test("router fallback honors explicit maxFallbacks override", () => {
+  const fallback: RouterFallbackConfig = {
+    maxFallbacks: 2,
+    default: Array.from({ length: 4 }, (_, index) => ref(index)),
+  };
+  const plan = planFallback(fallback, "explicit");
+  assert.equal(plan.attempts.length, 2);
+});

--- a/tests/router/streamingRecovery.e2e.spec.ts
+++ b/tests/router/streamingRecovery.e2e.spec.ts
@@ -1,0 +1,246 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  LITELLM_CONTINUATION_INSTRUCTION,
+  createModelRuntime,
+  parseModelConfig,
+} from "../../src/model/index.js";
+import type { CanonicalModelEvent, CanonicalModelRequest, ModelTransport } from "../../src/model/index.js";
+import { createRouterRuntime } from "../../src/router/index.js";
+import type { RouterConfig } from "../../src/router/config/schema.js";
+import type { RouterEvent } from "../../src/router/protocol/events.js";
+
+function request(): CanonicalModelRequest {
+  return {
+    provider: "openai",
+    model: "test-model",
+    messages: [{ role: "user", content: [{ type: "text", text: "hello" }] }],
+  };
+}
+
+function routerConfig(): RouterConfig {
+  return {
+    enabled: false,
+    scenarios: {
+      default: { id: "openai/test-model", provider: "openai", model: "test-model" },
+    },
+  };
+}
+
+function modelRuntime(fetchImpl: ModelTransport) {
+  const config = parseModelConfig({
+    providers: {
+      openai: {
+        protocol: "openai",
+        url: "https://example.test/v1",
+        apiKey: "test-key",
+        retry: { streamMaxRetries: 1, baseDelayMs: 1, maxDelayMs: 1, jitter: 0 },
+        models: { "test-model": {} },
+      },
+    },
+  });
+  return createModelRuntime(config, { fetch: fetchImpl });
+}
+
+function fallbackModelRuntime(fetchImpl: ModelTransport) {
+  const config = parseModelConfig({
+    providers: {
+      primary: {
+        protocol: "openai",
+        url: "https://primary.example.test/v1",
+        apiKey: "test-key",
+        retry: { streamMaxRetries: 0, baseDelayMs: 1, maxDelayMs: 1, jitter: 0 },
+        models: { primary: {} },
+      },
+      fallback: {
+        protocol: "openai",
+        url: "https://fallback.example.test/v1",
+        apiKey: "test-key",
+        retry: { streamMaxRetries: 0, baseDelayMs: 1, maxDelayMs: 1, jitter: 0 },
+        models: { fallback: {} },
+      },
+    },
+  });
+  return createModelRuntime(config, { fetch: fetchImpl });
+}
+
+function fallbackRouterConfig(transientMaxAttempts = 1): RouterConfig {
+  return {
+    enabled: true,
+    scenarios: {
+      default: { id: "primary/primary", provider: "primary", model: "primary" },
+    },
+    fallback: {
+      default: [{ id: "fallback/fallback", provider: "fallback", model: "fallback" }],
+      maxFallbacks: 5,
+    },
+    transientRetry: { enabled: true, maxAttempts: transientMaxAttempts, baseDelayMs: 1, maxDelayMs: 1 },
+    zeroUsageRetry: { enabled: false, maxAttempts: 1 },
+  };
+}
+
+function sseFrame(data: unknown): Uint8Array {
+  return new TextEncoder().encode(`data: ${JSON.stringify(data)}\n\n`);
+}
+
+function openAITextChunk(text: string): unknown {
+  return {
+    id: "chatcmpl-test",
+    object: "chat.completion.chunk",
+    choices: [{ index: 0, delta: { content: text }, finish_reason: null }],
+  };
+}
+
+function doneFrame(): Uint8Array {
+  return new TextEncoder().encode("data: [DONE]\n\n");
+}
+
+async function collect(stream: AsyncIterable<CanonicalModelEvent>): Promise<CanonicalModelEvent[]> {
+  const events: CanonicalModelEvent[] = [];
+  for await (const event of stream) {
+    events.push(event);
+  }
+  return events;
+}
+
+test("router stream recovers from pre-first-token network failure without continuation", async () => {
+  const bodies: unknown[] = [];
+  let calls = 0;
+  const fetchImpl: ModelTransport = async (_url, init) => {
+    calls += 1;
+    bodies.push(JSON.parse(String(init?.body)));
+    if (calls === 1) {
+      throw new Error("fetch failed");
+    }
+    return new Response(new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(sseFrame(openAITextChunk("ok")));
+        controller.enqueue(doneFrame());
+        controller.close();
+      },
+    }), { status: 200 });
+  };
+
+  const runtime = createRouterRuntime(routerConfig(), { modelRuntime: modelRuntime(fetchImpl) });
+  const events = await collect(runtime.stream(request(), { sessionId: "s1", turnId: "t1", isMainAgent: true }));
+
+  assert.equal(calls, 2);
+  assert.equal(JSON.stringify(bodies[1]).includes(LITELLM_CONTINUATION_INSTRUCTION), false);
+  assert.equal(events.some((event) => event.type === "text_delta" && event.text === "ok"), true);
+});
+
+test("router stream recovers from post-content dropped stream with LiteLLM continuation", async () => {
+  const bodies: unknown[] = [];
+  const routerEvents: RouterEvent[] = [];
+  let calls = 0;
+  const fetchImpl: ModelTransport = async (_url, init) => {
+    calls += 1;
+    bodies.push(JSON.parse(String(init?.body)));
+    const chunks = calls === 1
+      ? [sseFrame(openAITextChunk("partial before drop"))]
+      : [sseFrame(openAITextChunk("continued")), doneFrame()];
+    return new Response(new ReadableStream<Uint8Array>({
+      start(controller) {
+        for (const chunk of chunks) controller.enqueue(chunk);
+        controller.close();
+      },
+    }), { status: 200 });
+  };
+
+  const runtime = createRouterRuntime(routerConfig(), {
+    modelRuntime: modelRuntime(fetchImpl),
+    events: { emit: (event) => routerEvents.push(event) },
+  });
+  const events = await collect(runtime.stream(request(), { sessionId: "s2", turnId: "t2", isMainAgent: true }));
+
+  assert.equal(calls, 2);
+  assert.equal(JSON.stringify(bodies[1]).includes(LITELLM_CONTINUATION_INSTRUCTION), true);
+  assert.equal(JSON.stringify(bodies[1]).includes("partial before drop"), true);
+  assert.equal(routerEvents.some((event) => event.type === "pilotdeck_router_retry_progress" && event.reason === "continuation"), true);
+  assert.equal(events.some((event) => event.type === "text_delta" && event.text === "continued"), true);
+});
+
+test("router falls back on pre-content 429 and respects Retry-After in progress", async () => {
+  const bodies: unknown[] = [];
+  const routerEvents: RouterEvent[] = [];
+  let calls = 0;
+  const fetchImpl: ModelTransport = async (_url, init) => {
+    calls += 1;
+    bodies.push(JSON.parse(String(init?.body)));
+    if (calls === 1) {
+      return Response.json({ error: { message: "rate limit" } }, { status: 429, headers: { "retry-after": "2" } });
+    }
+    return new Response(new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(sseFrame(openAITextChunk("fallback ok")));
+        controller.enqueue(doneFrame());
+        controller.close();
+      },
+    }), { status: 200 });
+  };
+
+  const runtime = createRouterRuntime(fallbackRouterConfig(), {
+    modelRuntime: fallbackModelRuntime(fetchImpl),
+    events: { emit: (event) => routerEvents.push(event) },
+  });
+  const events = await collect(runtime.stream(request(), { sessionId: "s3", turnId: "t3", isMainAgent: true }));
+
+  assert.equal(calls, 2);
+  assert.equal(JSON.stringify(bodies[1]).includes(LITELLM_CONTINUATION_INSTRUCTION), false);
+  assert.equal(routerEvents.some((event) => event.type === "pilotdeck_router_fallback"), true);
+  assert.equal(routerEvents.some((event) => event.type === "pilotdeck_router_retry_progress" && event.delayMs === 2_000), true);
+  assert.equal(events.some((event) => event.type === "text_delta" && event.text === "fallback ok"), true);
+});
+
+test("router does not retry or fallback non-retryable 400", async () => {
+  const routerEvents: RouterEvent[] = [];
+  let calls = 0;
+  const fetchImpl: ModelTransport = async () => {
+    calls += 1;
+    return Response.json({ error: { message: "bad request", type: "invalid_request" } }, { status: 400 });
+  };
+
+  const runtime = createRouterRuntime(fallbackRouterConfig(), {
+    modelRuntime: fallbackModelRuntime(fetchImpl),
+    events: { emit: (event) => routerEvents.push(event) },
+  });
+  const events = await collect(runtime.stream(request(), { sessionId: "s4", turnId: "t4", isMainAgent: true }));
+
+  assert.equal(calls, 1);
+  assert.equal(routerEvents.some((event) => event.type === "pilotdeck_router_fallback"), false);
+  assert.equal(events.some((event) => event.type === "error" && event.error.retryable === false), true);
+});
+
+test("router mid-stream continuation starts after any visible generated content", async () => {
+  const bodies: unknown[] = [];
+  let calls = 0;
+  const fetchImpl: ModelTransport = async (_url, init) => {
+    calls += 1;
+    bodies.push(JSON.parse(String(init?.body)));
+    if (calls === 1) {
+      return new Response(new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(sseFrame(openAITextChunk("tiny")));
+          controller.enqueue(sseFrame({ error: { message: "overloaded", type: "overloaded_error" } }));
+          controller.close();
+        },
+      }), { status: 200 });
+    }
+    return new Response(new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(sseFrame(openAITextChunk("after tiny continuation")));
+        controller.enqueue(doneFrame());
+        controller.close();
+      },
+    }), { status: 200 });
+  };
+
+  const runtime = createRouterRuntime(fallbackRouterConfig(2), { modelRuntime: fallbackModelRuntime(fetchImpl) });
+  const events = await collect(runtime.stream(request(), { sessionId: "s5", turnId: "t5", isMainAgent: true }));
+
+  assert.equal(calls, 2);
+  assert.equal(JSON.stringify(bodies[1]).includes(LITELLM_CONTINUATION_INSTRUCTION), true);
+  assert.equal(JSON.stringify(bodies[1]).includes("tiny"), true);
+  assert.equal(events.some((event) => event.type === "text_delta" && event.text === "after tiny continuation"), true);
+});

--- a/tests/router/streamingRecovery.e2e.spec.ts
+++ b/tests/router/streamingRecovery.e2e.spec.ts
@@ -161,7 +161,7 @@ test("router stream recovers from post-content dropped stream with LiteLLM conti
   assert.equal(events.some((event) => event.type === "text_delta" && event.text === "continued"), true);
 });
 
-test("router falls back on pre-content 429 and respects Retry-After in progress", async () => {
+test("router falls back on pre-content 429 without reporting an unslept Retry-After delay", async () => {
   const bodies: unknown[] = [];
   const routerEvents: RouterEvent[] = [];
   let calls = 0;
@@ -189,7 +189,7 @@ test("router falls back on pre-content 429 and respects Retry-After in progress"
   assert.equal(calls, 2);
   assert.equal(JSON.stringify(bodies[1]).includes(LITELLM_CONTINUATION_INSTRUCTION), false);
   assert.equal(routerEvents.some((event) => event.type === "pilotdeck_router_fallback"), true);
-  assert.equal(routerEvents.some((event) => event.type === "pilotdeck_router_retry_progress" && event.delayMs === 2_000), true);
+  assert.equal(routerEvents.some((event) => event.type === "pilotdeck_router_retry_progress" && event.delayMs === 2_000), false);
   assert.equal(events.some((event) => event.type === "text_delta" && event.text === "fallback ok"), true);
 });
 

--- a/ui/server/pilotdeck-bridge.js
+++ b/ui/server/pilotdeck-bridge.js
@@ -610,11 +610,16 @@ export function gatewayEventToFrames(event, sessionId, provider) {
                 ];
             }
             if (event.event === 'retry_progress') {
+                const retryText = detail.reason === 'continuation'
+                    ? 'Continuing response'
+                    : detail.reason === 'rate_limit' || detail.reason === 'overloaded'
+                        ? 'Switching model'
+                        : 'Reconnecting';
                 return [
                     createNormalizedMessage({
                         ...base,
                         kind: 'status',
-                        text: `Reconnecting... ${detail.attempt}/${detail.maxAttempts}`,
+                        text: `${retryText}... ${detail.attempt}/${detail.maxAttempts}`,
                         tokens: 0,
                         canInterrupt: true,
                         retryProgress: {


### PR DESCRIPTION
## Summary
- Align streaming retry, fallback, continuation, and transport defaults with LiteLLM semantics
- Add LiteLLM-style continuation request builder and retry/fallback progress reporting
- Add deterministic mock coverage for unstable streams plus opt-in ModelBest real endpoint smoke tests

## Tests
- pnpm exec tsc -p tsconfig.json --noEmit
- pnpm run build
- node --test --test-timeout 60000 dist/tests/model/litellmStreamingDefaults.spec.js dist/tests/model/modelBestRealStreaming.smoke.spec.js dist/tests/router/fallbackPlan.spec.js dist/tests/router/streamingRecovery.e2e.spec.js dist/tests/cli/proxyDefaults.spec.js
- MODELBEST_API_KEY=*** PILOTDECK_RUN_MODELBEST_REAL_E2E=1 node --test --test-timeout 120000 dist/tests/model/modelBestRealStreaming.smoke.spec.js