### PR TITLE
Fix settings recovery from invalid YAML

### DIFF
--- a/ui/server/routes/config.js
+++ b/ui/server/routes/config.js
@@ -38,6 +38,23 @@ async function notifyGatewayConfigReload() {
 const router = express.Router();
 
 function serializeConfigResponse(record, reloadResult = null) {
+  if (record.parseError) {
+    return {
+      exists: record.exists,
+      path: record.configPath,
+      raw: record.raw,
+      config: maskSecrets(record.config),
+      configDisabled: true,
+      parseError: record.parseError,
+      validation: {
+        valid: false,
+        errors: [`Invalid YAML: ${record.parseError}`],
+        warnings: [],
+      },
+      ...(reloadResult ? { reload: reloadResult } : {}),
+    };
+  }
+
   const validation = validatePilotDeckConfig(record.config);
   const maskedConfig = maskSecrets(record.config);
   // Prefer the disk's actual YAML for the "raw" view so non-ui-internal
@@ -230,7 +247,9 @@ router.put('/', async (req, res) => {
       // Re-hydrate any field the UI received as "********" with the
       // original disk value so saving the masked view back is a no-op
       // for secrets the user didn't actually touch.
-      const restored = preserveMaskedSecrets(parsed, diskRecord.rawYaml ?? {});
+      const restored = diskRecord.parseError
+        ? parsed
+        : preserveMaskedSecrets(parsed, diskRecord.rawYaml ?? {});
       suppressNextWatchEvent();
       saved = await writeRawPilotDeckYaml(restored);
     } else if (req.body?.config && typeof req.body.config === 'object') {

--- a/ui/server/routes/config.js
+++ b/ui/server/routes/config.js
@@ -280,6 +280,18 @@ router.put('/', async (req, res) => {
 router.post('/reload', async (_req, res) => {
   try {
     const record = readPilotDeckConfigFile();
+    if (record.parseError) {
+      return res.status(400).json({
+        error: 'Invalid config YAML',
+        configDisabled: true,
+        parseError: record.parseError,
+        validation: {
+          valid: false,
+          errors: [`Invalid YAML: ${record.parseError}`],
+          warnings: [],
+        },
+      });
+    }
     const validation = validatePilotDeckConfig(record.config);
     if (!validation.valid) {
       return res.status(400).json({ error: 'Invalid config', validation });

--- a/ui/server/routes/config.js
+++ b/ui/server/routes/config.js
@@ -253,6 +253,18 @@ router.put('/', async (req, res) => {
       suppressNextWatchEvent();
       saved = await writeRawPilotDeckYaml(restored);
     } else if (req.body?.config && typeof req.body.config === 'object') {
+      if (diskRecord.parseError) {
+        return res.status(400).json({
+          error: 'Invalid config YAML; repair raw YAML before using structured config updates',
+          configDisabled: true,
+          parseError: diskRecord.parseError,
+          validation: {
+            valid: false,
+            errors: [`Invalid YAML: ${diskRecord.parseError}`],
+            warnings: [],
+          },
+        });
+      }
       const restored = preserveMaskedSecrets(req.body.config, diskRecord.config);
       suppressNextWatchEvent();
       saved = await writePilotDeckConfig(restored);

--- a/ui/server/routes/config.test.js
+++ b/ui/server/routes/config.test.js
@@ -1,0 +1,108 @@
+import express from 'express';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const nativeFetch = globalThis.fetch;
+const tempDirs = [];
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.resetModules();
+  delete process.env.PILOT_HOME;
+  delete process.env.PILOTDECK_CONFIG_PATH;
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('config routes invalid YAML fallback', () => {
+  it('returns raw invalid YAML instead of failing GET /api/config', async () => {
+    const brokenRaw = 'schemaVersion: 1\nmodel:\n  providers: [\n';
+    const { request } = await createConfigApp(brokenRaw);
+
+    const response = await request('/api/config');
+
+    expect(response.status).toBe(200);
+    expect(response.body.raw).toBe(brokenRaw);
+    expect(response.body.configDisabled).toBe(true);
+    expect(response.body.parseError).toEqual(expect.any(String));
+    expect(response.body.validation.valid).toBe(false);
+    expect(response.body.validation.errors[0]).toMatch(/^Invalid YAML:/);
+  });
+
+  it('saves repaired raw YAML after the existing file is invalid', async () => {
+    const { request, configPath } = await createConfigApp('schemaVersion: 1\nmodel:\n  providers: [\n');
+    const repaired = stringifyYaml({
+      schemaVersion: 1,
+      agent: { model: 'openai/gpt-4.1-mini' },
+      model: {
+        providers: {
+          openai: {
+            protocol: 'openai',
+            url: 'https://api.openai.com/v1',
+            apiKey: 'sk-test',
+            models: { 'gpt-4.1-mini': {} },
+          },
+        },
+      },
+    });
+
+    const response = await request('/api/config', {
+      method: 'PUT',
+      body: JSON.stringify({ raw: repaired }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body.configDisabled).toBeUndefined();
+    expect(response.body.validation.valid).toBe(true);
+    expect(parseYaml(readFileSync(configPath, 'utf8')).model.providers.openai.apiKey).toBe('sk-test');
+  });
+});
+
+async function createConfigApp(initialRaw) {
+  const pilotHome = mkdtempSync(join(tmpdir(), 'pilotdeck-config-route-'));
+  tempDirs.push(pilotHome);
+  const configPath = join(pilotHome, 'pilotdeck.yaml');
+  writeFileSync(configPath, initialRaw, 'utf8');
+
+  process.env.PILOT_HOME = pilotHome;
+  process.env.PILOTDECK_CONFIG_PATH = configPath;
+
+  vi.resetModules();
+  vi.doMock('../services/pilotdeckConfigWatcher.js', () => ({
+    suppressNextWatchEvent: vi.fn(),
+  }));
+  vi.doMock('../services/pilotdeckConfigReloader.js', () => ({
+    reloadPilotDeckConfig: vi.fn(async () => ({ processEnv: { reloaded: true } })),
+  }));
+  vi.doMock('../pilotdeck-bridge.js', () => ({
+    getPilotDeckGateway: vi.fn(async () => ({ reloadConfig: vi.fn(async () => undefined) })),
+  }));
+
+  const { default: configRoutes } = await import('./config.js');
+  const app = express();
+  app.use(express.json());
+  app.use('/api/config', configRoutes);
+
+  return {
+    configPath,
+    request: (path, init) => requestJson(app, path, init),
+  };
+}
+
+async function requestJson(app, path, init = {}) {
+  const server = app.listen(0);
+  try {
+    const { port } = server.address();
+    const response = await nativeFetch(`http://127.0.0.1:${port}${path}`, {
+      headers: { 'Content-Type': 'application/json', ...(init.headers || {}) },
+      ...init,
+    });
+    return { status: response.status, body: await response.json() };
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+}

--- a/ui/server/routes/config.test.js
+++ b/ui/server/routes/config.test.js
@@ -73,6 +73,21 @@ describe('config routes invalid YAML fallback', () => {
     expect(response.body.validation.errors[0]).toMatch(/^Invalid YAML:/);
     expect(reloadPilotDeckConfig).not.toHaveBeenCalled();
   });
+
+  it('rejects structured config saves without overwriting invalid YAML', async () => {
+    const brokenRaw = 'schemaVersion: 1\nmodel:\n  providers: [\n';
+    const { request, configPath } = await createConfigApp(brokenRaw);
+
+    const response = await request('/api/config', {
+      method: 'PUT',
+      body: JSON.stringify({ config: { schemaVersion: 1, model: { providers: {} } } }),
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.body.configDisabled).toBe(true);
+    expect(response.body.validation.errors[0]).toMatch(/^Invalid YAML:/);
+    expect(readFileSync(configPath, 'utf8')).toBe(brokenRaw);
+  });
 });
 
 async function createConfigApp(initialRaw, overrides = {}) {

--- a/ui/server/routes/config.test.js
+++ b/ui/server/routes/config.test.js
@@ -60,9 +60,22 @@ describe('config routes invalid YAML fallback', () => {
     expect(response.body.validation.valid).toBe(true);
     expect(parseYaml(readFileSync(configPath, 'utf8')).model.providers.openai.apiKey).toBe('sk-test');
   });
+
+  it('rejects reload without applying defaults when YAML is invalid', async () => {
+    const reloadPilotDeckConfig = vi.fn(async () => ({ processEnv: { reloaded: true } }));
+    const { request } = await createConfigApp('schemaVersion: 1\nmodel:\n  providers: [\n', { reloadPilotDeckConfig });
+
+    const response = await request('/api/config/reload', { method: 'POST' });
+
+    expect(response.status).toBe(400);
+    expect(response.body.configDisabled).toBe(true);
+    expect(response.body.validation.valid).toBe(false);
+    expect(response.body.validation.errors[0]).toMatch(/^Invalid YAML:/);
+    expect(reloadPilotDeckConfig).not.toHaveBeenCalled();
+  });
 });
 
-async function createConfigApp(initialRaw) {
+async function createConfigApp(initialRaw, overrides = {}) {
   const pilotHome = mkdtempSync(join(tmpdir(), 'pilotdeck-config-route-'));
   tempDirs.push(pilotHome);
   const configPath = join(pilotHome, 'pilotdeck.yaml');
@@ -76,7 +89,7 @@ async function createConfigApp(initialRaw) {
     suppressNextWatchEvent: vi.fn(),
   }));
   vi.doMock('../services/pilotdeckConfigReloader.js', () => ({
-    reloadPilotDeckConfig: vi.fn(async () => ({ processEnv: { reloaded: true } })),
+    reloadPilotDeckConfig: overrides.reloadPilotDeckConfig ?? vi.fn(async () => ({ processEnv: { reloaded: true } })),
   }));
   vi.doMock('../pilotdeck-bridge.js', () => ({
     getPilotDeckGateway: vi.fn(async () => ({ reloadConfig: vi.fn(async () => undefined) })),

--- a/ui/server/routes/memory.js
+++ b/ui/server/routes/memory.js
@@ -70,7 +70,17 @@ function getGlobalMemorySettings() {
 }
 
 async function saveGlobalMemorySettings(partial = {}) {
-  const { config } = readPilotDeckConfigFile();
+  const record = readPilotDeckConfigFile();
+  if (record.parseError) {
+    const error = new Error('Invalid config YAML; repair raw YAML before updating memory settings');
+    error.validation = {
+      valid: false,
+      errors: [`Invalid YAML: ${record.parseError}`],
+      warnings: [],
+    };
+    throw error;
+  }
+  const { config } = record;
   const current = getGlobalMemorySettingsFromConfig(config);
   const next = {
     reasoningMode: partial.reasoningMode === 'accuracy_first'

--- a/ui/server/services/pilotdeckConfig.js
+++ b/ui/server/services/pilotdeckConfig.js
@@ -480,12 +480,25 @@ export function readPilotDeckConfigFile() {
       raw: '',
       config: buildDefaultPilotDeckConfig(),
       rawYaml: {},
+      parseError: null,
     };
   }
   const raw = fs.readFileSync(configPath, 'utf8');
-  const parsed = parseYaml(raw) || {};
+  let parsed;
+  try {
+    parsed = parseYaml(raw) || {};
+  } catch (error) {
+    return {
+      exists: true,
+      configPath,
+      raw,
+      config: buildDefaultPilotDeckConfig(),
+      rawYaml: null,
+      parseError: error instanceof Error ? error.message : String(error),
+    };
+  }
   const config = normalizePilotDeckConfig(parsed);
-  return { exists: true, configPath, raw, config, rawYaml: parsed };
+  return { exists: true, configPath, raw, config, rawYaml: parsed, parseError: null };
 }
 
 // Keep `router.scenarios.default` aligned with `agent.model` whenever we

--- a/ui/server/services/pilotdeckConfig.test.js
+++ b/ui/server/services/pilotdeckConfig.test.js
@@ -1,5 +1,69 @@
-import { describe, expect, it } from 'vitest';
-import { sanitizeProviderCredentials, validatePilotDeckConfig } from './pilotdeckConfig.js';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { readPilotDeckConfigFile, sanitizeProviderCredentials, validatePilotDeckConfig } from './pilotdeckConfig.js';
+
+const tempDirs = [];
+
+afterEach(() => {
+    delete process.env.PILOTDECK_CONFIG_PATH;
+    for (const dir of tempDirs.splice(0)) {
+        rmSync(dir, { recursive: true, force: true });
+    }
+});
+
+function useTempConfig(contents, filename = 'pilotdeck.yaml') {
+    const dir = mkdtempSync(join(tmpdir(), 'pilotdeck-config-test-'));
+    tempDirs.push(dir);
+    const configPath = join(dir, filename);
+    if (contents !== null) {
+        writeFileSync(configPath, contents, 'utf8');
+    }
+    process.env.PILOTDECK_CONFIG_PATH = configPath;
+    return configPath;
+}
+
+describe('readPilotDeckConfigFile fallback behavior', () => {
+    it('returns defaults when the config file is missing', () => {
+        const configPath = useTempConfig(null);
+
+        const record = readPilotDeckConfigFile();
+
+        expect(record.exists).toBe(false);
+        expect(record.configPath).toBe(configPath);
+        expect(record.raw).toBe('');
+        expect(record.rawYaml).toEqual({});
+        expect(record.parseError).toBeNull();
+        expect(record.config.schemaVersion).toBe(1);
+    });
+
+    it('reads and normalizes valid YAML', () => {
+        useTempConfig('schemaVersion: 1\nmodel:\n  providers: {}\n');
+
+        const record = readPilotDeckConfigFile();
+
+        expect(record.exists).toBe(true);
+        expect(record.parseError).toBeNull();
+        expect(record.rawYaml).toMatchObject({ schemaVersion: 1, model: { providers: {} } });
+        expect(record.config.model.providers).toEqual({});
+        expect(record.config.memory.enabled).toBe(true);
+    });
+
+    it('keeps raw YAML and falls back to defaults when YAML is invalid', () => {
+        const raw = 'schemaVersion: 1\nmodel:\n  providers: [\n';
+        useTempConfig(raw);
+
+        const record = readPilotDeckConfigFile();
+
+        expect(record.exists).toBe(true);
+        expect(record.raw).toBe(raw);
+        expect(record.rawYaml).toBeNull();
+        expect(record.parseError).toEqual(expect.any(String));
+        expect(record.config.schemaVersion).toBe(1);
+        expect(record.config.model.providers).toEqual({});
+    });
+});
 
 describe('validatePilotDeckConfig gateway validation', () => {
     it('rejects non-object gateway config', () => {

--- a/ui/server/services/pilotdeckConfigWatcher.js
+++ b/ui/server/services/pilotdeckConfigWatcher.js
@@ -62,6 +62,24 @@ async function handleChange(configPath) {
     return;
   }
 
+  if (record.parseError) {
+    onEventHandler?.({
+      source: 'watcher',
+      path: record.configPath,
+      raw: record.raw,
+      configDisabled: true,
+      parseError: record.parseError,
+      validation: {
+        valid: false,
+        errors: [`Invalid YAML: ${record.parseError}`],
+        warnings: [],
+      },
+      reload: null,
+      timestamp: new Date().toISOString(),
+    });
+    return;
+  }
+
   const validation = validatePilotDeckConfig(record.config);
   // Mirror serializeConfigResponse: emit the masked disk YAML so the
   // UI's hot-reload sees full router/gateway/adapters/etc. segments

--- a/ui/src/components/settings/view/tabs/PilotDeckConfigTab.tsx
+++ b/ui/src/components/settings/view/tabs/PilotDeckConfigTab.tsx
@@ -3400,6 +3400,8 @@ export default function PilotDeckConfigTab({
 	    loading,
 	    saving,
 	    opening,
+	    configDisabled,
+	    parseError: serverParseError,
 	    error,
 	    refresh,
 	    save,
@@ -3423,7 +3425,7 @@ export default function PilotDeckConfigTab({
   // truth — every form patch reserialises back into raw, which keeps the
   // existing save/watcher pipeline (and hot-reload) functional unchanged.
   const parsedConfig = useMemo(() => safeParseYaml(raw), [raw]);
-  const parseError = !parsedConfig && raw.trim().length > 0;
+  const parseError = configDisabled || (!parsedConfig && raw.trim().length > 0);
 
   // Form patches: take the next config, stringify back into YAML, push into
   // the existing `setRaw`. This is what keeps the save+reload pipeline a
@@ -3553,7 +3555,7 @@ export default function PilotDeckConfigTab({
                   {t('pilotDeckConfig.rawYaml.configInvalid')}
                 </div>
                 <div className="mt-0.5 pl-6 text-[11px] leading-4">
-                  {t('pilotDeckConfig.status.fixYamlInFilesystem')}
+                  {t('pilotDeckConfig.status.fixYamlInRawEditor')}
                 </div>
               </div>
             )}
@@ -3591,14 +3593,16 @@ export default function PilotDeckConfigTab({
             )}
             {parseError && (
               <div className="mt-3 rounded-lg border border-destructive/30 bg-destructive/10 p-3 text-xs text-destructive">
-                {t('pilotDeckConfig.rawYaml.yamlParseError')}
+                {serverParseError
+                  ? t('pilotDeckConfig.rawYaml.yamlParseErrorWithDetail', { error: serverParseError })
+                  : t('pilotDeckConfig.rawYaml.yamlParseError')}
               </div>
             )}
           </>
         )}
       </SettingsCard>
 
-      {parsedConfig ? (
+      {!configDisabled && parsedConfig ? (
         activeSection ? (
           <div className="space-y-4">
             <button

--- a/ui/src/components/settings/view/tabs/PilotDeckConfigTab.tsx
+++ b/ui/src/components/settings/view/tabs/PilotDeckConfigTab.tsx
@@ -3631,8 +3631,23 @@ export default function PilotDeckConfigTab({
           <ConfigSectionHome onSelect={setActiveSection} />
         )
       ) : (
-        <SettingsCard className="p-5 text-xs text-muted-foreground">
-          {t('pilotDeckConfig.rawYaml.cannotParse')}
+        <SettingsCard className="space-y-3 p-5">
+          <div>
+            <div className="text-sm font-semibold text-foreground">{t('pilotDeckConfig.rawYaml.rawYaml')}</div>
+            <div className="mt-1 text-xs text-muted-foreground">{t('pilotDeckConfig.rawYaml.cannotParse')}</div>
+          </div>
+          <textarea
+            value={raw}
+            onChange={(event) => setRaw(event.target.value)}
+            spellCheck={false}
+            className="min-h-[360px] w-full resize-y rounded-md border border-border bg-background px-3 py-2 font-mono text-xs leading-5 text-foreground outline-none focus:ring-1 focus:ring-ring"
+          />
+          <div className="flex justify-end">
+            <Button type="button" size="sm" onClick={save} disabled={saving || !isDirty} className="h-8 gap-1.5 px-2.5 text-xs">
+              <Save className="mr-1.5 h-3.5 w-3.5" />
+              {saving ? t('pilotDeckConfig.actions.saving') : t('pilotDeckConfig.actions.saveAndReloadShort')}
+            </Button>
+          </div>
         </SettingsCard>
       )}
 

--- a/ui/src/hooks/usePilotDeckConfig.ts
+++ b/ui/src/hooks/usePilotDeckConfig.ts
@@ -29,6 +29,8 @@ type ConfigResponse = {
   exists: boolean;
   path: string;
   raw: string;
+  configDisabled?: boolean;
+  parseError?: string | null;
   validation: ConfigValidation;
   reload?: ConfigReload;
 };
@@ -46,6 +48,8 @@ export function usePilotDeckConfig() {
   const [exists, setExists] = useState(false);
   const [validation, setValidation] = useState<ConfigValidation | null>(null);
   const [reload, setReload] = useState<ConfigReload | null>(null);
+  const [configDisabled, setConfigDisabled] = useState(false);
+  const [parseError, setParseError] = useState<string | null>(null);
   const [lastReloadInfo, setLastReloadInfo] = useState<ReloadInfo | null>(null);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
@@ -79,6 +83,8 @@ export function usePilotDeckConfig() {
     setRaw(data.raw);
     savedRawRef.current = data.raw;
     setExists(data.exists);
+    setConfigDisabled(data.configDisabled === true);
+    setParseError(data.parseError ?? null);
     setValidation(data.validation);
     setReload((data.reload as ConfigReload | undefined) ?? null);
     setLastReloadInfo({ source, at: Date.now() });
@@ -172,6 +178,8 @@ export function usePilotDeckConfig() {
         );
         setValidation(payload.validation);
         setReload((payload.reload as ConfigReload | undefined) ?? null);
+        setConfigDisabled(payload.configDisabled === true);
+        setParseError(payload.parseError ?? null);
         setPath(payload.path);
         setExists(true);
         setLastReloadInfo({ source, at: Date.now() });
@@ -183,6 +191,8 @@ export function usePilotDeckConfig() {
           exists: true,
           path: payload.path,
           raw: payload.raw ?? '',
+          configDisabled: payload.configDisabled,
+          parseError: payload.parseError,
           validation: payload.validation,
           reload: payload.reload as ConfigReload | undefined,
         },
@@ -260,6 +270,8 @@ export function usePilotDeckConfig() {
     exists,
     validation,
     reload,
+    configDisabled,
+    parseError,
     lastReloadInfo,
     isDirty,
     externalChangeNotice,

--- a/ui/src/i18n/locales/en/settings.json
+++ b/ui/src/i18n/locales/en/settings.json
@@ -576,6 +576,7 @@
 	      "unsavedChanges": "Unsaved changes",
 	      "noUnsavedChanges": "No unsaved changes",
 	      "fixYamlInFilesystem": "Fix the config file in the filesystem, then refresh.",
+	      "fixYamlInRawEditor": "Fix the Raw YAML below, then save to re-enable form settings.",
 	      "subsystems": {
 	        "pending": "Waiting for config parsing.",
 	        "processEnv": {
@@ -606,8 +607,9 @@
 	      "configInvalidSeeBelow": "Config has validation errors — see below",
 	      "errors": "Errors",
 	      "warnings": "Warnings",
-	      "yamlParseError": "The config file YAML failed to parse. Fix it in the filesystem, then refresh.",
-	      "cannotParse": "Could not parse the config file YAML. Fix it in the filesystem, then refresh.",
+	      "yamlParseError": "The config file YAML failed to parse. Fix the Raw YAML below, then save.",
+	      "yamlParseErrorWithDetail": "The config file YAML failed to parse: {{error}}",
+	      "cannotParse": "Could not parse the config file YAML. Fix the Raw YAML above, then save to restore form settings.",
 	      "rawYaml": "Raw YAML"
 	    },
     "sectionGroups": {

--- a/ui/src/i18n/locales/zh-CN/settings.json
+++ b/ui/src/i18n/locales/zh-CN/settings.json
@@ -576,6 +576,7 @@
 	      "unsavedChanges": "未保存更改",
 	      "noUnsavedChanges": "无未保存更改",
 	      "fixYamlInFilesystem": "请在文件系统中修复配置文件后刷新。",
+	      "fixYamlInRawEditor": "请先修复下方原始 YAML，然后保存以重新启用表单设置。",
 	      "subsystems": {
 	        "pending": "等待配置解析。",
 	        "processEnv": {
@@ -606,8 +607,9 @@
 	      "configInvalidSeeBelow": "配置存在校验错误——见下方",
 	      "errors": "错误",
 	      "warnings": "警告",
-	      "yamlParseError": "配置文件 YAML 解析失败。请在文件系统中修复后刷新。",
-	      "cannotParse": "无法解析配置文件 YAML。请在文件系统中修复后点击刷新。",
+	      "yamlParseError": "配置文件 YAML 解析失败。请修复下方原始 YAML 后保存。",
+	      "yamlParseErrorWithDetail": "配置文件 YAML 解析失败：{{error}}",
+	      "cannotParse": "无法解析配置文件 YAML。请修复上方原始 YAML 后保存，以恢复表单设置。",
 	      "rawYaml": "原始 YAML"
 	    },
     "sectionGroups": {


### PR DESCRIPTION
## Summary\n- keep /api/config available when pilotdeck.yaml has invalid YAML\n- return raw invalid YAML plus parse diagnostics so Settings can recover in-place\n- hide structured settings while raw YAML is disabled and add regression coverage\n\n## Tests\n- npm --prefix ui test -- --run server/services/pilotdeckConfig.test.js server/routes/config.test.js\n- git diff --check\n\nNote: npm --prefix ui run typecheck still reports pre-existing repo-wide React type/version and unrelated TS errors.