### PR TITLE
Improve generated file links in chat

### DIFF
--- a/src/context/prompt/PromptAssembler.ts
+++ b/src/context/prompt/PromptAssembler.ts
@@ -99,6 +99,9 @@ export class PromptAssembler {
       "Reusable script workflow:",
       "When code is more than a tiny one-off command, or you expect to rerun it with changed parameters, write it to a workspace file first with write_file, then run it with bash. Prefer scripts with CLI arguments, environment variables, or a small config section so parameters can be adjusted with edit_file or command args. Do not pack large Python/JS/shell programs into bash heredocs or long `python -c` / `node -e` strings. After each run, inspect output and edit the saved script instead of regenerating a new inline command.",
       "",
+      "File delivery links:",
+      "When you create, modify, export, render, or otherwise produce a user-facing file, include a Markdown link to that file in the final response. Use relative links for files under the current cwd, e.g. `[open report.pdf](report.pdf)`. Use `file://` absolute links only for files outside the cwd, e.g. `[open file](file:///absolute/path/file.pdf)`. Do not claim that a file was opened automatically; provide a clickable link instead.",
+      "",
       "Todo workflow:",
       "For complex tasks, tasks with 3+ steps, multi-file changes, long-running work, or tasks that require verification, create a todo list with todo_write before making substantive changes. Keep the list editable: update it after each meaningful step, before and after long-running commands when useful, when new required work or risks are discovered, and before the final response. Use stable ids and merge updates when available; preserve completed facts and mark obsolete work as cancelled instead of silently deleting it. Persist important intermediate findings under the current workspace (cwd) when they are needed for recovery or final handoff, such as `.pilotdeck/work/<session-id>/findings.md`, `todo_history.md`, `verification.md`, and `artifacts/`; if no session id is available, use `.pilotdeck/work/current/`. Verify completed work when possible and align the final todo state with the final answer.",
     ];
