### PR TITLE
fix(feishu): preserve encryptKey and verifyToken on config save

### DIFF
--- a/ui/server/routes/gateway.js
+++ b/ui/server/routes/gateway.js
@@ -291,11 +291,13 @@ router.get('/feishu/qr-poll', async (req, res) => {
       // Auto-save to config
       const config = loadYaml();
       if (!config.adapters) config.adapters = {};
+      const previous = config.adapters.feishu ?? {};
       config.adapters.feishu = {
+        ...previous,
         enabled: true,
         appId,
         appSecret,
-        connectionMode: 'stream',
+        connectionMode: previous.connectionMode || 'stream',
         domainName: domain,
       };
       saveYaml(config);
@@ -340,12 +342,14 @@ router.post('/feishu/save', async (req, res) => {
   try {
     const config = loadYaml();
     if (!config.adapters) config.adapters = {};
+    const previous = config.adapters.feishu ?? {};
     config.adapters.feishu = {
+      ...previous,
       enabled: true,
       appId,
       appSecret,
-      connectionMode: connectionMode || 'stream',
-      domainName: domainName || 'feishu',
+      connectionMode: connectionMode || previous.connectionMode || 'stream',
+      domainName: domainName || previous.domainName || 'feishu',
     };
     saveYaml(config);
 


### PR DESCRIPTION
## Summary

- Fix `/feishu/save` and `/feishu/qr-poll` routes to preserve existing config fields (e.g. `encryptKey`, `verifyToken`) when saving Feishu settings, instead of replacing the entire config object.
- Follows the same merge-with-previous pattern already used by `writeWeComConfig`.

Closes #227

## Test plan

- [ ] Manually set `encryptKey` and `verifyToken` in `pilotdeck.yaml`, then save Feishu settings from the UI — verify both fields survive.
- [ ] Repeat via QR scan flow — verify fields survive.
- [ ] Verify that explicitly changed fields (`appId`, `appSecret`, `connectionMode`, `domainName`) are updated correctly.


Made with [Cursor](https://cursor.com)