### PR TITLE
fix: validate path type and encoding enum in /files/write route

### DIFF
--- a/src/adapters/web/httpRouter.ts
+++ b/src/adapters/web/httpRouter.ts
@@ -85,7 +85,7 @@ export async function handleWebApiRequest(
       }
       if (subPath === "/files/write" && request.method === "POST") {
         const body = await readJsonBody<{ path?: string; content?: string; encoding?: "utf8" | "base64" }>(request);
-        if (!body?.path || typeof body.content !== "string") {
+        if (typeof body?.path !== "string" || !body.path || typeof body.content !== "string" || (body.encoding !== undefined && body.encoding !== "utf8" && body.encoding !== "base64")) {
           sendJson(response, 400, {
             error: { code: "invalid_body", message: "Expected { path, content[, encoding] }" },
           });


### PR DESCRIPTION
## Summary

- Reject non-string `path` values (e.g. `{}`, `[]`, `123`) with `400 invalid_body` instead of letting them reach Node `path` APIs and causing `500 internal_error`.
- Reject unsupported `encoding` values (e.g. `"hex"`) with `400 invalid_body` instead of silently falling back to UTF-8.

Closes #341
Closes #342

## Test plan

- [x] `tsc --noEmit` passes
- [x] All 75 existing tests pass, 0 regressions

Made with [Cursor](https://cursor.com)