### PR TITLE
Queue chat sends while agent is busy

### DIFF
--- a/src/context/prompt/PromptAssembler.ts
+++ b/src/context/prompt/PromptAssembler.ts
@@ -99,6 +99,9 @@ export class PromptAssembler {
       "Reusable script workflow:",
       "When code is more than a tiny one-off command, or you expect to rerun it with changed parameters, write it to a workspace file first with write_file, then run it with bash. Prefer scripts with CLI arguments, environment variables, or a small config section so parameters can be adjusted with edit_file or command args. Do not pack large Python/JS/shell programs into bash heredocs or long `python -c` / `node -e` strings. After each run, inspect output and edit the saved script instead of regenerating a new inline command.",
       "",
+      "File delivery links:",
+      "When you create, modify, export, render, or otherwise produce a user-facing file, include a Markdown link to that file in the final response. Use relative links for files under the current cwd, e.g. `[open report.pdf](report.pdf)`. Use `file://` absolute links only for files outside the cwd, e.g. `[open file](file:///absolute/path/file.pdf)`. Do not claim that a file was opened automatically; provide a clickable link instead.",
+      "",
       "Todo workflow:",
       "For complex tasks, tasks with 3+ steps, multi-file changes, long-running work, or tasks that require verification, create a todo list with todo_write before making substantive changes. Keep the list editable: update it after each meaningful step, before and after long-running commands when useful, when new required work or risks are discovered, and before the final response. Use stable ids and merge updates when available; preserve completed facts and mark obsolete work as cancelled instead of silently deleting it. Persist important intermediate findings under the current workspace (cwd) when they are needed for recovery or final handoff, such as `.pilotdeck/work/<session-id>/findings.md`, `todo_history.md`, `verification.md`, and `artifacts/`; if no session id is available, use `.pilotdeck/work/current/`. Verify completed work when possible and align the final todo state with the final answer.",
     ];
