### PR TITLE
Fix busy-send force semantics

### DIFF
--- a/ui/server/pilotdeck-bridge.js
+++ b/ui/server/pilotdeck-bridge.js
@@ -1144,7 +1144,12 @@ export async function abortViaGateway(sessionId, _provider = 'pilotdeck') {
     if (!sessionKey) return false;
     const state = sessionState.get(sessionKey);
     try {
-        await gw.abortTurn({ sessionKey, runId: state?.runId });
+        const runId = state?.runId;
+        await gw.abortTurn({ sessionKey, runId });
+        if (state && (!runId || state.runId === runId)) {
+            state.active = false;
+            state.runId = undefined;
+        }
         return true;
     } catch (error) {
         console.warn('[pilotdeck-bridge] abortTurn failed:', error);

--- a/ui/server/pilotdeck-bridge.js
+++ b/ui/server/pilotdeck-bridge.js
@@ -934,22 +934,36 @@ export async function runChatViaGateway(
 
     const state = ensureSessionState(sessionKey, projectKey, channelKey);
 
-    // If a previous turn for this session is still in-flight (e.g. the
-    // browser reloaded while a permission prompt was pending), abort it
-    // before starting the new one. Without this the gateway rejects
-    // with session_busy because the old turn's inFlightTurns slot is
-    // still occupied.
+    // Normal chat submits should not abort active work. A forced submit is an
+    // explicit user action from the composer: stop the current turn, then start
+    // the new queued message immediately.
     if (state.active && state.runId) {
-        console.log(
-            `[pilotdeck-bridge] aborting stale turn ${state.runId} for ${sessionKey} before resubmit`,
-        );
-        try {
-            await gw.abortTurn({ sessionKey, runId: state.runId, reason: 'system:stale_turn' });
-        } catch (err) {
-            console.warn('[pilotdeck-bridge] stale abort failed (continuing):', err?.message || err);
+        if (options?.forceStart === true) {
+            console.log(
+                `[pilotdeck-bridge] force-start aborting active turn ${state.runId} for ${sessionKey}`,
+            );
+            try {
+                await gw.abortTurn({ sessionKey, runId: state.runId, reason: 'user:force_start_next_turn' });
+            } catch (err) {
+                console.warn('[pilotdeck-bridge] force-start abort failed (continuing):', err?.message || err);
+            }
+            state.active = false;
+            state.runId = undefined;
+        } else {
+            const message = 'This session is still processing a previous turn. Please wait for it to finish before sending another message.';
+            console.warn(`[pilotdeck-bridge] rejected busy submit for ${sessionKey}; active run ${state.runId}`);
+            writer.send(
+                createNormalizedMessage({
+                    provider,
+                    sessionId: sessionKey,
+                    kind: 'error',
+                    code: 'session_busy',
+                    content: message,
+                    userHint: message,
+                }),
+            );
+            return;
         }
-        state.active = false;
-        state.runId = undefined;
     }
 
     if (isNewSession) {

--- a/ui/server/pilotdeck-bridge.js
+++ b/ui/server/pilotdeck-bridge.js
@@ -945,7 +945,19 @@ export async function runChatViaGateway(
             try {
                 await gw.abortTurn({ sessionKey, runId: state.runId, reason: 'user:force_start_next_turn' });
             } catch (err) {
-                console.warn('[pilotdeck-bridge] force-start abort failed (continuing):', err?.message || err);
+                const message = 'Could not stop the current turn before sending the queued message. Please wait for the current turn to finish or try stopping it again.';
+                console.warn('[pilotdeck-bridge] force-start abort failed:', err?.message || err);
+                writer.send(
+                    createNormalizedMessage({
+                        provider,
+                        sessionId: sessionKey,
+                        kind: 'error',
+                        code: 'force_start_abort_failed',
+                        content: message,
+                        userHint: message,
+                    }),
+                );
+                return;
             }
             state.active = false;
             state.runId = undefined;

--- a/ui/src/components/chat-v2/ComposerV2.tsx
+++ b/ui/src/components/chat-v2/ComposerV2.tsx
@@ -347,9 +347,9 @@ export default function ComposerV2({
   const sendTitle = isSubmitPending || hasUploadingImages
     ? (t('input.sending', { defaultValue: 'Sending...' }) as string)
     : isBusySendConfirmed
-      ? (t('input.queuedSendConfirmed', { defaultValue: 'Queued — will send when the current turn finishes' }) as string)
+      ? (t('input.queuedSendConfirmed', { defaultValue: 'Stopping current turn — sending next message' }) as string)
       : isBusySendQueued
-        ? (t('input.queuedSendConfirm', { defaultValue: 'Queued — click send again to send now' }) as string)
+        ? (t('input.queuedSendConfirm', { defaultValue: 'Queued — click send again to stop this turn and send now' }) as string)
       : isLoading
         ? (t('input.queueSend', { defaultValue: 'Queue message' }) as string)
         : (t('input.send', { defaultValue: 'Send' }) as string);
@@ -764,8 +764,8 @@ export default function ComposerV2({
                     <div className="hidden min-w-0 flex-1 items-center justify-end gap-1 px-2 text-[12px] text-amber-700 dark:text-amber-300 sm:flex">
                       <span className="truncate rounded-full bg-amber-50 px-2 py-1 dark:bg-amber-950/30">
                         {isBusySendConfirmed
-                          ? t('input.queuedSendConfirmedInline', { defaultValue: 'Queued; sends after this turn' })
-                          : t('input.queuedSendConfirmInline', { defaultValue: 'Queued; click send again to send now' })}
+                          ? t('input.queuedSendConfirmedInline', { defaultValue: 'Stopping current turn; sending next' })
+                          : t('input.queuedSendConfirmInline', { defaultValue: 'Queued; click again to stop this turn and send now' })}
                       </span>
                       <button
                         type="button"

--- a/ui/src/components/chat/hooks/useChatComposerState.ts
+++ b/ui/src/components/chat/hooks/useChatComposerState.ts
@@ -244,7 +244,7 @@ export function useChatComposerState({
     queuedBusySendSnapshotRef.current = null;
     setIsBusySendQueued(false);
     setIsBusySendConfirmed(false);
-  }, [syncQueuedBusySendSnapshot]);
+  }, []);
 
   const syncQueuedBusySendSnapshot = useCallback((updates: Partial<QueuedBusySendSnapshot> = {}) => {
     if (!queuedBusySendRef.current) return;

--- a/ui/src/components/chat/hooks/useChatComposerState.ts
+++ b/ui/src/components/chat/hooks/useChatComposerState.ts
@@ -127,6 +127,13 @@ type UploadedAttachmentFile = {
   mimeType?: string;
 };
 
+type QueuedBusySendSnapshot = {
+  input: string;
+  attachedImages: File[];
+  documentReferences: DocumentSelectionReference[];
+  forceStart?: boolean;
+};
+
 export function shouldCycleRunModeOnKeyDown(
   event: Pick<KeyboardEvent<HTMLTextAreaElement>, 'key' | 'shiftKey'>,
   {
@@ -228,6 +235,7 @@ export function useChatComposerState({
   const inputValueRef = useRef(input);
   const queuedBusySendRef = useRef(false);
   const queuedBusySendConfirmedRef = useRef(false);
+  const queuedBusySendSnapshotRef = useRef<QueuedBusySendSnapshot | null>(null);
   const pendingSessionGrantResolversRef = useRef(new Map<string, (result: PermissionGrantResult) => void>());
 
   useEffect(() => {
@@ -757,9 +765,12 @@ export function useChatComposerState({
       event: FormEvent<HTMLFormElement> | MouseEvent | TouchEvent | KeyboardEvent<HTMLTextAreaElement>,
     ) => {
       event.preventDefault();
-      const currentInput = inputValueRef.current;
-      const hasDocumentReferences = documentReferences.length > 0;
-      const hasAttachments = attachedImages.length > 0 || hasDocumentReferences;
+      const queuedSnapshot = queuedBusySendSnapshotRef.current;
+      const currentInput = queuedSnapshot?.input ?? inputValueRef.current;
+      const submitAttachedImages = queuedSnapshot?.attachedImages ?? attachedImages;
+      const submitDocumentReferences = queuedSnapshot?.documentReferences ?? documentReferences;
+      const hasDocumentReferences = submitDocumentReferences.length > 0;
+      const hasAttachments = submitAttachedImages.length > 0 || hasDocumentReferences;
       if ((!currentInput.trim() && !hasAttachments) || !selectedProject) {
         return;
       }
@@ -767,20 +778,50 @@ export function useChatComposerState({
       if (isLoading && !isBusySendQueued) {
         queuedBusySendRef.current = true;
         queuedBusySendConfirmedRef.current = false;
+        queuedBusySendSnapshotRef.current = {
+          input: currentInput,
+          attachedImages: [...attachedImages],
+          documentReferences: [...documentReferences],
+        };
         setIsBusySendQueued(true);
         setIsBusySendConfirmed(false);
         return;
       }
 
       if (isLoading && isBusySendQueued) {
-        queuedBusySendRef.current = false;
-        queuedBusySendConfirmedRef.current = false;
-        setIsBusySendQueued(false);
-        setIsBusySendConfirmed(false);
+        queuedBusySendSnapshotRef.current = {
+          input: currentInput,
+          attachedImages: submitAttachedImages,
+          documentReferences: submitDocumentReferences,
+          forceStart: true,
+        };
+        queuedBusySendConfirmedRef.current = true;
+        setIsBusySendConfirmed(true);
+        if (canAbortSession) {
+          const pendingSessionId = typeof window !== 'undefined' ? sessionStorage.getItem('pendingSessionId') : null;
+          const targetSessionId = [
+            currentSessionId,
+            pendingViewSessionRef.current?.sessionId || null,
+            pendingSessionId,
+            selectedSession?.id || null,
+          ].find((sessionId) => Boolean(sessionId) && !isTemporarySessionId(sessionId));
+
+          if (targetSessionId) {
+            sendMessage({
+              type: 'abort-session',
+              sessionId: targetSessionId,
+              provider: 'pilotdeck',
+            });
+            setCanAbortSession(false);
+            setIsAborting(true);
+          }
+        }
+        return;
       }
 
       queuedBusySendRef.current = false;
       queuedBusySendConfirmedRef.current = false;
+      queuedBusySendSnapshotRef.current = null;
       setIsBusySendQueued(false);
       setIsBusySendConfirmed(false);
 
@@ -848,9 +889,9 @@ export function useChatComposerState({
 
       let uploadedImages: unknown[] = [];
       let uploadedFiles: UploadedAttachmentFile[] = [];
-      if (attachedImages.length > 0) {
+      if (submitAttachedImages.length > 0) {
         const formData = new FormData();
-        attachedImages.forEach((file) => {
+        submitAttachedImages.forEach((file) => {
           formData.append('attachments', file);
         });
 
@@ -880,8 +921,8 @@ export function useChatComposerState({
         }
       }
 
-      const documentReferenceAttachments = documentReferences.map(documentReferenceToAttachment);
-      messageContent = `${messageContent}${buildAttachmentPathNote(uploadedFiles)}${formatDocumentSelectionPromptBlock(documentReferences)}`;
+      const documentReferenceAttachments = submitDocumentReferences.map(documentReferenceToAttachment);
+      messageContent = `${messageContent}${buildAttachmentPathNote(uploadedFiles)}${formatDocumentSelectionPromptBlock(submitDocumentReferences)}`;
 
       const effectiveSessionId = submitTargetSessionId;
       const sessionToActivate = effectiveSessionId || optimisticSessionId;
@@ -959,6 +1000,7 @@ export function useChatComposerState({
         sessionSummary,
         images: uploadedImages,
         attachments: [...uploadedFiles, ...documentReferenceAttachments],
+        forceStart: queuedSnapshot?.forceStart === true,
       });
 
       setInput('');
@@ -985,6 +1027,7 @@ export function useChatComposerState({
       executeCommand,
       isLoading,
       isBusySendQueued,
+      canAbortSession,
       onSessionActive,
       onSessionActivityBump,
       onSessionProcessing,
@@ -997,6 +1040,7 @@ export function useChatComposerState({
       selectedProject,
       sendMessage,
       setCanAbortSession,
+      setIsAborting,
       addMessage,
       setClaudeStatus,
       setPilotDeckStatus,
@@ -1024,6 +1068,7 @@ export function useChatComposerState({
       } else {
         queuedBusySendRef.current = false;
         queuedBusySendConfirmedRef.current = false;
+        queuedBusySendSnapshotRef.current = null;
         setIsBusySendQueued(false);
         setIsBusySendConfirmed(false);
       }
@@ -1083,6 +1128,7 @@ export function useChatComposerState({
       inputValueRef.current = newValue;
       queuedBusySendRef.current = false;
       queuedBusySendConfirmedRef.current = false;
+      queuedBusySendSnapshotRef.current = null;
       setIsBusySendQueued(false);
       setIsBusySendConfirmed(false);
       setCursorPosition(cursorPos);
@@ -1102,6 +1148,7 @@ export function useChatComposerState({
   const cancelBusySendQueue = useCallback(() => {
     queuedBusySendRef.current = false;
     queuedBusySendConfirmedRef.current = false;
+    queuedBusySendSnapshotRef.current = null;
     setIsBusySendQueued(false);
     setIsBusySendConfirmed(false);
   }, []);

--- a/ui/src/components/chat/hooks/useChatComposerState.ts
+++ b/ui/src/components/chat/hooks/useChatComposerState.ts
@@ -244,16 +244,29 @@ export function useChatComposerState({
     queuedBusySendSnapshotRef.current = null;
     setIsBusySendQueued(false);
     setIsBusySendConfirmed(false);
-  }, []);
+  }, [syncQueuedBusySendSnapshot]);
+
+  const syncQueuedBusySendSnapshot = useCallback((updates: Partial<QueuedBusySendSnapshot> = {}) => {
+    if (!queuedBusySendRef.current) return;
+    const previous = queuedBusySendSnapshotRef.current;
+    queuedBusySendSnapshotRef.current = {
+      input: updates.input ?? previous?.input ?? inputValueRef.current,
+      attachedImages: updates.attachedImages ?? previous?.attachedImages ?? attachedImages,
+      documentReferences: updates.documentReferences ?? previous?.documentReferences ?? documentReferences,
+      ...(previous?.forceStart ? { forceStart: true } : {}),
+      ...(updates.forceStart ? { forceStart: true } : {}),
+    };
+  }, [attachedImages, documentReferences]);
 
   useEffect(() => {
     const handleAddDocumentReference = (event: Event) => {
       const detail = (event as CustomEvent).detail;
       if (!isDocumentSelectionReference(detail)) return;
-      cancelBusySendQueue();
       setDocumentReferences((previous) => {
         if (previous.some((reference) => reference.id === detail.id)) return previous;
-        return [...previous, detail];
+        const next = [...previous, detail];
+        syncQueuedBusySendSnapshot({ documentReferences: next });
+        return next;
       });
       requestAnimationFrame(() => {
         textareaRef.current?.focus();
@@ -264,7 +277,7 @@ export function useChatComposerState({
     return () => {
       window.removeEventListener('pilotdeck:add-chat-reference', handleAddDocumentReference);
     };
-  }, [cancelBusySendQueue]);
+  }, [syncQueuedBusySendSnapshot]);
 
   useEffect(() => {
     if (!subscribe) {
@@ -716,7 +729,6 @@ export function useChatComposerState({
     });
 
     if (validFiles.length > 0) {
-      cancelBusySendQueue();
       setAttachedImages((previous) => {
         const result = addAttachmentFiles(previous, validFiles);
         if (result.droppedCount > 0) {
@@ -726,6 +738,7 @@ export function useChatComposerState({
             return next;
           });
         }
+        syncQueuedBusySendSnapshot({ attachedImages: result.files });
         return result.files;
       });
     }
@@ -1140,7 +1153,7 @@ export function useChatComposerState({
 
       setInput(newValue);
       inputValueRef.current = newValue;
-      cancelBusySendQueue();
+      syncQueuedBusySendSnapshot({ input: newValue });
       setCursorPosition(cursorPos);
 
       if (!newValue.trim()) {
@@ -1152,7 +1165,7 @@ export function useChatComposerState({
 
       handleCommandInputChange(newValue, cursorPos);
     },
-    [cancelBusySendQueue, handleCommandInputChange, resetCommandMenuState, setCursorPosition],
+    [handleCommandInputChange, resetCommandMenuState, setCursorPosition, syncQueuedBusySendSnapshot],
   );
 
   const insertAtCursor = useCallback(
@@ -1461,13 +1474,21 @@ export function useChatComposerState({
     selectFile,
     attachedImages,
     setAttachedImages: (value: SetStateAction<File[]>) => {
-      cancelBusySendQueue();
-      setAttachedImages(value);
+      setAttachedImages((previous) => {
+        const next = typeof value === 'function'
+          ? (value as (previous: File[]) => File[])(previous)
+          : value;
+        syncQueuedBusySendSnapshot({ attachedImages: next });
+        return next;
+      });
     },
     documentReferences,
     removeDocumentReference: (id: string) => {
-      cancelBusySendQueue();
-      setDocumentReferences((previous) => previous.filter((reference) => reference.id !== id));
+      setDocumentReferences((previous) => {
+        const next = previous.filter((reference) => reference.id !== id);
+        syncQueuedBusySendSnapshot({ documentReferences: next });
+        return next;
+      });
     },
     uploadingImages,
     imageErrors,

--- a/ui/src/components/chat/hooks/useChatComposerState.ts
+++ b/ui/src/components/chat/hooks/useChatComposerState.ts
@@ -789,6 +789,12 @@ export function useChatComposerState({
       }
 
       if (isLoading && isBusySendQueued) {
+        queuedBusySendSnapshotRef.current = {
+          input: currentInput,
+          attachedImages: submitAttachedImages,
+          documentReferences: submitDocumentReferences,
+        };
+
         const pendingSessionId = typeof window !== 'undefined' ? sessionStorage.getItem('pendingSessionId') : null;
         const targetSessionId = [
           currentSessionId,
@@ -802,9 +808,7 @@ export function useChatComposerState({
         }
 
         queuedBusySendSnapshotRef.current = {
-          input: currentInput,
-          attachedImages: submitAttachedImages,
-          documentReferences: submitDocumentReferences,
+          ...queuedBusySendSnapshotRef.current,
           forceStart: true,
         };
         queuedBusySendConfirmedRef.current = true;

--- a/ui/src/components/chat/hooks/useChatComposerState.ts
+++ b/ui/src/components/chat/hooks/useChatComposerState.ts
@@ -1179,6 +1179,7 @@ export function useChatComposerState({
 
       setInput(nextValue);
       inputValueRef.current = nextValue;
+      syncQueuedBusySendSnapshot({ input: nextValue });
       setCursorPosition(nextCursor);
 
       if (char === '/') {
@@ -1198,7 +1199,7 @@ export function useChatComposerState({
         }
       });
     },
-    [handleCommandInputChange, input, setCursorPosition, setInput, textareaRef],
+    [handleCommandInputChange, input, setCursorPosition, setInput, syncQueuedBusySendSnapshot, textareaRef],
   );
 
   const handleKeyDown = useCallback(
@@ -1267,13 +1268,14 @@ export function useChatComposerState({
     setInput('');
     inputValueRef.current = '';
     setDocumentReferences([]);
+    cancelBusySendQueue();
     resetCommandMenuState();
     if (textareaRef.current) {
       textareaRef.current.style.height = 'auto';
       textareaRef.current.focus();
     }
     setIsTextareaExpanded(false);
-  }, [resetCommandMenuState]);
+  }, [cancelBusySendQueue, resetCommandMenuState]);
 
   const handleAbortSession = useCallback(() => {
     if (!canAbortSession) {

--- a/ui/src/components/chat/hooks/useChatComposerState.ts
+++ b/ui/src/components/chat/hooks/useChatComposerState.ts
@@ -238,10 +238,19 @@ export function useChatComposerState({
   const queuedBusySendSnapshotRef = useRef<QueuedBusySendSnapshot | null>(null);
   const pendingSessionGrantResolversRef = useRef(new Map<string, (result: PermissionGrantResult) => void>());
 
+  const cancelBusySendQueue = useCallback(() => {
+    queuedBusySendRef.current = false;
+    queuedBusySendConfirmedRef.current = false;
+    queuedBusySendSnapshotRef.current = null;
+    setIsBusySendQueued(false);
+    setIsBusySendConfirmed(false);
+  }, []);
+
   useEffect(() => {
     const handleAddDocumentReference = (event: Event) => {
       const detail = (event as CustomEvent).detail;
       if (!isDocumentSelectionReference(detail)) return;
+      cancelBusySendQueue();
       setDocumentReferences((previous) => {
         if (previous.some((reference) => reference.id === detail.id)) return previous;
         return [...previous, detail];
@@ -255,7 +264,7 @@ export function useChatComposerState({
     return () => {
       window.removeEventListener('pilotdeck:add-chat-reference', handleAddDocumentReference);
     };
-  }, []);
+  }, [cancelBusySendQueue]);
 
   useEffect(() => {
     if (!subscribe) {
@@ -707,6 +716,7 @@ export function useChatComposerState({
     });
 
     if (validFiles.length > 0) {
+      cancelBusySendQueue();
       setAttachedImages((previous) => {
         const result = addAttachmentFiles(previous, validFiles);
         if (result.droppedCount > 0) {
@@ -1130,11 +1140,7 @@ export function useChatComposerState({
 
       setInput(newValue);
       inputValueRef.current = newValue;
-      queuedBusySendRef.current = false;
-      queuedBusySendConfirmedRef.current = false;
-      queuedBusySendSnapshotRef.current = null;
-      setIsBusySendQueued(false);
-      setIsBusySendConfirmed(false);
+      cancelBusySendQueue();
       setCursorPosition(cursorPos);
 
       if (!newValue.trim()) {
@@ -1146,16 +1152,8 @@ export function useChatComposerState({
 
       handleCommandInputChange(newValue, cursorPos);
     },
-    [handleCommandInputChange, resetCommandMenuState, setCursorPosition],
+    [cancelBusySendQueue, handleCommandInputChange, resetCommandMenuState, setCursorPosition],
   );
-
-  const cancelBusySendQueue = useCallback(() => {
-    queuedBusySendRef.current = false;
-    queuedBusySendConfirmedRef.current = false;
-    queuedBusySendSnapshotRef.current = null;
-    setIsBusySendQueued(false);
-    setIsBusySendConfirmed(false);
-  }, []);
 
   const insertAtCursor = useCallback(
     (char: string) => {
@@ -1462,9 +1460,13 @@ export function useChatComposerState({
     renderInputWithMentions,
     selectFile,
     attachedImages,
-    setAttachedImages,
+    setAttachedImages: (value: SetStateAction<File[]>) => {
+      cancelBusySendQueue();
+      setAttachedImages(value);
+    },
     documentReferences,
     removeDocumentReference: (id: string) => {
+      cancelBusySendQueue();
       setDocumentReferences((previous) => previous.filter((reference) => reference.id !== id));
     },
     uploadingImages,

--- a/ui/src/components/chat/hooks/useChatComposerState.ts
+++ b/ui/src/components/chat/hooks/useChatComposerState.ts
@@ -789,6 +789,18 @@ export function useChatComposerState({
       }
 
       if (isLoading && isBusySendQueued) {
+        const pendingSessionId = typeof window !== 'undefined' ? sessionStorage.getItem('pendingSessionId') : null;
+        const targetSessionId = [
+          currentSessionId,
+          pendingViewSessionRef.current?.sessionId || null,
+          pendingSessionId,
+          selectedSession?.id || null,
+        ].find((sessionId) => Boolean(sessionId) && !isTemporarySessionId(sessionId));
+
+        if (!canAbortSession || !targetSessionId) {
+          return;
+        }
+
         queuedBusySendSnapshotRef.current = {
           input: currentInput,
           attachedImages: submitAttachedImages,
@@ -797,25 +809,13 @@ export function useChatComposerState({
         };
         queuedBusySendConfirmedRef.current = true;
         setIsBusySendConfirmed(true);
-        if (canAbortSession) {
-          const pendingSessionId = typeof window !== 'undefined' ? sessionStorage.getItem('pendingSessionId') : null;
-          const targetSessionId = [
-            currentSessionId,
-            pendingViewSessionRef.current?.sessionId || null,
-            pendingSessionId,
-            selectedSession?.id || null,
-          ].find((sessionId) => Boolean(sessionId) && !isTemporarySessionId(sessionId));
-
-          if (targetSessionId) {
-            sendMessage({
-              type: 'abort-session',
-              sessionId: targetSessionId,
-              provider: 'pilotdeck',
-            });
-            setCanAbortSession(false);
-            setIsAborting(true);
-          }
-        }
+        sendMessage({
+          type: 'abort-session',
+          sessionId: targetSessionId,
+          provider: 'pilotdeck',
+        });
+        setCanAbortSession(false);
+        setIsAborting(true);
         return;
       }
 

--- a/ui/src/components/chat/hooks/useChatComposerState.ts
+++ b/ui/src/components/chat/hooks/useChatComposerState.ts
@@ -1300,6 +1300,8 @@ export function useChatComposerState({
       return;
     }
 
+    cancelBusySendQueue();
+
     sendMessage({
       type: 'abort-session',
       sessionId: targetSessionId,
@@ -1313,7 +1315,7 @@ export function useChatComposerState({
       tokens: 0,
       can_interrupt: false,
     });
-  }, [canAbortSession, currentSessionId, pendingViewSessionRef, selectedSession?.id, sendMessage, setCanAbortSession, setClaudeStatus, setIsAborting, setPilotDeckStatus]);
+  }, [canAbortSession, cancelBusySendQueue, currentSessionId, pendingViewSessionRef, selectedSession?.id, sendMessage, setCanAbortSession, setClaudeStatus, setIsAborting, setPilotDeckStatus]);
 
   const handleGrantToolPermission = useCallback(
     (suggestion: { entry: string; toolName: string }) => {

--- a/ui/src/components/chat/hooks/useChatRealtimeHandlers.ts
+++ b/ui/src/components/chat/hooks/useChatRealtimeHandlers.ts
@@ -312,7 +312,6 @@ export function useChatRealtimeHandlers({
       if (thinkingBySessionRef.current.has(sid)) {
         thinkingBySessionRef.current.delete(sid);
       }
-      sessionStore.clearAssistantRealtime?.(sid);
     }
 
     if (msg.kind === 'agent_activity') {

--- a/ui/src/components/chat/hooks/useChatRealtimeHandlers.ts
+++ b/ui/src/components/chat/hooks/useChatRealtimeHandlers.ts
@@ -420,7 +420,7 @@ export function useChatRealtimeHandlers({
       // Finalize thinking if still active (model moved past thinking)
       if (thinkingBySessionRef.current.has(sid)) {
         thinkingBySessionRef.current.delete(sid);
-        sessionStore.finalizeStreamingThinking(sid);
+        sessionStore.finalizeStreamingThinking(sid, msgRunId);
       }
       // Finalize content stream on tool_use / complete / error.
       // The gateway may not send stream_end, so tool_use is the

--- a/ui/src/components/chat/hooks/useChatRealtimeHandlers.ts
+++ b/ui/src/components/chat/hooks/useChatRealtimeHandlers.ts
@@ -187,7 +187,9 @@ export function useChatRealtimeHandlers({
             const slot = sessionStore.getSessionSlot?.(statusSessionId);
             const hasLiveStreaming = Boolean(slot?.realtimeMessages?.some((message) => (
               message.id === `__streaming_${statusSessionId}`
+              || message.id.startsWith(`__streaming_${statusSessionId}_`)
               || message.id === `__streaming_thinking_${statusSessionId}`
+              || message.id.startsWith(`__streaming_thinking_${statusSessionId}_`)
             )));
             const replayedToolIds = new Set(
               (slot?.realtimeMessages || [])

--- a/ui/src/components/chat/utils/sessionLauncher.ts
+++ b/ui/src/components/chat/utils/sessionLauncher.ts
@@ -21,6 +21,7 @@ type StartSessionOptions = {
   alwaysOnPlanId?: string;
   alwaysOnExecutionToken?: string;
   workspaceCwd?: string;
+  forceStart?: boolean;
 };
 
 const VALID_PERMISSION_MODES = new Set<PermissionMode>([
@@ -97,6 +98,7 @@ export function startSessionCommand({
   alwaysOnPlanId,
   alwaysOnExecutionToken,
   workspaceCwd,
+  forceStart,
 }: StartSessionOptions): string {
   const sessionToActivate =
     sessionId || temporarySessionId || createTemporarySessionId();
@@ -124,6 +126,7 @@ export function startSessionCommand({
       ...(Array.isArray(images) && images.length > 0 ? { images } : {}),
       ...(Array.isArray(attachments) && attachments.length > 0 ? { attachments } : {}),
       ...(workspaceCwd ? { workspaceCwd } : {}),
+      ...(forceStart ? { forceStart: true } : {}),
     },
   });
 


### PR DESCRIPTION
## Summary
- snapshot queued busy-send drafts so attachments/references stay stable
- make the second send click explicitly abort the active turn and submit the queued message with `forceStart`
- keep non-forced busy submits from accidentally aborting active work
- update composer copy to describe stop-and-send behavior

## Validation
- `npm --prefix ui test -- useChatComposerState.test.ts MessagesPaneV2.render.test.tsx`
- `npm --prefix ui run build`
- Browser E2E: queued a second message during a long first turn, clicked send again, confirmed the first turn was aborted and the second message completed
