### PR TITLE
feat(tools): improve tool call recovery and availability

### DIFF
--- a/src/agent/loop/AgentLoop.ts
+++ b/src/agent/loop/AgentLoop.ts
@@ -13,6 +13,7 @@ import {
   type CanonicalModelRequest,
   type CanonicalToolSchema,
   type CanonicalUsage,
+  type CanonicalToolCallBlock,
   materializeMediaReferences,
   type PartialTextToolCallInfo,
   getSelfCorrectPrompt,
@@ -537,8 +538,14 @@ export class AgentLoop {
 
       const assembled = assembleAssistantMessage(assembler);
       usage = mergeUsage(usage, assembled.usage);
-      finalMessage = assembled.message;
-      let toolCalls = collectToolCalls(assembled.message);
+      let assistantMessage = assembled.message;
+      let toolCalls = collectToolCalls(assistantMessage);
+      if (assembled.hasTextFallbackToolCalls) {
+        const repaired = this.repairTextExtractedToolNames(assistantMessage, toolCalls);
+        assistantMessage = repaired.message;
+        toolCalls = repaired.toolCalls;
+      }
+      finalMessage = assistantMessage;
       expireConsumedTransientPrompts();
 
       if (assembled.hasPartialTextToolCall) {
@@ -669,9 +676,9 @@ export class AgentLoop {
         return { result, messages };
       }
 
-      messages.push(assembled.message);
-      yield { type: "assistant_message", sessionId: input.sessionId, turnId: input.turnId, message: assembled.message };
-      await input.onDurableMessage?.(assembled.message);
+      messages.push(assistantMessage);
+      yield { type: "assistant_message", sessionId: input.sessionId, turnId: input.turnId, message: assistantMessage };
+      await input.onDurableMessage?.(assistantMessage);
 
       if (assembled.error) {
         if (toolCalls.length > 0) {
@@ -816,7 +823,7 @@ export class AgentLoop {
       }
 
       if (toolCalls.length === 0) {
-        const assistantText = textFromMessage(assembled.message);
+        const assistantText = textFromMessage(assistantMessage);
 
         // Global guard: empty assistant response (no text, no tool calls).
         // The model produced nothing visible — typically because extended
@@ -967,7 +974,7 @@ export class AgentLoop {
 
         const stopHooks = await this.dispatchLifecycle(input, "Stop", {
           stopHookActive: false,
-          lastAssistantMessage: textFromMessage(assembled.message),
+          lastAssistantMessage: textFromMessage(assistantMessage),
         });
         yield { type: "stop_requested", sessionId: input.sessionId, turnId: input.turnId };
         messages.push(...stopHooks.messages);
@@ -1008,10 +1015,6 @@ export class AgentLoop {
         await captureTurn(result.type === "error");
         yield { type: "turn_completed", sessionId: input.sessionId, turnId: input.turnId, result };
         return { result, messages };
-      }
-
-      if (assembled.hasTextFallbackToolCalls) {
-        toolCalls = this.repairTextExtractedToolNames(toolCalls);
       }
 
       yield { type: "tool_calls_detected", sessionId: input.sessionId, turnId: input.turnId, calls: toolCalls };
@@ -1401,13 +1404,32 @@ export class AgentLoop {
     };
   }
 
-  private repairTextExtractedToolNames(toolCalls: CanonicalToolCall[]): CanonicalToolCall[] {
-    if (toolCalls.length === 0) return toolCalls;
+  private repairTextExtractedToolNames(
+    message: CanonicalMessage,
+    toolCalls: CanonicalToolCall[],
+  ): { message: CanonicalMessage; toolCalls: CanonicalToolCall[] } {
+    if (toolCalls.length === 0) return { message, toolCalls };
     const validNames = new Set(this.dependencies.tools.registry.list().map((tool) => tool.name));
-    return toolCalls.map((call) => {
+    const repairedById = new Map<string, string>();
+    const repairedToolCalls = toolCalls.map((call) => {
       const repaired = repairToolName(call.name, validNames, this.config.toolAliases);
-      return repaired ? { ...call, name: repaired.name } : call;
+      if (!repaired) return call;
+      repairedById.set(call.id, repaired.name);
+      return { ...call, name: repaired.name };
     });
+    if (repairedById.size === 0) return { message, toolCalls };
+
+    return {
+      message: {
+        ...message,
+        content: message.content.map((block) => {
+          if (block.type !== "tool_call") return block;
+          const repairedName = repairedById.get(block.id);
+          return repairedName ? ({ ...block, name: repairedName } satisfies CanonicalToolCallBlock) : block;
+        }),
+      },
+      toolCalls: repairedToolCalls,
+    };
   }
 
   private createToolContext(

--- a/src/agent/loop/AgentLoop.ts
+++ b/src/agent/loop/AgentLoop.ts
@@ -15,6 +15,8 @@ import {
   type CanonicalUsage,
   materializeMediaReferences,
   type PartialTextToolCallInfo,
+  getSelfCorrectPrompt,
+  detectFormatByText,
 } from "../../model/index.js";
 import type {
   PilotDeckToolDefinition,
@@ -52,6 +54,7 @@ import {
   isAskModeAllowedTool,
 } from "../../tool/askModeConstraints.js";
 import { buildAskModeAgentToolSchema } from "../../tool/builtin/agent.js";
+import { repairToolName } from "../../model/streaming/repairToolName.js";
 
 const TOOL_EVENT_PUMP_INTERVAL_MS = 500;
 const SUBAGENT_STATUS_HEARTBEAT_MS = 2_000;
@@ -208,6 +211,7 @@ export class AgentLoop {
     let consecutiveEmptyCount = 0;
     const MAX_JSON_SELF_CORRECT_RETRIES = 3;
     let jsonSelfCorrectCount = 0;
+    let hasAttemptedToolCallRetry = false;
     const largeFileRepair = new LargeFileRepair();
 
     /**
@@ -534,7 +538,7 @@ export class AgentLoop {
       const assembled = assembleAssistantMessage(assembler);
       usage = mergeUsage(usage, assembled.usage);
       finalMessage = assembled.message;
-      const toolCalls = collectToolCalls(assembled.message);
+      let toolCalls = collectToolCalls(assembled.message);
       expireConsumedTransientPrompts();
 
       if (assembled.hasPartialTextToolCall) {
@@ -933,6 +937,34 @@ export class AgentLoop {
           continue;
         }
 
+        if (!assembled.hasPartialTextToolCall && assembled.hasUnparsedTextToolCall) {
+          if (!hasAttemptedToolCallRetry) {
+            hasAttemptedToolCallRetry = true;
+            pushTransientSyntheticPrompt(
+              getSelfCorrectPrompt(this.config.toolCallFormat ?? assembled.textToolCallFormat, assistantText),
+              "unparsed_tool_call_retry",
+            );
+            yield {
+              type: "turn_continued",
+              sessionId: input.sessionId,
+              turnId: input.turnId,
+              reason: "model_error",
+            };
+            continue;
+          }
+
+          yield {
+            type: "warning",
+            sessionId: input.sessionId,
+            turnId: input.turnId,
+            code: "unparsed_tool_call",
+            message: "Model attempted to call a tool but the output could not be parsed. The response may be incomplete.",
+            metadata: {
+              detectedFormat: assembled.textToolCallFormat ?? detectFormatByText(assistantText)?.id,
+            },
+          };
+        }
+
         const stopHooks = await this.dispatchLifecycle(input, "Stop", {
           stopHookActive: false,
           lastAssistantMessage: textFromMessage(assembled.message),
@@ -976,6 +1008,10 @@ export class AgentLoop {
         await captureTurn(result.type === "error");
         yield { type: "turn_completed", sessionId: input.sessionId, turnId: input.turnId, result };
         return { result, messages };
+      }
+
+      if (assembled.hasTextFallbackToolCalls) {
+        toolCalls = this.repairTextExtractedToolNames(toolCalls);
       }
 
       yield { type: "tool_calls_detected", sessionId: input.sessionId, turnId: input.turnId, calls: toolCalls };
@@ -1208,6 +1244,7 @@ export class AgentLoop {
         consecutiveEmptyCount = 0;
         hasAttemptedOutputRetry = false;
         hasAttemptedEmptyRetry = false;
+        hasAttemptedToolCallRetry = false;
       }
 
       if (this.config.stopOnStructuredOutput && structuredOutput !== undefined) {
@@ -1362,6 +1399,15 @@ export class AgentLoop {
       metadata: this.config.metadata,
       cacheBreakpoints: prepared.cacheBreakpoints,
     };
+  }
+
+  private repairTextExtractedToolNames(toolCalls: CanonicalToolCall[]): CanonicalToolCall[] {
+    if (toolCalls.length === 0) return toolCalls;
+    const validNames = new Set(this.dependencies.tools.registry.list().map((tool) => tool.name));
+    return toolCalls.map((call) => {
+      const repaired = repairToolName(call.name, validNames, this.config.toolAliases);
+      return repaired ? { ...call, name: repaired.name } : call;
+    });
   }
 
   private createToolContext(

--- a/src/agent/protocol/events.ts
+++ b/src/agent/protocol/events.ts
@@ -30,6 +30,7 @@ export type AgentEvent =
   | { type: "compact_started"; sessionId: string; turnId: string; trigger: string; preTokens: number }
   | { type: "compact_completed"; sessionId: string; turnId: string; status: string; preTokens: number; postTokens?: number }
   | { type: "context_budget"; sessionId: string; turnId: string; snapshot: TokenBudgetSnapshot }
+  | { type: "warning"; sessionId: string; turnId: string; code: string; message: string; metadata?: Record<string, unknown> }
   | { type: "agent_status"; sessionId: string; turnId: string; event: string; detail?: Record<string, unknown> }
   | { type: "subagent_started"; sessionId: string; turnId: string; subagentId: string; subagentType: string; toolCallId?: string }
   | { type: "subagent_completed"; sessionId: string; turnId: string; subagentId: string; subagentType: string; success: boolean; durationMs: number }

--- a/src/agent/runtime/AgentRuntimeConfig.ts
+++ b/src/agent/runtime/AgentRuntimeConfig.ts
@@ -15,6 +15,8 @@ export type AgentRuntimeConfig = {
   toolChoice?: CanonicalToolChoice;
   /** Optional model/provider-specific aliases for emitted tool names. */
   toolAliases?: Record<string, string>;
+  /** Optional text tool-call format hint for self-correction prompts. */
+  toolCallFormat?: string;
   maxContextMessages?: number;
   stopOnStructuredOutput?: boolean;
   runMode?: AgentRunMode;

--- a/src/cli/createLocalGateway.ts
+++ b/src/cli/createLocalGateway.ts
@@ -68,9 +68,14 @@ import { createSessionTitleGenerator } from "../session/title/SessionTitleGenera
 import { readWebSessionMessages, readSubagentWebMessages } from "../web/server/readSessionMessages.js";
 import { forkWebSession } from "../web/server/forkSession.js";
 import { describeWebProject, listWebProjects } from "../web/server/listProjects.js";
-import { BackgroundTaskRuntime } from "../task/runtime/BackgroundTaskRuntime.js";
-import { createBuiltinRegistry, createPlanFileManager } from "../tool/index.js";
-import type { PilotDeckToolDefinition, ToolRegistry, PilotDeckElicitationChannel } from "../tool/index.js";
+import { BackgroundTaskRuntime, type BackgroundTaskCompletionEvent } from "../task/runtime/BackgroundTaskRuntime.js";
+import { createBuiltinRegistry, createPlanFileManager, filterAvailableTools } from "../tool/index.js";
+import type {
+  PilotDeckElicitationChannel,
+  PilotDeckToolDefinition,
+  PilotDeckUnavailableToolDiagnostic,
+  ToolRegistry,
+} from "../tool/index.js";
 import { createRouterRuntime, type RouterRuntime } from "../router/index.js";
 import { SessionRouterStore } from "../router/session/SessionRouterStore.js";
 import type { RouterEventBus, RouterEvent } from "../router/protocol/events.js";
@@ -406,6 +411,7 @@ type ProjectRuntime = {
   router: RouterRuntime;
   pluginRuntime: PluginRuntime;
   tools: ToolRegistry;
+  unavailableTools?: PilotDeckUnavailableToolDiagnostic[];
   projectStorage: GatewayProjectStorageOptions;
   /** Per-project background task runtime (shared across sessions). C5. */
   backgroundTasks: BackgroundTaskRuntime;
@@ -487,6 +493,26 @@ class ProjectRuntimeRegistry {
 
   setGateway(gateway: InProcessGateway): void {
     this.gateway = gateway;
+  }
+
+  private emitBackgroundTaskCompletion(event: BackgroundTaskCompletionEvent): void {
+    if (!event.sessionId || !this.gateway) {
+      return;
+    }
+    const outputPreview = event.outputPreview.trimEnd();
+    this.gateway.emitForSession(event.sessionId, {
+      type: "agent_status",
+      event: "background_task_completed",
+      detail: {
+        taskId: event.taskId,
+        status: event.status,
+        exitCode: event.exitCode ?? null,
+        totalBytes: event.totalBytes,
+        startedAt: event.startedAt,
+        endedAt: event.endedAt,
+        ...(outputPreview ? { outputPreview } : {}),
+      },
+    });
   }
 
   private buildRouterEventBus(): RouterEventBus {
@@ -629,7 +655,10 @@ class ProjectRuntimeRegistry {
       events: this.buildRouterEventBus(),
       telemetry: this.options.telemetry,
     });
-    const backgroundTasks = new BackgroundTaskRuntime({ now: this.options.now });
+    const backgroundTasks = new BackgroundTaskRuntime({
+      now: this.options.now,
+      onCompletion: (event) => this.emitBackgroundTaskCompletion(event),
+    });
     const webSearchConfig = snapshot.config.tools?.webSearch;
     const tools = createBuiltinRegistry({
       backgroundTasks: { runtime: backgroundTasks },
@@ -900,6 +929,14 @@ class ProjectRuntimeRegistry {
         }
       }
     }
+
+    const availability = await filterAvailableTools(sessionTools, {
+      cwd: runtime.projectRoot,
+      env: this.options.env,
+    });
+    sessionTools = availability.registry;
+    runtime.unavailableTools = availability.unavailable;
+
     // Inject the gateway's interactive permission hook so the agent's
     // PermissionRequest lifecycle is round-tripped through whichever
     // client is streaming this session (Web UI, TUI, etc.) instead of

--- a/src/gateway/client/InProcessGateway.ts
+++ b/src/gateway/client/InProcessGateway.ts
@@ -1377,6 +1377,12 @@ export function mapAgentEvent(event: AgentEvent, runId: string): GatewayEvent[] 
         ratio: event.snapshot.ratio,
         state: event.snapshot.state,
       }];
+    case "warning":
+      return [{
+        type: "agent_status",
+        event: "warning",
+        detail: { code: event.code, message: event.message, metadata: event.metadata },
+      }];
     case "agent_status":
       return [{
         type: "agent_status",

--- a/src/model/index.ts
+++ b/src/model/index.ts
@@ -19,6 +19,8 @@ export {
 } from "./streaming/normalizeStreamEvent.js";
 export {
   extractTextToolCalls,
+  detectFormatByText,
+  getSelfCorrectPrompt,
   hasTextToolCallSyntax,
   type PartialTextToolCallFormat,
   type PartialTextToolCallInfo,

--- a/src/model/streaming/assembleModelMessage.ts
+++ b/src/model/streaming/assembleModelMessage.ts
@@ -28,6 +28,8 @@ export type ModelMessageAssemblerState = {
   hasPartialTextToolCall?: boolean;
   partialTextToolCall?: PartialTextToolCallInfo;
   hasTextFallbackToolCalls?: boolean;
+  textToolCallFormat?: PartialTextToolCallInfo["format"];
+  hasUnparsedTextToolCall?: boolean;
 };
 
 export type AssembledAssistantMessage = {
@@ -40,6 +42,8 @@ export type AssembledAssistantMessage = {
   hasPartialTextToolCall?: boolean;
   partialTextToolCall?: PartialTextToolCallInfo;
   hasTextFallbackToolCalls?: boolean;
+  textToolCallFormat?: PartialTextToolCallInfo["format"];
+  hasUnparsedTextToolCall?: boolean;
 };
 
 export function createModelMessageAssemblerState(): ModelMessageAssemblerState {
@@ -106,20 +110,25 @@ export function assembleAssistantMessage(state: ModelMessageAssemblerState): Ass
     );
     if (textIdx >= 0) {
       const textBlock = state.content[textIdx] as CanonicalTextBlock;
-      const { toolCalls, remainingText, partialToolCall } = extractTextToolCalls(textBlock.text);
+      const parseResult = extractTextToolCalls(textBlock.text);
+      const { detectedFormat, parseError, partialToolCall } = parseResult;
+      state.textToolCallFormat = detectedFormat;
       if (partialToolCall) {
         state.hasPartialTextToolCall = true;
         state.partialTextToolCall = partialToolCall;
       }
-      if (toolCalls.length > 0) {
-        console.log(`[text-tool-call-fallback] Extracted ${toolCalls.length} tool call(s) from assistant text`);
+      if (parseError) {
+        state.hasUnparsedTextToolCall = true;
+      }
+      if (parseResult.toolCalls.length > 0) {
+        console.log(`[text-tool-call-fallback] Extracted ${parseResult.toolCalls.length} tool call(s) from assistant text (format: ${detectedFormat ?? "unknown"})`);
         state.hasTextFallbackToolCalls = true;
-        if (remainingText.length > 0) {
-          (state.content[textIdx] as CanonicalTextBlock).text = remainingText;
+        if (parseResult.remainingText.length > 0) {
+          (state.content[textIdx] as CanonicalTextBlock).text = parseResult.remainingText;
         } else {
           state.content.splice(textIdx, 1);
         }
-        for (const tc of toolCalls) {
+        for (const tc of parseResult.toolCalls) {
           state.content.push({ type: "tool_call", ...tc });
           state.toolCalls.push(tc);
         }
@@ -142,6 +151,8 @@ export function assembleAssistantMessage(state: ModelMessageAssemblerState): Ass
     hasPartialTextToolCall: state.hasPartialTextToolCall,
     partialTextToolCall: state.partialTextToolCall,
     hasTextFallbackToolCalls: state.hasTextFallbackToolCalls,
+    textToolCallFormat: state.textToolCallFormat,
+    hasUnparsedTextToolCall: state.hasUnparsedTextToolCall,
   };
 }
 

--- a/src/model/streaming/parseTextToolCalls.ts
+++ b/src/model/streaming/parseTextToolCalls.ts
@@ -1,11 +1,19 @@
 import { randomUUID } from "node:crypto";
 import type { CanonicalToolCall } from "../protocol/canonical.js";
+import {
+  detectFormatByText,
+  getSelfCorrectPrompt,
+  getToolCallFormats,
+  registerToolCallFormat,
+} from "./toolCallFormats.js";
 
 export type TextToolCallParseResult = {
   toolCalls: CanonicalToolCall[];
   remainingText: string;
   partialToolCall?: PartialTextToolCallInfo;
   extractedFromText?: boolean;
+  detectedFormat?: PartialTextToolCallFormat;
+  parseError?: boolean;
 };
 
 export type PartialTextToolCallFormat =
@@ -21,6 +29,8 @@ export type PartialTextToolCallInfo = {
   preview: string;
 };
 
+export { detectFormatByText, getSelfCorrectPrompt };
+
 /**
  * Attempt to extract structured tool calls from assistant text content.
  *
@@ -34,16 +44,10 @@ export type PartialTextToolCallInfo = {
  */
 export function extractTextToolCalls(text: string): TextToolCallParseResult {
   let firstPartial: PartialTextToolCallInfo | undefined;
-  const parsers = [
-    tryParseQwenXml,
-    tryParseDeepSeekDsml,
-    tryParseHermesJson,
-    tryParseMistral,
-    tryParseLlama,
-  ];
 
-  for (const parser of parsers) {
-    const result = parser(text);
+  for (const format of getToolCallFormats()) {
+    const markerHit = format.markers.some((marker) => text.includes(marker));
+    const result = format.parse(text);
     if (result?.partialToolCall && !firstPartial) {
       firstPartial = result.partialToolCall;
     }
@@ -51,6 +55,15 @@ export function extractTextToolCalls(text: string): TextToolCallParseResult {
       return {
         ...result,
         extractedFromText: true,
+        detectedFormat: format.id,
+        partialToolCall: result.partialToolCall ?? firstPartial,
+      };
+    }
+    if (markerHit && result) {
+      return {
+        ...result,
+        detectedFormat: format.id,
+        parseError: true,
         partialToolCall: result.partialToolCall ?? firstPartial,
       };
     }
@@ -58,18 +71,12 @@ export function extractTextToolCalls(text: string): TextToolCallParseResult {
 
   const partialToolCall = firstPartial ?? detectPartialTextToolCall(text);
   return partialToolCall
-    ? { toolCalls: [], remainingText: text, partialToolCall }
+    ? { toolCalls: [], remainingText: text, partialToolCall, detectedFormat: partialToolCall.format, parseError: true }
     : { toolCalls: [], remainingText: text };
 }
 
 export function hasTextToolCallSyntax(text: string): boolean {
-  return (
-    hasQwenMarker(text) ||
-    hasDsmlMarker(text) ||
-    hasHermesMarker(text) ||
-    hasMistralMarker(text) ||
-    hasLlamaMarker(text)
-  );
+  return detectFormatByText(text) !== undefined;
 }
 
 // ---------------------------------------------------------------------------
@@ -733,3 +740,53 @@ function preview(text: string): string {
 function generateId(): string {
   return `text_tc_${randomUUID().slice(0, 8)}`;
 }
+
+registerToolCallFormat({
+  id: "qwen_xml",
+  displayName: "Qwen XML",
+  modelFamilies: ["qwen"],
+  markers: ["<function=", "</function>", "<parameter=", "</parameter>"],
+  parse: tryParseQwenXml,
+  selfCorrectPrompt: "Use <function=TOOL_NAME> with one <parameter=NAME>VALUE</parameter> block for each argument, and close with </function>.",
+  example: "<function=read_file>\n<parameter=path>/tmp/example.txt</parameter>\n</function>",
+});
+
+registerToolCallFormat({
+  id: "deepseek_dsml",
+  displayName: "DeepSeek DSML",
+  modelFamilies: ["deepseek"],
+  markers: ["\uff5cDSML\uff5c"],
+  parse: tryParseDeepSeekDsml,
+  selfCorrectPrompt: "Use one <｜DSML｜invoke name=\"TOOL_NAME\"> block with <｜DSML｜parameter name=\"ARG\">VALUE</content> children.",
+  example: "<｜DSML｜tool_calls>\n<｜DSML｜invoke name=\"read_file\">\n<｜DSML｜parameter name=\"path\">/tmp/example.txt</content>\n</｜DSML｜invoke>\n</｜DSML｜tool_calls>",
+});
+
+registerToolCallFormat({
+  id: "hermes_json",
+  displayName: "Hermes JSON",
+  modelFamilies: ["hermes", "nous"],
+  markers: ["<tool_call>", "</tool_call>"],
+  parse: tryParseHermesJson,
+  selfCorrectPrompt: "Use a <tool_call> block containing valid JSON with string field name and object field arguments.",
+  example: "<tool_call>\n{\"name\":\"read_file\",\"arguments\":{\"path\":\"/tmp/example.txt\"}}\n</tool_call>",
+});
+
+registerToolCallFormat({
+  id: "mistral",
+  displayName: "Mistral tool calls",
+  modelFamilies: ["mistral", "mixtral"],
+  markers: [MISTRAL_MARKER],
+  parse: tryParseMistral,
+  selfCorrectPrompt: "Use [TOOL_CALLS] followed by a valid JSON array of tool call objects with name and arguments.",
+  example: "[TOOL_CALLS] [{\"name\":\"read_file\",\"arguments\":{\"path\":\"/tmp/example.txt\"}}]",
+});
+
+registerToolCallFormat({
+  id: "llama",
+  displayName: "Llama python-tag tool call",
+  modelFamilies: ["llama"],
+  markers: [LLAMA_TAG],
+  parse: tryParseLlama,
+  selfCorrectPrompt: "Use <|python_tag|> followed by a valid JSON object with name and arguments.",
+  example: "<|python_tag|>{\"name\":\"read_file\",\"arguments\":{\"path\":\"/tmp/example.txt\"}}",
+});

--- a/src/model/streaming/repairToolName.ts
+++ b/src/model/streaming/repairToolName.ts
@@ -1,0 +1,85 @@
+export type ToolNameRepairResult = {
+  name: string;
+  reason: "alias" | "case_insensitive" | "normalized" | "edit_distance";
+};
+
+export function repairToolName(
+  name: string,
+  validNames: Iterable<string>,
+  aliases: Record<string, string> = {},
+): ToolNameRepairResult | undefined {
+  const raw = name.trim();
+  if (raw.length === 0) return undefined;
+
+  const valid = [...validNames];
+  if (valid.includes(raw)) return undefined;
+
+  const aliasTarget = aliases[raw] ?? aliases[raw.toLowerCase()];
+  if (aliasTarget && valid.includes(aliasTarget)) {
+    return { name: aliasTarget, reason: "alias" };
+  }
+
+  const lower = raw.toLowerCase();
+  const caseMatch = valid.find((candidate) => candidate.toLowerCase() === lower);
+  if (caseMatch) {
+    return { name: caseMatch, reason: "case_insensitive" };
+  }
+
+  const normalized = normalizeToolName(raw);
+  const normalizedMatch = valid.find((candidate) => normalizeToolName(candidate) === normalized);
+  if (normalizedMatch) {
+    return { name: normalizedMatch, reason: "normalized" };
+  }
+
+  const best = bestEditDistanceMatch(raw, valid);
+  if (best && best.distance <= maxSafeEditDistance(raw, best.name)) {
+    return { name: best.name, reason: "edit_distance" };
+  }
+
+  return undefined;
+}
+
+function normalizeToolName(name: string): string {
+  return name.toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
+function maxSafeEditDistance(a: string, b: string): number {
+  const shortest = Math.min(a.length, b.length);
+  if (shortest < 5) return 0;
+  if (shortest < 9) return 1;
+  return 2;
+}
+
+function bestEditDistanceMatch(
+  raw: string,
+  valid: string[],
+): { name: string; distance: number } | undefined {
+  let best: { name: string; distance: number } | undefined;
+  for (const candidate of valid) {
+    const distance = levenshtein(raw.toLowerCase(), candidate.toLowerCase());
+    if (!best || distance < best.distance) {
+      best = { name: candidate, distance };
+    } else if (best && distance === best.distance) {
+      best = undefined;
+    }
+  }
+  return best;
+}
+
+function levenshtein(a: string, b: string): number {
+  const previous = Array.from({ length: b.length + 1 }, (_, index) => index);
+  const current = Array.from({ length: b.length + 1 }, () => 0);
+
+  for (let i = 1; i <= a.length; i++) {
+    current[0] = i;
+    for (let j = 1; j <= b.length; j++) {
+      const substitution = previous[j - 1] + (a[i - 1] === b[j - 1] ? 0 : 1);
+      current[j] = Math.min(previous[j] + 1, current[j - 1] + 1, substitution);
+    }
+    for (let j = 0; j <= b.length; j++) {
+      previous[j] = current[j];
+    }
+  }
+
+  return previous[b.length] ?? Number.POSITIVE_INFINITY;
+}

--- a/src/model/streaming/toolCallFormats.ts
+++ b/src/model/streaming/toolCallFormats.ts
@@ -1,0 +1,63 @@
+import type { TextToolCallParseResult, PartialTextToolCallFormat } from "./parseTextToolCalls.js";
+
+export type ToolCallFormatDefinition = {
+  id: PartialTextToolCallFormat;
+  displayName: string;
+  modelFamilies: string[];
+  markers: string[];
+  parse: (text: string) => TextToolCallParseResult | null;
+  selfCorrectPrompt: string;
+  example: string;
+};
+
+const registry: ToolCallFormatDefinition[] = [];
+
+export function registerToolCallFormat(format: ToolCallFormatDefinition): void {
+  const existing = registry.findIndex((entry) => entry.id === format.id);
+  if (existing >= 0) {
+    registry[existing] = format;
+    return;
+  }
+  registry.push(format);
+}
+
+export function getToolCallFormats(): readonly ToolCallFormatDefinition[] {
+  return registry;
+}
+
+export function getFormatById(id: string | undefined): ToolCallFormatDefinition | undefined {
+  if (!id || id === "auto") return undefined;
+  return registry.find((format) => format.id === id);
+}
+
+export function detectFormatByText(text: string): ToolCallFormatDefinition | undefined {
+  return registry.find((format) => format.markers.some((marker) => text.includes(marker)));
+}
+
+export function looksLikeUnparsedToolCall(text: string): boolean {
+  return detectFormatByText(text) !== undefined;
+}
+
+export function getSelfCorrectPrompt(
+  formatId: string | undefined,
+  failedText: string,
+): string {
+  const selected = getFormatById(formatId) ?? detectFormatByText(failedText) ?? registry[0];
+  const excerpt = failedText.trim().slice(0, 2_000);
+  if (!selected) {
+    return [
+      "Your previous response looked like a tool call, but it could not be parsed.",
+      "Retry by emitting exactly one valid tool call using the required tool-call syntax.",
+      "Do not explain the mistake or wrap the tool call in Markdown.",
+      excerpt ? `Previous unparsable text:\n${excerpt}` : undefined,
+    ].filter(Boolean).join("\n\n");
+  }
+
+  return [
+    `Your previous response looked like a ${selected.displayName} tool call, but it could not be parsed.`,
+    selected.selfCorrectPrompt,
+    "Retry by emitting exactly one valid tool call. Do not explain the mistake or wrap the tool call in Markdown.",
+    `Example:\n${selected.example}`,
+    excerpt ? `Previous unparsable text:\n${excerpt}` : undefined,
+  ].filter(Boolean).join("\n\n");
+}

--- a/src/task/protocol/types.ts
+++ b/src/task/protocol/types.ts
@@ -23,6 +23,8 @@ export type PilotDeckBackgroundBashTask = {
   type: "local_bash";
   /** T4 — owning agent; agent exit triggers `killForAgent(agentId)`. */
   agentId?: string;
+  /** Owning gateway/agent session for best-effort completion notifications. */
+  sessionId?: string;
   /** T5 — UI badge variant (`bash` plain task vs. long-running `monitor`). */
   kind: PilotDeckBackgroundTaskKind;
   command: string;

--- a/src/task/runtime/BackgroundTaskRuntime.ts
+++ b/src/task/runtime/BackgroundTaskRuntime.ts
@@ -26,10 +26,24 @@ import { randomUUID } from "node:crypto";
 import { TaskOutputStore } from "../storage/TaskOutputStore.js";
 import type {
   PilotDeckBackgroundBashTask,
+  PilotDeckBackgroundTaskStatus,
   PilotDeckBackgroundTaskKind,
   PilotDeckBackgroundTaskListFilter,
   PilotDeckTaskOutputSlice,
 } from "../protocol/types.js";
+
+export type BackgroundTaskCompletionEvent = {
+  sessionId?: string;
+  taskId: string;
+  status: Extract<PilotDeckBackgroundTaskStatus, "completed" | "failed" | "cancelled">;
+  exitCode?: number | null;
+  outputPreview: string;
+  totalBytes: number;
+  startedAt: string;
+  endedAt: string;
+};
+
+export type BackgroundTaskCompletionHandler = (event: BackgroundTaskCompletionEvent) => void;
 
 export type BackgroundTaskRuntimeOptions = {
   /** Optional dir under which to spill output (default: in-memory only). */
@@ -40,12 +54,17 @@ export type BackgroundTaskRuntimeOptions = {
   spawn?: typeof spawn;
   /** Hard cap on simultaneous tasks (default: 32). */
   maxTasks?: number;
+  /** Optional completion sink for hosts that want one-shot background task notifications. */
+  onCompletion?: BackgroundTaskCompletionHandler;
+  /** Maximum bytes included in completion output previews (default: 4000). */
+  completionPreviewBytes?: number;
 };
 
 export type StartTaskSpec = {
   command: string;
   cwd: string;
   env?: NodeJS.ProcessEnv;
+  sessionId?: string;
   agentId?: string;
   kind?: PilotDeckBackgroundTaskKind;
 };
@@ -64,13 +83,14 @@ type RuntimeEntry = {
 
 const DEFAULT_GRACE_MS = 5_000;
 const DEFAULT_MAX_TASKS = 32;
+const DEFAULT_COMPLETION_PREVIEW_BYTES = 4_000;
 
 export class BackgroundTaskRuntime {
   private readonly entries = new Map<string, RuntimeEntry>();
   private readonly options: Required<
     Pick<BackgroundTaskRuntimeOptions, "now" | "spawn" | "maxTasks">
   > &
-    Pick<BackgroundTaskRuntimeOptions, "diskSpillDir">;
+    Pick<BackgroundTaskRuntimeOptions, "diskSpillDir" | "onCompletion" | "completionPreviewBytes">;
 
   constructor(options: BackgroundTaskRuntimeOptions = {}) {
     this.options = {
@@ -78,6 +98,8 @@ export class BackgroundTaskRuntime {
       spawn: options.spawn ?? spawn,
       maxTasks: options.maxTasks ?? DEFAULT_MAX_TASKS,
       diskSpillDir: options.diskSpillDir,
+      onCompletion: options.onCompletion,
+      completionPreviewBytes: options.completionPreviewBytes ?? DEFAULT_COMPLETION_PREVIEW_BYTES,
     };
   }
 
@@ -117,6 +139,7 @@ export class BackgroundTaskRuntime {
       taskId,
       type: "local_bash",
       agentId: spec.agentId,
+      sessionId: spec.sessionId,
       kind: spec.kind ?? "bash",
       command: spec.command,
       cwd: spec.cwd,
@@ -157,6 +180,7 @@ export class BackgroundTaskRuntime {
       output.append(Buffer.from(`spawn error: ${message}\n`));
       task.outputBytes = output.totalBytes();
       this.entries.set(taskId, { task, output, done: Promise.resolve() });
+      this.notifyCompletion(task, output);
       resolveDone();
       return task;
     }
@@ -188,6 +212,7 @@ export class BackgroundTaskRuntime {
         task.status = "failed";
       }
       task.completionStatusSentInAttachment = true;
+      this.notifyCompletion(task, output);
       resolveDone();
     });
 
@@ -256,5 +281,28 @@ export class BackgroundTaskRuntime {
     if (!entry) throw new Error(`Unknown taskId: ${taskId}`);
     await entry.done;
     return entry.task;
+  }
+
+  private notifyCompletion(task: PilotDeckBackgroundBashTask, output: TaskOutputStore): void {
+    if (!this.options.onCompletion || !task.endedAt) {
+      return;
+    }
+    const previewBytes = Math.max(0, this.options.completionPreviewBytes ?? DEFAULT_COMPLETION_PREVIEW_BYTES);
+    const totalBytes = output.totalBytes();
+    const slice = output.readSlice(Math.max(0, totalBytes - previewBytes), previewBytes);
+    try {
+      this.options.onCompletion({
+        taskId: task.taskId,
+        sessionId: task.sessionId,
+        status: task.status as BackgroundTaskCompletionEvent["status"],
+        exitCode: task.exitCode,
+        outputPreview: slice.content,
+        totalBytes,
+        startedAt: task.startedAt.toISOString(),
+        endedAt: task.endedAt.toISOString(),
+      });
+    } catch {
+      // Completion notifications are best-effort and must never break task cleanup.
+    }
   }
 }

--- a/src/tool/builtin/bash.ts
+++ b/src/tool/builtin/bash.ts
@@ -42,15 +42,31 @@ const BASH_TOOL_DESCRIPTION = `Run a shell command in the PilotDeck workspace.
 Usage:
 - The \`command\` parameter is passed to the system shell (\`cmd.exe\` on Windows, \`/bin/sh\` on macOS/Linux).
 - The shell runs in the current workspace directory and inherits the tool runtime environment.
-- Use \`timeout\` to override the command timeout in milliseconds. When omitted, the default is 30000ms. Values above 600000ms are clamped to the maximum.
+- Use \`timeout\` to override the command timeout in milliseconds. When omitted, the default is 30000ms. Values above 600000ms are rejected; use task_create for longer-running commands.
 - Use \`description\` to provide a short, clear label for logs and audits. Prefer 3-10 words that say what the command does.
 - Use this tool for short shell commands, simple pipelines, and running saved workspace scripts.
+- Use task_create for long-running work such as dev servers, watchers, builds, test suites, deploys, CI pollers, or commands that need more than the maximum foreground timeout. Poll with task_output and stop long-lived processes with task_stop.
 - For non-trivial code or anything you will debug/rerun with changed parameters, first create or edit a script file with write_file/edit_file, then run that file. Avoid large inline heredocs, \`python - <<...\`, long \`python -c\`, or long \`node -e\` programs when a saved script would be reusable.
+- Do not use shell-level backgrounding (\`nohup\`, \`disown\`, \`setsid\`, trailing \`&\`) in bash. Use task_create so PilotDeck can track lifecycle and output.
 - Read-only shell commands (for example \`pwd\`, \`ls\`, \`git status\`, \`git diff\`, \`git log\`) are treated as read-only. Commands with side effects require permission, and known-dangerous commands are denied outright.
 - The tool returns stdout, stderr, exit code, and duration. Non-zero exits raise a tool error, and timeouts raise \`tool_timeout\`.
 - Successful results begin with \`BASH_RESULT[success][...]\` plus Assertions. Read \`retrieved_data_available\` before treating \`exit_code: 0\` as task progress: exit code 0 only proves the process succeeded, not that useful task data was retrieved.
 - If a task needs content but the result is \`empty_stdout\` or \`stderr_only\`, run a follow-up command that prints or verifies the needed data instead of assuming progress.
 - If you have no command to run, respond with text instead of calling bash.`;
+
+const LONG_TASK_HINT =
+  "Use task_create to start a tracked background task, task_output to poll output, and task_stop to clean up long-lived processes.";
+
+const SHELL_BACKGROUND_WRAPPER_RE = /(?:^|[;&|]\s*|&&\s*|\|\|\s*|\$\(\s*)(?:nohup|disown|setsid)\b/iu;
+const TRAILING_BACKGROUND_RE = /(?:^|[^&])&\s*(?:[)#}\]]\s*)?$/u;
+const INLINE_BACKGROUND_RE = /(?:^|[;|]\s*)[^\n;&|]+&\s*(?:[;|]|&&|\|\|)/u;
+const LONG_LIVED_COMMAND_PATTERNS = [
+  /(?:^|\s)(?:npm|pnpm|yarn|bun)\s+(?:run\s+)?(?:dev|start|serve|preview|watch)\b/iu,
+  /(?:^|\s)(?:vite|webpack(?:-dev-server)?|next|nuxt|astro|remix|svelte-kit)\b(?:[^\n]*\s(?:dev|start|preview|--host)\b|[^\n]*$)/iu,
+  /(?:^|\s)(?:python(?:3)?\s+-m\s+http\.server|uvicorn|gunicorn|flask\s+run|streamlit\s+run|fastapi\s+dev)\b/iu,
+  /(?:^|\s)(?:nodemon|tsx\s+watch|ts-node-dev|watchmedo)\b/iu,
+  /(?:^|\s)(?:cargo\s+watch|watchexec|entr)\b/iu,
+];
 
 export function createBashTool(options?: CreateBashToolOptions): PilotDeckToolDefinition<BashInput, BashOutput> {
   const runner = options?.runner ?? new NodeShellCommandRunner();
@@ -73,7 +89,7 @@ export function createBashTool(options?: CreateBashToolOptions): PilotDeckToolDe
         },
         timeout: {
           type: "integer",
-          description: "Optional timeout in milliseconds. Defaults to 30000. Max 600000.",
+          description: "Optional timeout in milliseconds. Defaults to 30000. Max 600000; larger values are rejected. Use task_create for longer-running commands.",
         },
         description: {
           type: "string",
@@ -88,7 +104,17 @@ export function createBashTool(options?: CreateBashToolOptions): PilotDeckToolDe
     checkPermissions: async (input) => input.command ? classifyBashPermission(input.command) : ({ type: "allow" as const, reason: { type: "runtime" as const, message: "Empty command is safe" } }),
     execute: async (input, context) => {
       const command = input.command.trim();
-      const timeoutMs = Math.min(Math.max(1, input.timeout ?? defaultTimeoutMs), maxTimeoutMs);
+      if (input.timeout !== undefined && input.timeout > maxTimeoutMs) {
+        throw new PilotDeckToolRuntimeError(
+          "invalid_tool_input",
+          `Foreground bash timeout ${input.timeout}ms exceeds the maximum of ${maxTimeoutMs}ms. ${LONG_TASK_HINT}`,
+        );
+      }
+      const backgroundGuidance = foregroundBackgroundGuidance(command);
+      if (backgroundGuidance) {
+        throw new PilotDeckToolRuntimeError("invalid_tool_input", `${backgroundGuidance} ${LONG_TASK_HINT}`);
+      }
+      const timeoutMs = Math.max(1, input.timeout ?? defaultTimeoutMs);
       const progress = context.progress;
       const toolCallId = ""; // ToolRuntime fills this via metadata; we pull from context if available.
       const emitProgress = progress
@@ -239,6 +265,33 @@ function formatShellFailure(
     lines.push("", "stdout:", result.stdout.trimEnd());
   }
   return lines.join("\n");
+}
+
+function foregroundBackgroundGuidance(command: string): string | undefined {
+  if (looksLikeHelpOrVersionCommand(command)) {
+    return undefined;
+  }
+
+  const unquoted = stripQuotedText(command);
+  if (SHELL_BACKGROUND_WRAPPER_RE.test(unquoted)) {
+    return "Foreground bash command uses shell-level background wrappers (nohup/disown/setsid).";
+  }
+  if (INLINE_BACKGROUND_RE.test(unquoted) || TRAILING_BACKGROUND_RE.test(unquoted)) {
+    return "Foreground bash command uses shell-level '&' backgrounding.";
+  }
+  if (LONG_LIVED_COMMAND_PATTERNS.some((pattern) => pattern.test(unquoted))) {
+    return "Foreground bash command appears to start a long-lived server, watcher, or dev process.";
+  }
+  return undefined;
+}
+
+function looksLikeHelpOrVersionCommand(command: string): boolean {
+  const normalized = command.trim().toLowerCase();
+  return /(?:^|\s)(?:--help|-h|help|--version|-v|version)\s*$/u.test(normalized);
+}
+
+function stripQuotedText(command: string): string {
+  return command.replace(/(['"])(?:\\.|(?!\1).)*\1/gu, "").replace(/`(?:\\.|[^`])*`/gu, "");
 }
 
 export type { PilotDeckCommandOptions, PilotDeckCommandResult, PilotDeckCommandRunner } from "./bash/commandRunner.js";

--- a/src/tool/builtin/taskTools.ts
+++ b/src/tool/builtin/taskTools.ts
@@ -163,6 +163,7 @@ export function createTaskCreateTool(
         command: input.command,
         cwd: context.cwd,
         env: context.env,
+        sessionId: context.sessionId,
         agentId: input.agentId,
         kind: input.kind,
       });

--- a/src/tool/builtin/webSearch.ts
+++ b/src/tool/builtin/webSearch.ts
@@ -1,6 +1,7 @@
 import type { PermissionResult } from "../../permission/index.js";
 import { PilotDeckToolRuntimeError } from "../protocol/errors.js";
 import type {
+  PilotDeckToolAvailabilityContext,
   PilotDeckToolDefinition,
   PilotDeckToolExecutionOutput,
   PilotDeckToolRuntimeContext,
@@ -114,6 +115,7 @@ Usage notes:
     isReadOnly: () => true,
     isConcurrencySafe: () => true,
     isOpenWorld: () => true,
+    checkAvailability: (context) => checkWebSearchAvailability(options, context),
     checkPermissions: async (): Promise<PermissionResult> => ({
       type: "ask",
       reason: {
@@ -188,6 +190,36 @@ Usage notes:
       });
     },
   };
+}
+
+function checkWebSearchAvailability(
+  options: CreateWebSearchToolOptions,
+  context: PilotDeckToolAvailabilityContext,
+) {
+  const runtimeContext = {
+    cwd: context.cwd,
+    env: context.env,
+  } as PilotDeckToolRuntimeContext;
+  const provider = resolveProvider(options.provider, options.apiKey, runtimeContext);
+  const apiKey = resolveApiKey(options.apiKey, provider, runtimeContext);
+  const custom = normalizeCustomProviderConfig(options.customProvider);
+
+  if (!apiKey && !(provider === "custom" && custom.auth === "none")) {
+    return {
+      ok: false as const,
+      code: "setup_required" as const,
+      reason: "web_search requires an API key.",
+    };
+  }
+  if (provider === "custom" && !options.endpoint?.trim()) {
+    return {
+      ok: false as const,
+      code: "setup_required" as const,
+      reason: "web_search custom provider requires an endpoint URL.",
+    };
+  }
+
+  return { ok: true as const };
 }
 
 function resolveProvider(

--- a/src/tool/index.ts
+++ b/src/tool/index.ts
@@ -30,6 +30,8 @@ export type {
 } from "./protocol/schema.js";
 export type {
   PilotDeckToolCall,
+  PilotDeckToolAvailability,
+  PilotDeckToolAvailabilityContext,
   PilotDeckToolDefinition,
   PilotDeckToolExecutionOutput,
   PilotDeckToolSupplementalMessage,
@@ -53,6 +55,11 @@ export type {
 } from "./protocol/types.js";
 export { ToolRegistry } from "./registry/ToolRegistry.js";
 export { createBuiltinRegistry, type CreateBuiltinRegistryOptions } from "./registry/createBuiltinRegistry.js";
+export {
+  filterAvailableTools,
+  type FilterAvailableToolsResult,
+  type PilotDeckUnavailableToolDiagnostic,
+} from "./registry/filterAvailableTools.js";
 export { ConcurrentToolScheduler } from "./scheduler/ConcurrentToolScheduler.js";
 export { SequentialToolScheduler } from "./scheduler/SequentialToolScheduler.js";
 export type { PilotDeckToolScheduler } from "./scheduler/ToolScheduler.js";

--- a/src/tool/protocol/types.ts
+++ b/src/tool/protocol/types.ts
@@ -133,6 +133,15 @@ export type PilotDeckToolExecutionOutput<Output = unknown> = {
   metadata?: Record<string, unknown>;
 };
 
+export type PilotDeckToolAvailability =
+  | { ok: true }
+  | { ok: false; code: "setup_required" | "unavailable" | "failed_check"; reason: string };
+
+export type PilotDeckToolAvailabilityContext = {
+  cwd: string;
+  env?: NodeJS.ProcessEnv;
+};
+
 /**
  * Tool progress event emitted via `PilotDeckToolRuntimeContext.progress`.
  * The sink is fire-and-forget — progress events MUST NOT replace the final
@@ -389,6 +398,7 @@ export type PilotDeckToolDefinition<Input = unknown, Output = unknown> = {
   requiresUserInteraction?(input: Input): boolean;
   isOpenWorld?(input: Input): boolean;
   validateInput?(input: Input, context: PilotDeckToolRuntimeContext): Promise<PilotDeckToolValidationResult>;
+  checkAvailability?(context: PilotDeckToolAvailabilityContext): PilotDeckToolAvailability | Promise<PilotDeckToolAvailability>;
   checkPermissions?(input: Input, context: PilotDeckToolRuntimeContext): Promise<PermissionResult>;
   execute(input: Input, context: PilotDeckToolRuntimeContext): Promise<PilotDeckToolExecutionOutput<Output>>;
 };

--- a/src/tool/registry/filterAvailableTools.ts
+++ b/src/tool/registry/filterAvailableTools.ts
@@ -1,0 +1,70 @@
+import type {
+  PilotDeckToolAvailability,
+  PilotDeckToolAvailabilityContext,
+  PilotDeckToolDefinition,
+} from "../protocol/types.js";
+import { ToolRegistry } from "./ToolRegistry.js";
+
+export type PilotDeckUnavailableToolDiagnostic = {
+  toolName: string;
+  code: Exclude<PilotDeckToolAvailability, { ok: true }>["code"];
+  reason: string;
+};
+
+export type FilterAvailableToolsResult = {
+  registry: ToolRegistry;
+  unavailable: PilotDeckUnavailableToolDiagnostic[];
+};
+
+export async function filterAvailableTools(
+  registry: ToolRegistry,
+  context: PilotDeckToolAvailabilityContext,
+): Promise<FilterAvailableToolsResult> {
+  const filtered = new ToolRegistry();
+  const unavailable: PilotDeckUnavailableToolDiagnostic[] = [];
+  const checkCache = new Map<
+    NonNullable<PilotDeckToolDefinition["checkAvailability"]>,
+    Promise<PilotDeckToolAvailability>
+  >();
+
+  for (const tool of registry.list()) {
+    const availability = await resolveToolAvailability(tool, context, checkCache);
+    if (availability.ok) {
+      filtered.register(tool);
+      continue;
+    }
+
+    unavailable.push({
+      toolName: tool.name,
+      code: availability.code,
+      reason: availability.reason,
+    });
+  }
+
+  return { registry: filtered, unavailable };
+}
+
+async function resolveToolAvailability(
+  tool: PilotDeckToolDefinition,
+  context: PilotDeckToolAvailabilityContext,
+  cache: Map<NonNullable<PilotDeckToolDefinition["checkAvailability"]>, Promise<PilotDeckToolAvailability>>,
+): Promise<PilotDeckToolAvailability> {
+  const check = tool.checkAvailability;
+  if (!check) {
+    return { ok: true };
+  }
+
+  let promise = cache.get(check);
+  if (!promise) {
+    promise = Promise.resolve()
+      .then(() => check(context))
+      .catch((error): PilotDeckToolAvailability => ({
+        ok: false,
+        code: "failed_check",
+        reason: error instanceof Error ? error.message : String(error),
+      }));
+    cache.set(check, promise);
+  }
+
+  return promise;
+}

--- a/tests/agent/agentLoopToolNameRepair.spec.ts
+++ b/tests/agent/agentLoopToolNameRepair.spec.ts
@@ -1,0 +1,110 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { AgentLoop, type AgentLoopInput } from "../../src/agent/index.js";
+import type { AgentRuntimeConfig } from "../../src/agent/runtime/AgentRuntimeConfig.js";
+import type { AgentRuntimeDependencies } from "../../src/agent/runtime/AgentRuntimeDependencies.js";
+import type { CanonicalMessage, CanonicalModelRequest, CanonicalToolCall } from "../../src/model/index.js";
+import type { RouterDecision } from "../../src/router/protocol/decision.js";
+import { ToolRegistry, type PilotDeckToolDefinition, type PilotDeckToolResult } from "../../src/tool/index.js";
+
+function createReadFileTool(): PilotDeckToolDefinition {
+  return {
+    name: "read_file",
+    description: "Read a file.",
+    kind: "filesystem",
+    inputSchema: { type: "object", additionalProperties: false, properties: {} },
+    isReadOnly: () => true,
+    isConcurrencySafe: () => true,
+    execute: async () => ({ content: [{ type: "text", text: "ok" }] }),
+  };
+}
+
+function createConfig(): AgentRuntimeConfig {
+  return {
+    provider: "test",
+    model: "test-model",
+    cwd: process.cwd(),
+    permissionMode: "default",
+    permissionContext: {
+      cwd: process.cwd(),
+      additionalWorkingDirectories: [],
+      mode: "default",
+      canPrompt: false,
+      bypassAvailable: false,
+      rules: { allow: [], deny: [], ask: [] },
+    },
+  };
+}
+
+function createDecision(request: CanonicalModelRequest): RouterDecision {
+  return {
+    provider: request.provider,
+    model: request.model,
+    scenarioType: "default",
+    isSubagent: false,
+    orchestrating: false,
+    resolvedFrom: "scenario",
+    mutations: {},
+  };
+}
+
+test("text-fallback tool name repair updates durable assistant message before execution", async () => {
+  const registry = new ToolRegistry();
+  registry.register(createReadFileTool());
+  const durableMessages: CanonicalMessage[] = [];
+  let executedToolName: string | undefined;
+
+  const dependencies: AgentRuntimeDependencies = {
+    router: {
+      decide: async (input) => createDecision(input.request),
+      execute: async function* () {
+        yield { type: "message_start", role: "assistant" as const };
+        yield {
+          type: "text_delta",
+          text: "<function=READ_FILE>\n<parameter=path>/tmp/a.txt</parameter>\n</function>",
+        };
+        yield { type: "message_end", finishReason: "stop" as const };
+      },
+      stream: async function* () {},
+    },
+    tools: {
+      registry,
+      scheduler: {
+        executeAll: async (calls: CanonicalToolCall[]): Promise<PilotDeckToolResult[]> => {
+          executedToolName = calls[0]?.name;
+          return calls.map((call) => ({
+            type: "success" as const,
+            toolCallId: call.id,
+            toolName: call.name,
+            content: [{ type: "text", text: "ok" }],
+            startedAt: new Date(0).toISOString(),
+            completedAt: new Date(0).toISOString(),
+          }));
+        },
+      },
+    },
+    now: () => new Date(0),
+  };
+
+  const loop = new AgentLoop(createConfig(), dependencies);
+  const input: AgentLoopInput = {
+    sessionId: "s",
+    turnId: "t",
+    maxTurns: 1,
+    messages: [{ role: "user", content: [{ type: "text", text: "read it" }] }],
+    onDurableMessage: (message) => {
+      durableMessages.push(message);
+    },
+  };
+
+  for await (const _event of loop.run(input)) {
+    // consume stream
+  }
+
+  const assistant = durableMessages.find((message) => message.role === "assistant");
+  const toolCall = assistant?.content.find((block) => block.type === "tool_call");
+  assert.equal(toolCall?.type, "tool_call");
+  assert.equal(toolCall?.name, "read_file");
+  assert.equal(executedToolName, "read_file");
+});

--- a/tests/model/textToolCalls.spec.ts
+++ b/tests/model/textToolCalls.spec.ts
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  assembleAssistantMessage,
+  createModelMessageAssemblerState,
+  detectFormatByText,
+  extractTextToolCalls,
+  getSelfCorrectPrompt,
+} from "../../src/model/index.js";
+import { repairToolName } from "../../src/model/streaming/repairToolName.js";
+
+test("extracts supported text tool call formats", () => {
+  const cases = [
+    {
+      name: "qwen_xml",
+      text: "<function=read_file>\n<parameter=path>/tmp/a.txt</parameter>\n</function>",
+    },
+    {
+      name: "deepseek_dsml",
+      text: "<｜DSML｜tool_calls>\n<｜DSML｜invoke name=\"read_file\">\n<｜DSML｜parameter name=\"path\">/tmp/a.txt</content>\n</｜DSML｜invoke>\n</｜DSML｜tool_calls>",
+    },
+    {
+      name: "hermes_json",
+      text: "<tool_call>{\"name\":\"read_file\",\"arguments\":{\"path\":\"/tmp/a.txt\"}}</tool_call>",
+    },
+    {
+      name: "mistral",
+      text: "[TOOL_CALLS] [{\"name\":\"read_file\",\"arguments\":{\"path\":\"/tmp/a.txt\"}}]",
+    },
+    {
+      name: "llama",
+      text: "<|python_tag|>{\"name\":\"read_file\",\"parameters\":{\"path\":\"/tmp/a.txt\"}}",
+    },
+  ] as const;
+
+  for (const item of cases) {
+    const result = extractTextToolCalls(item.text);
+    assert.equal(result.detectedFormat, item.name);
+    assert.equal(result.toolCalls.length, 1);
+    assert.equal(result.toolCalls[0]?.name, "read_file");
+    assert.equal(result.extractedFromText, true);
+  }
+});
+
+test("reports partial tool calls without extracting a call", () => {
+  const result = extractTextToolCalls("<function=read_file>\n<parameter=path>/tmp/a.txt");
+  assert.equal(result.toolCalls.length, 0);
+  assert.equal(result.detectedFormat, "qwen_xml");
+  assert.equal(result.parseError, true);
+  assert.equal(result.partialToolCall?.format, "qwen_xml");
+});
+
+test("marks unparsed text tool calls on assembled messages", () => {
+  const state = createModelMessageAssemblerState();
+  state.content.push({ type: "text", text: "[TOOL_CALLS] not-json" });
+  const assembled = assembleAssistantMessage(state);
+  assert.equal(assembled.toolCalls.length, 0);
+  assert.equal(assembled.hasUnparsedTextToolCall, true);
+  assert.equal(assembled.textToolCallFormat, "mistral");
+});
+
+test("builds format-aware self-correction prompts", () => {
+  const prompt = getSelfCorrectPrompt("qwen_xml", "<function=read_file>");
+  assert.match(prompt, /Qwen XML/);
+  assert.match(prompt, /<function=read_file>/);
+});
+
+test("detects tool call format by marker", () => {
+  assert.equal(detectFormatByText("[TOOL_CALLS] []")?.id, "mistral");
+});
+
+test("repairs safe tool name variants", () => {
+  const valid = ["read_file", "write_file", "bash"];
+  assert.deepEqual(repairToolName("cat", valid, { cat: "read_file" }), {
+    name: "read_file",
+    reason: "alias",
+  });
+  assert.deepEqual(repairToolName("READ_FILE", valid), {
+    name: "read_file",
+    reason: "case_insensitive",
+  });
+  assert.deepEqual(repairToolName("read-file", valid), {
+    name: "read_file",
+    reason: "normalized",
+  });
+  assert.deepEqual(repairToolName("read_fiel", valid), {
+    name: "read_file",
+    reason: "edit_distance",
+  });
+});
+
+test("does not repair low-confidence tool names", () => {
+  assert.equal(repairToolName("run", ["bash", "read_file"]), undefined);
+  assert.equal(repairToolName("unknown_tool", ["bash", "read_file"]), undefined);
+});

--- a/tests/task/backgroundTaskRuntime.spec.ts
+++ b/tests/task/backgroundTaskRuntime.spec.ts
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { BackgroundTaskRuntime, type BackgroundTaskCompletionEvent } from "../../src/task/runtime/BackgroundTaskRuntime.js";
+
+describe("BackgroundTaskRuntime completion notifications", () => {
+  it("emits one completion event with bounded output preview", async () => {
+    const events: BackgroundTaskCompletionEvent[] = [];
+    const runtime = new BackgroundTaskRuntime({
+      onCompletion: (event) => events.push(event),
+      completionPreviewBytes: 10,
+    });
+
+    const task = await runtime.start({
+      command: `${process.execPath} -e "process.stdout.write('0123456789abcdef')"`,
+      cwd: process.cwd(),
+      sessionId: "session-1",
+    });
+    const completed = await runtime.waitFor(task.taskId);
+
+    assert.equal(completed.status, "completed");
+    assert.equal(events.length, 1);
+    assert.equal(events[0]?.sessionId, "session-1");
+    assert.equal(events[0]?.taskId, task.taskId);
+    assert.equal(events[0]?.status, "completed");
+    assert.equal(events[0]?.exitCode, 0);
+    assert.equal(events[0]?.totalBytes, 16);
+    assert.equal(events[0]?.outputPreview, "6789abcdef");
+    assert.ok(events[0]?.startedAt);
+    assert.ok(events[0]?.endedAt);
+  });
+
+  it("emits cancelled when a running task is stopped", async () => {
+    const events: BackgroundTaskCompletionEvent[] = [];
+    const runtime = new BackgroundTaskRuntime({ onCompletion: (event) => events.push(event) });
+
+    const task = await runtime.start({
+      command: `${process.execPath} -e "setTimeout(() => {}, 10000)"`,
+      cwd: process.cwd(),
+      sessionId: "session-2",
+    });
+    await runtime.stop(task.taskId, { graceMs: 1 });
+
+    assert.equal(events.length, 1);
+    assert.equal(events[0]?.status, "cancelled");
+    assert.equal(events[0]?.taskId, task.taskId);
+  });
+});

--- a/tests/tool/bash.spec.ts
+++ b/tests/tool/bash.spec.ts
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { createDefaultPermissionContext, PermissionRuntime } from "../../src/permission/index.js";
+import { createBashTool } from "../../src/tool/builtin/bash.js";
+import { ToolRuntime } from "../../src/tool/execution/ToolRuntime.js";
+import { ToolRegistry } from "../../src/tool/registry/ToolRegistry.js";
+import type { PilotDeckCommandRunner, PilotDeckToolRuntimeContext } from "../../src/tool/index.js";
+
+function createContext(): PilotDeckToolRuntimeContext {
+  const cwd = "/tmp/workspace";
+  return {
+    sessionId: "session-1",
+    turnId: "turn-1",
+    cwd,
+    permissionMode: "bypassPermissions",
+    permissionContext: createDefaultPermissionContext({ cwd, mode: "bypassPermissions", canPrompt: false }),
+  };
+}
+
+function createRuntime(runner: PilotDeckCommandRunner): ToolRuntime {
+  const registry = new ToolRegistry();
+  registry.register(createBashTool({ runner, maxTimeoutMs: 600_000 }));
+  return new ToolRuntime(registry, new PermissionRuntime());
+}
+
+describe("bash long-running guardrails", () => {
+  it("rejects foreground timeout above the maximum", async () => {
+    let ran = false;
+    const runtime = createRuntime({
+      run: async () => {
+        ran = true;
+        return { exitCode: 0, stdout: "", stderr: "", timedOut: false, durationMs: 1 };
+      },
+    });
+
+    const result = await runtime.execute({ id: "call-1", name: "bash", input: { command: "echo ok", timeout: 600_001 } }, createContext());
+
+    assert.equal(result.type, "error");
+    assert.equal(result.error.code, "invalid_tool_input");
+    assert.match(result.error.message, /task_create/u);
+    assert.equal(ran, false);
+  });
+
+  it("rejects long-lived and shell-backgrounded foreground commands", async () => {
+    const runtime = createRuntime({
+      run: async () => ({ exitCode: 0, stdout: "", stderr: "", timedOut: false, durationMs: 1 }),
+    });
+    const commands = [
+      "pnpm dev",
+      "npm run dev",
+      "vite --host 0.0.0.0",
+      "python -m http.server 8000",
+      "nohup node server.js &",
+      "setsid node server.js",
+      "node server.js &",
+    ];
+
+    for (const command of commands) {
+      const result = await runtime.execute({ id: `call-${command}`, name: "bash", input: { command } }, createContext());
+      assert.equal(result.type, "error", command);
+      assert.equal(result.error.code, "invalid_tool_input", command);
+      assert.match(result.error.message, /task_create/u, command);
+      assert.match(result.error.message, /task_output/u, command);
+    }
+  });
+
+  it("allows help commands and timeout exactly at the maximum", async () => {
+    const seen: Array<{ command: string; timeoutMs: number }> = [];
+    const runtime = createRuntime({
+      run: async (command, options) => {
+        seen.push({ command, timeoutMs: options.timeoutMs });
+        return { exitCode: 0, stdout: "usage", stderr: "", timedOut: false, durationMs: 1 };
+      },
+    });
+
+    const help = await runtime.execute({ id: "call-help", name: "bash", input: { command: "pnpm dev --help" } }, createContext());
+    assert.equal(help.type, "success");
+
+    const max = await runtime.execute({ id: "call-max", name: "bash", input: { command: "echo ok", timeout: 600_000 } }, createContext());
+    assert.equal(max.type, "success");
+    assert.deepEqual(seen.map((item) => item.timeoutMs), [30_000, 600_000]);
+  });
+});

--- a/tests/tool/toolAvailability.spec.ts
+++ b/tests/tool/toolAvailability.spec.ts
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { PilotDeckToolDefinition } from "../../src/tool/protocol/types.js";
+import { filterAvailableTools } from "../../src/tool/registry/filterAvailableTools.js";
+import { ToolRegistry } from "../../src/tool/registry/ToolRegistry.js";
+
+function createTool(
+  name: string,
+  overrides: Partial<PilotDeckToolDefinition> = {},
+): PilotDeckToolDefinition {
+  return {
+    name,
+    description: `${name} test tool`,
+    kind: "custom",
+    inputSchema: { type: "object", additionalProperties: false, properties: {} },
+    isReadOnly: () => true,
+    isConcurrencySafe: () => true,
+    execute: async () => ({ content: [{ type: "text", text: name }] }),
+    ...overrides,
+  };
+}
+
+test("filterAvailableTools removes unavailable tools and keeps diagnostics", async () => {
+  const registry = new ToolRegistry();
+  registry.register(createTool("available"));
+  registry.register(createTool("missing_setup", {
+    checkAvailability: () => ({ ok: false, code: "setup_required", reason: "missing API key" }),
+  }));
+
+  const result = await filterAvailableTools(registry, { cwd: process.cwd(), env: {} });
+
+  assert.equal(result.registry.has("available"), true);
+  assert.equal(result.registry.has("missing_setup"), false);
+  assert.deepEqual(result.unavailable, [
+    { toolName: "missing_setup", code: "setup_required", reason: "missing API key" },
+  ]);
+});
+
+test("filterAvailableTools converts throwing checks into failed_check diagnostics", async () => {
+  const registry = new ToolRegistry();
+  registry.register(createTool("broken", {
+    checkAvailability: () => {
+      throw new Error("boom");
+    },
+  }));
+
+  const result = await filterAvailableTools(registry, { cwd: process.cwd(), env: {} });
+
+  assert.equal(result.registry.has("broken"), false);
+  assert.deepEqual(result.unavailable, [
+    { toolName: "broken", code: "failed_check", reason: "boom" },
+  ]);
+});
+
+test("filterAvailableTools caches shared checks within one filtering pass", async () => {
+  let calls = 0;
+  const sharedCheck = () => {
+    calls += 1;
+    return { ok: true as const };
+  };
+  const registry = new ToolRegistry();
+  registry.register(createTool("one", { checkAvailability: sharedCheck }));
+  registry.register(createTool("two", { checkAvailability: sharedCheck }));
+
+  const result = await filterAvailableTools(registry, { cwd: process.cwd(), env: {} });
+
+  assert.equal(result.registry.has("one"), true);
+  assert.equal(result.registry.has("two"), true);
+  assert.equal(calls, 1);
+});

--- a/tests/tool/webSearchAvailability.spec.ts
+++ b/tests/tool/webSearchAvailability.spec.ts
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createWebSearchTool } from "../../src/tool/builtin/webSearch.js";
+import { filterAvailableTools } from "../../src/tool/registry/filterAvailableTools.js";
+import { ToolRegistry } from "../../src/tool/registry/ToolRegistry.js";
+
+async function availabilityForWebSearch(options: Parameters<typeof createWebSearchTool>[0], env: NodeJS.ProcessEnv = {}) {
+  const registry = new ToolRegistry();
+  registry.register(createWebSearchTool(options));
+  return filterAvailableTools(registry, { cwd: process.cwd(), env });
+}
+
+test("web_search is unavailable when no API key is configured", async () => {
+  const result = await availabilityForWebSearch({}, {});
+
+  assert.equal(result.registry.has("web_search"), false);
+  assert.deepEqual(result.unavailable, [
+    { toolName: "web_search", code: "setup_required", reason: "web_search requires an API key." },
+  ]);
+});
+
+test("web_search is available with GLM, ZAI, Tavily, or explicit API keys", async () => {
+  const cases: Array<[string, Parameters<typeof createWebSearchTool>[0], NodeJS.ProcessEnv]> = [
+    ["GLM env", {}, { GLM_WEB_SEARCH_API_KEY: "glm-key" }],
+    ["ZAI env", {}, { ZAI_API_KEY: "zai-key" }],
+    ["Tavily env", { provider: "tavily" }, { TAVILY_API_KEY: "tavily-key" }],
+    ["explicit key", { apiKey: "explicit-key" }, {}],
+  ];
+
+  for (const [name, options, env] of cases) {
+    const result = await availabilityForWebSearch(options, env);
+    assert.equal(result.registry.has("web_search"), true, name);
+    assert.deepEqual(result.unavailable, [], name);
+  }
+});
+
+test("custom web_search auth none requires only an endpoint", async () => {
+  const available = await availabilityForWebSearch({
+    provider: "custom",
+    endpoint: "https://search.example.test",
+    customProvider: { auth: "none" },
+  }, {});
+  assert.equal(available.registry.has("web_search"), true);
+  assert.deepEqual(available.unavailable, []);
+
+  const unavailable = await availabilityForWebSearch({
+    provider: "custom",
+    customProvider: { auth: "none" },
+  }, {});
+  assert.equal(unavailable.registry.has("web_search"), false);
+  assert.deepEqual(unavailable.unavailable, [
+    {
+      toolName: "web_search",
+      code: "setup_required",
+      reason: "web_search custom provider requires an endpoint URL.",
+    },
+  ]);
+});


### PR DESCRIPTION
## Summary
- add a registry-backed text tool-call parser with format-aware self-correction prompts
- repair safe text-fallback tool name variants before execution
- add tool availability checks/filtering, web_search setup gating, bash long-task guardrails, and background-task completion notifications

## Tests
- npm test