### PR TITLE
Fix model list fetching in setup UI

### DIFF
--- a/ui/server/routes/config.js
+++ b/ui/server/routes/config.js
@@ -424,8 +424,8 @@ router.post('/models', async (req, res) => {
       if (typeof provider?.apiKey === 'string') effectiveApiKey = provider.apiKey;
     } catch { /* fall through to validation below */ }
   }
-  if (!baseUrl || !effectiveApiKey || effectiveApiKey === '********') {
-    return res.status(400).json({ ok: false, error: 'baseUrl and apiKey are required' });
+  if (!baseUrl) {
+    return res.status(400).json({ ok: false, error: 'baseUrl is required' });
   }
 
   const normalizedType = String(providerType || '').toLowerCase();
@@ -439,10 +439,13 @@ router.post('/models', async (req, res) => {
   try {
     const urls = buildProviderModelsEndpointCandidates({ protocol, baseUrl: normalizedBaseUrl });
     const headers = isGoogle
-      ? { 'x-goog-api-key': effectiveApiKey }
+      ? (effectiveApiKey && effectiveApiKey !== '********' ? { 'x-goog-api-key': effectiveApiKey } : {})
       : isAnthropic
-        ? { 'x-api-key': effectiveApiKey, 'anthropic-version': '2023-06-01' }
-        : { Authorization: `Bearer ${effectiveApiKey}` };
+        ? {
+            ...(effectiveApiKey && effectiveApiKey !== '********' ? { 'x-api-key': effectiveApiKey } : {}),
+            'anthropic-version': '2023-06-01',
+          }
+        : (effectiveApiKey && effectiveApiKey !== '********' ? { Authorization: `Bearer ${effectiveApiKey}` } : {});
     const { url, response, responseText } = await fetchWithEndpointFallback(
       urls,
       { method: 'GET', headers, signal: controller.signal },

--- a/ui/src/components/onboarding/view/subcomponents/LlmConfigurationStep.tsx
+++ b/ui/src/components/onboarding/view/subcomponents/LlmConfigurationStep.tsx
@@ -353,9 +353,6 @@ export default function LlmConfigurationStep({ onSaved }: LlmConfigurationStepPr
               }`}
             >
               <div className="font-medium">{provider.displayName}</div>
-              <div className="mt-0.5 text-[11px] opacity-60">
-                {provider.models.length} model{provider.models.length === 1 ? '' : 's'}
-              </div>
               {selectedProvider?.id === provider.id && (
                 <Check className="absolute right-2 top-2 h-4 w-4 text-foreground" strokeWidth={2.5} />
               )}

--- a/ui/src/components/onboarding/view/subcomponents/LlmConfigurationStep.tsx
+++ b/ui/src/components/onboarding/view/subcomponents/LlmConfigurationStep.tsx
@@ -151,11 +151,14 @@ export default function LlmConfigurationStep({ onSaved }: LlmConfigurationStepPr
     fetchProviderModels({ protocol: effectiveProtocol, baseUrl: effectiveUrl, apiKey: hasUsableApiKey(key) ? key : '', providerId: effectiveProviderId })
       .then((models) => {
         if (controller.signal.aborted) return;
-        setApiModels(models);
+        setApiModels(!hasUsableApiKey(key) && models.length === 0 ? selectedProvider.models : models);
         setModelListStatus('idle');
-        if (models.length > 0 && !models.some((model) => model.id === selectedModelId)) {
-          setSelectedModelId(models[0].id);
-        }
+        const nextModels = !hasUsableApiKey(key) && models.length === 0 ? selectedProvider.models : models;
+        setSelectedModelId((current) => (
+          nextModels.length > 0 && !nextModels.some((model) => model.id === current)
+            ? nextModels[0].id
+            : current
+        ));
       })
       .catch((error) => {
         if (controller.signal.aborted) return;
@@ -177,18 +180,21 @@ export default function LlmConfigurationStep({ onSaved }: LlmConfigurationStepPr
         apiKey: hasUsableApiKey(key) ? key : '',
         providerId: effectiveProviderId,
       });
-      setApiModels(models);
+      const nextModels = !hasUsableApiKey(key) && !isCustomMode && selectedProvider
+        ? (models.length > 0 ? models : selectedProvider.models)
+        : models;
+      setApiModels(nextModels);
       setModelListStatus('idle');
       setSelectedModelId((current) => (
-        models.length > 0 && !models.some((model) => model.id === current)
-          ? models[0].id
+        nextModels.length > 0 && !nextModels.some((model) => model.id === current)
+          ? nextModels[0].id
           : current
       ));
     } catch (error) {
       setModelListStatus('error');
       setModelListMessage(error instanceof Error ? error.message : String(error));
     }
-  }, [apiKey, canFetchModels, effectiveProviderId, effectiveProtocol, effectiveUrl]);
+  }, [apiKey, canFetchModels, effectiveProviderId, effectiveProtocol, effectiveUrl, isCustomMode, selectedProvider]);
 
   const handleProviderSelect = useCallback((provider: CatalogProvider) => {
     setSelectedProvider((prev) => {
@@ -503,7 +509,7 @@ export default function LlmConfigurationStep({ onSaved }: LlmConfigurationStepPr
                 <Loader2 className="h-3 w-3 animate-spin" /> Fetching remote model list...
               </p>
             )}
-            {isCustomMode && (
+            {selectedProvider && (
               <button
                 type="button"
                 onClick={handleFetchModels}

--- a/ui/src/components/onboarding/view/subcomponents/LlmConfigurationStep.tsx
+++ b/ui/src/components/onboarding/view/subcomponents/LlmConfigurationStep.tsx
@@ -174,12 +174,14 @@ export default function LlmConfigurationStep({ onSaved }: LlmConfigurationStepPr
     setModelListMessage('');
     try {
       const key = apiKey.trim();
-      const models = await fetchProviderModels({
-        protocol: effectiveProtocol,
-        baseUrl: effectiveUrl,
-        apiKey: hasUsableApiKey(key) ? key : '',
-        providerId: effectiveProviderId,
-      });
+      const models = !isCustomMode && !hasUsableApiKey(key)
+        ? await fetchRemoteDefaultModels(effectiveProviderId)
+        : await fetchProviderModels({
+            protocol: effectiveProtocol,
+            baseUrl: effectiveUrl,
+            apiKey: hasUsableApiKey(key) ? key : '',
+            providerId: effectiveProviderId,
+          });
       const nextModels = !hasUsableApiKey(key) && !isCustomMode && selectedProvider
         ? (models.length > 0 ? models : selectedProvider.models)
         : models;

--- a/ui/src/components/onboarding/view/subcomponents/LlmConfigurationStep.tsx
+++ b/ui/src/components/onboarding/view/subcomponents/LlmConfigurationStep.tsx
@@ -7,7 +7,7 @@ import {
   type CatalogProvider,
   type CatalogProviderProtocol,
 } from '../../../../shared/catalogProviders';
-import { fetchProviderModels, type ApiModelListItem } from '../../../../shared/modelListApi';
+import { fetchProviderModels, fetchRemoteDefaultModels, type ApiModelListItem } from '../../../../shared/modelListApi';
 
 type LlmConfigurationStepProps = {
   onSaved: () => void | Promise<void>;
@@ -98,6 +98,7 @@ export default function LlmConfigurationStep({ onSaved }: LlmConfigurationStepPr
     ? customProtocol
     : (selectedProvider?.protocol ?? 'openai');
   const effectiveProviderId = isCustomMode ? customProviderId.trim() : (selectedProvider?.id ?? '');
+  const canFetchModels = Boolean(selectedProvider && effectiveProviderId && effectiveUrl);
   const canTest = Boolean(
     selectedProvider &&
     apiKey.trim() &&
@@ -113,12 +114,41 @@ export default function LlmConfigurationStep({ onSaved }: LlmConfigurationStepPr
   }, [effectiveProviderId, effectiveUrl, effectiveProtocol]);
 
   useEffect(() => {
-    const key = apiKey.trim();
-    if (!selectedProvider || !effectiveProviderId || !effectiveUrl || !key || hasUsableApiKey(key) === false) return;
+    if (!selectedProvider || isCustomMode || apiKey.trim()) return;
+    const catalogModels = selectedProvider.models;
     const controller = new AbortController();
     setModelListStatus('loading');
     setModelListMessage('');
-    fetchProviderModels({ protocol: effectiveProtocol, baseUrl: effectiveUrl, apiKey: key })
+    fetchRemoteDefaultModels(selectedProvider.id)
+      .then((models) => {
+        if (controller.signal.aborted) return;
+        setApiModels(models.length > 0 ? models : catalogModels);
+        setModelListStatus('idle');
+        const nextModels = models.length > 0 ? models : catalogModels;
+        setSelectedModelId((current) => (
+          nextModels.length > 0 && !nextModels.some((model) => model.id === current)
+            ? nextModels[0].id
+            : current
+        ));
+      })
+      .catch((error) => {
+        if (controller.signal.aborted) return;
+        setApiModels(catalogModels);
+        setModelListStatus('idle');
+        const message = error instanceof Error ? error.message : String(error);
+        setModelListMessage(`Using bundled model list. Remote model list unavailable: ${message}`);
+      });
+    return () => controller.abort();
+  }, [apiKey, isCustomMode, selectedProvider]);
+
+  useEffect(() => {
+    const key = apiKey.trim();
+    if (!selectedProvider || !effectiveProviderId || !effectiveUrl) return;
+    if (!hasUsableApiKey(key) && !isCustomMode) return;
+    const controller = new AbortController();
+    setModelListStatus('loading');
+    setModelListMessage('');
+    fetchProviderModels({ protocol: effectiveProtocol, baseUrl: effectiveUrl, apiKey: hasUsableApiKey(key) ? key : '', providerId: effectiveProviderId })
       .then((models) => {
         if (controller.signal.aborted) return;
         setApiModels(models);
@@ -133,7 +163,32 @@ export default function LlmConfigurationStep({ onSaved }: LlmConfigurationStepPr
         setModelListMessage(error instanceof Error ? error.message : String(error));
       });
     return () => controller.abort();
-  }, [apiKey, effectiveProviderId, effectiveProtocol, effectiveUrl, selectedModelId, selectedProvider]);
+  }, [apiKey, effectiveProviderId, effectiveProtocol, effectiveUrl, isCustomMode, selectedModelId, selectedProvider]);
+
+  const handleFetchModels = useCallback(async () => {
+    if (!canFetchModels) return;
+    setModelListStatus('loading');
+    setModelListMessage('');
+    try {
+      const key = apiKey.trim();
+      const models = await fetchProviderModels({
+        protocol: effectiveProtocol,
+        baseUrl: effectiveUrl,
+        apiKey: hasUsableApiKey(key) ? key : '',
+        providerId: effectiveProviderId,
+      });
+      setApiModels(models);
+      setModelListStatus('idle');
+      setSelectedModelId((current) => (
+        models.length > 0 && !models.some((model) => model.id === current)
+          ? models[0].id
+          : current
+      ));
+    } catch (error) {
+      setModelListStatus('error');
+      setModelListMessage(error instanceof Error ? error.message : String(error));
+    }
+  }, [apiKey, canFetchModels, effectiveProviderId, effectiveProtocol, effectiveUrl]);
 
   const handleProviderSelect = useCallback((provider: CatalogProvider) => {
     setSelectedProvider((prev) => {
@@ -445,11 +500,24 @@ export default function LlmConfigurationStep({ onSaved }: LlmConfigurationStepPr
             )}
             {modelListStatus === 'loading' && (
               <p className="mt-1 inline-flex items-center gap-1 text-[11px] text-muted-foreground">
-                <Loader2 className="h-3 w-3 animate-spin" /> Fetching models from API...
+                <Loader2 className="h-3 w-3 animate-spin" /> Fetching remote model list...
               </p>
+            )}
+            {isCustomMode && (
+              <button
+                type="button"
+                onClick={handleFetchModels}
+                disabled={!canFetchModels || modelListStatus === 'loading'}
+                className="mt-2 text-xs text-muted-foreground hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                Fetch model list
+              </button>
             )}
             {modelListStatus === 'error' && modelListMessage && (
               <p className="mt-1 text-[11px] text-destructive">{modelListMessage}</p>
+            )}
+            {modelListStatus === 'idle' && modelListMessage && (
+              <p className="mt-1 text-[11px] text-muted-foreground">{modelListMessage}</p>
             )}
             {selectedModels.length > 0 && (
               <div className="mt-2">

--- a/ui/src/components/settings/view/tabs/PilotDeckConfigTab.tsx
+++ b/ui/src/components/settings/view/tabs/PilotDeckConfigTab.tsx
@@ -1360,9 +1360,6 @@ function CatalogPicker({
             className="rounded-md border border-border bg-background px-3 py-2 text-left text-sm transition-colors hover:border-foreground/40 hover:bg-muted"
           >
             <div className="font-medium text-foreground">{p.displayName}</div>
-            <div className="mt-0.5 text-[10px] text-muted-foreground">
-              {t('pilotDeckConfig.panels.models.modelCount', { count: p.models.length })}
-            </div>
           </button>
         ))}
         <button

--- a/ui/src/components/settings/view/tabs/PilotDeckConfigTab.tsx
+++ b/ui/src/components/settings/view/tabs/PilotDeckConfigTab.tsx
@@ -1043,9 +1043,9 @@ function ProviderCard({
     setApiModelsStatus('loading');
     setApiModelsError('');
     try {
-      const models = !hasProviderApiKey && catalogEntry
-        ? await fetchRemoteDefaultModels(providerId)
-        : await fetchProviderModels({ protocol, baseUrl: effectiveUrl, apiKey: hasProviderApiKey ? provider.apiKey : '', providerId });
+      const models = hasProviderApiKey || !catalogEntry || effectiveUrl !== catalogEntry.defaultUrl
+        ? await fetchProviderModels({ protocol, baseUrl: effectiveUrl, apiKey: hasProviderApiKey ? provider.apiKey : '', providerId })
+        : await fetchRemoteDefaultModels(providerId);
       setApiModels(!hasProviderApiKey && catalogEntry && models.length === 0 ? catalogEntry.models : models);
       setApiModelsStatus('idle');
     } catch (error) {

--- a/ui/src/components/settings/view/tabs/PilotDeckConfigTab.tsx
+++ b/ui/src/components/settings/view/tabs/PilotDeckConfigTab.tsx
@@ -1043,7 +1043,7 @@ function ProviderCard({
     setApiModelsStatus('loading');
     setApiModelsError('');
     try {
-      const models = hasProviderApiKey || !catalogEntry || effectiveUrl !== catalogEntry.defaultUrl
+      const models = hasProviderApiKey || !catalogEntry || ![catalogEntry.defaultUrl, catalogEntry.modelListUrl].includes(effectiveUrl)
         ? await fetchProviderModels({ protocol, baseUrl: effectiveUrl, apiKey: hasProviderApiKey ? provider.apiKey : '', providerId })
         : await fetchRemoteDefaultModels(providerId);
       setApiModels(!hasProviderApiKey && catalogEntry && models.length === 0 ? catalogEntry.models : models);

--- a/ui/src/components/settings/view/tabs/PilotDeckConfigTab.tsx
+++ b/ui/src/components/settings/view/tabs/PilotDeckConfigTab.tsx
@@ -1046,7 +1046,7 @@ function ProviderCard({
       const models = !hasProviderApiKey && catalogEntry
         ? await fetchRemoteDefaultModels(providerId)
         : await fetchProviderModels({ protocol, baseUrl: effectiveUrl, apiKey: hasProviderApiKey ? provider.apiKey : '', providerId });
-      setApiModels(models);
+      setApiModels(!hasProviderApiKey && catalogEntry && models.length === 0 ? catalogEntry.models : models);
       setApiModelsStatus('idle');
     } catch (error) {
       setApiModelsStatus('error');

--- a/ui/src/components/settings/view/tabs/PilotDeckConfigTab.tsx
+++ b/ui/src/components/settings/view/tabs/PilotDeckConfigTab.tsx
@@ -57,7 +57,7 @@ import {
   type CatalogProviderProtocol,
   type CatalogModel,
 } from '../../../../shared/catalogProviders';
-import { fetchProviderModels, type ApiModelListItem } from '../../../../shared/modelListApi';
+import { fetchProviderModels, fetchRemoteDefaultModels, type ApiModelListItem } from '../../../../shared/modelListApi';
 import type { SettingsProject } from '../../types/types';
 import { isCronConfigEnabled, patch } from './pilotDeckConfigForm';
 
@@ -1036,13 +1036,16 @@ function ProviderCard({
     }
   };
   const visibleModels: Array<ApiModelListItem | CatalogModel> = apiModels ?? catalogEntry?.models ?? [];
-  const canFetchModels = Boolean(effectiveUrl && provider.apiKey);
+  const hasProviderApiKey = Boolean(provider.apiKey) && !isMaskedKey;
+  const canFetchModels = Boolean(effectiveUrl);
   const refreshModels = async () => {
     if (!canFetchModels) return;
     setApiModelsStatus('loading');
     setApiModelsError('');
     try {
-      const models = await fetchProviderModels({ protocol, baseUrl: effectiveUrl, apiKey: provider.apiKey ?? '', providerId });
+      const models = !hasProviderApiKey && catalogEntry
+        ? await fetchRemoteDefaultModels(providerId)
+        : await fetchProviderModels({ protocol, baseUrl: effectiveUrl, apiKey: hasProviderApiKey ? provider.apiKey : '', providerId });
       setApiModels(models);
       setApiModelsStatus('idle');
     } catch (error) {
@@ -1050,6 +1053,28 @@ function ProviderCard({
       setApiModelsError(error instanceof Error ? error.message : String(error));
     }
   };
+
+  useEffect(() => {
+    if (!catalogEntry || hasProviderApiKey) return;
+    const catalogModels = catalogEntry.models;
+    const controller = new AbortController();
+    setApiModelsStatus('loading');
+    setApiModelsError('');
+    fetchRemoteDefaultModels(providerId)
+      .then((models) => {
+        if (controller.signal.aborted) return;
+        setApiModels(models.length > 0 ? models : catalogModels);
+        setApiModelsStatus('idle');
+      })
+      .catch((error) => {
+        if (controller.signal.aborted) return;
+        setApiModels(catalogModels);
+        setApiModelsStatus('idle');
+        const message = error instanceof Error ? error.message : String(error);
+        setApiModelsError(`Using bundled model list. Remote model list unavailable: ${message}`);
+      });
+    return () => controller.abort();
+  }, [catalogEntry, hasProviderApiKey, providerId]);
 
   return (
     <div className="space-y-3 rounded-lg border border-border bg-background/50 p-4 transition-colors">
@@ -1166,11 +1191,16 @@ function ProviderCard({
             className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] text-muted-foreground hover:bg-accent hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
           >
             <RefreshCw className={cn('h-2.5 w-2.5', apiModelsStatus === 'loading' && 'animate-spin')} />
-            Fetch API models
+            {hasProviderApiKey || !catalogEntry ? 'Fetch API models' : 'Fetch remote models'}
           </button>
         </div>
         {apiModelsStatus === 'error' && apiModelsError && (
           <div className="mb-2 rounded-md border border-destructive/30 bg-destructive/5 px-2 py-1 text-[11px] text-destructive">
+            {apiModelsError}
+          </div>
+        )}
+        {apiModelsStatus === 'idle' && apiModelsError && (
+          <div className="mb-2 rounded-md border border-border bg-muted/30 px-2 py-1 text-[11px] text-muted-foreground">
             {apiModelsError}
           </div>
         )}

--- a/ui/src/shared/catalogProviders.ts
+++ b/ui/src/shared/catalogProviders.ts
@@ -26,6 +26,7 @@ export type CatalogProvider = {
   displayName: string;
   protocol: CatalogProviderProtocol;
   defaultUrl: string;
+  modelListUrl?: string;
   models: CatalogModel[];
 };
 
@@ -90,6 +91,7 @@ export const CATALOG_PROVIDERS: CatalogProvider[] = [
     displayName: 'DeepSeek',
     protocol: 'openai',
     defaultUrl: 'https://api.deepseek.com/v1',
+    modelListUrl: 'https://api.deepseek.com/models',
     models: [
       { id: 'deepseek-v4-pro', displayName: 'DeepSeek V4 Pro', maxContextTokens: 1048576, maxOutputTokens: 393216 },
       { id: 'deepseek-v4-flash', displayName: 'DeepSeek V4 Flash', maxContextTokens: 1048576, maxOutputTokens: 393216 },
@@ -125,7 +127,7 @@ export const CATALOG_PROVIDERS: CatalogProvider[] = [
     id: 'minimax',
     displayName: 'MiniMax',
     protocol: 'openai',
-    defaultUrl: 'https://api.minimaxi.com/v1',
+    defaultUrl: 'https://api.minimax.io/v1',
     models: [
       { id: 'MiniMax-M2.5', displayName: 'MiniMax M2.5', maxContextTokens: 1000000 },
       { id: 'MiniMax-M2.7-highspeed', displayName: 'MiniMax M2.7 Highspeed', maxContextTokens: 1000000 },

--- a/ui/src/shared/modelListApi.ts
+++ b/ui/src/shared/modelListApi.ts
@@ -1,5 +1,5 @@
 import { authenticatedFetch } from '../utils/api';
-import type { CatalogModel, CatalogProviderProtocol } from './catalogProviders';
+import { findCatalogProviderById, type CatalogModel, type CatalogProviderProtocol } from './catalogProviders';
 
 export type ApiModelListItem = Pick<CatalogModel, 'id' | 'displayName'>;
 
@@ -33,10 +33,11 @@ function normalizeModelList(models: unknown[]): ApiModelListItem[] {
 }
 
 export async function fetchRemoteDefaultModels(providerId: string): Promise<ApiModelListItem[]> {
-  if (providerId !== 'openrouter') return [];
+  const provider = findCatalogProviderById(providerId);
+  if (!provider?.defaultUrl) return [];
   return fetchProviderModels({
-    protocol: 'openai',
-    baseUrl: 'https://openrouter.ai/api/v1',
+    protocol: provider.protocol,
+    baseUrl: provider.defaultUrl,
     apiKey: '',
     providerId,
   });

--- a/ui/src/shared/modelListApi.ts
+++ b/ui/src/shared/modelListApi.ts
@@ -37,7 +37,7 @@ export async function fetchRemoteDefaultModels(providerId: string): Promise<ApiM
   if (!provider?.defaultUrl) return [];
   return fetchProviderModels({
     protocol: provider.protocol,
-    baseUrl: provider.defaultUrl,
+    baseUrl: provider.modelListUrl ?? provider.defaultUrl,
     apiKey: '',
     providerId,
   });

--- a/ui/src/shared/modelListApi.ts
+++ b/ui/src/shared/modelListApi.ts
@@ -34,23 +34,12 @@ function normalizeModelList(models: unknown[]): ApiModelListItem[] {
 
 export async function fetchRemoteDefaultModels(providerId: string): Promise<ApiModelListItem[]> {
   if (providerId !== 'openrouter') return [];
-  const controller = new AbortController();
-  const timer = window.setTimeout(() => controller.abort(), 10_000);
-  try {
-    const response = await fetch('https://openrouter.ai/api/v1/models', {
-      headers: { Accept: 'application/json' },
-      signal: controller.signal,
-    });
-    const data = await response.json().catch(() => ({}));
-    if (!response.ok) {
-      const message = data?.error?.message || data?.message || `HTTP ${response.status}`;
-      throw new Error(String(message));
-    }
-    const models = Array.isArray(data?.data) ? data.data : Array.isArray(data?.models) ? data.models : [];
-    return normalizeModelList(models);
-  } finally {
-    window.clearTimeout(timer);
-  }
+  return fetchProviderModels({
+    protocol: 'openai',
+    baseUrl: 'https://openrouter.ai/api/v1',
+    apiKey: '',
+    providerId,
+  });
 }
 
 export async function fetchProviderModels({

--- a/ui/src/shared/modelListApi.ts
+++ b/ui/src/shared/modelListApi.ts
@@ -3,6 +3,56 @@ import type { CatalogModel, CatalogProviderProtocol } from './catalogProviders';
 
 export type ApiModelListItem = Pick<CatalogModel, 'id' | 'displayName'>;
 
+function normalizeModelListItem(model: unknown): ApiModelListItem | null {
+  if (!model || typeof model !== 'object') return null;
+  const record = model as Record<string, unknown>;
+  const id = typeof record.id === 'string'
+    ? record.id.trim()
+    : typeof record.name === 'string'
+      ? record.name.replace(/^models\//, '').trim()
+      : '';
+  if (!id) return null;
+  const displayName = typeof record.displayName === 'string' && record.displayName.trim()
+    ? record.displayName.trim()
+    : typeof record.display_name === 'string' && record.display_name.trim()
+      ? record.display_name.trim()
+      : id;
+  return { id, displayName };
+}
+
+function normalizeModelList(models: unknown[]): ApiModelListItem[] {
+  const seen = new Set<string>();
+  const normalized: ApiModelListItem[] = [];
+  for (const model of models) {
+    const item = normalizeModelListItem(model);
+    if (!item || seen.has(item.id)) continue;
+    seen.add(item.id);
+    normalized.push(item);
+  }
+  return normalized;
+}
+
+export async function fetchRemoteDefaultModels(providerId: string): Promise<ApiModelListItem[]> {
+  if (providerId !== 'openrouter') return [];
+  const controller = new AbortController();
+  const timer = window.setTimeout(() => controller.abort(), 10_000);
+  try {
+    const response = await fetch('https://openrouter.ai/api/v1/models', {
+      headers: { Accept: 'application/json' },
+      signal: controller.signal,
+    });
+    const data = await response.json().catch(() => ({}));
+    if (!response.ok) {
+      const message = data?.error?.message || data?.message || `HTTP ${response.status}`;
+      throw new Error(String(message));
+    }
+    const models = Array.isArray(data?.data) ? data.data : Array.isArray(data?.models) ? data.models : [];
+    return normalizeModelList(models);
+  } finally {
+    window.clearTimeout(timer);
+  }
+}
+
 export async function fetchProviderModels({
   protocol,
   baseUrl,
@@ -11,7 +61,7 @@ export async function fetchProviderModels({
 }: {
   protocol: CatalogProviderProtocol;
   baseUrl: string;
-  apiKey: string;
+  apiKey?: string;
   providerId?: string;
 }): Promise<ApiModelListItem[]> {
   const res = await authenticatedFetch('/api/config/models', {
@@ -28,18 +78,5 @@ export async function fetchProviderModels({
     throw new Error(data?.error || 'Failed to fetch model list.');
   }
   const models = Array.isArray(data?.models) ? data.models : [];
-  return models
-    .map((model: unknown) => {
-      if (!model || typeof model !== 'object') return null;
-      const record = model as Record<string, unknown>;
-      const id = typeof record.id === 'string' ? record.id.trim() : '';
-      if (!id) return null;
-      return {
-        id,
-        displayName: typeof record.displayName === 'string' && record.displayName.trim()
-          ? record.displayName.trim()
-          : id,
-      };
-    })
-    .filter((model: ApiModelListItem | null): model is ApiModelListItem => Boolean(model));
+  return normalizeModelList(models);
 }


### PR DESCRIPTION
## Summary
- fetch remote model lists through the backend proxy for onboarding/settings instead of browser-side cross-origin calls
- add model-list fetch controls for onboarding catalog/custom providers and settings providers
- use provider-specific documented model-list endpoints where needed, with catalog fallback for providers that require API keys
- hide bundled catalog model counts from provider tiles to avoid mismatches with fetched lists

## Testing
- npm --prefix ui run build