@@ -137,6 +140,7 @@ export class PromptAssembler {
     lines.push("<user-context>");
     lines.push(`cwd: ${input.cwd}`);
     lines.push("IMPORTANT: When the user does not specify an explicit file path, all file paths in tool calls MUST be relative to the cwd above — use \"foo.html\", not an absolute path like \"/home/user/foo.html\". If the user explicitly provides a path, respect their choice.");
+    lines.push("IMPORTANT: In final responses, make generated or modified files clickable using Markdown links. Prefer cwd-relative links for cwd files, and file:// absolute links for files outside cwd.");
     lines.push(`model: ${input.provider}/${input.model}`);
     lines.push(`permission_mode: ${input.permissionMode}`);
     if (input.runMode) {

--- a/ui/src/components/chat-v2/MessageRowV2.tsx
+++ b/ui/src/components/chat-v2/MessageRowV2.tsx
@@ -65,6 +65,31 @@ const getAttachmentAccent = (name?: string, mimeType?: string): string => {
   return 'bg-neutral-500 text-white';
 };
 
+const LINKABLE_INLINE_FILE_EXTENSIONS = new Set([
+  'pdf', 'html', 'htm', 'png', 'jpg', 'jpeg', 'gif', 'webp', 'svg',
+  'txt', 'md', 'csv', 'json', 'doc', 'docx', 'xls', 'xlsx', 'ppt', 'pptx', 'py', 'js', 'ts', 'tsx', 'css',
+]);
+
+const escapeMarkdownLinkText = (value: string): string => value.replace(/([\\\]\[])/g, '\\$1');
+
+const toFileHref = (pathValue: string): string => {
+  if (/^file:\/\//i.test(pathValue)) return pathValue;
+  if (pathValue.startsWith('/')) return `file://${encodeURI(pathValue)}`;
+  return encodeURI(pathValue.replace(/\\/g, '/'));
+};
+
+function linkifyFilePaths(content: string): string {
+  const pattern = /((?:file:\/\/)?\/(?:[^\s`'"<>])+\.[A-Za-z0-9]{1,10}|(?:\.\/)?\b[A-Za-z0-9._-][A-Za-z0-9._/-]*\.[A-Za-z0-9]{1,10}\b)/gu;
+  return content.replace(pattern, (match, pathValue: string, offset: number, fullText: string) => {
+    const before = fullText.slice(Math.max(0, offset - 2), offset);
+    const after = fullText.slice(offset + match.length, offset + match.length + 1);
+    if (before.includes('](') || after === ')') return match;
+    const extension = pathValue.split('.').pop()?.toLowerCase() || '';
+    if (!LINKABLE_INLINE_FILE_EXTENSIONS.has(extension)) return match;
+    return `[${escapeMarkdownLinkText(pathValue)}](${toFileHref(pathValue)})`;
+  });
+}
+
 function attachmentToDocumentReference(attachment: ChatAttachment): DocumentSelectionReference | null {
   if (attachment.kind !== DOCUMENT_SELECTION_ATTACHMENT_KIND || !attachment.selectedText) return null;
   const filePath = attachment.filePath || attachment.path || '';
@@ -163,6 +188,10 @@ function MessageRowV2({
   );
   const thinkingDisplayText = useTypewriter(formattedContent, !!message.isStreaming && !!message.isThinking, 4);
   const contentDisplayText = useTypewriter(formattedContent, !!message.isStreaming && !message.isThinking, 6);
+  const linkedContentDisplayText = useMemo(
+    () => (message.isStreaming ? contentDisplayText : linkifyFilePaths(contentDisplayText)),
+    [contentDisplayText, message.isStreaming],
+  );
   const messageImages = useMemo(
     () =>
       Array.isArray(message.images)
@@ -455,7 +484,7 @@ function MessageRowV2({
   }
 
   // Assistant: plain prose, no avatar and no bubble.
-  const hasAssistantProse = formattedContent.trim().length > 0;
+  const hasAssistantProse = linkedContentDisplayText.trim().length > 0;
   const showStreamingCursor = Boolean(message.isStreaming && !contentDisplayText);
   const resolvedShowAssistantActions = showAssistantActions ?? true;
   const showAssistantCopyButton = resolvedShowAssistantActions && hasAssistantProse;
@@ -470,7 +499,7 @@ function MessageRowV2({
         <span className="inline-block h-4 w-2 animate-pulse bg-neutral-400 dark:bg-neutral-500" />
       ) : (
         <Markdown className="prose prose-sm prose-neutral max-w-none dark:prose-invert prose-headings:mb-2 prose-headings:mt-4 prose-h2:text-lg prose-h3:text-base prose-p:my-2 prose-pre:my-3 prose-ol:my-2 prose-ul:my-2 prose-table:my-0 prose-hr:my-4" projectName={selectedProject?.name}
-        onFileOpen={onFileOpen} isStreaming={message.isStreaming}>{contentDisplayText}</Markdown>
+        onFileOpen={onFileOpen} isStreaming={message.isStreaming}>{linkedContentDisplayText}</Markdown>
       )}
       {shouldRenderAssistantActions ? (
         <div className="mt-1.5 flex justify-end gap-1">
@@ -485,7 +514,7 @@ function MessageRowV2({
               variant="action-row"
             />
           ) : null}
-          {showAssistantCopyButton ? <CopyMarkdownButton content={formattedContent} /> : null}
+          {showAssistantCopyButton ? <CopyMarkdownButton content={linkedContentDisplayText} /> : null}
         </div>
       ) : null}
     </div>

--- a/ui/src/components/chat/utils/resolveMarkdownFileHref.ts
+++ b/ui/src/components/chat/utils/resolveMarkdownFileHref.ts
@@ -69,6 +69,15 @@ export function resolveMarkdownFileHref(
 
   const hasProtocol = /^([a-z][a-z0-9+.-]*:|\/\/)/i.test(trimmed);
 
+  if (/^file:\/\//i.test(trimmed)) {
+    try {
+      const url = new URL(trimmed);
+      return decodePath(url.pathname) || null;
+    } catch {
+      return null;
+    }
+  }
+
   if (trimmed.startsWith('/')) {
     return resolveProjectPathFromPathname(decodePath(trimmed));
   }


### PR DESCRIPTION
## Summary
- prompt agents to include clickable Markdown links for generated or modified files
- automatically linkify file paths in assistant responses
- support file:// links in Markdown file resolution

## Validation
- npm exec eslint src/components/chat-v2/MessageRowV2.tsx src/components/chat/utils/resolveMarkdownFileHref.ts
- npm run build