### PR TITLE
Avoid linkifying file paths inside code

### DIFF
--- a/ui/src/components/chat-v2/MessageRowV2.tsx
+++ b/ui/src/components/chat-v2/MessageRowV2.tsx
@@ -24,6 +24,7 @@ import { processSummaryToTrace, type ProcessAttachment } from './processGrouping
 import SubagentCard from './SubagentCard';
 import { useTypewriter } from './useTypewriter';
 import DocumentReferenceChip from './DocumentReferenceChip';
+import { linkifyFilePathsOutsideCode } from './linkifyFilePathsOutsideCode';
 
 type DiffLine = { type: string; content: string; lineNum: number };
 
@@ -64,31 +65,6 @@ const getAttachmentAccent = (name?: string, mimeType?: string): string => {
   if (label === 'ppt' || label === 'pptx') return 'bg-orange-500 text-white';
   return 'bg-neutral-500 text-white';
 };
-
-const LINKABLE_INLINE_FILE_EXTENSIONS = new Set([
-  'pdf', 'html', 'htm', 'png', 'jpg', 'jpeg', 'gif', 'webp', 'svg',
-  'txt', 'md', 'csv', 'json', 'doc', 'docx', 'xls', 'xlsx', 'ppt', 'pptx', 'py', 'js', 'ts', 'tsx', 'css',
-]);
-
-const escapeMarkdownLinkText = (value: string): string => value.replace(/([\\\]\[])/g, '\\$1');
-
-const toFileHref = (pathValue: string): string => {
-  if (/^file:\/\//i.test(pathValue)) return pathValue;
-  if (pathValue.startsWith('/')) return `file://${encodeURI(pathValue)}`;
-  return encodeURI(pathValue.replace(/\\/g, '/'));
-};
-
-function linkifyFilePaths(content: string): string {
-  const pattern = /((?:file:\/\/)?\/(?:[^\s`'"<>])+\.[A-Za-z0-9]{1,10}|(?:\.\/)?\b[A-Za-z0-9._-][A-Za-z0-9._/-]*\.[A-Za-z0-9]{1,10}\b)/gu;
-  return content.replace(pattern, (match, pathValue: string, offset: number, fullText: string) => {
-    const before = fullText.slice(Math.max(0, offset - 2), offset);
-    const after = fullText.slice(offset + match.length, offset + match.length + 1);
-    if (before.includes('](') || after === ')') return match;
-    const extension = pathValue.split('.').pop()?.toLowerCase() || '';
-    if (!LINKABLE_INLINE_FILE_EXTENSIONS.has(extension)) return match;
-    return `[${escapeMarkdownLinkText(pathValue)}](${toFileHref(pathValue)})`;
-  });
-}
 
 function attachmentToDocumentReference(attachment: ChatAttachment): DocumentSelectionReference | null {
   if (attachment.kind !== DOCUMENT_SELECTION_ATTACHMENT_KIND || !attachment.selectedText) return null;
@@ -189,7 +165,7 @@ function MessageRowV2({
   const thinkingDisplayText = useTypewriter(formattedContent, !!message.isStreaming && !!message.isThinking, 4);
   const contentDisplayText = useTypewriter(formattedContent, !!message.isStreaming && !message.isThinking, 6);
   const linkedContentDisplayText = useMemo(
-    () => (message.isStreaming ? contentDisplayText : linkifyFilePaths(contentDisplayText)),
+    () => (message.isStreaming ? contentDisplayText : linkifyFilePathsOutsideCode(contentDisplayText)),
     [contentDisplayText, message.isStreaming],
   );
   const messageImages = useMemo(
@@ -514,7 +490,7 @@ function MessageRowV2({
               variant="action-row"
             />
           ) : null}
-          {showAssistantCopyButton ? <CopyMarkdownButton content={linkedContentDisplayText} /> : null}
+          {showAssistantCopyButton ? <CopyMarkdownButton content={formattedContent} /> : null}
         </div>
       ) : null}
     </div>

--- a/ui/src/components/chat-v2/linkifyFilePathsOutsideCode.spec.ts
+++ b/ui/src/components/chat-v2/linkifyFilePathsOutsideCode.spec.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { linkifyFilePathsOutsideCode } from './linkifyFilePathsOutsideCode';
+
+describe('linkifyFilePathsOutsideCode', () => {
+  it('linkifies prose file paths', () => {
+    expect(linkifyFilePathsOutsideCode('See docs/report.pdf for details.'))
+      .toBe('See [docs/report.pdf](docs/report.pdf) for details.');
+  });
+
+  it('does not linkify inline code', () => {
+    expect(linkifyFilePathsOutsideCode('Run `cat docs/report.pdf` first.'))
+      .toBe('Run `cat docs/report.pdf` first.');
+  });
+
+  it('does not linkify fenced code blocks', () => {
+    const markdown = ['```ts', "import './foo.ts';", '```', 'Then open docs/report.pdf.'].join('\n');
+    expect(linkifyFilePathsOutsideCode(markdown))
+      .toBe(['```ts', "import './foo.ts';", '```', 'Then open [docs/report.pdf](docs/report.pdf).'].join('\n'));
+  });
+});

--- a/ui/src/components/chat-v2/linkifyFilePathsOutsideCode.ts
+++ b/ui/src/components/chat-v2/linkifyFilePathsOutsideCode.ts
@@ -1,0 +1,76 @@
+const LINKABLE_INLINE_FILE_EXTENSIONS = new Set([
+  'pdf', 'html', 'htm', 'png', 'jpg', 'jpeg', 'gif', 'webp', 'svg',
+  'txt', 'md', 'csv', 'json', 'doc', 'docx', 'xls', 'xlsx', 'ppt', 'pptx', 'py', 'js', 'ts', 'tsx', 'css',
+]);
+
+const escapeMarkdownLinkText = (value: string): string => value.replace(/([\\\]\[])/g, '\\$1');
+
+const toFileHref = (pathValue: string): string => {
+  if (/^file:\/\//i.test(pathValue)) return pathValue;
+  if (pathValue.startsWith('/')) return `file://${encodeURI(pathValue)}`;
+  return encodeURI(pathValue.replace(/\\/g, '/'));
+};
+
+function linkifyFilePaths(content: string): string {
+  const pattern = /((?:file:\/\/)?\/(?:[^\s`'"<>])+\.[A-Za-z0-9]{1,10}|(?:\.\/)?\b[A-Za-z0-9._-][A-Za-z0-9._/-]*\.[A-Za-z0-9]{1,10}\b)/gu;
+  return content.replace(pattern, (match, pathValue: string, offset: number, fullText: string) => {
+    const before = fullText.slice(Math.max(0, offset - 2), offset);
+    const after = fullText.slice(offset + match.length, offset + match.length + 1);
+    if (before.includes('](') || after === ')') return match;
+    const extension = pathValue.split('.').pop()?.toLowerCase() || '';
+    if (!LINKABLE_INLINE_FILE_EXTENSIONS.has(extension)) return match;
+    return `[${escapeMarkdownLinkText(pathValue)}](${toFileHref(pathValue)})`;
+  });
+}
+
+function linkifyInlineMarkdownText(content: string): string {
+  let result = '';
+  let index = 0;
+
+  while (index < content.length) {
+    const codeStart = content.indexOf('`', index);
+    if (codeStart === -1) {
+      result += linkifyFilePaths(content.slice(index));
+      break;
+    }
+
+    result += linkifyFilePaths(content.slice(index, codeStart));
+
+    const fenceEnd = content.slice(codeStart).match(/^`+/)?.[0] ?? '`';
+    const codeEnd = content.indexOf(fenceEnd, codeStart + fenceEnd.length);
+    if (codeEnd === -1) {
+      result += linkifyFilePaths(content.slice(codeStart));
+      break;
+    }
+
+    result += content.slice(codeStart, codeEnd + fenceEnd.length);
+    index = codeEnd + fenceEnd.length;
+  }
+
+  return result;
+}
+
+export function linkifyFilePathsOutsideCode(content: string): string {
+  const lines = content.split(/(\n)/);
+  let inFencedCodeBlock = false;
+  let atLineStart = true;
+
+  return lines.map((segment) => {
+    if (segment === '\n') {
+      atLineStart = true;
+      return segment;
+    }
+
+    const fenceMatch = atLineStart ? segment.match(/^\s*(`{3,}|~{3,})/) : null;
+    if (fenceMatch) {
+      inFencedCodeBlock = !inFencedCodeBlock;
+      atLineStart = false;
+      return segment;
+    }
+
+    atLineStart = false;
+    if (inFencedCodeBlock) return segment;
+
+    return linkifyInlineMarkdownText(segment);
+  }).join('');
+}


### PR DESCRIPTION
## Summary\n- Keep generated file path links out of inline code and fenced code blocks\n- Preserve original assistant Markdown when copying responses\n- Add focused coverage for the chat file-path linkifier\n\n## Validation\n- vitest run src/components/chat-v2/linkifyFilePathsOutsideCode.spec.ts\n- eslint src/components/chat-v2/MessageRowV2.tsx src/components/chat-v2/linkifyFilePathsOutsideCode.ts src/components/chat-v2/linkifyFilePathsOutsideCode.spec.ts