### PR TITLE
fix(model): resolve catalog provider API keys from declared env vars

### DIFF
--- a/src/model/config/parseModelConfig.ts
+++ b/src/model/config/parseModelConfig.ts
@@ -104,7 +104,7 @@ function parseProvider(providerId: string, rawProvider: unknown, env?: Credentia
     id: providerId,
     protocol,
     url: rawUrl,
-    apiKey: resolveProviderApiKey(providerId, provider.apiKey, env),
+    apiKey: resolveProviderApiKey(providerId, provider.apiKey, catalogProvider?.apiKeyEnvVar, env),
     timeoutMs: readOptionalPositiveNumber(provider.timeoutMs, "timeoutMs"),
     headers: readStringRecord(provider.headers, "headers"),
     extraBody: isRecord(provider.extraBody) ? (provider.extraBody as Record<string, unknown>) : undefined,
@@ -113,11 +113,19 @@ function parseProvider(providerId: string, rawProvider: unknown, env?: Credentia
   };
 }
 
-function resolveProviderApiKey(providerId: string, value: unknown, env?: CredentialEnv): string {
+function resolveProviderApiKey(
+  providerId: string,
+  value: unknown,
+  catalogApiKeyEnvVar: string | undefined,
+  env?: CredentialEnv,
+): string {
   if (providerId === "ollama" && value === undefined) {
     return "ollama";
   }
-  return resolveApiKey(value, env);
+  const effectiveValue = value === undefined ? (
+    catalogApiKeyEnvVar ? `\${${catalogApiKeyEnvVar}}` : undefined
+  ) : value;
+  return resolveApiKey(effectiveValue, env);
 }
 
 function resolveDefaultProviderUrl(

--- a/tests/model/parseModelConfig.spec.ts
+++ b/tests/model/parseModelConfig.spec.ts
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { ModelConfigError, parseModelConfig } from "../../src/model/index.js";
+
+const anthropicModelId = "claude-sonnet-4-5-20250929";
+
+function catalogAnthropicProvider(extra: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    providers: {
+      anthropic: {
+        ...extra,
+        models: {
+          [anthropicModelId]: {},
+        },
+      },
+    },
+  };
+}
+
+function assertMissingApiKey(fn: () => void, messagePattern?: RegExp): void {
+  assert.throws(fn, (error: unknown) => {
+    assert.equal(error instanceof ModelConfigError, true);
+    assert.equal((error as ModelConfigError).code, "missing_api_key");
+    if (messagePattern) {
+      assert.match((error as Error).message, messagePattern);
+    }
+    return true;
+  });
+}
+
+test("parseModelConfig resolves catalog apiKeyEnvVar when provider apiKey is absent", () => {
+  const config = parseModelConfig(catalogAnthropicProvider(), {
+    env: { ANTHROPIC_API_KEY: " sk-test-from-env \n" },
+  });
+
+  assert.equal(config.providers.anthropic.protocol, "anthropic");
+  assert.equal(config.providers.anthropic.url, "https://api.anthropic.com");
+  assert.equal(config.providers.anthropic.apiKey, "sk-test-from-env");
+});
+
+test("parseModelConfig keeps explicit env apiKey resolution ahead of catalog apiKeyEnvVar", () => {
+  const config = parseModelConfig(catalogAnthropicProvider({
+    apiKey: "${CUSTOM_ANTHROPIC_KEY}",
+  }), {
+    env: {
+      ANTHROPIC_API_KEY: "catalog-key",
+      CUSTOM_ANTHROPIC_KEY: "explicit-key",
+    },
+  });
+
+  assert.equal(config.providers.anthropic.apiKey, "explicit-key");
+});
+
+test("parseModelConfig reports missing catalog env apiKey as missing_api_key", () => {
+  assertMissingApiKey(() => {
+    parseModelConfig(catalogAnthropicProvider(), { env: {} });
+  }, /ANTHROPIC_API_KEY/);
+});
+
+test("parseModelConfig still requires apiKey for non-catalog providers", () => {
+  assertMissingApiKey(() => {
+    parseModelConfig({
+      providers: {
+        custom: {
+          protocol: "openai",
+          url: "https://example.test/v1",
+          models: { "custom-model": {} },
+        },
+      },
+    }, { env: { OPENAI_API_KEY: "sk-test-from-env" } });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #339

This PR fixes credential resolution for built-in catalog providers that declare `apiKeyEnvVar`.

Previously, catalog providers could inherit protocol, default URL, and model defaults, but `parseModelConfig` ignored `apiKeyEnvVar` when resolving credentials. As a result, providers such as Anthropic still failed with `missing_api_key` unless users repeated `apiKey: ${ANTHROPIC_API_KEY}` in config.

Changes:
- Use catalog `apiKeyEnvVar` as the default API key source when provider `apiKey` is absent.
- Keep explicit `apiKey` config higher priority than catalog defaults.
- Reuse existing `resolveApiKey` env resolution, trimming, and error behavior.
- Preserve existing behavior for non-catalog providers and `ollama`.

## Tests

Added coverage for:
- Resolving Anthropic catalog credentials from `ANTHROPIC_API_KEY`.
- Preserving explicit `${ENV_VAR}` API key behavior.
- Reporting `missing_api_key` when the catalog env var is absent.
- Keeping non-catalog providers unchanged when no `apiKey` is configured.

Verified with:
- `npm run build`
- `node --test --test-timeout 60000 dist/tests/model/parseModelConfig.spec.js`
- `node --test --test-timeout 60000 dist/tests/model/*.spec.js`
- `npx tsc -p tsconfig.json --noEmit`