### PR TITLE
fix(ui): normalize Windows path suggestions

### DIFF
--- a/ui/server/index.js
+++ b/ui/server/index.js
@@ -884,15 +884,61 @@ app.get('/api/search/conversations', authenticateToken, async (req, res) => {
     }
 });
 
+const normalizeWindowsDriveRoot = (inputPath) => {
+    if (process.platform !== 'win32' || typeof inputPath !== 'string') {
+        return inputPath;
+    }
+
+    const trimmedPath = inputPath.trim();
+    return /^[A-Za-z]:$/.test(trimmedPath) ? `${trimmedPath}\\` : inputPath;
+};
+
 const expandWorkspacePath = (inputPath) => {
     if (!inputPath) return inputPath;
-    if (inputPath === '~') {
+    const normalizedInput = normalizeWindowsDriveRoot(inputPath);
+    if (normalizedInput === '~') {
         return WORKSPACES_ROOT;
     }
-    if (inputPath.startsWith('~/') || inputPath.startsWith('~\\')) {
-        return path.join(WORKSPACES_ROOT, inputPath.slice(2));
+    if (normalizedInput.startsWith('~/') || normalizedInput.startsWith('~\\')) {
+        return path.join(WORKSPACES_ROOT, normalizedInput.slice(2));
     }
-    return inputPath;
+    return normalizedInput;
+};
+
+const isWindowsDriveBrowserRoot = (inputPath) => {
+    if (process.platform !== 'win32' || typeof inputPath !== 'string') {
+        return false;
+    }
+
+    const trimmedPath = inputPath.trim();
+    return trimmedPath === '/' || trimmedPath === '\\';
+};
+
+const getWindowsDriveSuggestions = async () => {
+    if (process.platform !== 'win32') {
+        return [];
+    }
+
+    const driveLetters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('');
+    const driveChecks = driveLetters.map(async (letter) => {
+        const drivePath = `${letter}:\\`;
+        try {
+            const stats = await fsPromises.stat(drivePath);
+            if (!stats.isDirectory()) {
+                return null;
+            }
+            return {
+                path: drivePath,
+                name: drivePath,
+                type: 'directory',
+            };
+        } catch (error) {
+            return null;
+        }
+    });
+
+    const drives = await Promise.all(driveChecks);
+    return drives.filter(Boolean);
 };
 
 function resolvePathInProject(projectRoot, targetPath = '') {
@@ -1107,6 +1153,15 @@ app.get('/api/browse-filesystem', authenticateToken, async (req, res) => {
         console.log('[API] WORKSPACES_ROOT is:', WORKSPACES_ROOT);
         // Default to home directory if no path provided
         const defaultRoot = WORKSPACES_ROOT;
+
+        if (isWindowsDriveBrowserRoot(dirPath)) {
+            const suggestions = await getWindowsDriveSuggestions();
+            return res.json({
+                path: '/',
+                suggestions,
+            });
+        }
+
         let targetPath = dirPath ? expandWorkspacePath(dirPath) : defaultRoot;
 
         // Resolve and normalize the path

--- a/ui/src/components/project-creation-wizard/components/FolderBrowserModal.tsx
+++ b/ui/src/components/project-creation-wizard/components/FolderBrowserModal.tsx
@@ -60,6 +60,11 @@ export default function FolderBrowserModal({
     [folders, showHiddenFolders],
   );
 
+  const isWindowsDrivePicker = useMemo(
+    () => currentPath === '/' && folders.some((folder) => /^[A-Za-z]:\\$/.test(folder.path)),
+    [currentPath, folders],
+  );
+
   const resetNewFolderState = () => {
     setShowNewFolderInput(false);
     setNewFolderName('');
@@ -72,6 +77,10 @@ export default function FolderBrowserModal({
   };
 
   const handleCreateFolder = useCallback(async () => {
+    if (isWindowsDrivePicker) {
+      return;
+    }
+
     if (!newFolderName.trim()) {
       return;
     }
@@ -89,7 +98,7 @@ export default function FolderBrowserModal({
     } finally {
       setCreatingFolder(false);
     }
-  }, [currentPath, loadFolders, newFolderName]);
+  }, [currentPath, isWindowsDrivePicker, loadFolders, newFolderName]);
 
   const parentPath = getParentPath(currentPath);
 
@@ -128,6 +137,7 @@ export default function FolderBrowserModal({
                   : 'text-muted-foreground hover:bg-accent hover:text-foreground'
               }`}
               title="Create new folder"
+              disabled={isWindowsDrivePicker}
             >
               <Plus className="h-5 w-5" strokeWidth={1.75} />
             </button>
@@ -141,7 +151,7 @@ export default function FolderBrowserModal({
           </div>
         </div>
 
-        {showNewFolderInput && (
+        {showNewFolderInput && !isWindowsDrivePicker && (
           <div className="border-b border-border bg-muted/40 px-4 py-3">
             <div className="flex items-center gap-2">
               <Input
@@ -245,6 +255,7 @@ export default function FolderBrowserModal({
             <Button
               variant="outline"
               onClick={() => onFolderSelected(currentPath, autoAdvanceOnSelect)}
+              disabled={isWindowsDrivePicker}
             >
               Use this folder
             </Button>

--- a/ui/src/components/project-creation-wizard/components/WorkspacePathField.tsx
+++ b/ui/src/components/project-creation-wizard/components/WorkspacePathField.tsx
@@ -26,7 +26,7 @@ export default function WorkspacePathField({
   const [showFolderBrowser, setShowFolderBrowser] = useState(false);
 
   useEffect(() => {
-    if (value.trim().length <= 2) {
+    if (value.trim().length < 2) {
       setPathSuggestions([]);
       setShowPathDropdown(false);
       return;

--- a/ui/src/components/project-creation-wizard/components/WorkspacePathField.tsx
+++ b/ui/src/components/project-creation-wizard/components/WorkspacePathField.tsx
@@ -6,6 +6,9 @@ import { getSuggestionRootPath } from '../utils/pathUtils';
 import type { FolderSuggestion, WorkspaceType } from '../types';
 import FolderBrowserModal from './FolderBrowserModal';
 
+const normalizePathForSuggestionMatch = (pathValue: string) =>
+  pathValue.trim().replace(/\\/g, '/').toLowerCase();
+
 type WorkspacePathFieldProps = {
   workspaceType: WorkspaceType;
   value: string;
@@ -37,11 +40,11 @@ export default function WorkspacePathField({
       try {
         const directoryPath = getSuggestionRootPath(value);
         const result = await browseFilesystemFolders(directoryPath);
-        const normalizedInput = value.toLowerCase();
+        const normalizedInput = normalizePathForSuggestionMatch(value);
 
         const matchingSuggestions = result.suggestions
           .filter((suggestion) => {
-            const normalizedSuggestion = suggestion.path.toLowerCase();
+            const normalizedSuggestion = normalizePathForSuggestionMatch(suggestion.path);
             return (
               normalizedSuggestion.startsWith(normalizedInput) &&
               normalizedSuggestion !== normalizedInput

--- a/ui/src/components/project-creation-wizard/utils/pathUtils.ts
+++ b/ui/src/components/project-creation-wizard/utils/pathUtils.ts
@@ -1,7 +1,7 @@
 import type { WorkspaceType } from '../types';
 
 const SSH_PREFIXES = ['git@', 'ssh://'];
-const WINDOWS_DRIVE_PATTERN = /^[A-Za-z]:\\?$/;
+const WINDOWS_DRIVE_PATTERN = /^[A-Za-z]:[\\/]?$/;
 
 export const isSshGitUrl = (url: string): boolean => {
   const trimmedUrl = url.trim();
@@ -18,6 +18,10 @@ export const isCloneWorkflow = (workspaceType: WorkspaceType, githubUrl: string)
 
 export const getSuggestionRootPath = (inputPath: string): string => {
   const trimmedPath = inputPath.trim();
+  if (/^[A-Za-z]:$/.test(trimmedPath)) {
+    return `${trimmedPath}\\`;
+  }
+
   const lastSeparatorIndex = Math.max(trimmedPath.lastIndexOf('/'), trimmedPath.lastIndexOf('\\'));
   if (lastSeparatorIndex === 2 && /^[A-Za-z]:/.test(trimmedPath)) {
     return `${trimmedPath.slice(0, 2)}\\`;
@@ -28,8 +32,11 @@ export const getSuggestionRootPath = (inputPath: string): string => {
 
 // Handles root edge cases for Unix-like and Windows paths.
 export const getParentPath = (currentPath: string): string | null => {
-  if (currentPath === '/' || WINDOWS_DRIVE_PATTERN.test(currentPath)) {
+  if (currentPath === '/') {
     return null;
+  }
+  if (WINDOWS_DRIVE_PATTERN.test(currentPath)) {
+    return '/';
   }
   if (currentPath === '~') {
     return '/';
@@ -50,6 +57,9 @@ export const getParentPath = (currentPath: string): string | null => {
 export const joinFolderPath = (basePath: string, folderName: string): string => {
   const normalizedBasePath = basePath.trim().replace(/[\\/]+$/, '');
   const separator =
-    normalizedBasePath.includes('\\') && !normalizedBasePath.includes('/') ? '\\' : '/';
+    WINDOWS_DRIVE_PATTERN.test(normalizedBasePath) ||
+    (normalizedBasePath.includes('\\') && !normalizedBasePath.includes('/'))
+      ? '\\'
+      : '/';
   return `${normalizedBasePath}${separator}${folderName.trim()}`;
 };


### PR DESCRIPTION
## Summary\n- Normalize Windows path separators before matching workspace path suggestions\n- Allow drive-root input like C: to trigger autocomplete\n\n## Validation\n- git diff --check passed for touched files\n- npm run typecheck currently fails due to unrelated existing React/type errors in the workspace\n