### PR TITLE
docs: clarify source deployment bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,14 @@ cd ..
 PilotDeck reads `~/.pilotdeck/pilotdeck.yaml`. You can create it manually, let the bootstrap script generate one, **or just open the Web UI and configure providers visually in the settings panel.**
 Supported protocols include OpenAI, Anthropic, native Google Gemini, DeepSeek, Qwen, Kimi, MiniMax and other OpenAI-compatible endpoints.
 
+If you do not already have a config file, generate a placeholder before starting in production mode:
+
+```bash
+node scripts/bootstrap-pilotdeck-config.mjs
+```
+
+This creates `~/.pilotdeck/pilotdeck.yaml` with onboarding placeholders so the Gateway can boot; you can then replace them in the Web UI settings panel.
+
 ```yaml
 schemaVersion: 1
 agent:

--- a/README.md
+++ b/README.md
@@ -327,13 +327,13 @@ cd ..
 PilotDeck reads `~/.pilotdeck/pilotdeck.yaml`. You can create it manually, let the bootstrap script generate one, **or just open the Web UI and configure providers visually in the settings panel.**
 Supported protocols include OpenAI, Anthropic, native Google Gemini, DeepSeek, Qwen, Kimi, MiniMax and other OpenAI-compatible endpoints.
 
-If you do not already have a config file, generate a placeholder before starting in production mode:
+If you do not already have a config file, prepare the Web UI onboarding flow before starting in production mode:
 
 ```bash
 node scripts/bootstrap-pilotdeck-config.mjs
 ```
 
-This creates `~/.pilotdeck/pilotdeck.yaml` with onboarding placeholders so the Gateway can boot; you can then replace them in the Web UI settings panel.
+This initializes `~/.pilotdeck/pilotdeck.yaml` for first-run onboarding so the Gateway can boot. Then open the Web UI and finish provider/API key setup in the onboarding/settings panel.
 
 ```yaml
 schemaVersion: 1

--- a/README.zh.md
+++ b/README.zh.md
@@ -325,6 +325,14 @@ cd ..
 PilotDeck 依赖 `~/.pilotdeck/pilotdeck.yaml` 进行配置。您可以手动创建、运行启动脚本自动生成，**或者在启动 Web UI 后直接在设置界面中进行可视化配置**。
 支持 OpenAI、Anthropic、原生 Google Gemini、DeepSeek、Qwen、Kimi、MiniMax 等多种协议。
 
+如果本机还没有配置文件，生产模式启动前请先生成占位配置：
+
+```bash
+node scripts/bootstrap-pilotdeck-config.mjs
+```
+
+该命令会创建 `~/.pilotdeck/pilotdeck.yaml`，使用可启动 Gateway 的占位值；随后可在 Web UI 设置面板中替换为真实 Provider 信息。
+
 ```yaml
 schemaVersion: 1
 agent:

--- a/README.zh.md
+++ b/README.zh.md
@@ -325,13 +325,13 @@ cd ..
 PilotDeck 依赖 `~/.pilotdeck/pilotdeck.yaml` 进行配置。您可以手动创建、运行启动脚本自动生成，**或者在启动 Web UI 后直接在设置界面中进行可视化配置**。
 支持 OpenAI、Anthropic、原生 Google Gemini、DeepSeek、Qwen、Kimi、MiniMax 等多种协议。
 
-如果本机还没有配置文件，生产模式启动前请先生成占位配置：
+如果本机还没有配置文件，生产模式启动前请先准备 Web UI 的首次 onboarding 流程：
 
 ```bash
 node scripts/bootstrap-pilotdeck-config.mjs
 ```
 
-该命令会创建 `~/.pilotdeck/pilotdeck.yaml`，使用可启动 Gateway 的占位值；随后可在 Web UI 设置面板中替换为真实 Provider 信息。
+该命令会初始化 `~/.pilotdeck/pilotdeck.yaml`，让 Gateway 可以启动并进入首次 onboarding。随后打开 Web UI，在 onboarding/设置面板中完成 Provider 和 API Key 配置。
 
 ```yaml
 schemaVersion: 1


### PR DESCRIPTION
## Summary
- document the bootstrap step required before source production startup without an existing config
- mirror the clarification in the Chinese README

## Verification
- npm install
- cd ui && npm install
- npm run build
- cd ui && npm run build
- with empty PILOT_HOME: bootstrap config, then start built UI/Gateway until both report ready