### PR TITLE
Harden provider connection probes

### DIFF
--- a/src/model/providerEndpoint.ts
+++ b/src/model/providerEndpoint.ts
@@ -55,9 +55,10 @@ function buildEndpointCandidates(baseUrl: string, defaultVersion: string, endpoi
   if (baseUrlEndsWithEndpoint(normalizedBase, normalizedEndpointPath)) return [normalizedBase];
   const unversionedEndpoint = joinUrl(normalizedBase, normalizedEndpointPath);
   if (hasVersionSegment(normalizedBase)) return [unversionedEndpoint];
+  const versionedEndpoint = joinUrl(normalizedBase, [defaultVersion, normalizedEndpointPath].filter(Boolean).join("/"));
   return uniqueUrls([
+    versionedEndpoint,
     unversionedEndpoint,
-    joinUrl(normalizedBase, [defaultVersion, normalizedEndpointPath].filter(Boolean).join("/")),
   ]);
 }
 

--- a/src/model/providerEndpoint.ts
+++ b/src/model/providerEndpoint.ts
@@ -1,0 +1,84 @@
+export type ProviderEndpointProtocol = "openai" | "openai-responses" | "anthropic" | "google";
+
+const VERSION_SEGMENT_PATTERN = /^v\d+(?:beta\d*)?$/i;
+
+function trimSlashes(value: string): string {
+  return value.replace(/^\/+|\/+$/g, "");
+}
+
+function joinUrl(base: string, path: string): string {
+  return `${base.replace(/\/+$/, "")}/${path.replace(/^\/+/, "")}`;
+}
+
+function getPathSegments(baseUrl: string): string[] {
+  try {
+    return new URL(baseUrl).pathname.split("/").filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+function hasVersionSegment(baseUrl: string): boolean {
+  return getPathSegments(baseUrl).some((segment) => VERSION_SEGMENT_PATTERN.test(segment));
+}
+
+function pathEndsWith(baseUrl: string, suffix: string[]): boolean {
+  const segments = getPathSegments(baseUrl).map((segment) => segment.toLowerCase());
+  const normalizedSuffix = suffix.map((segment) => segment.toLowerCase());
+  if (segments.length < normalizedSuffix.length) return false;
+  return normalizedSuffix.every((segment, index) => segments[segments.length - normalizedSuffix.length + index] === segment);
+}
+
+function buildVersionedEndpoint(baseUrl: string, defaultVersion: string, endpointPath: string): string {
+  const normalizedBase = baseUrl.trim().replace(/\/+$/, "");
+  const normalizedEndpointPath = trimSlashes(endpointPath);
+  const endpointSegments = normalizedEndpointPath.split("/").filter(Boolean);
+  if (pathEndsWith(normalizedBase, endpointSegments)) return normalizedBase;
+  const prefix = hasVersionSegment(normalizedBase) ? "" : defaultVersion;
+  return joinUrl(normalizedBase, [prefix, normalizedEndpointPath].filter(Boolean).join("/"));
+}
+
+export function normalizeGoogleProbeModel(model: string): string {
+  const text = String(model || "").trim();
+  const withoutProvider = text.startsWith("google/") ? text.slice("google/".length) : text;
+  if (withoutProvider === "gemini-3-pro") return "gemini-3-pro-preview";
+  if (withoutProvider === "gemini-3.1-pro") return "gemini-3.1-pro-preview";
+  if (withoutProvider === "gemini-3-flash") return "gemini-3-flash-preview";
+  if (withoutProvider === "gemini-3.1-flash" || withoutProvider === "gemini-3.1-flash-preview") {
+    return "gemini-3-flash-preview";
+  }
+  if (withoutProvider === "gemini-3.1-flash-lite") return "gemini-3.1-flash-lite-preview";
+  return withoutProvider;
+}
+
+export function buildProviderChatEndpoint(input: {
+  protocol: ProviderEndpointProtocol;
+  baseUrl: string;
+  model?: string;
+  googleMethod?: string;
+}): string {
+  const normalizedProtocol = input.protocol;
+  if (normalizedProtocol === "anthropic") {
+    return buildVersionedEndpoint(input.baseUrl, "v1", "messages");
+  }
+  if (normalizedProtocol === "openai-responses") {
+    return buildVersionedEndpoint(input.baseUrl, "v1", "responses");
+  }
+  if (normalizedProtocol === "google") {
+    const method = input.googleMethod || "generateContent";
+    const model = encodeURIComponent(normalizeGoogleProbeModel(input.model || ""));
+    const normalizedBase = input.baseUrl.trim().replace(/\/+$/, "") || "https://generativelanguage.googleapis.com";
+    return buildVersionedEndpoint(normalizedBase, "v1beta", `models/${model}:${method}`);
+  }
+  return buildVersionedEndpoint(input.baseUrl, "v1", "chat/completions");
+}
+
+export function buildProviderModelsEndpoint(input: {
+  protocol: ProviderEndpointProtocol;
+  baseUrl: string;
+}): string {
+  if (input.protocol === "google") {
+    return buildVersionedEndpoint(input.baseUrl, "v1beta", "models");
+  }
+  return buildVersionedEndpoint(input.baseUrl, "v1", "models");
+}

--- a/src/model/providerEndpoint.ts
+++ b/src/model/providerEndpoint.ts
@@ -125,3 +125,25 @@ export function buildProviderModelsEndpointCandidates(input: {
   }
   return buildEndpointCandidates(input.baseUrl, "v1", "models");
 }
+
+export function isExpectedProviderResponseShape(protocol: ProviderEndpointProtocol, body: unknown): boolean {
+  if (!body || typeof body !== "object") return false;
+  const record = body as Record<string, unknown>;
+  if (protocol === "anthropic") {
+    return Array.isArray(record.content) || record.type === "message";
+  }
+  if (protocol === "google") {
+    return Array.isArray(record.candidates);
+  }
+  if (protocol === "openai-responses") {
+    return record.object === "response" || Array.isArray(record.output) || typeof record.output_text === "string";
+  }
+  return Array.isArray(record.choices);
+}
+
+export function isExpectedProviderModelsResponseShape(protocol: ProviderEndpointProtocol, body: unknown): boolean {
+  if (!body || typeof body !== "object") return false;
+  const record = body as Record<string, unknown>;
+  if (protocol === "google") return Array.isArray(record.models);
+  return Array.isArray(record.data) || Array.isArray(record.models);
+}

--- a/src/model/providerEndpoint.ts
+++ b/src/model/providerEndpoint.ts
@@ -10,6 +10,10 @@ function joinUrl(base: string, path: string): string {
   return `${base.replace(/\/+$/, "")}/${path.replace(/^\/+/, "")}`;
 }
 
+function uniqueUrls(urls: string[]): string[] {
+  return [...new Set(urls.filter(Boolean))];
+}
+
 function getPathSegments(baseUrl: string): string[] {
   try {
     return new URL(baseUrl).pathname.split("/").filter(Boolean);
@@ -29,13 +33,36 @@ function pathEndsWith(baseUrl: string, suffix: string[]): boolean {
   return normalizedSuffix.every((segment, index) => segments[segments.length - normalizedSuffix.length + index] === segment);
 }
 
-function buildVersionedEndpoint(baseUrl: string, defaultVersion: string, endpointPath: string): string {
-  const normalizedBase = baseUrl.trim().replace(/\/+$/, "");
+function baseUrlEndsWithEndpoint(baseUrl: string, endpointPath: string): boolean {
   const normalizedEndpointPath = trimSlashes(endpointPath);
   const endpointSegments = normalizedEndpointPath.split("/").filter(Boolean);
-  if (pathEndsWith(normalizedBase, endpointSegments)) return normalizedBase;
-  const prefix = hasVersionSegment(normalizedBase) ? "" : defaultVersion;
-  return joinUrl(normalizedBase, [prefix, normalizedEndpointPath].filter(Boolean).join("/"));
+  if (pathEndsWith(baseUrl, endpointSegments)) return true;
+
+  if (endpointSegments.length === 2 && endpointSegments[0].toLowerCase() === "models") {
+    const segments = getPathSegments(baseUrl).map((segment) => segment.toLowerCase());
+    const last = segments.at(-1) || "";
+    const methodSeparator = endpointSegments[1].indexOf(":");
+    const methodSuffix = methodSeparator >= 0 ? endpointSegments[1].slice(methodSeparator).toLowerCase() : "";
+    return Boolean(methodSuffix) && segments.at(-2) === "models" && last.endsWith(methodSuffix);
+  }
+
+  return false;
+}
+
+function buildEndpointCandidates(baseUrl: string, defaultVersion: string, endpointPath: string): string[] {
+  const normalizedBase = baseUrl.trim().replace(/\/+$/, "");
+  const normalizedEndpointPath = trimSlashes(endpointPath);
+  if (baseUrlEndsWithEndpoint(normalizedBase, normalizedEndpointPath)) return [normalizedBase];
+  const unversionedEndpoint = joinUrl(normalizedBase, normalizedEndpointPath);
+  if (hasVersionSegment(normalizedBase)) return [unversionedEndpoint];
+  return uniqueUrls([
+    unversionedEndpoint,
+    joinUrl(normalizedBase, [defaultVersion, normalizedEndpointPath].filter(Boolean).join("/")),
+  ]);
+}
+
+function buildVersionedEndpoint(baseUrl: string, defaultVersion: string, endpointPath: string): string {
+  return buildEndpointCandidates(baseUrl, defaultVersion, endpointPath)[0] || "";
 }
 
 export function normalizeGoogleProbeModel(model: string): string {
@@ -57,28 +84,44 @@ export function buildProviderChatEndpoint(input: {
   model?: string;
   googleMethod?: string;
 }): string {
+  return buildProviderChatEndpointCandidates(input)[0] || "";
+}
+
+export function buildProviderChatEndpointCandidates(input: {
+  protocol: ProviderEndpointProtocol;
+  baseUrl: string;
+  model?: string;
+  googleMethod?: string;
+}): string[] {
   const normalizedProtocol = input.protocol;
   if (normalizedProtocol === "anthropic") {
-    return buildVersionedEndpoint(input.baseUrl, "v1", "messages");
+    return buildEndpointCandidates(input.baseUrl, "v1", "messages");
   }
   if (normalizedProtocol === "openai-responses") {
-    return buildVersionedEndpoint(input.baseUrl, "v1", "responses");
+    return buildEndpointCandidates(input.baseUrl, "v1", "responses");
   }
   if (normalizedProtocol === "google") {
     const method = input.googleMethod || "generateContent";
     const model = encodeURIComponent(normalizeGoogleProbeModel(input.model || ""));
     const normalizedBase = input.baseUrl.trim().replace(/\/+$/, "") || "https://generativelanguage.googleapis.com";
-    return buildVersionedEndpoint(normalizedBase, "v1beta", `models/${model}:${method}`);
+    return buildEndpointCandidates(normalizedBase, "v1beta", `models/${model}:${method}`);
   }
-  return buildVersionedEndpoint(input.baseUrl, "v1", "chat/completions");
+  return buildEndpointCandidates(input.baseUrl, "v1", "chat/completions");
 }
 
 export function buildProviderModelsEndpoint(input: {
   protocol: ProviderEndpointProtocol;
   baseUrl: string;
 }): string {
+  return buildProviderModelsEndpointCandidates(input)[0] || "";
+}
+
+export function buildProviderModelsEndpointCandidates(input: {
+  protocol: ProviderEndpointProtocol;
+  baseUrl: string;
+}): string[] {
   if (input.protocol === "google") {
-    return buildVersionedEndpoint(input.baseUrl, "v1beta", "models");
+    return buildEndpointCandidates(input.baseUrl, "v1beta", "models");
   }
-  return buildVersionedEndpoint(input.baseUrl, "v1", "models");
+  return buildEndpointCandidates(input.baseUrl, "v1", "models");
 }

--- a/src/model/streaming/streamModel.ts
+++ b/src/model/streaming/streamModel.ts
@@ -16,6 +16,7 @@ import { parseModelResponse } from "../response/parseModelResponse.js";
 import { createStreamNormalizerState, normalizeStreamEvent } from "./normalizeStreamEvent.js";
 import { createGoogleStreamState, normalizeGoogleStreamEvent } from "../providers/google/stream.js";
 import { normalizeProviderBaseUrl } from "../normalizeProviderBaseUrl.js";
+import { buildProviderChatEndpoint } from "../providerEndpoint.js";
 import { StreamingCheckpointManager } from "./StreamingCheckpoint.js";
 
 export type ModelTransport = typeof fetch;
@@ -501,15 +502,7 @@ function forwardAbort(source: AbortSignal, target: AbortController): () => void 
 }
 
 function buildEndpoint(provider: ProviderConfig, _stream: boolean): string {
-  if (provider.protocol === "anthropic") {
-    return joinUrl(provider.url, "v1/messages");
-  }
-
-  if (provider.protocol === "openai-responses") {
-    return joinUrl(provider.url, "responses");
-  }
-
-  return joinUrl(provider.url, "chat/completions");
+  return buildProviderChatEndpoint({ protocol: provider.protocol, baseUrl: provider.url });
 }
 
 function buildHeaders(provider: ProviderConfig): HeadersInit {
@@ -699,8 +692,4 @@ function createAbortError(reason?: unknown): Error {
 
 function isAbortError(error: unknown): boolean {
   return error instanceof Error && (error.name === "AbortError" || error.message.toLowerCase().includes("aborted"));
-}
-
-function joinUrl(base: string, path: string): string {
-  return `${base.replace(/\/+$/, "")}/${path.replace(/^\/+/, "")}`;
 }

--- a/src/model/streaming/streamModel.ts
+++ b/src/model/streaming/streamModel.ts
@@ -16,7 +16,7 @@ import { parseModelResponse } from "../response/parseModelResponse.js";
 import { createStreamNormalizerState, normalizeStreamEvent } from "./normalizeStreamEvent.js";
 import { createGoogleStreamState, normalizeGoogleStreamEvent } from "../providers/google/stream.js";
 import { normalizeProviderBaseUrl } from "../normalizeProviderBaseUrl.js";
-import { buildProviderChatEndpointCandidates } from "../providerEndpoint.js";
+import { buildProviderChatEndpointCandidates, isExpectedProviderResponseShape } from "../providerEndpoint.js";
 import { StreamingCheckpointManager } from "./StreamingCheckpoint.js";
 
 export type ModelTransport = typeof fetch;
@@ -511,7 +511,7 @@ async function sendWithEndpointFallback(
   let lastResponse: Response | undefined;
   for (const endpoint of endpoints) {
     const response = await transport(endpoint, fetchOptions);
-    if (response.ok || endpoints.length === 1 || !isEndpointFallbackStatus(response.status)) {
+    if (await shouldUseEndpointResponse(provider, response, stream, endpoints.length)) {
       return response;
     }
     lastResponse = response;
@@ -521,6 +521,22 @@ async function sendWithEndpointFallback(
 
 function isEndpointFallbackStatus(status: number): boolean {
   return status === 400 || status === 404 || status === 405;
+}
+
+async function shouldUseEndpointResponse(
+  provider: ProviderConfig,
+  response: Response,
+  stream: boolean,
+  endpointCount: number,
+): Promise<boolean> {
+  if (!response.ok) return endpointCount === 1 || !isEndpointFallbackStatus(response.status);
+  if (stream || endpointCount === 1) return true;
+  try {
+    const body = await response.clone().json();
+    return isExpectedProviderResponseShape(provider.protocol, body);
+  } catch {
+    return false;
+  }
 }
 
 function buildHeaders(provider: ProviderConfig): HeadersInit {

--- a/src/model/streaming/streamModel.ts
+++ b/src/model/streaming/streamModel.ts
@@ -16,7 +16,7 @@ import { parseModelResponse } from "../response/parseModelResponse.js";
 import { createStreamNormalizerState, normalizeStreamEvent } from "./normalizeStreamEvent.js";
 import { createGoogleStreamState, normalizeGoogleStreamEvent } from "../providers/google/stream.js";
 import { normalizeProviderBaseUrl } from "../normalizeProviderBaseUrl.js";
-import { buildProviderChatEndpoint } from "../providerEndpoint.js";
+import { buildProviderChatEndpointCandidates } from "../providerEndpoint.js";
 import { StreamingCheckpointManager } from "./StreamingCheckpoint.js";
 
 export type ModelTransport = typeof fetch;
@@ -476,7 +476,7 @@ async function sendProviderRequest(
       body: JSON.stringify(finalBody),
       signal: controller.signal,
     };
-    return await transport(buildEndpoint(provider, stream), fetchOptions);
+    return await sendWithEndpointFallback(provider, stream, transport, fetchOptions);
   } catch (error) {
     if (signal?.aborted) {
       throw createAbortError(signal.reason);
@@ -501,8 +501,26 @@ function forwardAbort(source: AbortSignal, target: AbortController): () => void 
   return () => source.removeEventListener("abort", onAbort);
 }
 
-function buildEndpoint(provider: ProviderConfig, _stream: boolean): string {
-  return buildProviderChatEndpoint({ protocol: provider.protocol, baseUrl: provider.url });
+async function sendWithEndpointFallback(
+  provider: ProviderConfig,
+  stream: boolean,
+  transport: ModelTransport,
+  fetchOptions: RequestInit,
+): Promise<Response> {
+  const endpoints = buildProviderChatEndpointCandidates({ protocol: provider.protocol, baseUrl: provider.url });
+  let lastResponse: Response | undefined;
+  for (const endpoint of endpoints) {
+    const response = await transport(endpoint, fetchOptions);
+    if (response.ok || endpoints.length === 1 || !isEndpointFallbackStatus(response.status)) {
+      return response;
+    }
+    lastResponse = response;
+  }
+  return lastResponse as Response;
+}
+
+function isEndpointFallbackStatus(status: number): boolean {
+  return status === 400 || status === 404 || status === 405;
 }
 
 function buildHeaders(provider: ProviderConfig): HeadersInit {

--- a/tests/model/providerEndpoint.spec.ts
+++ b/tests/model/providerEndpoint.spec.ts
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildProviderChatEndpoint, buildProviderModelsEndpoint } from "../../src/model/providerEndpoint.js";
+
+test("buildProviderChatEndpoint adds default protocol versions", () => {
+  assert.equal(
+    buildProviderChatEndpoint({ protocol: "openai", baseUrl: "https://api.openai.com" }),
+    "https://api.openai.com/v1/chat/completions",
+  );
+  assert.equal(
+    buildProviderChatEndpoint({ protocol: "anthropic", baseUrl: "https://api.anthropic.com" }),
+    "https://api.anthropic.com/v1/messages",
+  );
+  assert.equal(
+    buildProviderChatEndpoint({ protocol: "google", baseUrl: "https://generativelanguage.googleapis.com", model: "gemini-pro" }),
+    "https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent",
+  );
+});
+
+test("buildProviderChatEndpoint does not duplicate existing version segments", () => {
+  assert.equal(
+    buildProviderChatEndpoint({ protocol: "openai", baseUrl: "https://api.openai.com/v1" }),
+    "https://api.openai.com/v1/chat/completions",
+  );
+  assert.equal(
+    buildProviderChatEndpoint({ protocol: "openai-responses", baseUrl: "https://api.openai.com/v1/" }),
+    "https://api.openai.com/v1/responses",
+  );
+  assert.equal(
+    buildProviderChatEndpoint({ protocol: "google", baseUrl: "https://generativelanguage.googleapis.com/v1", model: "gemini-pro" }),
+    "https://generativelanguage.googleapis.com/v1/models/gemini-pro:generateContent",
+  );
+});
+
+test("buildProviderChatEndpoint preserves provider-specific API version paths", () => {
+  assert.equal(
+    buildProviderChatEndpoint({ protocol: "openai", baseUrl: "https://dashscope.aliyuncs.com/compatible-mode/v1" }),
+    "https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions",
+  );
+  assert.equal(
+    buildProviderChatEndpoint({ protocol: "openai", baseUrl: "https://ark.cn-beijing.volces.com/api/v3" }),
+    "https://ark.cn-beijing.volces.com/api/v3/chat/completions",
+  );
+  assert.equal(
+    buildProviderChatEndpoint({ protocol: "openai", baseUrl: "https://api.z.ai/api/paas/v4" }),
+    "https://api.z.ai/api/paas/v4/chat/completions",
+  );
+});
+
+test("buildProviderModelsEndpoint matches protocol version rules", () => {
+  assert.equal(
+    buildProviderModelsEndpoint({ protocol: "openai", baseUrl: "https://api.openai.com" }),
+    "https://api.openai.com/v1/models",
+  );
+  assert.equal(
+    buildProviderModelsEndpoint({ protocol: "openai", baseUrl: "https://api.openai.com/v1" }),
+    "https://api.openai.com/v1/models",
+  );
+  assert.equal(
+    buildProviderModelsEndpoint({ protocol: "anthropic", baseUrl: "https://api.anthropic.com" }),
+    "https://api.anthropic.com/v1/models",
+  );
+  assert.equal(
+    buildProviderModelsEndpoint({ protocol: "google", baseUrl: "https://generativelanguage.googleapis.com" }),
+    "https://generativelanguage.googleapis.com/v1beta/models",
+  );
+  assert.equal(
+    buildProviderModelsEndpoint({ protocol: "openai", baseUrl: "https://dashscope.aliyuncs.com/compatible-mode/v1" }),
+    "https://dashscope.aliyuncs.com/compatible-mode/v1/models",
+  );
+});

--- a/tests/model/providerEndpoint.spec.ts
+++ b/tests/model/providerEndpoint.spec.ts
@@ -9,35 +9,35 @@ import {
   isExpectedProviderResponseShape,
 } from "../../src/model/providerEndpoint.js";
 
-test("buildProviderChatEndpoint prefers unversioned endpoints for root base URLs", () => {
+test("buildProviderChatEndpoint prefers protocol-versioned endpoints for root base URLs", () => {
   assert.equal(
     buildProviderChatEndpoint({ protocol: "openai", baseUrl: "https://api.openai.com" }),
-    "https://api.openai.com/chat/completions",
+    "https://api.openai.com/v1/chat/completions",
   );
   assert.equal(
     buildProviderChatEndpoint({ protocol: "anthropic", baseUrl: "https://api.anthropic.com" }),
-    "https://api.anthropic.com/messages",
+    "https://api.anthropic.com/v1/messages",
   );
   assert.equal(
     buildProviderChatEndpoint({ protocol: "google", baseUrl: "https://generativelanguage.googleapis.com", model: "gemini-pro" }),
-    "https://generativelanguage.googleapis.com/models/gemini-pro:generateContent",
+    "https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent",
   );
 });
 
 test("buildProviderChatEndpointCandidates falls back to default protocol versions", () => {
   assert.deepEqual(
     buildProviderChatEndpointCandidates({ protocol: "openai", baseUrl: "https://api.openai.com" }),
-    ["https://api.openai.com/chat/completions", "https://api.openai.com/v1/chat/completions"],
+    ["https://api.openai.com/v1/chat/completions", "https://api.openai.com/chat/completions"],
   );
   assert.deepEqual(
     buildProviderChatEndpointCandidates({ protocol: "anthropic", baseUrl: "https://api.anthropic.com" }),
-    ["https://api.anthropic.com/messages", "https://api.anthropic.com/v1/messages"],
+    ["https://api.anthropic.com/v1/messages", "https://api.anthropic.com/messages"],
   );
   assert.deepEqual(
     buildProviderChatEndpointCandidates({ protocol: "google", baseUrl: "https://generativelanguage.googleapis.com", model: "gemini-pro" }),
     [
-      "https://generativelanguage.googleapis.com/models/gemini-pro:generateContent",
       "https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent",
+      "https://generativelanguage.googleapis.com/models/gemini-pro:generateContent",
     ],
   );
 });
@@ -94,7 +94,7 @@ test("buildProviderChatEndpoint preserves provider-specific API version paths", 
 test("buildProviderModelsEndpoint matches protocol version rules", () => {
   assert.equal(
     buildProviderModelsEndpoint({ protocol: "openai", baseUrl: "https://api.openai.com" }),
-    "https://api.openai.com/models",
+    "https://api.openai.com/v1/models",
   );
   assert.equal(
     buildProviderModelsEndpoint({ protocol: "openai", baseUrl: "https://api.openai.com/v1" }),
@@ -102,11 +102,11 @@ test("buildProviderModelsEndpoint matches protocol version rules", () => {
   );
   assert.equal(
     buildProviderModelsEndpoint({ protocol: "anthropic", baseUrl: "https://api.anthropic.com" }),
-    "https://api.anthropic.com/models",
+    "https://api.anthropic.com/v1/models",
   );
   assert.equal(
     buildProviderModelsEndpoint({ protocol: "google", baseUrl: "https://generativelanguage.googleapis.com" }),
-    "https://generativelanguage.googleapis.com/models",
+    "https://generativelanguage.googleapis.com/v1beta/models",
   );
   assert.equal(
     buildProviderModelsEndpoint({ protocol: "openai", baseUrl: "https://dashscope.aliyuncs.com/compatible-mode/v1" }),
@@ -121,11 +121,11 @@ test("buildProviderModelsEndpoint matches protocol version rules", () => {
 test("buildProviderModelsEndpointCandidates falls back to default protocol versions", () => {
   assert.deepEqual(
     buildProviderModelsEndpointCandidates({ protocol: "openai", baseUrl: "https://api.openai.com" }),
-    ["https://api.openai.com/models", "https://api.openai.com/v1/models"],
+    ["https://api.openai.com/v1/models", "https://api.openai.com/models"],
   );
   assert.deepEqual(
     buildProviderModelsEndpointCandidates({ protocol: "google", baseUrl: "https://generativelanguage.googleapis.com" }),
-    ["https://generativelanguage.googleapis.com/models", "https://generativelanguage.googleapis.com/v1beta/models"],
+    ["https://generativelanguage.googleapis.com/v1beta/models", "https://generativelanguage.googleapis.com/models"],
   );
 });
 

--- a/tests/model/providerEndpoint.spec.ts
+++ b/tests/model/providerEndpoint.spec.ts
@@ -5,6 +5,8 @@ import {
   buildProviderChatEndpointCandidates,
   buildProviderModelsEndpoint,
   buildProviderModelsEndpointCandidates,
+  isExpectedProviderModelsResponseShape,
+  isExpectedProviderResponseShape,
 } from "../../src/model/providerEndpoint.js";
 
 test("buildProviderChatEndpoint prefers unversioned endpoints for root base URLs", () => {
@@ -125,4 +127,18 @@ test("buildProviderModelsEndpointCandidates falls back to default protocol versi
     buildProviderModelsEndpointCandidates({ protocol: "google", baseUrl: "https://generativelanguage.googleapis.com" }),
     ["https://generativelanguage.googleapis.com/models", "https://generativelanguage.googleapis.com/v1beta/models"],
   );
+});
+
+test("provider response shape checks reject unrelated successful JSON", () => {
+  assert.equal(isExpectedProviderResponseShape("openai", { ok: true }), false);
+  assert.equal(isExpectedProviderResponseShape("openai", { choices: [] }), true);
+  assert.equal(isExpectedProviderResponseShape("openai-responses", { output_text: "ok" }), true);
+  assert.equal(isExpectedProviderResponseShape("anthropic", { type: "message" }), true);
+  assert.equal(isExpectedProviderResponseShape("google", { candidates: [] }), true);
+});
+
+test("provider models response shape checks reject unrelated successful JSON", () => {
+  assert.equal(isExpectedProviderModelsResponseShape("openai", { ok: true }), false);
+  assert.equal(isExpectedProviderModelsResponseShape("openai", { data: [] }), true);
+  assert.equal(isExpectedProviderModelsResponseShape("google", { models: [] }), true);
 });

--- a/tests/model/providerEndpoint.spec.ts
+++ b/tests/model/providerEndpoint.spec.ts
@@ -1,19 +1,42 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { buildProviderChatEndpoint, buildProviderModelsEndpoint } from "../../src/model/providerEndpoint.js";
+import {
+  buildProviderChatEndpoint,
+  buildProviderChatEndpointCandidates,
+  buildProviderModelsEndpoint,
+  buildProviderModelsEndpointCandidates,
+} from "../../src/model/providerEndpoint.js";
 
-test("buildProviderChatEndpoint adds default protocol versions", () => {
+test("buildProviderChatEndpoint prefers unversioned endpoints for root base URLs", () => {
   assert.equal(
     buildProviderChatEndpoint({ protocol: "openai", baseUrl: "https://api.openai.com" }),
-    "https://api.openai.com/v1/chat/completions",
+    "https://api.openai.com/chat/completions",
   );
   assert.equal(
     buildProviderChatEndpoint({ protocol: "anthropic", baseUrl: "https://api.anthropic.com" }),
-    "https://api.anthropic.com/v1/messages",
+    "https://api.anthropic.com/messages",
   );
   assert.equal(
     buildProviderChatEndpoint({ protocol: "google", baseUrl: "https://generativelanguage.googleapis.com", model: "gemini-pro" }),
-    "https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent",
+    "https://generativelanguage.googleapis.com/models/gemini-pro:generateContent",
+  );
+});
+
+test("buildProviderChatEndpointCandidates falls back to default protocol versions", () => {
+  assert.deepEqual(
+    buildProviderChatEndpointCandidates({ protocol: "openai", baseUrl: "https://api.openai.com" }),
+    ["https://api.openai.com/chat/completions", "https://api.openai.com/v1/chat/completions"],
+  );
+  assert.deepEqual(
+    buildProviderChatEndpointCandidates({ protocol: "anthropic", baseUrl: "https://api.anthropic.com" }),
+    ["https://api.anthropic.com/messages", "https://api.anthropic.com/v1/messages"],
+  );
+  assert.deepEqual(
+    buildProviderChatEndpointCandidates({ protocol: "google", baseUrl: "https://generativelanguage.googleapis.com", model: "gemini-pro" }),
+    [
+      "https://generativelanguage.googleapis.com/models/gemini-pro:generateContent",
+      "https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent",
+    ],
   );
 });
 
@@ -29,6 +52,25 @@ test("buildProviderChatEndpoint does not duplicate existing version segments", (
   assert.equal(
     buildProviderChatEndpoint({ protocol: "google", baseUrl: "https://generativelanguage.googleapis.com/v1", model: "gemini-pro" }),
     "https://generativelanguage.googleapis.com/v1/models/gemini-pro:generateContent",
+  );
+});
+
+test("buildProviderChatEndpoint accepts full endpoint URLs", () => {
+  assert.equal(
+    buildProviderChatEndpoint({ protocol: "openai", baseUrl: "https://api.openai.com/v1/chat/completions" }),
+    "https://api.openai.com/v1/chat/completions",
+  );
+  assert.equal(
+    buildProviderChatEndpoint({ protocol: "openai-responses", baseUrl: "https://api.openai.com/v1/responses" }),
+    "https://api.openai.com/v1/responses",
+  );
+  assert.equal(
+    buildProviderChatEndpoint({ protocol: "anthropic", baseUrl: "https://api.anthropic.com/v1/messages" }),
+    "https://api.anthropic.com/v1/messages",
+  );
+  assert.equal(
+    buildProviderChatEndpoint({ protocol: "google", baseUrl: "https://generativelanguage.googleapis.com/v1beta/models/gemini-3-pro-preview:generateContent", model: "gemini-pro" }),
+    "https://generativelanguage.googleapis.com/v1beta/models/gemini-3-pro-preview:generateContent",
   );
 });
 
@@ -50,7 +92,7 @@ test("buildProviderChatEndpoint preserves provider-specific API version paths", 
 test("buildProviderModelsEndpoint matches protocol version rules", () => {
   assert.equal(
     buildProviderModelsEndpoint({ protocol: "openai", baseUrl: "https://api.openai.com" }),
-    "https://api.openai.com/v1/models",
+    "https://api.openai.com/models",
   );
   assert.equal(
     buildProviderModelsEndpoint({ protocol: "openai", baseUrl: "https://api.openai.com/v1" }),
@@ -58,14 +100,29 @@ test("buildProviderModelsEndpoint matches protocol version rules", () => {
   );
   assert.equal(
     buildProviderModelsEndpoint({ protocol: "anthropic", baseUrl: "https://api.anthropic.com" }),
-    "https://api.anthropic.com/v1/models",
+    "https://api.anthropic.com/models",
   );
   assert.equal(
     buildProviderModelsEndpoint({ protocol: "google", baseUrl: "https://generativelanguage.googleapis.com" }),
-    "https://generativelanguage.googleapis.com/v1beta/models",
+    "https://generativelanguage.googleapis.com/models",
   );
   assert.equal(
     buildProviderModelsEndpoint({ protocol: "openai", baseUrl: "https://dashscope.aliyuncs.com/compatible-mode/v1" }),
     "https://dashscope.aliyuncs.com/compatible-mode/v1/models",
+  );
+  assert.equal(
+    buildProviderModelsEndpoint({ protocol: "openai", baseUrl: "https://api.openai.com/v1/models" }),
+    "https://api.openai.com/v1/models",
+  );
+});
+
+test("buildProviderModelsEndpointCandidates falls back to default protocol versions", () => {
+  assert.deepEqual(
+    buildProviderModelsEndpointCandidates({ protocol: "openai", baseUrl: "https://api.openai.com" }),
+    ["https://api.openai.com/models", "https://api.openai.com/v1/models"],
+  );
+  assert.deepEqual(
+    buildProviderModelsEndpointCandidates({ protocol: "google", baseUrl: "https://generativelanguage.googleapis.com" }),
+    ["https://generativelanguage.googleapis.com/models", "https://generativelanguage.googleapis.com/v1beta/models"],
   );
 });

--- a/tests/model/providerEndpointFallback.spec.ts
+++ b/tests/model/providerEndpointFallback.spec.ts
@@ -41,12 +41,12 @@ const request: CanonicalModelRequest = {
   stream: false,
 };
 
-test("complete falls back when unversioned endpoint returns unexpected JSON", async () => {
+test("complete falls back when protocol-versioned endpoint returns unexpected JSON", async () => {
   const calls: string[] = [];
   const fetchImpl = async (input: RequestInfo | URL): Promise<Response> => {
     const url = String(input);
     calls.push(url);
-    if (url === "https://api.openai.com/chat/completions") {
+    if (url === "https://api.openai.com/v1/chat/completions") {
       return Response.json({ ok: true });
     }
     return Response.json({ choices: [{ message: { content: "ok" }, finish_reason: "stop" }] });
@@ -55,8 +55,8 @@ test("complete falls back when unversioned endpoint returns unexpected JSON", as
   const response = await complete(request, modelConfig, { fetch: fetchImpl });
 
   assert.deepEqual(calls, [
-    "https://api.openai.com/chat/completions",
     "https://api.openai.com/v1/chat/completions",
+    "https://api.openai.com/chat/completions",
   ]);
   assert.deepEqual(response.content, [{ type: "text", text: "ok" }]);
 });

--- a/tests/model/providerEndpointFallback.spec.ts
+++ b/tests/model/providerEndpointFallback.spec.ts
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { complete } from "../../src/model/streaming/streamModel.js";
+import type { CanonicalModelRequest, ModelConfig } from "../../src/model/protocol/canonical.js";
+
+const modelConfig: ModelConfig = {
+  providers: {
+    openai: {
+      id: "openai",
+      protocol: "openai",
+      url: "https://api.openai.com",
+      apiKey: "sk-test",
+      headers: {},
+      retry: { requestMaxRetries: 0 },
+      models: {
+        "gpt-test": {
+          id: "gpt-test",
+          capabilities: {
+            supportsToolUse: false,
+            supportsStreaming: true,
+            supportsParallelToolCalls: false,
+            supportsThinking: false,
+            supportsJsonSchema: false,
+            supportsSystemPrompt: true,
+            supportsPromptCache: false,
+            maxContextTokens: 128,
+            maxOutputTokens: 16,
+          },
+          multimodal: { input: ["text"] },
+        },
+      },
+    },
+  },
+};
+
+const request: CanonicalModelRequest = {
+  provider: "openai",
+  model: "gpt-test",
+  messages: [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
+  maxOutputTokens: 8,
+  stream: false,
+};
+
+test("complete falls back when unversioned endpoint returns unexpected JSON", async () => {
+  const calls: string[] = [];
+  const fetchImpl = async (input: RequestInfo | URL): Promise<Response> => {
+    const url = String(input);
+    calls.push(url);
+    if (url === "https://api.openai.com/chat/completions") {
+      return Response.json({ ok: true });
+    }
+    return Response.json({ choices: [{ message: { content: "ok" }, finish_reason: "stop" }] });
+  };
+
+  const response = await complete(request, modelConfig, { fetch: fetchImpl });
+
+  assert.deepEqual(calls, [
+    "https://api.openai.com/chat/completions",
+    "https://api.openai.com/v1/chat/completions",
+  ]);
+  assert.deepEqual(response.content, [{ type: "text", text: "ok" }]);
+});

--- a/ui/server/routes/config.js
+++ b/ui/server/routes/config.js
@@ -94,7 +94,11 @@ function extractProbeText(body, providerKind) {
     const output = Array.isArray(body.output) ? body.output : [];
     return output
       .flatMap((item) => Array.isArray(item?.content) ? item.content : [])
-      .map((part) => (typeof part?.text === 'string' ? part.text : ''))
+      .map((part) => {
+        if (typeof part?.text === 'string') return part.text;
+        if (typeof part?.output_text === 'string') return part.output_text;
+        return '';
+      })
       .join('')
       .trim();
   }

--- a/ui/server/routes/config.js
+++ b/ui/server/routes/config.js
@@ -21,6 +21,10 @@ import { reloadPilotDeckConfig } from '../services/pilotdeckConfigReloader.js';
 import { suppressNextWatchEvent } from '../services/pilotdeckConfigWatcher.js';
 import { getPilotDeckGateway } from '../pilotdeck-bridge.js';
 import {
+  buildProviderChatEndpoint,
+  buildProviderModelsEndpoint,
+} from '../../../src/model/providerEndpoint.js';
+import {
   OFFICE_PREVIEW_SERVICE_LIBREOFFICE,
   OFFICE_PREVIEW_SERVICE_NONE,
   getLibreOfficeCandidateStatuses,
@@ -65,50 +69,49 @@ function broadcastConfigEvent(payload) {
   process.emit('pilotdeck:config-broadcast', payload);
 }
 
-function normalizeGoogleProbeModel(model) {
-  const text = String(model || '').trim();
-  const withoutProvider = text.startsWith('google/') ? text.slice('google/'.length) : text;
-  if (withoutProvider === 'gemini-3-pro') return 'gemini-3-pro-preview';
-  if (withoutProvider === 'gemini-3.1-pro') return 'gemini-3.1-pro-preview';
-  if (withoutProvider === 'gemini-3-flash') return 'gemini-3-flash-preview';
-  if (withoutProvider === 'gemini-3.1-flash' || withoutProvider === 'gemini-3.1-flash-preview') {
-    return 'gemini-3-flash-preview';
+function extractProbeText(body, providerKind) {
+  if (!body || typeof body !== 'object') return '';
+
+  if (providerKind === 'anthropic') {
+    const content = Array.isArray(body.content) ? body.content : [];
+    return content
+      .map((part) => (typeof part?.text === 'string' ? part.text : ''))
+      .join('')
+      .trim();
   }
-  if (withoutProvider === 'gemini-3.1-flash-lite') return 'gemini-3.1-flash-lite-preview';
-  return withoutProvider;
-}
 
-function buildGoogleGenerateContentUrl(baseUrl, model) {
-  const normalizedBaseUrl = String(baseUrl || 'https://generativelanguage.googleapis.com').trim().replace(/\/+$/, '')
-    || 'https://generativelanguage.googleapis.com';
-  const url = new URL(normalizedBaseUrl);
-  const parts = url.pathname.split('/').filter(Boolean);
-  const last = parts.at(-1);
-  const apiVersion = last === 'v1' || last === 'v1beta' ? last : 'v1beta';
-  const baseParts = last === 'v1' || last === 'v1beta' ? parts.slice(0, -1) : parts;
-  url.pathname = `/${[
-    ...baseParts,
-    apiVersion,
-    'models',
-    `${encodeURIComponent(normalizeGoogleProbeModel(model))}:generateContent`,
-  ].join('/')}`;
-  url.search = '';
-  url.hash = '';
-  return url.toString();
-}
+  if (providerKind === 'google') {
+    const candidates = Array.isArray(body.candidates) ? body.candidates : [];
+    return candidates
+      .flatMap((candidate) => Array.isArray(candidate?.content?.parts) ? candidate.content.parts : [])
+      .map((part) => (typeof part?.text === 'string' ? part.text : ''))
+      .join('')
+      .trim();
+  }
 
-function buildGoogleModelsUrl(baseUrl) {
-  const normalizedBaseUrl = String(baseUrl || 'https://generativelanguage.googleapis.com').trim().replace(/\/+$/, '')
-    || 'https://generativelanguage.googleapis.com';
-  const url = new URL(normalizedBaseUrl);
-  const parts = url.pathname.split('/').filter(Boolean);
-  const last = parts.at(-1);
-  const apiVersion = last === 'v1' || last === 'v1beta' ? last : 'v1beta';
-  const baseParts = last === 'v1' || last === 'v1beta' ? parts.slice(0, -1) : parts;
-  url.pathname = `/${[...baseParts, apiVersion, 'models'].join('/')}`;
-  url.search = '';
-  url.hash = '';
-  return url.toString();
+  if (providerKind === 'responses') {
+    if (typeof body.output_text === 'string' && body.output_text.trim()) return body.output_text.trim();
+    const output = Array.isArray(body.output) ? body.output : [];
+    return output
+      .flatMap((item) => Array.isArray(item?.content) ? item.content : [])
+      .map((part) => (typeof part?.text === 'string' ? part.text : ''))
+      .join('')
+      .trim();
+  }
+
+  const choices = Array.isArray(body.choices) ? body.choices : [];
+  return choices
+    .map((choice) => {
+      const content = choice?.message?.content;
+      if (typeof content === 'string') return content;
+      if (Array.isArray(content)) {
+        return content.map((part) => (typeof part?.text === 'string' ? part.text : '')).join('');
+      }
+      if (typeof choice?.text === 'string') return choice.text;
+      return '';
+    })
+    .join('')
+    .trim();
 }
 
 function normalizeModelListItem(item) {
@@ -340,15 +343,12 @@ router.post('/models', async (req, res) => {
   const isAnthropic = normalizedType === 'anthropic';
   const isGoogle = normalizedType === 'google';
   const normalizedBaseUrl = String(baseUrl).trim().replace(/\/+$/, '');
+  const protocol = isGoogle ? 'google' : isAnthropic ? 'anthropic' : 'openai';
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), 10_000);
 
   try {
-    const url = isGoogle
-      ? buildGoogleModelsUrl(normalizedBaseUrl)
-      : isAnthropic
-        ? `${normalizedBaseUrl}/v1/models`
-        : `${normalizedBaseUrl}/models`;
+    const url = buildProviderModelsEndpoint({ protocol, baseUrl: normalizedBaseUrl });
     const headers = isGoogle
       ? { 'x-goog-api-key': effectiveApiKey }
       : isAnthropic
@@ -401,7 +401,7 @@ router.post('/test-connection', async (req, res) => {
     let fetchOptions;
 
     if (isGoogle) {
-      url = buildGoogleGenerateContentUrl(normalizedBaseUrl, model);
+      url = buildProviderChatEndpoint({ protocol: 'google', baseUrl: normalizedBaseUrl, model });
       fetchOptions = {
         method: 'POST',
         headers: {
@@ -410,12 +410,12 @@ router.post('/test-connection', async (req, res) => {
         },
         body: JSON.stringify({
           contents: [{ role: 'user', parts: [{ text: 'Hi' }] }],
-          generationConfig: { maxOutputTokens: 1 },
+          generationConfig: { maxOutputTokens: 8 },
         }),
         signal: controller.signal,
       };
     } else if (isAnthropic) {
-      url = `${normalizedBaseUrl}/v1/messages`;
+      url = buildProviderChatEndpoint({ protocol: 'anthropic', baseUrl: normalizedBaseUrl });
       fetchOptions = {
         method: 'POST',
         headers: {
@@ -425,13 +425,13 @@ router.post('/test-connection', async (req, res) => {
         },
         body: JSON.stringify({
           model,
-          max_tokens: 1,
+          max_tokens: 8,
           messages: [{ role: 'user', content: 'Hi' }],
         }),
         signal: controller.signal,
       };
     } else if (isOpenAIResponses) {
-      url = `${normalizedBaseUrl}/responses`;
+      url = buildProviderChatEndpoint({ protocol: 'openai-responses', baseUrl: normalizedBaseUrl });
       fetchOptions = {
         method: 'POST',
         headers: {
@@ -447,7 +447,7 @@ router.post('/test-connection', async (req, res) => {
         signal: controller.signal,
       };
     } else {
-      url = `${normalizedBaseUrl}/chat/completions`;
+      url = buildProviderChatEndpoint({ protocol: 'openai', baseUrl: normalizedBaseUrl });
       fetchOptions = {
         method: 'POST',
         headers: {
@@ -456,7 +456,7 @@ router.post('/test-connection', async (req, res) => {
         },
         body: JSON.stringify({
           model,
-          max_tokens: 1,
+          max_tokens: 8,
           messages: [{ role: 'user', content: 'Hi' }],
         }),
         signal: controller.signal,
@@ -499,6 +499,15 @@ router.post('/test-connection', async (req, res) => {
         return res.json({
           ok: false,
           error: `Endpoint returned HTTP ${response.status}, but the response was not a valid ${expectedShape}. Check the base URL path.`,
+        });
+      }
+
+      const providerKind = isAnthropic ? 'anthropic' : isGoogle ? 'google' : isOpenAIResponses ? 'responses' : 'openai';
+      const probeText = extractProbeText(body, providerKind);
+      if (!probeText) {
+        return res.json({
+          ok: false,
+          error: `Endpoint returned a valid ${expectedShape}, but the model did not produce any chat text. Check that ${model} supports chat completions.`,
         });
       }
 

--- a/ui/server/routes/config.js
+++ b/ui/server/routes/config.js
@@ -23,6 +23,8 @@ import { getPilotDeckGateway } from '../pilotdeck-bridge.js';
 import {
   buildProviderChatEndpointCandidates,
   buildProviderModelsEndpointCandidates,
+  isExpectedProviderModelsResponseShape,
+  isExpectedProviderResponseShape,
 } from '../../../src/model/providerEndpoint.js';
 import {
   OFFICE_PREVIEW_SERVICE_LIBREOFFICE,
@@ -156,17 +158,40 @@ function isEndpointFallbackStatus(status) {
   return status === 400 || status === 404 || status === 405;
 }
 
-async function fetchWithEndpointFallback(urls, options) {
+async function fetchWithEndpointFallback(urls, options, isExpectedOkBody = null) {
   let lastResult = null;
   for (const url of urls) {
     const response = await fetch(url, options);
     const responseText = await response.text();
-    if (response.ok || urls.length === 1 || !isEndpointFallbackStatus(response.status)) {
+    if (response.ok) {
+      if (!isExpectedOkBody || urls.length === 1 || isExpectedOkBody(responseText)) {
+        return { url, response, responseText };
+      }
+      lastResult = { url, response, responseText };
+      continue;
+    }
+    if (urls.length === 1 || !isEndpointFallbackStatus(response.status)) {
       return { url, response, responseText };
     }
     lastResult = { url, response, responseText };
   }
   return lastResult;
+}
+
+function isExpectedJsonBody(protocol, responseText) {
+  try {
+    return isExpectedProviderResponseShape(protocol, responseText ? JSON.parse(responseText) : {});
+  } catch {
+    return false;
+  }
+}
+
+function isExpectedModelsJsonBody(protocol, responseText) {
+  try {
+    return isExpectedProviderModelsResponseShape(protocol, responseText ? JSON.parse(responseText) : {});
+  } catch {
+    return false;
+  }
 }
 
 router.get('/', (_req, res) => {
@@ -375,7 +400,11 @@ router.post('/models', async (req, res) => {
       : isAnthropic
         ? { 'x-api-key': effectiveApiKey, 'anthropic-version': '2023-06-01' }
         : { Authorization: `Bearer ${effectiveApiKey}` };
-    const { url, response, responseText } = await fetchWithEndpointFallback(urls, { method: 'GET', headers, signal: controller.signal });
+    const { url, response, responseText } = await fetchWithEndpointFallback(
+      urls,
+      { method: 'GET', headers, signal: controller.signal },
+      (text) => isExpectedModelsJsonBody(protocol, text),
+    );
     clearTimeout(timer);
     let body;
     try {
@@ -483,7 +512,14 @@ router.post('/test-connection', async (req, res) => {
       };
     }
 
-    const result = await fetchWithEndpointFallback(url, fetchOptions);
+    const responseProtocol = isGoogle
+      ? 'google'
+      : isAnthropic
+        ? 'anthropic'
+        : isOpenAIResponses
+          ? 'openai-responses'
+          : 'openai';
+    const result = await fetchWithEndpointFallback(url, fetchOptions, (responseText) => isExpectedJsonBody(responseProtocol, responseText));
     const { response, responseText } = result;
     url = result.url;
     clearTimeout(timer);

--- a/ui/server/routes/config.js
+++ b/ui/server/routes/config.js
@@ -21,8 +21,8 @@ import { reloadPilotDeckConfig } from '../services/pilotdeckConfigReloader.js';
 import { suppressNextWatchEvent } from '../services/pilotdeckConfigWatcher.js';
 import { getPilotDeckGateway } from '../pilotdeck-bridge.js';
 import {
-  buildProviderChatEndpoint,
-  buildProviderModelsEndpoint,
+  buildProviderChatEndpointCandidates,
+  buildProviderModelsEndpointCandidates,
 } from '../../../src/model/providerEndpoint.js';
 import {
   OFFICE_PREVIEW_SERVICE_LIBREOFFICE,
@@ -150,6 +150,23 @@ function parseModelListResponse(body) {
     models.push(model);
   }
   return models;
+}
+
+function isEndpointFallbackStatus(status) {
+  return status === 400 || status === 404 || status === 405;
+}
+
+async function fetchWithEndpointFallback(urls, options) {
+  let lastResult = null;
+  for (const url of urls) {
+    const response = await fetch(url, options);
+    const responseText = await response.text();
+    if (response.ok || urls.length === 1 || !isEndpointFallbackStatus(response.status)) {
+      return { url, response, responseText };
+    }
+    lastResult = { url, response, responseText };
+  }
+  return lastResult;
 }
 
 router.get('/', (_req, res) => {
@@ -352,15 +369,14 @@ router.post('/models', async (req, res) => {
   const timer = setTimeout(() => controller.abort(), 10_000);
 
   try {
-    const url = buildProviderModelsEndpoint({ protocol, baseUrl: normalizedBaseUrl });
+    const urls = buildProviderModelsEndpointCandidates({ protocol, baseUrl: normalizedBaseUrl });
     const headers = isGoogle
       ? { 'x-goog-api-key': effectiveApiKey }
       : isAnthropic
         ? { 'x-api-key': effectiveApiKey, 'anthropic-version': '2023-06-01' }
         : { Authorization: `Bearer ${effectiveApiKey}` };
-    const response = await fetch(url, { method: 'GET', headers, signal: controller.signal });
+    const { url, response, responseText } = await fetchWithEndpointFallback(urls, { method: 'GET', headers, signal: controller.signal });
     clearTimeout(timer);
-    const responseText = await response.text();
     let body;
     try {
       body = responseText ? JSON.parse(responseText) : {};
@@ -405,7 +421,7 @@ router.post('/test-connection', async (req, res) => {
     let fetchOptions;
 
     if (isGoogle) {
-      url = buildProviderChatEndpoint({ protocol: 'google', baseUrl: normalizedBaseUrl, model });
+      url = buildProviderChatEndpointCandidates({ protocol: 'google', baseUrl: normalizedBaseUrl, model });
       fetchOptions = {
         method: 'POST',
         headers: {
@@ -419,7 +435,7 @@ router.post('/test-connection', async (req, res) => {
         signal: controller.signal,
       };
     } else if (isAnthropic) {
-      url = buildProviderChatEndpoint({ protocol: 'anthropic', baseUrl: normalizedBaseUrl });
+      url = buildProviderChatEndpointCandidates({ protocol: 'anthropic', baseUrl: normalizedBaseUrl });
       fetchOptions = {
         method: 'POST',
         headers: {
@@ -435,7 +451,7 @@ router.post('/test-connection', async (req, res) => {
         signal: controller.signal,
       };
     } else if (isOpenAIResponses) {
-      url = buildProviderChatEndpoint({ protocol: 'openai-responses', baseUrl: normalizedBaseUrl });
+      url = buildProviderChatEndpointCandidates({ protocol: 'openai-responses', baseUrl: normalizedBaseUrl });
       fetchOptions = {
         method: 'POST',
         headers: {
@@ -451,7 +467,7 @@ router.post('/test-connection', async (req, res) => {
         signal: controller.signal,
       };
     } else {
-      url = buildProviderChatEndpoint({ protocol: 'openai', baseUrl: normalizedBaseUrl });
+      url = buildProviderChatEndpointCandidates({ protocol: 'openai', baseUrl: normalizedBaseUrl });
       fetchOptions = {
         method: 'POST',
         headers: {
@@ -467,9 +483,10 @@ router.post('/test-connection', async (req, res) => {
       };
     }
 
-    const response = await fetch(url, fetchOptions);
+    const result = await fetchWithEndpointFallback(url, fetchOptions);
+    const { response, responseText } = result;
+    url = result.url;
     clearTimeout(timer);
-    const responseText = await response.text();
     const expectedShape = isAnthropic
       ? 'Anthropic message'
       : isGoogle

--- a/ui/server/routes/config.test.js
+++ b/ui/server/routes/config.test.js
@@ -71,6 +71,29 @@ describe('config test-connection route', () => {
     expect(data.ok).toBe(false);
     expect(data.error).toContain('did not produce any chat text');
   });
+
+  it('accepts Responses API output_text content parts', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => jsonResponse({
+      object: 'response',
+      output: [{
+        type: 'message',
+        content: [{ type: 'output_text', output_text: 'ok' }],
+      }],
+    })));
+
+    const { request } = await createConfigApp();
+    const data = await request('/api/config/test-connection', {
+      method: 'POST',
+      body: JSON.stringify({
+        providerType: 'openai-responses',
+        baseUrl: 'https://api.openai.com/v1',
+        apiKey: 'sk-test',
+        model: 'gpt-test',
+      }),
+    });
+
+    expect(data.ok).toBe(true);
+  });
 });
 
 async function createConfigApp() {

--- a/ui/server/routes/config.test.js
+++ b/ui/server/routes/config.test.js
@@ -88,6 +88,62 @@ describe('config test-connection route', () => {
     ]);
   });
 
+  it('falls back to /v1/messages for Anthropic when unversioned probing returns unexpected JSON', async () => {
+    const calls = [];
+    vi.stubGlobal('fetch', vi.fn(async (url) => {
+      calls.push(String(url));
+      if (String(url) === 'https://api.anthropic.com/messages') {
+        return jsonResponse({ ok: true });
+      }
+      return jsonResponse({ type: 'message', content: [{ type: 'text', text: 'ok' }] });
+    }));
+
+    const { request } = await createConfigApp();
+    const data = await request('/api/config/test-connection', {
+      method: 'POST',
+      body: JSON.stringify({
+        providerType: 'anthropic',
+        baseUrl: 'https://api.anthropic.com',
+        apiKey: 'sk-test',
+        model: 'claude-test',
+      }),
+    });
+
+    expect(data.ok).toBe(true);
+    expect(calls).toEqual([
+      'https://api.anthropic.com/messages',
+      'https://api.anthropic.com/v1/messages',
+    ]);
+  });
+
+  it('falls back to /v1beta Gemini endpoint when unversioned probing returns unexpected JSON', async () => {
+    const calls = [];
+    vi.stubGlobal('fetch', vi.fn(async (url) => {
+      calls.push(String(url));
+      if (String(url) === 'https://generativelanguage.googleapis.com/models/gemini-pro:generateContent') {
+        return jsonResponse({ ok: true });
+      }
+      return jsonResponse({ candidates: [{ content: { parts: [{ text: 'ok' }] } }] });
+    }));
+
+    const { request } = await createConfigApp();
+    const data = await request('/api/config/test-connection', {
+      method: 'POST',
+      body: JSON.stringify({
+        providerType: 'google',
+        baseUrl: 'https://generativelanguage.googleapis.com',
+        apiKey: 'sk-test',
+        model: 'gemini-pro',
+      }),
+    });
+
+    expect(data.ok).toBe(true);
+    expect(calls).toEqual([
+      'https://generativelanguage.googleapis.com/models/gemini-pro:generateContent',
+      'https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent',
+    ]);
+  });
+
   it('does not duplicate existing version paths', async () => {
     const calls = [];
     vi.stubGlobal('fetch', vi.fn(async (url) => {

--- a/ui/server/routes/config.test.js
+++ b/ui/server/routes/config.test.js
@@ -1,0 +1,127 @@
+import express from 'express';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const nativeFetch = globalThis.fetch;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  vi.resetModules();
+});
+
+describe('config test-connection route', () => {
+  it('uses /v1/chat/completions for root OpenAI base URLs and requires text', async () => {
+    const calls = [];
+    vi.stubGlobal('fetch', vi.fn(async (url) => {
+      calls.push(String(url));
+      return jsonResponse({ choices: [{ message: { content: 'ok' } }] });
+    }));
+
+    const { request } = await createConfigApp();
+    const data = await request('/api/config/test-connection', {
+      method: 'POST',
+      body: JSON.stringify({
+        providerType: 'openai',
+        baseUrl: 'https://api.openai.com',
+        apiKey: 'sk-test',
+        model: 'gpt-test',
+      }),
+    });
+
+    expect(data.ok).toBe(true);
+    expect(calls).toEqual(['https://api.openai.com/v1/chat/completions']);
+  });
+
+  it('does not duplicate existing version paths', async () => {
+    const calls = [];
+    vi.stubGlobal('fetch', vi.fn(async (url) => {
+      calls.push(String(url));
+      return jsonResponse({ choices: [{ message: { content: 'ok' } }] });
+    }));
+
+    const { request } = await createConfigApp();
+    const data = await request('/api/config/test-connection', {
+      method: 'POST',
+      body: JSON.stringify({
+        providerType: 'openai',
+        baseUrl: 'https://api.openai.com/v1',
+        apiKey: 'sk-test',
+        model: 'gpt-test',
+      }),
+    });
+
+    expect(data.ok).toBe(true);
+    expect(calls).toEqual(['https://api.openai.com/v1/chat/completions']);
+  });
+
+  it('fails when the provider returns no chat text', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => jsonResponse({ choices: [{ message: { content: '' } }] })));
+
+    const { request } = await createConfigApp();
+    const data = await request('/api/config/test-connection', {
+      method: 'POST',
+      body: JSON.stringify({
+        providerType: 'openai',
+        baseUrl: 'https://api.openai.com',
+        apiKey: 'sk-test',
+        model: 'gpt-test',
+      }),
+    });
+
+    expect(data.ok).toBe(false);
+    expect(data.error).toContain('did not produce any chat text');
+  });
+});
+
+async function createConfigApp() {
+  vi.doMock('../services/pilotdeckConfigWatcher.js', () => ({
+    suppressNextWatchEvent: vi.fn(),
+  }));
+  vi.doMock('../services/pilotdeckConfigReloader.js', () => ({
+    reloadPilotDeckConfig: vi.fn(async () => undefined),
+  }));
+  vi.doMock('../services/pilotdeckConfig.js', async () => {
+    const actual = await vi.importActual('../services/pilotdeckConfig.js');
+    return {
+      ...actual,
+      readPilotDeckConfigFile: vi.fn(() => ({ exists: false, configPath: '', config: {}, rawYaml: {} })),
+      writePilotDeckConfig: vi.fn(),
+      writeRawPilotDeckYaml: vi.fn(),
+    };
+  });
+  vi.doMock('../pilotdeck-bridge.js', () => ({
+    getPilotDeckGateway: vi.fn(async () => ({ reloadConfig: vi.fn(async () => undefined) })),
+  }));
+
+  const { default: configRoutes } = await import('./config.js');
+  const app = express();
+  app.use(express.json());
+  app.use('/api/config', configRoutes);
+
+  return {
+    request: (path, init) => requestJson(app, path, init),
+  };
+}
+
+async function requestJson(app, path, init = {}) {
+  const server = app.listen(0);
+  try {
+    const { port } = server.address();
+    const response = await nativeFetch(`http://127.0.0.1:${port}${path}`, {
+      headers: { 'Content-Type': 'application/json', ...(init.headers || {}) },
+      ...init,
+    });
+    return response.json();
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+}
+
+function jsonResponse(payload) {
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    text: async () => JSON.stringify(payload),
+  };
+}

--- a/ui/server/routes/config.test.js
+++ b/ui/server/routes/config.test.js
@@ -10,7 +10,7 @@ afterEach(() => {
 });
 
 describe('config test-connection route', () => {
-  it('uses unversioned chat completions when the root base URL works', async () => {
+  it('uses protocol-versioned chat completions when the root base URL works', async () => {
     const calls = [];
     vi.stubGlobal('fetch', vi.fn(async (url) => {
       calls.push(String(url));
@@ -29,14 +29,14 @@ describe('config test-connection route', () => {
     });
 
     expect(data.ok).toBe(true);
-    expect(calls).toEqual(['https://api.openai.com/chat/completions']);
+    expect(calls).toEqual(['https://api.openai.com/v1/chat/completions']);
   });
 
-  it('falls back to /v1/chat/completions when unversioned probing misses', async () => {
+  it('falls back to unversioned chat completions when protocol-versioned probing misses', async () => {
     const calls = [];
     vi.stubGlobal('fetch', vi.fn(async (url) => {
       calls.push(String(url));
-      if (String(url) === 'https://api.openai.com/chat/completions') {
+      if (String(url) === 'https://api.openai.com/v1/chat/completions') {
         return jsonResponse({ error: { message: 'not found' } }, { ok: false, status: 404, statusText: 'Not Found' });
       }
       return jsonResponse({ choices: [{ message: { content: 'ok' } }] });
@@ -55,16 +55,16 @@ describe('config test-connection route', () => {
 
     expect(data.ok).toBe(true);
     expect(calls).toEqual([
-      'https://api.openai.com/chat/completions',
       'https://api.openai.com/v1/chat/completions',
+      'https://api.openai.com/chat/completions',
     ]);
   });
 
-  it('falls back to /v1/chat/completions when unversioned probing returns unexpected JSON', async () => {
+  it('falls back to unversioned chat completions when protocol-versioned probing returns unexpected JSON', async () => {
     const calls = [];
     vi.stubGlobal('fetch', vi.fn(async (url) => {
       calls.push(String(url));
-      if (String(url) === 'https://api.openai.com/chat/completions') {
+      if (String(url) === 'https://api.openai.com/v1/chat/completions') {
         return jsonResponse({ ok: true });
       }
       return jsonResponse({ choices: [{ message: { content: 'ok' } }] });
@@ -83,16 +83,16 @@ describe('config test-connection route', () => {
 
     expect(data.ok).toBe(true);
     expect(calls).toEqual([
-      'https://api.openai.com/chat/completions',
       'https://api.openai.com/v1/chat/completions',
+      'https://api.openai.com/chat/completions',
     ]);
   });
 
-  it('falls back to /v1/messages for Anthropic when unversioned probing returns unexpected JSON', async () => {
+  it('falls back to unversioned messages for Anthropic when protocol-versioned probing returns unexpected JSON', async () => {
     const calls = [];
     vi.stubGlobal('fetch', vi.fn(async (url) => {
       calls.push(String(url));
-      if (String(url) === 'https://api.anthropic.com/messages') {
+      if (String(url) === 'https://api.anthropic.com/v1/messages') {
         return jsonResponse({ ok: true });
       }
       return jsonResponse({ type: 'message', content: [{ type: 'text', text: 'ok' }] });
@@ -111,16 +111,16 @@ describe('config test-connection route', () => {
 
     expect(data.ok).toBe(true);
     expect(calls).toEqual([
-      'https://api.anthropic.com/messages',
       'https://api.anthropic.com/v1/messages',
+      'https://api.anthropic.com/messages',
     ]);
   });
 
-  it('falls back to /v1beta Gemini endpoint when unversioned probing returns unexpected JSON', async () => {
+  it('falls back to unversioned Gemini endpoint when protocol-versioned probing returns unexpected JSON', async () => {
     const calls = [];
     vi.stubGlobal('fetch', vi.fn(async (url) => {
       calls.push(String(url));
-      if (String(url) === 'https://generativelanguage.googleapis.com/models/gemini-pro:generateContent') {
+      if (String(url) === 'https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent') {
         return jsonResponse({ ok: true });
       }
       return jsonResponse({ candidates: [{ content: { parts: [{ text: 'ok' }] } }] });
@@ -139,8 +139,8 @@ describe('config test-connection route', () => {
 
     expect(data.ok).toBe(true);
     expect(calls).toEqual([
-      'https://generativelanguage.googleapis.com/models/gemini-pro:generateContent',
       'https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent',
+      'https://generativelanguage.googleapis.com/models/gemini-pro:generateContent',
     ]);
   });
 

--- a/ui/server/routes/config.test.js
+++ b/ui/server/routes/config.test.js
@@ -60,6 +60,34 @@ describe('config test-connection route', () => {
     ]);
   });
 
+  it('falls back to /v1/chat/completions when unversioned probing returns unexpected JSON', async () => {
+    const calls = [];
+    vi.stubGlobal('fetch', vi.fn(async (url) => {
+      calls.push(String(url));
+      if (String(url) === 'https://api.openai.com/chat/completions') {
+        return jsonResponse({ ok: true });
+      }
+      return jsonResponse({ choices: [{ message: { content: 'ok' } }] });
+    }));
+
+    const { request } = await createConfigApp();
+    const data = await request('/api/config/test-connection', {
+      method: 'POST',
+      body: JSON.stringify({
+        providerType: 'openai',
+        baseUrl: 'https://api.openai.com',
+        apiKey: 'sk-test',
+        model: 'gpt-test',
+      }),
+    });
+
+    expect(data.ok).toBe(true);
+    expect(calls).toEqual([
+      'https://api.openai.com/chat/completions',
+      'https://api.openai.com/v1/chat/completions',
+    ]);
+  });
+
   it('does not duplicate existing version paths', async () => {
     const calls = [];
     vi.stubGlobal('fetch', vi.fn(async (url) => {

--- a/ui/server/routes/config.test.js
+++ b/ui/server/routes/config.test.js
@@ -10,7 +10,7 @@ afterEach(() => {
 });
 
 describe('config test-connection route', () => {
-  it('uses /v1/chat/completions for root OpenAI base URLs and requires text', async () => {
+  it('uses unversioned chat completions when the root base URL works', async () => {
     const calls = [];
     vi.stubGlobal('fetch', vi.fn(async (url) => {
       calls.push(String(url));
@@ -29,7 +29,35 @@ describe('config test-connection route', () => {
     });
 
     expect(data.ok).toBe(true);
-    expect(calls).toEqual(['https://api.openai.com/v1/chat/completions']);
+    expect(calls).toEqual(['https://api.openai.com/chat/completions']);
+  });
+
+  it('falls back to /v1/chat/completions when unversioned probing misses', async () => {
+    const calls = [];
+    vi.stubGlobal('fetch', vi.fn(async (url) => {
+      calls.push(String(url));
+      if (String(url) === 'https://api.openai.com/chat/completions') {
+        return jsonResponse({ error: { message: 'not found' } }, { ok: false, status: 404, statusText: 'Not Found' });
+      }
+      return jsonResponse({ choices: [{ message: { content: 'ok' } }] });
+    }));
+
+    const { request } = await createConfigApp();
+    const data = await request('/api/config/test-connection', {
+      method: 'POST',
+      body: JSON.stringify({
+        providerType: 'openai',
+        baseUrl: 'https://api.openai.com',
+        apiKey: 'sk-test',
+        model: 'gpt-test',
+      }),
+    });
+
+    expect(data.ok).toBe(true);
+    expect(calls).toEqual([
+      'https://api.openai.com/chat/completions',
+      'https://api.openai.com/v1/chat/completions',
+    ]);
   });
 
   it('does not duplicate existing version paths', async () => {
@@ -45,6 +73,28 @@ describe('config test-connection route', () => {
       body: JSON.stringify({
         providerType: 'openai',
         baseUrl: 'https://api.openai.com/v1',
+        apiKey: 'sk-test',
+        model: 'gpt-test',
+      }),
+    });
+
+    expect(data.ok).toBe(true);
+    expect(calls).toEqual(['https://api.openai.com/v1/chat/completions']);
+  });
+
+  it('accepts full OpenAI-compatible endpoint URLs', async () => {
+    const calls = [];
+    vi.stubGlobal('fetch', vi.fn(async (url) => {
+      calls.push(String(url));
+      return jsonResponse({ choices: [{ message: { content: 'ok' } }] });
+    }));
+
+    const { request } = await createConfigApp();
+    const data = await request('/api/config/test-connection', {
+      method: 'POST',
+      body: JSON.stringify({
+        providerType: 'openai',
+        baseUrl: 'https://api.openai.com/v1/chat/completions',
         apiKey: 'sk-test',
         model: 'gpt-test',
       }),
@@ -140,11 +190,12 @@ async function requestJson(app, path, init = {}) {
   }
 }
 
-function jsonResponse(payload) {
+function jsonResponse(payload, overrides = {}) {
   return {
     ok: true,
     status: 200,
     statusText: 'OK',
+    ...overrides,
     text: async () => JSON.stringify(payload),
   };
 }


### PR DESCRIPTION
## Summary\n- unify provider endpoint construction for config probes, model listing, and runtime chat calls\n- support root base URLs by adding protocol-specific version paths without duplicating existing version segments\n- require test connection probes to receive non-empty chat text before reporting success\n\n## Testing\n- node --check ui/server/routes/config.js\n- node --check ui/server/routes/config.test.js\n- npx tsx --test tests/model/providerEndpoint.spec.ts\n\n## Notes\n- Full npm build was blocked locally because edgeclaw-memory-core could not find tsc in this worktree.\n- UI Vitest route smoke test could not run locally because vite/@vitejs/plugin-react dependencies were unavailable in this worktree.