### PR TITLE
fix(adapters): promote QQ to config-driven startup and add hot-reload for all channels

### DIFF
--- a/src/adapters/channel/qq/QQChannel.ts
+++ b/src/adapters/channel/qq/QQChannel.ts
@@ -3,7 +3,7 @@ import type { ChannelAdapter, ChannelHandle, ChannelLogger, ChannelStartDeps } f
 import { QQBotGateway, type QQBotCredentials, type QQGroupMessageEvent, type QQC2CMessageEvent } from "./qqbot-gateway.js";
 import { ImElicitationHelper } from "../protocol/ImElicitationHelper.js";
 import { ImPermissionHelper } from "../protocol/ImPermissionHelper.js";
-import { QQSessionMapper } from "./QQSessionMapper.js";
+import { QQSessionMapper, type QQSessionMapperState } from "./QQSessionMapper.js";
 import { renderQQEvent } from "./qq-render.js";
 
 export type QQChannelOptions = {
@@ -13,6 +13,7 @@ export type QQChannelOptions = {
   triggerPrefixes?: string[];
   mapper?: QQSessionMapper;
   maxMessageLength?: number;
+  onStateChange?: (state: QQSessionMapperState) => void;
 };
 
 const DEFAULT_PREFIXES = ["/ask", "/chat"];
@@ -26,6 +27,7 @@ export class QQChannel implements ChannelAdapter {
   private readonly triggerPrefixes: string[];
   private readonly mapper: QQSessionMapper;
   private readonly maxMessageLength: number;
+  private readonly onStateChange?: (state: QQSessionMapperState) => void;
 
   private gateway?: Gateway;
   private logger?: ChannelLogger;
@@ -43,6 +45,7 @@ export class QQChannel implements ChannelAdapter {
     this.triggerPrefixes = options.triggerPrefixes ?? DEFAULT_PREFIXES;
     this.mapper = options.mapper ?? new QQSessionMapper();
     this.maxMessageLength = options.maxMessageLength ?? DEFAULT_MAX_MSG_LEN;
+    this.onStateChange = options.onStateChange;
   }
 
   async start(deps: ChannelStartDeps): Promise<ChannelHandle> {
@@ -151,6 +154,9 @@ export class QQChannel implements ChannelAdapter {
     }
 
     const mapped = this.mapper.resolve({ groupId: groupOpenId, userId: userOpenId, text });
+    if (mapped.command === "new") {
+      this.onStateChange?.(this.mapper.snapshot());
+    }
 
     if (mapped.command === "new" && !mapped.message) {
       await this.sendReply(groupOpenId, "已创建新会话。", event.id);

--- a/src/cli/pilotdeck.ts
+++ b/src/cli/pilotdeck.ts
@@ -6,8 +6,8 @@ import { connectRemoteGatewayIfAvailable, type Gateway, type GatewayEvent, type 
 import {
   CliChannel, TuiChannel, FeishuChannel, WeixinChannel, QQChannel, WeComChannel,
   loadEnabledChannels, ChannelStatePersistence,
-  FeishuSessionMapper, WeixinSessionMapper, WeComSessionMapper,
-  type FeishuSessionMapperState, type WeixinSessionMapperState, type WeComSessionMapperState,
+  FeishuSessionMapper, WeixinSessionMapper, QQSessionMapper, WeComSessionMapper,
+  type FeishuSessionMapperState, type WeixinSessionMapperState, type QQSessionMapperState, type WeComSessionMapperState,
 } from "../adapters/index.js";
 import {
   migrateSkillsToPilotDeck,
@@ -282,6 +282,21 @@ async function main(argv = process.argv.slice(2)): Promise<void> {
         parts.push("weixin=started");
       }
 
+      const qqCfg = config.adapters?.qq;
+      if (qqCfg?.enabled === true) {
+        const savedQQ = await channelStatePersistence.load<QQSessionMapperState>("qq");
+        await serverRef.hotStartChannel(new QQChannel({
+          appId: qqCfg.appId,
+          clientSecret: qqCfg.clientSecret,
+          allowGroups: qqCfg.allowGroups,
+          triggerPrefixes: qqCfg.triggerPrefixes,
+          maxMessageLength: qqCfg.maxMessageLength,
+          mapper: savedQQ ? new QQSessionMapper(savedQQ) : undefined,
+          onStateChange: (state) => channelStatePersistence.save("qq", state),
+        }));
+        parts.push("qq=started");
+      }
+
       const wcCfg = config.adapters?.wecom;
       if (wcCfg?.enabled === true) {
         const savedWeCom = await channelStatePersistence.load<WeComSessionMapperState>("wecom");
@@ -292,6 +307,12 @@ async function main(argv = process.argv.slice(2)): Promise<void> {
           onStateChange: (state) => channelStatePersistence.save("wecom", state),
         }));
         parts.push("wecom=started");
+      }
+
+      const extraChannels = await loadEnabledChannels(config.adapters);
+      for (const ch of extraChannels) {
+        await serverRef.hotStartChannel(ch);
+        parts.push(`${ch.channelKey}=started`);
       }
 
       if (parts.length) {
@@ -325,6 +346,19 @@ async function main(argv = process.argv.slice(2)): Promise<void> {
           onStateChange: (state) => channelStatePersistence.save("weixin", state),
         })
       : undefined;
+    const qqCfg = snapshot.config.adapters?.qq;
+    const savedQQState = await channelStatePersistence.load<QQSessionMapperState>("qq");
+    const qqChannel = qqCfg?.enabled === true
+      ? new QQChannel({
+          appId: qqCfg.appId,
+          clientSecret: qqCfg.clientSecret,
+          allowGroups: qqCfg.allowGroups,
+          triggerPrefixes: qqCfg.triggerPrefixes,
+          maxMessageLength: qqCfg.maxMessageLength,
+          mapper: savedQQState ? new QQSessionMapper(savedQQState) : undefined,
+          onStateChange: (state) => channelStatePersistence.save("qq", state),
+        })
+      : undefined;
     const wecomCfg = snapshot.config.adapters?.wecom;
     const savedWeComState = await channelStatePersistence.load<WeComSessionMapperState>("wecom");
     const wecomChannel = wecomCfg?.enabled === true
@@ -342,7 +376,7 @@ async function main(argv = process.argv.slice(2)): Promise<void> {
       staticAssetsPath: resolve(projectRoot, "ui/dist"),
       feishu: feishuChannel,
       weixin: weixinChannel,
-      qq: new QQChannel(),
+      qq: qqChannel,
       channels: allChannels,
       config: snapshot.config,
     });

--- a/src/pilot/config/parseGatewayConfig.ts
+++ b/src/pilot/config/parseGatewayConfig.ts
@@ -81,6 +81,7 @@ export function parseAdaptersConfig(rawAdapters: unknown, diagnostics: PilotConf
     tui: parseAutoConnect(rawAdapters.tui),
     feishu: parseFeishu(rawAdapters.feishu),
     weixin: parseEnabledOnly(rawAdapters.weixin),
+    qq: parseQQ(rawAdapters.qq),
   };
 
   for (const key of PLATFORM_KEYS) {
@@ -132,6 +133,27 @@ function parseFeishu(raw: unknown): PilotAdaptersConfig["feishu"] {
     defaultSessionLabel: stringField(raw, "defaultSessionLabel", "general") ?? "general",
     connectionMode: mode === "stream" || mode === "webhook" ? mode : undefined,
     domainName: domain === "feishu" || domain === "lark" ? domain : undefined,
+  };
+}
+
+function parseQQ(raw: unknown): PilotAdaptersConfig["qq"] {
+  if (!isRecord(raw)) return undefined;
+  const groups = Array.isArray(raw.allowGroups)
+    ? (raw.allowGroups as unknown[]).filter((v): v is string => typeof v === "string")
+    : undefined;
+  const prefixes = Array.isArray(raw.triggerPrefixes)
+    ? (raw.triggerPrefixes as unknown[]).filter((v): v is string => typeof v === "string")
+    : undefined;
+  const maxLen = typeof raw.maxMessageLength === "number" && Number.isFinite(raw.maxMessageLength)
+    ? raw.maxMessageLength
+    : undefined;
+  return {
+    enabled: booleanField(raw, "enabled", false),
+    appId: stringField(raw, "appId"),
+    clientSecret: stringField(raw, "clientSecret"),
+    allowGroups: groups,
+    triggerPrefixes: prefixes,
+    maxMessageLength: maxLen,
   };
 }
 

--- a/src/pilot/config/types.ts
+++ b/src/pilot/config/types.ts
@@ -193,6 +193,14 @@ export type PilotAdaptersConfig = {
     domainName?: "feishu" | "lark";
   };
   weixin?: { enabled: boolean };
+  qq?: {
+    enabled: boolean;
+    appId?: string;
+    clientSecret?: string;
+    allowGroups?: string[];
+    triggerPrefixes?: string[];
+    maxMessageLength?: number;
+  };
   telegram?: PilotPlatformAdapterConfig;
   discord?: PilotPlatformAdapterConfig;
   slack?: PilotPlatformAdapterConfig;


### PR DESCRIPTION
## Summary

- **Issue #242**: Promote QQ channel from unconditional env-only startup to config-driven first-class adapter, aligned with Feishu/Weixin/WeCom. Users can now configure `adapters.qq` in `pilotdeck.yaml` with `enabled`, `appId`, `clientSecret`, `allowGroups`, `triggerPrefixes`, and `maxMessageLength`. When `adapters.qq` is not configured, the QQ channel is not started and no spurious log is emitted.
- **Issue #241**: Extend adapter hot-reload to cover QQ and all extra channels (Telegram, Discord, Slack, etc.). Previously only Feishu, Weixin, and WeCom were reloaded; now the hot-reload handler also rebuilds QQ from config and calls `loadEnabledChannels` to hot-start any enabled extra channel.

## Changes

| File | Change |
|---|---|
| `src/pilot/config/types.ts` | Add `qq` field to `PilotAdaptersConfig` |
| `src/pilot/config/parseGatewayConfig.ts` | Add `parseQQ()` parser for `adapters.qq` YAML section |
| `src/adapters/channel/qq/QQChannel.ts` | Add `onStateChange` callback to `QQChannelOptions` for state persistence |
| `src/cli/pilotdeck.ts` | Config-driven QQ startup + QQ hot-reload block + extra channels hot-reload via `loadEnabledChannels` |

## Test plan

- [x] TypeScript compiles with zero errors
- [x] Full test suite passes (75/75, 0 failures)
- [ ] Manual: start without `adapters.qq` config — no `QQ_BOT_APPID or QQ_BOT_SECRET not set` log
- [ ] Manual: add `adapters.qq.enabled: true` with credentials — QQ channel starts
- [ ] Manual: modify `adapters.telegram` at runtime — hot-reload picks it up
- [ ] Manual: existing Feishu/Weixin/WeCom behavior unchanged

Closes #241
Closes #242

Made with [Cursor](https://cursor.com)