@@ -137,6 +140,7 @@ export class PromptAssembler {
     lines.push("<user-context>");
     lines.push(`cwd: ${input.cwd}`);
     lines.push("IMPORTANT: When the user does not specify an explicit file path, all file paths in tool calls MUST be relative to the cwd above — use \"foo.html\", not an absolute path like \"/home/user/foo.html\". If the user explicitly provides a path, respect their choice.");
+    lines.push("IMPORTANT: In final responses, make generated or modified files clickable using Markdown links. Prefer cwd-relative links for cwd files, and file:// absolute links for files outside cwd.");
     lines.push(`model: ${input.provider}/${input.model}`);
     lines.push(`permission_mode: ${input.permissionMode}`);
     if (input.runMode) {

--- a/ui/server/pilotdeck-bridge.js
+++ b/ui/server/pilotdeck-bridge.js
@@ -1144,7 +1144,12 @@ export async function abortViaGateway(sessionId, _provider = 'pilotdeck') {
     if (!sessionKey) return false;
     const state = sessionState.get(sessionKey);
     try {
-        await gw.abortTurn({ sessionKey, runId: state?.runId });
+        const runId = state?.runId;
+        await gw.abortTurn({ sessionKey, runId });
+        if (state && (!runId || state.runId === runId)) {
+            state.active = false;
+            state.runId = undefined;
+        }
         return true;
     } catch (error) {
         console.warn('[pilotdeck-bridge] abortTurn failed:', error);

--- a/ui/server/pilotdeck-bridge.js
+++ b/ui/server/pilotdeck-bridge.js
@@ -934,22 +934,36 @@ export async function runChatViaGateway(
 
     const state = ensureSessionState(sessionKey, projectKey, channelKey);
 
-    // If a previous turn for this session is still in-flight (e.g. the
-    // browser reloaded while a permission prompt was pending), abort it
-    // before starting the new one. Without this the gateway rejects
-    // with session_busy because the old turn's inFlightTurns slot is
-    // still occupied.
+    // Normal chat submits should not abort active work. A forced submit is an
+    // explicit user action from the composer: stop the current turn, then start
+    // the new queued message immediately.
     if (state.active && state.runId) {
-        console.log(
-            `[pilotdeck-bridge] aborting stale turn ${state.runId} for ${sessionKey} before resubmit`,
-        );
-        try {
-            await gw.abortTurn({ sessionKey, runId: state.runId, reason: 'system:stale_turn' });
-        } catch (err) {
-            console.warn('[pilotdeck-bridge] stale abort failed (continuing):', err?.message || err);
+        if (options?.forceStart === true) {
+            console.log(
+                `[pilotdeck-bridge] force-start aborting active turn ${state.runId} for ${sessionKey}`,
+            );
+            try {
+                await gw.abortTurn({ sessionKey, runId: state.runId, reason: 'user:force_start_next_turn' });
+            } catch (err) {
+                console.warn('[pilotdeck-bridge] force-start abort failed (continuing):', err?.message || err);
+            }
+            state.active = false;
+            state.runId = undefined;
+        } else {
+            const message = 'This session is still processing a previous turn. Please wait for it to finish before sending another message.';
+            console.warn(`[pilotdeck-bridge] rejected busy submit for ${sessionKey}; active run ${state.runId}`);
+            writer.send(
+                createNormalizedMessage({
+                    provider,
+                    sessionId: sessionKey,
+                    kind: 'error',
+                    code: 'session_busy',
+                    content: message,
+                    userHint: message,
+                }),
+            );
+            return;
         }
-        state.active = false;
-        state.runId = undefined;
     }
 
     if (isNewSession) {

--- a/ui/server/pilotdeck-bridge.js
+++ b/ui/server/pilotdeck-bridge.js
@@ -359,7 +359,7 @@ function resolvePermissionMode(options) {
  * @returns {object[]} NormalizedMessage frames.
  */
 export function gatewayEventToFrames(event, sessionId, provider) {
-    const base = { sessionId, provider };
+    const base = { sessionId, provider, ...(event.runId ? { runId: event.runId } : {}) };
     switch (event.type) {
         case 'turn_started':
             return [

--- a/ui/server/pilotdeck-bridge.js
+++ b/ui/server/pilotdeck-bridge.js
@@ -945,7 +945,19 @@ export async function runChatViaGateway(
             try {
                 await gw.abortTurn({ sessionKey, runId: state.runId, reason: 'user:force_start_next_turn' });
             } catch (err) {
-                console.warn('[pilotdeck-bridge] force-start abort failed (continuing):', err?.message || err);
+                const message = 'Could not stop the current turn before sending the queued message. Please wait for the current turn to finish or try stopping it again.';
+                console.warn('[pilotdeck-bridge] force-start abort failed:', err?.message || err);
+                writer.send(
+                    createNormalizedMessage({
+                        provider,
+                        sessionId: sessionKey,
+                        kind: 'error',
+                        code: 'force_start_abort_failed',
+                        content: message,
+                        userHint: message,
+                    }),
+                );
+                return;
             }
             state.active = false;
             state.runId = undefined;

--- a/ui/src/components/chat-v2/ChatInterfaceV2.tsx
+++ b/ui/src/components/chat-v2/ChatInterfaceV2.tsx
@@ -220,6 +220,8 @@ function ChatInterfaceV2({
     handleGrantToolPermission,
     handleGrantSessionToolPermission,
     handleInputFocusChange,
+    isBusySendQueued,
+    isBusySendConfirmed,
   } = useChatComposerState({
     selectedProject,
     selectedSession,
@@ -521,6 +523,8 @@ function ChatInterfaceV2({
       isLoading={isLoading}
       canAbortSession={canAbortSession}
       isAbortPending={isAbortPending}
+      isBusySendQueued={isBusySendQueued}
+      isBusySendConfirmed={isBusySendConfirmed}
       tokenBudget={tokenBudget}
       thinkingMode={thinkingMode}
       thinkingModeAvailability={thinkingModeAvailability}

--- a/ui/src/components/chat-v2/ChatInterfaceV2.tsx
+++ b/ui/src/components/chat-v2/ChatInterfaceV2.tsx
@@ -222,6 +222,7 @@ function ChatInterfaceV2({
     handleInputFocusChange,
     isBusySendQueued,
     isBusySendConfirmed,
+    cancelBusySendQueue,
   } = useChatComposerState({
     selectedProject,
     selectedSession,
@@ -525,6 +526,7 @@ function ChatInterfaceV2({
       isAbortPending={isAbortPending}
       isBusySendQueued={isBusySendQueued}
       isBusySendConfirmed={isBusySendConfirmed}
+      onCancelBusySendQueue={cancelBusySendQueue}
       tokenBudget={tokenBudget}
       thinkingMode={thinkingMode}
       thinkingModeAvailability={thinkingModeAvailability}

--- a/ui/src/components/chat-v2/ComposerV2.tsx
+++ b/ui/src/components/chat-v2/ComposerV2.tsx
@@ -347,9 +347,9 @@ export default function ComposerV2({
   const sendTitle = isSubmitPending || hasUploadingImages
     ? (t('input.sending', { defaultValue: 'Sending...' }) as string)
     : isBusySendConfirmed
-      ? (t('input.queuedSendConfirmed', { defaultValue: 'Queued — will send when the current turn finishes' }) as string)
+      ? (t('input.queuedSendConfirmed', { defaultValue: 'Stopping current turn — sending next message' }) as string)
       : isBusySendQueued
-        ? (t('input.queuedSendConfirm', { defaultValue: 'Queued — click send again to send now' }) as string)
+        ? (t('input.queuedSendConfirm', { defaultValue: 'Queued — click send again to stop this turn and send now' }) as string)
       : isLoading
         ? (t('input.queueSend', { defaultValue: 'Queue message' }) as string)
         : (t('input.send', { defaultValue: 'Send' }) as string);
@@ -764,8 +764,8 @@ export default function ComposerV2({
                     <div className="hidden min-w-0 flex-1 items-center justify-end gap-1 px-2 text-[12px] text-amber-700 dark:text-amber-300 sm:flex">
                       <span className="truncate rounded-full bg-amber-50 px-2 py-1 dark:bg-amber-950/30">
                         {isBusySendConfirmed
-                          ? t('input.queuedSendConfirmedInline', { defaultValue: 'Queued; sends after this turn' })
-                          : t('input.queuedSendConfirmInline', { defaultValue: 'Queued; click send again to send now' })}
+                          ? t('input.queuedSendConfirmedInline', { defaultValue: 'Stopping current turn; sending next' })
+                          : t('input.queuedSendConfirmInline', { defaultValue: 'Queued; click again to stop this turn and send now' })}
                       </span>
                       <button
                         type="button"

--- a/ui/src/components/chat-v2/ComposerV2.tsx
+++ b/ui/src/components/chat-v2/ComposerV2.tsx
@@ -99,6 +99,8 @@ export type ComposerV2Props = {
   isLoading: boolean;
   canAbortSession: boolean;
   isAbortPending?: boolean;
+  isBusySendQueued?: boolean;
+  isBusySendConfirmed?: boolean;
   isSubmitPending?: boolean;
   tokenBudget?: Record<string, unknown> | null;
   thinkingMode: ThinkingModeId;
@@ -300,6 +302,8 @@ export default function ComposerV2({
   isLoading,
   canAbortSession,
   isAbortPending = false,
+  isBusySendQueued = false,
+  isBusySendConfirmed = false,
   isSubmitPending = false,
   tokenBudget,
   thinkingMode,
@@ -336,7 +340,17 @@ export default function ComposerV2({
   const hasDraftContent = input.trim().length > 0 || attachedImages.length > 0 || documentReferences.length > 0;
   const hasUploadingImages = uploadingImages.size > 0;
   const attachmentLimitError = imageErrors.get(MAX_ATTACHMENTS_ERROR_KEY);
-  const disabled = !hasDraftContent || isLoading || isSubmitPending || hasUploadingImages;
+  const disabled = !hasDraftContent || isSubmitPending || hasUploadingImages;
+  const showAbortButton = isLoading && canAbortSession && !hasDraftContent;
+  const sendTitle = isSubmitPending || hasUploadingImages
+    ? (t('input.sending', { defaultValue: 'Sending...' }) as string)
+    : isBusySendConfirmed
+      ? (t('input.queuedSendConfirmed', { defaultValue: 'Queued — will send when the current turn finishes' }) as string)
+      : isBusySendQueued
+        ? (t('input.queuedSendConfirm', { defaultValue: 'Queued — click send again to confirm' }) as string)
+      : isLoading
+        ? (t('input.queueSend', { defaultValue: 'Queue message' }) as string)
+        : (t('input.send', { defaultValue: 'Send' }) as string);
   const contextStatus = getContextStatus(tokenBudget);
   const effectiveThinkingMode = getEffectiveThinkingMode(thinkingMode, thinkingModeAvailability);
   const selectedThinkingMode = thinkingModes.find((option) => option.id === effectiveThinkingMode) || thinkingModes[0];
@@ -744,6 +758,16 @@ export default function ComposerV2({
                   </div>
                   </div>
 
+                  {isBusySendQueued ? (
+                    <div className="hidden min-w-0 flex-1 justify-end px-2 text-[12px] text-amber-700 dark:text-amber-300 sm:flex">
+                      <span className="truncate rounded-full bg-amber-50 px-2 py-1 dark:bg-amber-950/30">
+                        {isBusySendConfirmed
+                          ? t('input.queuedSendConfirmedInline', { defaultValue: 'Queued; sends after this turn' })
+                          : t('input.queuedSendConfirmInline', { defaultValue: 'Queued; click send again to confirm' })}
+                      </span>
+                    </div>
+                  ) : null}
+
                   <div className="pd-composer-toolbar-right ml-auto flex shrink-0 items-center gap-1">
                     <div
                       className="relative"
@@ -903,7 +927,7 @@ export default function ComposerV2({
                       ) : null}
                     </div>
 
-                    {isLoading && canAbortSession ? (
+                    {showAbortButton ? (
                       <button
                         type="button"
                         onClick={onAbortSession}
@@ -924,28 +948,29 @@ export default function ComposerV2({
                           <Square className="h-3.5 w-3.5" strokeWidth={2.5} fill="currentColor" />
                         )}
                       </button>
-                    ) : (
-                      <button
-                        type="submit"
-                        disabled={disabled}
-                        aria-busy={isSubmitPending || hasUploadingImages}
-                        className={cn(
-                          'inline-flex h-8 w-8 items-center justify-center rounded-lg bg-neutral-900 text-white transition hover:opacity-90 disabled:opacity-40 dark:bg-neutral-50 dark:text-neutral-900',
-                          (isSubmitPending || hasUploadingImages) && 'cursor-wait',
-                        )}
-                        title={
-                          isSubmitPending || hasUploadingImages
-                            ? (t('input.sending', { defaultValue: 'Sending...' }) as string)
-                            : (t('input.send', { defaultValue: 'Send' }) as string)
-                        }
-                      >
-                        {isSubmitPending || hasUploadingImages ? (
-                          <Loader2 className="h-4 w-4 animate-spin" strokeWidth={2.25} />
-                        ) : (
-                          <ArrowUp className="h-4 w-4" strokeWidth={2} />
-                        )}
-                      </button>
-                    )}
+                    ) : null}
+                    <button
+                      type="submit"
+                      disabled={disabled}
+                      aria-busy={isSubmitPending || hasUploadingImages || isBusySendConfirmed}
+                      className={cn(
+                        'inline-flex h-8 w-8 items-center justify-center rounded-lg bg-neutral-900 text-white transition hover:opacity-90 disabled:opacity-40 dark:bg-neutral-50 dark:text-neutral-900',
+                        isBusySendQueued && 'bg-amber-500 text-white hover:bg-amber-600 dark:bg-amber-400 dark:text-neutral-950 dark:hover:bg-amber-300',
+                        isBusySendConfirmed && 'cursor-wait',
+                        (isSubmitPending || hasUploadingImages) && 'cursor-wait',
+                      )}
+                      title={sendTitle}
+                    >
+                      {isSubmitPending || hasUploadingImages ? (
+                        <Loader2 className="h-4 w-4 animate-spin" strokeWidth={2.25} />
+                      ) : isBusySendConfirmed ? (
+                        <Loader2 className="h-4 w-4 animate-spin" strokeWidth={2.25} />
+                      ) : isBusySendQueued ? (
+                        <Check className="h-4 w-4" strokeWidth={2.25} />
+                      ) : (
+                        <ArrowUp className="h-4 w-4" strokeWidth={2} />
+                      )}
+                    </button>
                   </div>
                 </div>
             </div>

--- a/ui/src/components/chat-v2/ComposerV2.tsx
+++ b/ui/src/components/chat-v2/ComposerV2.tsx
@@ -101,6 +101,7 @@ export type ComposerV2Props = {
   isAbortPending?: boolean;
   isBusySendQueued?: boolean;
   isBusySendConfirmed?: boolean;
+  onCancelBusySendQueue?: () => void;
   isSubmitPending?: boolean;
   tokenBudget?: Record<string, unknown> | null;
   thinkingMode: ThinkingModeId;
@@ -304,6 +305,7 @@ export default function ComposerV2({
   isAbortPending = false,
   isBusySendQueued = false,
   isBusySendConfirmed = false,
+  onCancelBusySendQueue,
   isSubmitPending = false,
   tokenBudget,
   thinkingMode,
@@ -347,7 +349,7 @@ export default function ComposerV2({
     : isBusySendConfirmed
       ? (t('input.queuedSendConfirmed', { defaultValue: 'Queued — will send when the current turn finishes' }) as string)
       : isBusySendQueued
-        ? (t('input.queuedSendConfirm', { defaultValue: 'Queued — click send again to confirm' }) as string)
+        ? (t('input.queuedSendConfirm', { defaultValue: 'Queued — click send again to send now' }) as string)
       : isLoading
         ? (t('input.queueSend', { defaultValue: 'Queue message' }) as string)
         : (t('input.send', { defaultValue: 'Send' }) as string);
@@ -759,12 +761,20 @@ export default function ComposerV2({
                   </div>
 
                   {isBusySendQueued ? (
-                    <div className="hidden min-w-0 flex-1 justify-end px-2 text-[12px] text-amber-700 dark:text-amber-300 sm:flex">
+                    <div className="hidden min-w-0 flex-1 items-center justify-end gap-1 px-2 text-[12px] text-amber-700 dark:text-amber-300 sm:flex">
                       <span className="truncate rounded-full bg-amber-50 px-2 py-1 dark:bg-amber-950/30">
                         {isBusySendConfirmed
                           ? t('input.queuedSendConfirmedInline', { defaultValue: 'Queued; sends after this turn' })
-                          : t('input.queuedSendConfirmInline', { defaultValue: 'Queued; click send again to confirm' })}
+                          : t('input.queuedSendConfirmInline', { defaultValue: 'Queued; click send again to send now' })}
                       </span>
+                      <button
+                        type="button"
+                        onClick={onCancelBusySendQueue}
+                        className="rounded-full px-2 py-1 text-amber-700 transition hover:bg-amber-100 dark:text-amber-300 dark:hover:bg-amber-950/50"
+                        title={t('input.cancelQueuedSend', { defaultValue: 'Cancel queued message' }) as string}
+                      >
+                        {t('input.cancelQueuedSendShort', { defaultValue: 'Cancel' })}
+                      </button>
                     </div>
                   ) : null}
 

--- a/ui/src/components/chat-v2/MessagesPaneV2.tsx
+++ b/ui/src/components/chat-v2/MessagesPaneV2.tsx
@@ -471,15 +471,21 @@ export default function MessagesPaneV2({
   );
   const renderableMessages = useMemo(
     () => {
-      const filtered = visibleMessages.filter((message) =>
+      const lastUserIndex = isAssistantWorking
+        ? visibleMessages.reduce((lastIndex, message, index) => (
+            message.type === 'user' ? index : lastIndex
+          ), -1)
+        : -1;
+      const filtered = visibleMessages.filter((message, index) =>
         !message.isAgentActivity &&
         !isSubagentThinkingPlaceholder(message) &&
+        !(isAssistantWorking && message.isThinking && !message.isStreaming && index < lastUserIndex) &&
         (!inlineThinking && isStreamingThinkingMessage(message) ? false : true) &&
         !(message.isThinking && !showThinking)
       );
       return filtered;
     },
-    [visibleMessages, showThinking, inlineThinking],
+    [visibleMessages, showThinking, inlineThinking, isAssistantWorking],
   );
   const liveProcessDetailMessages = useMemo(
     () => isAssistantWorking ? getLiveProcessDetailMessages(renderableMessages) : [],

--- a/ui/src/components/chat/hooks/useChatComposerState.ts
+++ b/ui/src/components/chat/hooks/useChatComposerState.ts
@@ -244,7 +244,7 @@ export function useChatComposerState({
     queuedBusySendSnapshotRef.current = null;
     setIsBusySendQueued(false);
     setIsBusySendConfirmed(false);
-  }, [syncQueuedBusySendSnapshot]);
+  }, []);
 
   const syncQueuedBusySendSnapshot = useCallback((updates: Partial<QueuedBusySendSnapshot> = {}) => {
     if (!queuedBusySendRef.current) return;

--- a/ui/src/components/chat/hooks/useChatComposerState.ts
+++ b/ui/src/components/chat/hooks/useChatComposerState.ts
@@ -127,6 +127,13 @@ type UploadedAttachmentFile = {
   mimeType?: string;
 };
 
+type QueuedBusySendSnapshot = {
+  input: string;
+  attachedImages: File[];
+  documentReferences: DocumentSelectionReference[];
+  forceStart?: boolean;
+};
+
 export function shouldCycleRunModeOnKeyDown(
   event: Pick<KeyboardEvent<HTMLTextAreaElement>, 'key' | 'shiftKey'>,
   {
@@ -228,6 +235,7 @@ export function useChatComposerState({
   const inputValueRef = useRef(input);
   const queuedBusySendRef = useRef(false);
   const queuedBusySendConfirmedRef = useRef(false);
+  const queuedBusySendSnapshotRef = useRef<QueuedBusySendSnapshot | null>(null);
   const pendingSessionGrantResolversRef = useRef(new Map<string, (result: PermissionGrantResult) => void>());
 
   useEffect(() => {
@@ -757,9 +765,12 @@ export function useChatComposerState({
       event: FormEvent<HTMLFormElement> | MouseEvent | TouchEvent | KeyboardEvent<HTMLTextAreaElement>,
     ) => {
       event.preventDefault();
-      const currentInput = inputValueRef.current;
-      const hasDocumentReferences = documentReferences.length > 0;
-      const hasAttachments = attachedImages.length > 0 || hasDocumentReferences;
+      const queuedSnapshot = queuedBusySendSnapshotRef.current;
+      const currentInput = queuedSnapshot?.input ?? inputValueRef.current;
+      const submitAttachedImages = queuedSnapshot?.attachedImages ?? attachedImages;
+      const submitDocumentReferences = queuedSnapshot?.documentReferences ?? documentReferences;
+      const hasDocumentReferences = submitDocumentReferences.length > 0;
+      const hasAttachments = submitAttachedImages.length > 0 || hasDocumentReferences;
       if ((!currentInput.trim() && !hasAttachments) || !selectedProject) {
         return;
       }
@@ -767,20 +778,50 @@ export function useChatComposerState({
       if (isLoading && !isBusySendQueued) {
         queuedBusySendRef.current = true;
         queuedBusySendConfirmedRef.current = false;
+        queuedBusySendSnapshotRef.current = {
+          input: currentInput,
+          attachedImages: [...attachedImages],
+          documentReferences: [...documentReferences],
+        };
         setIsBusySendQueued(true);
         setIsBusySendConfirmed(false);
         return;
       }
 
       if (isLoading && isBusySendQueued) {
-        queuedBusySendRef.current = false;
-        queuedBusySendConfirmedRef.current = false;
-        setIsBusySendQueued(false);
-        setIsBusySendConfirmed(false);
+        queuedBusySendSnapshotRef.current = {
+          input: currentInput,
+          attachedImages: submitAttachedImages,
+          documentReferences: submitDocumentReferences,
+          forceStart: true,
+        };
+        queuedBusySendConfirmedRef.current = true;
+        setIsBusySendConfirmed(true);
+        if (canAbortSession) {
+          const pendingSessionId = typeof window !== 'undefined' ? sessionStorage.getItem('pendingSessionId') : null;
+          const targetSessionId = [
+            currentSessionId,
+            pendingViewSessionRef.current?.sessionId || null,
+            pendingSessionId,
+            selectedSession?.id || null,
+          ].find((sessionId) => Boolean(sessionId) && !isTemporarySessionId(sessionId));
+
+          if (targetSessionId) {
+            sendMessage({
+              type: 'abort-session',
+              sessionId: targetSessionId,
+              provider: 'pilotdeck',
+            });
+            setCanAbortSession(false);
+            setIsAborting(true);
+          }
+        }
+        return;
       }
 
       queuedBusySendRef.current = false;
       queuedBusySendConfirmedRef.current = false;
+      queuedBusySendSnapshotRef.current = null;
       setIsBusySendQueued(false);
       setIsBusySendConfirmed(false);
 
@@ -848,9 +889,9 @@ export function useChatComposerState({
 
       let uploadedImages: unknown[] = [];
       let uploadedFiles: UploadedAttachmentFile[] = [];
-      if (attachedImages.length > 0) {
+      if (submitAttachedImages.length > 0) {
         const formData = new FormData();
-        attachedImages.forEach((file) => {
+        submitAttachedImages.forEach((file) => {
           formData.append('attachments', file);
         });
 
@@ -880,8 +921,8 @@ export function useChatComposerState({
         }
       }
 
-      const documentReferenceAttachments = documentReferences.map(documentReferenceToAttachment);
-      messageContent = `${messageContent}${buildAttachmentPathNote(uploadedFiles)}${formatDocumentSelectionPromptBlock(documentReferences)}`;
+      const documentReferenceAttachments = submitDocumentReferences.map(documentReferenceToAttachment);
+      messageContent = `${messageContent}${buildAttachmentPathNote(uploadedFiles)}${formatDocumentSelectionPromptBlock(submitDocumentReferences)}`;
 
       const effectiveSessionId = submitTargetSessionId;
       const sessionToActivate = effectiveSessionId || optimisticSessionId;
@@ -959,6 +1000,7 @@ export function useChatComposerState({
         sessionSummary,
         images: uploadedImages,
         attachments: [...uploadedFiles, ...documentReferenceAttachments],
+        forceStart: queuedSnapshot?.forceStart === true,
       });
 
       setInput('');
@@ -985,6 +1027,7 @@ export function useChatComposerState({
       executeCommand,
       isLoading,
       isBusySendQueued,
+      canAbortSession,
       onSessionActive,
       onSessionActivityBump,
       onSessionProcessing,
@@ -997,6 +1040,7 @@ export function useChatComposerState({
       selectedProject,
       sendMessage,
       setCanAbortSession,
+      setIsAborting,
       addMessage,
       setClaudeStatus,
       setPilotDeckStatus,
@@ -1024,6 +1068,7 @@ export function useChatComposerState({
       } else {
         queuedBusySendRef.current = false;
         queuedBusySendConfirmedRef.current = false;
+        queuedBusySendSnapshotRef.current = null;
         setIsBusySendQueued(false);
         setIsBusySendConfirmed(false);
       }
@@ -1083,6 +1128,7 @@ export function useChatComposerState({
       inputValueRef.current = newValue;
       queuedBusySendRef.current = false;
       queuedBusySendConfirmedRef.current = false;
+      queuedBusySendSnapshotRef.current = null;
       setIsBusySendQueued(false);
       setIsBusySendConfirmed(false);
       setCursorPosition(cursorPos);
@@ -1102,6 +1148,7 @@ export function useChatComposerState({
   const cancelBusySendQueue = useCallback(() => {
     queuedBusySendRef.current = false;
     queuedBusySendConfirmedRef.current = false;
+    queuedBusySendSnapshotRef.current = null;
     setIsBusySendQueued(false);
     setIsBusySendConfirmed(false);
   }, []);

--- a/ui/src/components/chat/hooks/useChatComposerState.ts
+++ b/ui/src/components/chat/hooks/useChatComposerState.ts
@@ -215,6 +215,8 @@ export function useChatComposerState({
   const [uploadingImages, setUploadingImages] = useState<Map<string, number>>(new Map());
   const [imageErrors, setImageErrors] = useState<Map<string, string>>(new Map());
   const [isTextareaExpanded, setIsTextareaExpanded] = useState(false);
+  const [isBusySendQueued, setIsBusySendQueued] = useState(false);
+  const [isBusySendConfirmed, setIsBusySendConfirmed] = useState(false);
   const [thinkingMode, setThinkingModeState] = useState<ThinkingModeId>('default');
 
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -224,6 +226,8 @@ export function useChatComposerState({
     ((event: FormEvent<HTMLFormElement> | MouseEvent | TouchEvent | KeyboardEvent<HTMLTextAreaElement>) => Promise<void>) | null
   >(null);
   const inputValueRef = useRef(input);
+  const queuedBusySendRef = useRef(false);
+  const queuedBusySendConfirmedRef = useRef(false);
   const pendingSessionGrantResolversRef = useRef(new Map<string, (result: PermissionGrantResult) => void>());
 
   useEffect(() => {
@@ -756,9 +760,28 @@ export function useChatComposerState({
       const currentInput = inputValueRef.current;
       const hasDocumentReferences = documentReferences.length > 0;
       const hasAttachments = attachedImages.length > 0 || hasDocumentReferences;
-      if ((!currentInput.trim() && !hasAttachments) || isLoading || !selectedProject) {
+      if ((!currentInput.trim() && !hasAttachments) || !selectedProject) {
         return;
       }
+
+      if (isLoading && !isBusySendQueued) {
+        queuedBusySendRef.current = true;
+        queuedBusySendConfirmedRef.current = false;
+        setIsBusySendQueued(true);
+        setIsBusySendConfirmed(false);
+        return;
+      }
+
+      if (isLoading && isBusySendQueued) {
+        queuedBusySendConfirmedRef.current = true;
+        setIsBusySendConfirmed(true);
+        return;
+      }
+
+      queuedBusySendRef.current = false;
+      queuedBusySendConfirmedRef.current = false;
+      setIsBusySendQueued(false);
+      setIsBusySendConfirmed(false);
 
       // Intercept slash commands: if input starts with /commandName, execute as command with args.
       // Skip when handleCustomCommand just pushed a passthrough back into the
@@ -960,6 +983,7 @@ export function useChatComposerState({
       currentSessionId,
       executeCommand,
       isLoading,
+      isBusySendQueued,
       onSessionActive,
       onSessionActivityBump,
       onSessionProcessing,
@@ -990,7 +1014,24 @@ export function useChatComposerState({
 
   useEffect(() => {
     inputValueRef.current = input;
+    queuedBusySendRef.current = false;
+    queuedBusySendConfirmedRef.current = false;
+    setIsBusySendQueued(false);
+    setIsBusySendConfirmed(false);
   }, [input]);
+
+  useEffect(() => {
+    if (!isLoading) {
+      if (queuedBusySendRef.current && queuedBusySendConfirmedRef.current && handleSubmitRef.current) {
+        handleSubmitRef.current(createFakeSubmitEvent());
+      } else {
+        queuedBusySendRef.current = false;
+        queuedBusySendConfirmedRef.current = false;
+        setIsBusySendQueued(false);
+        setIsBusySendConfirmed(false);
+      }
+    }
+  }, [isLoading]);
 
   useEffect(() => {
     if (!selectedProject) {
@@ -1388,6 +1429,8 @@ export function useChatComposerState({
     handleGrantSessionToolPermission,
     handleInputFocusChange,
     isInputFocused,
+    isBusySendQueued,
+    isBusySendConfirmed,
   };
 }
 

--- a/ui/src/components/chat/hooks/useChatComposerState.ts
+++ b/ui/src/components/chat/hooks/useChatComposerState.ts
@@ -244,16 +244,29 @@ export function useChatComposerState({
     queuedBusySendSnapshotRef.current = null;
     setIsBusySendQueued(false);
     setIsBusySendConfirmed(false);
-  }, []);
+  }, [syncQueuedBusySendSnapshot]);
+
+  const syncQueuedBusySendSnapshot = useCallback((updates: Partial<QueuedBusySendSnapshot> = {}) => {
+    if (!queuedBusySendRef.current) return;
+    const previous = queuedBusySendSnapshotRef.current;
+    queuedBusySendSnapshotRef.current = {
+      input: updates.input ?? previous?.input ?? inputValueRef.current,
+      attachedImages: updates.attachedImages ?? previous?.attachedImages ?? attachedImages,
+      documentReferences: updates.documentReferences ?? previous?.documentReferences ?? documentReferences,
+      ...(previous?.forceStart ? { forceStart: true } : {}),
+      ...(updates.forceStart ? { forceStart: true } : {}),
+    };
+  }, [attachedImages, documentReferences]);
 
   useEffect(() => {
     const handleAddDocumentReference = (event: Event) => {
       const detail = (event as CustomEvent).detail;
       if (!isDocumentSelectionReference(detail)) return;
-      cancelBusySendQueue();
       setDocumentReferences((previous) => {
         if (previous.some((reference) => reference.id === detail.id)) return previous;
-        return [...previous, detail];
+        const next = [...previous, detail];
+        syncQueuedBusySendSnapshot({ documentReferences: next });
+        return next;
       });
       requestAnimationFrame(() => {
         textareaRef.current?.focus();
@@ -264,7 +277,7 @@ export function useChatComposerState({
     return () => {
       window.removeEventListener('pilotdeck:add-chat-reference', handleAddDocumentReference);
     };
-  }, [cancelBusySendQueue]);
+  }, [syncQueuedBusySendSnapshot]);
 
   useEffect(() => {
     if (!subscribe) {
@@ -716,7 +729,6 @@ export function useChatComposerState({
     });
 
     if (validFiles.length > 0) {
-      cancelBusySendQueue();
       setAttachedImages((previous) => {
         const result = addAttachmentFiles(previous, validFiles);
         if (result.droppedCount > 0) {
@@ -726,6 +738,7 @@ export function useChatComposerState({
             return next;
           });
         }
+        syncQueuedBusySendSnapshot({ attachedImages: result.files });
         return result.files;
       });
     }
@@ -1140,7 +1153,7 @@ export function useChatComposerState({
 
       setInput(newValue);
       inputValueRef.current = newValue;
-      cancelBusySendQueue();
+      syncQueuedBusySendSnapshot({ input: newValue });
       setCursorPosition(cursorPos);
 
       if (!newValue.trim()) {
@@ -1152,7 +1165,7 @@ export function useChatComposerState({
 
       handleCommandInputChange(newValue, cursorPos);
     },
-    [cancelBusySendQueue, handleCommandInputChange, resetCommandMenuState, setCursorPosition],
+    [handleCommandInputChange, resetCommandMenuState, setCursorPosition, syncQueuedBusySendSnapshot],
   );
 
   const insertAtCursor = useCallback(
@@ -1461,13 +1474,21 @@ export function useChatComposerState({
     selectFile,
     attachedImages,
     setAttachedImages: (value: SetStateAction<File[]>) => {
-      cancelBusySendQueue();
-      setAttachedImages(value);
+      setAttachedImages((previous) => {
+        const next = typeof value === 'function'
+          ? (value as (previous: File[]) => File[])(previous)
+          : value;
+        syncQueuedBusySendSnapshot({ attachedImages: next });
+        return next;
+      });
     },
     documentReferences,
     removeDocumentReference: (id: string) => {
-      cancelBusySendQueue();
-      setDocumentReferences((previous) => previous.filter((reference) => reference.id !== id));
+      setDocumentReferences((previous) => {
+        const next = previous.filter((reference) => reference.id !== id);
+        syncQueuedBusySendSnapshot({ documentReferences: next });
+        return next;
+      });
     },
     uploadingImages,
     imageErrors,

--- a/ui/src/components/chat/hooks/useChatComposerState.ts
+++ b/ui/src/components/chat/hooks/useChatComposerState.ts
@@ -789,6 +789,12 @@ export function useChatComposerState({
       }
 
       if (isLoading && isBusySendQueued) {
+        queuedBusySendSnapshotRef.current = {
+          input: currentInput,
+          attachedImages: submitAttachedImages,
+          documentReferences: submitDocumentReferences,
+        };
+
         const pendingSessionId = typeof window !== 'undefined' ? sessionStorage.getItem('pendingSessionId') : null;
         const targetSessionId = [
           currentSessionId,
@@ -802,9 +808,7 @@ export function useChatComposerState({
         }
 
         queuedBusySendSnapshotRef.current = {
-          input: currentInput,
-          attachedImages: submitAttachedImages,
-          documentReferences: submitDocumentReferences,
+          ...queuedBusySendSnapshotRef.current,
           forceStart: true,
         };
         queuedBusySendConfirmedRef.current = true;

--- a/ui/src/components/chat/hooks/useChatComposerState.ts
+++ b/ui/src/components/chat/hooks/useChatComposerState.ts
@@ -1179,6 +1179,7 @@ export function useChatComposerState({
 
       setInput(nextValue);
       inputValueRef.current = nextValue;
+      syncQueuedBusySendSnapshot({ input: nextValue });
       setCursorPosition(nextCursor);
 
       if (char === '/') {
@@ -1198,7 +1199,7 @@ export function useChatComposerState({
         }
       });
     },
-    [handleCommandInputChange, input, setCursorPosition, setInput, textareaRef],
+    [handleCommandInputChange, input, setCursorPosition, setInput, syncQueuedBusySendSnapshot, textareaRef],
   );
 
   const handleKeyDown = useCallback(
@@ -1267,13 +1268,14 @@ export function useChatComposerState({
     setInput('');
     inputValueRef.current = '';
     setDocumentReferences([]);
+    cancelBusySendQueue();
     resetCommandMenuState();
     if (textareaRef.current) {
       textareaRef.current.style.height = 'auto';
       textareaRef.current.focus();
     }
     setIsTextareaExpanded(false);
-  }, [resetCommandMenuState]);
+  }, [cancelBusySendQueue, resetCommandMenuState]);
 
   const handleAbortSession = useCallback(() => {
     if (!canAbortSession) {

--- a/ui/src/components/chat/hooks/useChatComposerState.ts
+++ b/ui/src/components/chat/hooks/useChatComposerState.ts
@@ -773,9 +773,10 @@ export function useChatComposerState({
       }
 
       if (isLoading && isBusySendQueued) {
-        queuedBusySendConfirmedRef.current = true;
-        setIsBusySendConfirmed(true);
-        return;
+        queuedBusySendRef.current = false;
+        queuedBusySendConfirmedRef.current = false;
+        setIsBusySendQueued(false);
+        setIsBusySendConfirmed(false);
       }
 
       queuedBusySendRef.current = false;
@@ -1014,15 +1015,11 @@ export function useChatComposerState({
 
   useEffect(() => {
     inputValueRef.current = input;
-    queuedBusySendRef.current = false;
-    queuedBusySendConfirmedRef.current = false;
-    setIsBusySendQueued(false);
-    setIsBusySendConfirmed(false);
   }, [input]);
 
   useEffect(() => {
     if (!isLoading) {
-      if (queuedBusySendRef.current && queuedBusySendConfirmedRef.current && handleSubmitRef.current) {
+      if (queuedBusySendRef.current && handleSubmitRef.current) {
         handleSubmitRef.current(createFakeSubmitEvent());
       } else {
         queuedBusySendRef.current = false;
@@ -1084,6 +1081,10 @@ export function useChatComposerState({
 
       setInput(newValue);
       inputValueRef.current = newValue;
+      queuedBusySendRef.current = false;
+      queuedBusySendConfirmedRef.current = false;
+      setIsBusySendQueued(false);
+      setIsBusySendConfirmed(false);
       setCursorPosition(cursorPos);
 
       if (!newValue.trim()) {
@@ -1097,6 +1098,13 @@ export function useChatComposerState({
     },
     [handleCommandInputChange, resetCommandMenuState, setCursorPosition],
   );
+
+  const cancelBusySendQueue = useCallback(() => {
+    queuedBusySendRef.current = false;
+    queuedBusySendConfirmedRef.current = false;
+    setIsBusySendQueued(false);
+    setIsBusySendConfirmed(false);
+  }, []);
 
   const insertAtCursor = useCallback(
     (char: string) => {
@@ -1431,6 +1439,7 @@ export function useChatComposerState({
     isInputFocused,
     isBusySendQueued,
     isBusySendConfirmed,
+    cancelBusySendQueue,
   };
 }
 

--- a/ui/src/components/chat/hooks/useChatComposerState.ts
+++ b/ui/src/components/chat/hooks/useChatComposerState.ts
@@ -238,10 +238,19 @@ export function useChatComposerState({
   const queuedBusySendSnapshotRef = useRef<QueuedBusySendSnapshot | null>(null);
   const pendingSessionGrantResolversRef = useRef(new Map<string, (result: PermissionGrantResult) => void>());
 
+  const cancelBusySendQueue = useCallback(() => {
+    queuedBusySendRef.current = false;
+    queuedBusySendConfirmedRef.current = false;
+    queuedBusySendSnapshotRef.current = null;
+    setIsBusySendQueued(false);
+    setIsBusySendConfirmed(false);
+  }, []);
+
   useEffect(() => {
     const handleAddDocumentReference = (event: Event) => {
       const detail = (event as CustomEvent).detail;
       if (!isDocumentSelectionReference(detail)) return;
+      cancelBusySendQueue();
       setDocumentReferences((previous) => {
         if (previous.some((reference) => reference.id === detail.id)) return previous;
         return [...previous, detail];
@@ -255,7 +264,7 @@ export function useChatComposerState({
     return () => {
       window.removeEventListener('pilotdeck:add-chat-reference', handleAddDocumentReference);
     };
-  }, []);
+  }, [cancelBusySendQueue]);
 
   useEffect(() => {
     if (!subscribe) {
@@ -707,6 +716,7 @@ export function useChatComposerState({
     });
 
     if (validFiles.length > 0) {
+      cancelBusySendQueue();
       setAttachedImages((previous) => {
         const result = addAttachmentFiles(previous, validFiles);
         if (result.droppedCount > 0) {
@@ -1130,11 +1140,7 @@ export function useChatComposerState({
 
       setInput(newValue);
       inputValueRef.current = newValue;
-      queuedBusySendRef.current = false;
-      queuedBusySendConfirmedRef.current = false;
-      queuedBusySendSnapshotRef.current = null;
-      setIsBusySendQueued(false);
-      setIsBusySendConfirmed(false);
+      cancelBusySendQueue();
       setCursorPosition(cursorPos);
 
       if (!newValue.trim()) {
@@ -1146,16 +1152,8 @@ export function useChatComposerState({
 
       handleCommandInputChange(newValue, cursorPos);
     },
-    [handleCommandInputChange, resetCommandMenuState, setCursorPosition],
+    [cancelBusySendQueue, handleCommandInputChange, resetCommandMenuState, setCursorPosition],
   );
-
-  const cancelBusySendQueue = useCallback(() => {
-    queuedBusySendRef.current = false;
-    queuedBusySendConfirmedRef.current = false;
-    queuedBusySendSnapshotRef.current = null;
-    setIsBusySendQueued(false);
-    setIsBusySendConfirmed(false);
-  }, []);
 
   const insertAtCursor = useCallback(
     (char: string) => {
@@ -1462,9 +1460,13 @@ export function useChatComposerState({
     renderInputWithMentions,
     selectFile,
     attachedImages,
-    setAttachedImages,
+    setAttachedImages: (value: SetStateAction<File[]>) => {
+      cancelBusySendQueue();
+      setAttachedImages(value);
+    },
     documentReferences,
     removeDocumentReference: (id: string) => {
+      cancelBusySendQueue();
       setDocumentReferences((previous) => previous.filter((reference) => reference.id !== id));
     },
     uploadingImages,

--- a/ui/src/components/chat/hooks/useChatComposerState.ts
+++ b/ui/src/components/chat/hooks/useChatComposerState.ts
@@ -789,6 +789,18 @@ export function useChatComposerState({
       }
 
       if (isLoading && isBusySendQueued) {
+        const pendingSessionId = typeof window !== 'undefined' ? sessionStorage.getItem('pendingSessionId') : null;
+        const targetSessionId = [
+          currentSessionId,
+          pendingViewSessionRef.current?.sessionId || null,
+          pendingSessionId,
+          selectedSession?.id || null,
+        ].find((sessionId) => Boolean(sessionId) && !isTemporarySessionId(sessionId));
+
+        if (!canAbortSession || !targetSessionId) {
+          return;
+        }
+
         queuedBusySendSnapshotRef.current = {
           input: currentInput,
           attachedImages: submitAttachedImages,
@@ -797,25 +809,13 @@ export function useChatComposerState({
         };
         queuedBusySendConfirmedRef.current = true;
         setIsBusySendConfirmed(true);
-        if (canAbortSession) {
-          const pendingSessionId = typeof window !== 'undefined' ? sessionStorage.getItem('pendingSessionId') : null;
-          const targetSessionId = [
-            currentSessionId,
-            pendingViewSessionRef.current?.sessionId || null,
-            pendingSessionId,
-            selectedSession?.id || null,
-          ].find((sessionId) => Boolean(sessionId) && !isTemporarySessionId(sessionId));
-
-          if (targetSessionId) {
-            sendMessage({
-              type: 'abort-session',
-              sessionId: targetSessionId,
-              provider: 'pilotdeck',
-            });
-            setCanAbortSession(false);
-            setIsAborting(true);
-          }
-        }
+        sendMessage({
+          type: 'abort-session',
+          sessionId: targetSessionId,
+          provider: 'pilotdeck',
+        });
+        setCanAbortSession(false);
+        setIsAborting(true);
         return;
       }
 

--- a/ui/src/components/chat/hooks/useChatComposerState.ts
+++ b/ui/src/components/chat/hooks/useChatComposerState.ts
@@ -1300,6 +1300,8 @@ export function useChatComposerState({
       return;
     }
 
+    cancelBusySendQueue();
+
     sendMessage({
       type: 'abort-session',
       sessionId: targetSessionId,
@@ -1313,7 +1315,7 @@ export function useChatComposerState({
       tokens: 0,
       can_interrupt: false,
     });
-  }, [canAbortSession, currentSessionId, pendingViewSessionRef, selectedSession?.id, sendMessage, setCanAbortSession, setClaudeStatus, setIsAborting, setPilotDeckStatus]);
+  }, [canAbortSession, cancelBusySendQueue, currentSessionId, pendingViewSessionRef, selectedSession?.id, sendMessage, setCanAbortSession, setClaudeStatus, setIsAborting, setPilotDeckStatus]);
 
   const handleGrantToolPermission = useCallback(
     (suggestion: { entry: string; toolName: string }) => {

--- a/ui/src/components/chat/hooks/useChatRealtimeHandlers.ts
+++ b/ui/src/components/chat/hooks/useChatRealtimeHandlers.ts
@@ -288,6 +288,8 @@ export function useChatRealtimeHandlers({
       warnDroppedFrame(msg);
       return;
     }
+    const msgRunId = typeof msg.runId === 'string' && msg.runId.trim() ? msg.runId.trim() : undefined;
+    const streamKey = msgRunId ? `${sid}_${msgRunId}` : sid;
 
     if (!getExplicitSessionId(msg) && fallbackSessionId) {
       warnResolvedSessionId(msg, sid);
@@ -304,6 +306,13 @@ export function useChatRealtimeHandlers({
     // until some other state change (like clicking stop) triggers a re-render.
     if (isForActiveView) {
       sessionStore.setActiveSession(sid);
+    }
+
+    if (msg.kind === 'text' && msg.role === 'user') {
+      if (thinkingBySessionRef.current.has(sid)) {
+        thinkingBySessionRef.current.delete(sid);
+      }
+      sessionStore.clearAssistantRealtime?.(sid);
     }
 
     if (msg.kind === 'agent_activity') {
@@ -368,13 +377,13 @@ export function useChatRealtimeHandlers({
       // Content starting means thinking is done
       if (thinkingBySessionRef.current.has(sid)) {
         thinkingBySessionRef.current.delete(sid);
-        sessionStore.finalizeStreamingThinking(sid);
+        sessionStore.finalizeStreamingThinking(sid, msgRunId);
       }
       const slot = sessionStore.getSessionSlot?.(sid);
-      const streamId = `__streaming_${sid}`;
+      const streamId = `__streaming_${streamKey}`;
       const existing = slot?.realtimeMessages.find((m: any) => m.id === streamId);
       const currentText = existing?.content || '';
-      sessionStore.updateStreaming(sid, currentText + text, provider);
+      sessionStore.updateStreaming(sid, currentText + text, provider, msgRunId);
       return;
     }
 
@@ -386,10 +395,10 @@ export function useChatRealtimeHandlers({
       thinkingBySessionRef.current.set(sid, true as any);
       // Read current thinking content and append delta
       const slot = sessionStore.getSessionSlot?.(sid);
-      const streamId = `__streaming_thinking_${sid}`;
+      const streamId = `__streaming_thinking_${streamKey}`;
       const existing = slot?.realtimeMessages.find((m: any) => m.id === streamId);
       const currentText = existing?.content || '';
-      sessionStore.updateStreamingThinking(sid, currentText + text, provider);
+      sessionStore.updateStreamingThinking(sid, currentText + text, provider, msgRunId);
       return;
     }
 
@@ -398,9 +407,9 @@ export function useChatRealtimeHandlers({
       // Finalize thinking if still active
       if (thinkingBySessionRef.current.has(sid)) {
         thinkingBySessionRef.current.delete(sid);
-        sessionStore.finalizeStreamingThinking(sid);
+        sessionStore.finalizeStreamingThinking(sid, msgRunId);
       }
-      sessionStore.finalizeStreaming(sid);
+      sessionStore.finalizeStreaming(sid, msgRunId);
       return;
     }
 
@@ -418,10 +427,10 @@ export function useChatRealtimeHandlers({
       // The gateway may not send stream_end, so tool_use is the
       // reliable signal that the text block has ended.
       if (msg.kind === 'tool_use' || msg.kind === 'complete' || msg.kind === 'error') {
-        sessionStore.finalizeStreaming(sid);
+        sessionStore.finalizeStreaming(sid, msgRunId);
       }
       if (msg.kind === 'complete' || msg.kind === 'error') {
-        sessionStore.finalizeStreamingThinking(sid);
+        sessionStore.finalizeStreamingThinking(sid, msgRunId);
       }
     }
 
@@ -473,8 +482,8 @@ export function useChatRealtimeHandlers({
           if (thinkingBySessionRef.current.has(sid)) {
             thinkingBySessionRef.current.delete(sid);
           }
-          sessionStore.finalizeStreamingThinking(sid);
-          sessionStore.finalizeStreaming(sid);
+          sessionStore.finalizeStreamingThinking(sid, msgRunId);
+          sessionStore.finalizeStreaming(sid, msgRunId);
         }
 
         if (isForActiveView) {

--- a/ui/src/components/chat/hooks/useChatRealtimeHandlers.ts
+++ b/ui/src/components/chat/hooks/useChatRealtimeHandlers.ts
@@ -312,7 +312,6 @@ export function useChatRealtimeHandlers({
       if (thinkingBySessionRef.current.has(sid)) {
         thinkingBySessionRef.current.delete(sid);
       }
-      sessionStore.clearAssistantRealtime?.(sid);
     }
 
     if (msg.kind === 'agent_activity') {

--- a/ui/src/components/chat/hooks/useChatRealtimeHandlers.ts
+++ b/ui/src/components/chat/hooks/useChatRealtimeHandlers.ts
@@ -420,7 +420,7 @@ export function useChatRealtimeHandlers({
       // Finalize thinking if still active (model moved past thinking)
       if (thinkingBySessionRef.current.has(sid)) {
         thinkingBySessionRef.current.delete(sid);
-        sessionStore.finalizeStreamingThinking(sid);
+        sessionStore.finalizeStreamingThinking(sid, msgRunId);
       }
       // Finalize content stream on tool_use / complete / error.
       // The gateway may not send stream_end, so tool_use is the

--- a/ui/src/components/chat/hooks/useChatRealtimeHandlers.ts
+++ b/ui/src/components/chat/hooks/useChatRealtimeHandlers.ts
@@ -187,7 +187,9 @@ export function useChatRealtimeHandlers({
             const slot = sessionStore.getSessionSlot?.(statusSessionId);
             const hasLiveStreaming = Boolean(slot?.realtimeMessages?.some((message) => (
               message.id === `__streaming_${statusSessionId}`
+              || message.id.startsWith(`__streaming_${statusSessionId}_`)
               || message.id === `__streaming_thinking_${statusSessionId}`
+              || message.id.startsWith(`__streaming_thinking_${statusSessionId}_`)
             )));
             const replayedToolIds = new Set(
               (slot?.realtimeMessages || [])

--- a/ui/src/components/chat/utils/sessionLauncher.ts
+++ b/ui/src/components/chat/utils/sessionLauncher.ts
@@ -21,6 +21,7 @@ type StartSessionOptions = {
   alwaysOnPlanId?: string;
   alwaysOnExecutionToken?: string;
   workspaceCwd?: string;
+  forceStart?: boolean;
 };
 
 const VALID_PERMISSION_MODES = new Set<PermissionMode>([
@@ -97,6 +98,7 @@ export function startSessionCommand({
   alwaysOnPlanId,
   alwaysOnExecutionToken,
   workspaceCwd,
+  forceStart,
 }: StartSessionOptions): string {
   const sessionToActivate =
     sessionId || temporarySessionId || createTemporarySessionId();
@@ -124,6 +126,7 @@ export function startSessionCommand({
       ...(Array.isArray(images) && images.length > 0 ? { images } : {}),
       ...(Array.isArray(attachments) && attachments.length > 0 ? { attachments } : {}),
       ...(workspaceCwd ? { workspaceCwd } : {}),
+      ...(forceStart ? { forceStart: true } : {}),
     },
   });
 

--- a/ui/src/stores/useSessionStore.ts
+++ b/ui/src/stores/useSessionStore.ts
@@ -438,6 +438,10 @@ function forceRecomputeMerged(slot: SessionSlot): void {
   slot.merged = computeMerged(slot.serverMessages, slot.realtimeMessages);
 }
 
+function streamingKey(sessionId: string, runId?: string): string {
+  return runId ? `${sessionId}_${runId}` : sessionId;
+}
+
 /**
  * Patch a single streaming row in `slot.merged` without recomputing the full list.
  * Returns true when the merged row was updated in place.
@@ -1015,9 +1019,9 @@ export function useSessionStore() {
    * Update or create a streaming message (accumulated text so far).
    * Uses a well-known ID so subsequent calls replace the same message.
    */
-  const updateStreaming = useCallback((sessionId: string, accumulatedText: string, msgProvider: SessionProvider) => {
+  const updateStreaming = useCallback((sessionId: string, accumulatedText: string, msgProvider: SessionProvider, runId?: string) => {
     const slot = getSlot(sessionId);
-    const streamId = `__streaming_${sessionId}`;
+    const streamId = `__streaming_${streamingKey(sessionId, runId)}`;
     const idx = slot.realtimeMessages.findIndex(m => m.id === streamId);
     if (idx >= 0) {
       // Subsequent delta — preserve the original turn-start timestamp so
@@ -1053,6 +1057,7 @@ export function useSessionStore() {
         provider: msgProvider,
         kind: 'stream_delta',
         content: accumulatedText,
+        runId,
         serverTailIdAtStart: serverTailId ?? undefined,
       };
       slot.realtimeMessages = [...slot.realtimeMessages, msg];
@@ -1065,10 +1070,10 @@ export function useSessionStore() {
    * Finalize streaming: convert the streaming message to a regular text message.
    * The well-known streaming ID is replaced with a unique text message ID.
    */
-  const finalizeStreaming = useCallback((sessionId: string) => {
+  const finalizeStreaming = useCallback((sessionId: string, runId?: string) => {
     const slot = storeRef.current.get(sessionId);
     if (!slot) return;
-    const streamId = `__streaming_${sessionId}`;
+    const streamId = `__streaming_${streamingKey(sessionId, runId)}`;
     const idx = slot.realtimeMessages.findIndex(m => m.id === streamId);
     if (idx >= 0) {
       const stream = slot.realtimeMessages[idx];
@@ -1090,9 +1095,9 @@ export function useSessionStore() {
    * Update or create a streaming thinking message (accumulated thinking so far).
    * Mirrors updateStreaming but uses kind='thinking' and a separate well-known ID.
    */
-  const updateStreamingThinking = useCallback((sessionId: string, accumulatedText: string, msgProvider: SessionProvider) => {
+  const updateStreamingThinking = useCallback((sessionId: string, accumulatedText: string, msgProvider: SessionProvider, runId?: string) => {
     const slot = getSlot(sessionId);
-    const streamId = `__streaming_thinking_${sessionId}`;
+    const streamId = `__streaming_thinking_${streamingKey(sessionId, runId)}`;
     const idx = slot.realtimeMessages.findIndex(m => m.id === streamId);
     if (idx >= 0) {
       const existing = slot.realtimeMessages[idx];
@@ -1121,6 +1126,7 @@ export function useSessionStore() {
         provider: msgProvider,
         kind: 'thinking',
         content: accumulatedText,
+        runId,
         serverTailIdAtStart: serverTailId ?? undefined,
       };
       slot.realtimeMessages = [...slot.realtimeMessages, msg];
@@ -1133,10 +1139,10 @@ export function useSessionStore() {
    * Finalize streaming thinking: replace the well-known streaming thinking ID
    * with a unique ID so subsequent thinking blocks don't overwrite it.
    */
-  const finalizeStreamingThinking = useCallback((sessionId: string) => {
+  const finalizeStreamingThinking = useCallback((sessionId: string, runId?: string) => {
     const slot = storeRef.current.get(sessionId);
     if (!slot) return;
-    const streamId = `__streaming_thinking_${sessionId}`;
+    const streamId = `__streaming_thinking_${streamingKey(sessionId, runId)}`;
     const idx = slot.realtimeMessages.findIndex(m => m.id === streamId);
     if (idx >= 0) {
       const stream = slot.realtimeMessages[idx];
@@ -1162,6 +1168,21 @@ export function useSessionStore() {
       recomputeMergedIfNeeded(slot);
       notify(sessionId);
     }
+  }, [notify]);
+
+  const clearAssistantRealtime = useCallback((sessionId: string) => {
+    const slot = storeRef.current.get(sessionId);
+    if (!slot) return;
+    const nextRealtime = slot.realtimeMessages.filter((message) => {
+      if (message.kind === 'thinking' || message.kind === 'stream_delta' || message.kind === 'stream_end') {
+        return false;
+      }
+      return !(message.kind === 'text' && message.role === 'assistant');
+    });
+    if (nextRealtime.length === slot.realtimeMessages.length) return;
+    slot.realtimeMessages = nextRealtime;
+    recomputeMergedIfNeeded(slot);
+    notify(sessionId);
   }, [notify]);
 
   /**
@@ -1200,6 +1221,7 @@ export function useSessionStore() {
     updateStreamingThinking,
     finalizeStreamingThinking,
     clearRealtime,
+    clearAssistantRealtime,
     getMessages,
     getActivityMessages,
     getSubagentDetailMessages,
@@ -1215,7 +1237,7 @@ export function useSessionStore() {
     appendRealtime, upsertActivity, setActivities, appendRealtimeBatch, refreshFromServer,
     setActiveSession, setStatus, isStale, updateStreaming, finalizeStreaming,
     updateStreamingThinking, finalizeStreamingThinking,
-    clearRealtime, getMessages, getActivityMessages, getSubagentDetailMessages, getSessionSlot,
+    clearRealtime, clearAssistantRealtime, getMessages, getActivityMessages, getSubagentDetailMessages, getSessionSlot,
     recordSubagentLink, appendSubagentDetailMessage, updateSubagentDetailStreaming,
     finalizeSubagentDetailStreaming, updateSubagentDetailThinking, finalizeSubagentDetailThinking,
   ]);


### PR DESCRIPTION
## Summary
- allow composing messages while an agent turn is running
- queue a busy send for automatic delivery when the current turn completes
- allow clicking send again to force-send by interrupting the current turn
- isolate streaming/thinking render state by run id to avoid stale turn bleed-through
- add a cancel action for queued busy sends

## Testing
- git diff --check
- manual verification in Vite dev UI at http://localhost:5173/p/general