### PR TITLE
Add blocking wait for background tasks

### DIFF
--- a/src/context/compaction/protectedContext.ts
+++ b/src/context/compaction/protectedContext.ts
@@ -18,6 +18,8 @@ export const DEFAULT_PROTECTED_TOOL_RESULT_NAMES: ReadonlySet<string> = new Set(
   "TaskList",
   "task_output",
   "TaskOutput",
+  "task_wait",
+  "TaskWait",
   "task_stop",
   "TaskStop",
 ]);

--- a/src/context/prompt/PromptAssembler.ts
+++ b/src/context/prompt/PromptAssembler.ts
@@ -101,9 +101,6 @@ export class PromptAssembler {
       "",
       "File delivery links:",
       "When you create, modify, export, render, or otherwise produce a user-facing file, include a Markdown link to that file in the final response. Use relative links for files under the current cwd, e.g. `[open report.pdf](report.pdf)`. Use `file://` absolute links only for files outside the cwd, e.g. `[open file](file:///absolute/path/file.pdf)`. Do not claim that a file was opened automatically; provide a clickable link instead.",
-      "",
-      "Todo workflow:",
-      "For complex tasks, tasks with 3+ steps, multi-file changes, long-running work, or tasks that require verification, create a todo list with todo_write before making substantive changes. Keep the list editable: update it after each meaningful step, before and after long-running commands when useful, when new required work or risks are discovered, and before the final response. Use stable ids and merge updates when available; preserve completed facts and mark obsolete work as cancelled instead of silently deleting it. Persist important intermediate findings under the current workspace (cwd) when they are needed for recovery or final handoff, such as `.pilotdeck/work/<session-id>/findings.md`, `todo_history.md`, `verification.md`, and `artifacts/`; if no session id is available, use `.pilotdeck/work/current/`. Verify completed work when possible and align the final todo state with the final answer.",
     ];
 
     const permissionLine = formatPermissionMode(input.permissionMode);

--- a/src/task/runtime/BackgroundTaskRuntime.ts
+++ b/src/task/runtime/BackgroundTaskRuntime.ts
@@ -81,6 +81,7 @@ export type WaitTaskOptions = {
 export type WaitTaskResult = {
   task: PilotDeckBackgroundBashTask;
   timedOut: boolean;
+  outcome: "completed" | "timeout" | "aborted";
   waitedMs: number;
 };
 
@@ -158,9 +159,15 @@ export class BackgroundTaskRuntime {
     if (abortPromise) waits.push(abortPromise);
     const result = await Promise.race(waits);
 
+    const outcome = result === "timeout"
+      ? "timeout"
+      : result === "aborted"
+        ? "aborted"
+        : "completed";
     return {
       task: entry.task,
-      timedOut: result === "timeout" || result === "aborted",
+      timedOut: outcome === "timeout" || outcome === "aborted",
+      outcome,
       waitedMs: Date.now() - startedAt,
     };
   }

--- a/src/task/runtime/BackgroundTaskRuntime.ts
+++ b/src/task/runtime/BackgroundTaskRuntime.ts
@@ -73,6 +73,17 @@ export type StopTaskOptions = {
   graceMs?: number;
 };
 
+export type WaitTaskOptions = {
+  timeoutMs?: number;
+  abortSignal?: AbortSignal;
+};
+
+export type WaitTaskResult = {
+  task: PilotDeckBackgroundBashTask;
+  timedOut: boolean;
+  waitedMs: number;
+};
+
 type RuntimeEntry = {
   task: PilotDeckBackgroundBashTask;
   child?: ChildProcess;
@@ -119,6 +130,39 @@ export class BackgroundTaskRuntime {
 
   get(taskId: string): PilotDeckBackgroundBashTask | undefined {
     return this.entries.get(taskId)?.task;
+  }
+
+  async wait(taskId: string, options: WaitTaskOptions = {}): Promise<WaitTaskResult | undefined> {
+    const entry = this.entries.get(taskId);
+    if (!entry) return undefined;
+
+    const startedAt = Date.now();
+    const timeoutMs = Math.max(0, Math.floor(options.timeoutMs ?? 0));
+    const timeoutPromise = timeoutMs > 0
+      ? new Promise<"timeout">((resolve) => {
+          setTimeout(() => resolve("timeout"), timeoutMs).unref?.();
+        })
+      : undefined;
+    const abortPromise = options.abortSignal
+      ? new Promise<"aborted">((resolve) => {
+          if (options.abortSignal?.aborted) {
+            resolve("aborted");
+            return;
+          }
+          options.abortSignal?.addEventListener("abort", () => resolve("aborted"), { once: true });
+        })
+      : undefined;
+
+    const waits: Array<Promise<void | "timeout" | "aborted">> = [entry.done];
+    if (timeoutPromise) waits.push(timeoutPromise);
+    if (abortPromise) waits.push(abortPromise);
+    const result = await Promise.race(waits);
+
+    return {
+      task: entry.task,
+      timedOut: result === "timeout" || result === "aborted",
+      waitedMs: Date.now() - startedAt,
+    };
   }
 
   /**

--- a/src/task/runtime/BackgroundTaskRuntime.ts
+++ b/src/task/runtime/BackgroundTaskRuntime.ts
@@ -144,13 +144,15 @@ export class BackgroundTaskRuntime {
           setTimeout(() => resolve("timeout"), timeoutMs).unref?.();
         })
       : undefined;
+    let abortHandler: (() => void) | undefined;
     const abortPromise = options.abortSignal
       ? new Promise<"aborted">((resolve) => {
           if (options.abortSignal?.aborted) {
             resolve("aborted");
             return;
           }
-          options.abortSignal?.addEventListener("abort", () => resolve("aborted"), { once: true });
+          abortHandler = () => resolve("aborted");
+          options.abortSignal?.addEventListener("abort", abortHandler, { once: true });
         })
       : undefined;
 
@@ -158,6 +160,9 @@ export class BackgroundTaskRuntime {
     if (timeoutPromise) waits.push(timeoutPromise);
     if (abortPromise) waits.push(abortPromise);
     const result = await Promise.race(waits);
+    if (abortHandler) {
+      options.abortSignal?.removeEventListener("abort", abortHandler);
+    }
 
     const outcome = result === "timeout"
       ? "timeout"

--- a/src/tool/builtin/bash.ts
+++ b/src/tool/builtin/bash.ts
@@ -42,10 +42,10 @@ const BASH_TOOL_DESCRIPTION = `Run a shell command in the PilotDeck workspace.
 Usage:
 - The \`command\` parameter is passed to the system shell (\`cmd.exe\` on Windows, \`/bin/sh\` on macOS/Linux).
 - The shell runs in the current workspace directory and inherits the tool runtime environment.
-- Use \`timeout\` to override the command timeout in milliseconds. When omitted, the default is 30000ms. Values above 600000ms are rejected; use task_create for longer-running commands.
+- Use \`timeout\` to override the command timeout in milliseconds. When omitted, the default is 30000ms. Values above 600000ms are rejected; lower the foreground timeout to 600000 or less, or use task_create followed by task_wait for background work that should finish.
 - Use \`description\` to provide a short, clear label for logs and audits. Prefer 3-10 words that say what the command does.
 - Use this tool for short shell commands, simple pipelines, and running saved workspace scripts.
-- Use task_create for long-running work such as dev servers, watchers, builds, test suites, deploys, CI pollers, or commands that need more than the maximum foreground timeout. Poll with task_output and stop long-lived processes with task_stop.
+- Use task_create for long-running work such as dev servers, watchers, builds, test suites, deploys, CI pollers, or commands that need more than the maximum foreground timeout. For background work that should finish, call task_wait after task_create. Use task_output for progress checks and task_stop for long-lived processes.
 - For non-trivial code or anything you will debug/rerun with changed parameters, first create or edit a script file with write_file/edit_file, then run that file. Avoid large inline heredocs, \`python - <<...\`, long \`python -c\`, or long \`node -e\` programs when a saved script would be reusable.
 - Do not use shell-level backgrounding (\`nohup\`, \`disown\`, \`setsid\`, trailing \`&\`) in bash. Use task_create so PilotDeck can track lifecycle and output.
 - Read-only shell commands (for example \`pwd\`, \`ls\`, \`git status\`, \`git diff\`, \`git log\`) are treated as read-only. Commands with side effects require permission, and known-dangerous commands are denied outright.
@@ -55,7 +55,7 @@ Usage:
 - If you have no command to run, respond with text instead of calling bash.`;
 
 const LONG_TASK_HINT =
-  "Use task_create to start a tracked background task, task_output to poll output, and task_stop to clean up long-lived processes.";
+  "Use timeout=600000 or less for foreground bash. If the command must run in the background, use task_create and then task_wait to block for completion; use task_output only for progress checks and task_stop to clean up long-lived processes.";
 
 const SHELL_BACKGROUND_WRAPPER_RE = /(?:^|[;&|]\s*|&&\s*|\|\|\s*|\$\(\s*)(?:nohup|disown|setsid)\b/iu;
 const TRAILING_BACKGROUND_RE = /(?:^|[^&])&\s*(?:[)#}\]]\s*)?$/u;
@@ -89,7 +89,7 @@ export function createBashTool(options?: CreateBashToolOptions): PilotDeckToolDe
         },
         timeout: {
           type: "integer",
-          description: "Optional timeout in milliseconds. Defaults to 30000. Max 600000; larger values are rejected. Use task_create for longer-running commands.",
+          description: "Optional timeout in milliseconds. Defaults to 30000. Max 600000; larger values are rejected. Use timeout=600000 or less for foreground bash, or task_create followed by task_wait for background work that should finish.",
         },
         description: {
           type: "string",

--- a/src/tool/builtin/taskTools.ts
+++ b/src/tool/builtin/taskTools.ts
@@ -400,6 +400,12 @@ export function createTaskWaitTool(
           `Unknown taskId: ${input.taskId}`,
         );
       }
+      if (waited.outcome === "aborted") {
+        throw new PilotDeckToolRuntimeError(
+          "tool_aborted",
+          `task_wait aborted before task ${input.taskId} finished.`,
+        );
+      }
       const slice = rt.getOutput(input.taskId, requestedOffset, input.maxBytes);
       const data: TaskWaitResult = {
         taskId: input.taskId,

--- a/src/tool/builtin/taskTools.ts
+++ b/src/tool/builtin/taskTools.ts
@@ -5,6 +5,7 @@
  *   - task_create  → `BackgroundTaskRuntime.start`
  *   - task_list    → `BackgroundTaskRuntime.list`
  *   - task_output  → `BackgroundTaskRuntime.getOutput` (incremental polling)
+ *   - task_wait    → `BackgroundTaskRuntime.wait` + final output slice
  *   - task_stop    → `BackgroundTaskRuntime.stop`
  *
  * The runtime is injected once at registry construction (no per-call
@@ -75,6 +76,18 @@ export type TaskOutputResult = {
   exitCode?: number | null;
 };
 
+export type TaskWaitInput = {
+  taskId: string;
+  timeoutMs?: number;
+  offset?: number;
+  maxBytes?: number;
+};
+
+export type TaskWaitResult = TaskOutputResult & {
+  waitedMs: number;
+  timedOut: boolean;
+};
+
 export type TaskStopInput = {
   taskId: string;
   graceMs?: number;
@@ -90,6 +103,8 @@ const TERMINAL_TASK_STATUSES = new Set<PilotDeckBackgroundTaskStatus>([
   "failed",
   "cancelled",
 ]);
+const DEFAULT_TASK_WAIT_TIMEOUT_MS = 600_000;
+const MAX_TASK_WAIT_TIMEOUT_MS = 600_000;
 
 function ensureRuntime(runtime: BackgroundTaskRuntime | undefined): BackgroundTaskRuntime {
   if (!runtime) {
@@ -125,6 +140,22 @@ function formatTaskOutputText(data: TaskOutputResult, requestedOffset: number): 
   return `${header}\n${data.content}`;
 }
 
+function formatTaskWaitText(data: TaskWaitResult, requestedOffset: number): string {
+  const exitCode = data.exitCode ?? "null";
+  const header = `task_wait taskId=${data.taskId} status=${data.status} waitedMs=${data.waitedMs} offset=${requestedOffset} nextOffset=${data.nextOffset} totalBytes=${data.totalBytes} truncated=${data.truncated} exitCode=${exitCode}`;
+  const hasNewOutput = data.content.length > 0;
+  const isFinished = isTerminalTaskStatus(data.status) && data.nextOffset >= data.totalBytes;
+  const body = hasNewOutput ? `\n${data.content}` : "";
+
+  if (isFinished) {
+    return `${header}${body}\nTask finished; no further polling is needed.`;
+  }
+  if (data.timedOut) {
+    return `${header}${body}\nTask is still running after timeoutMs; use task_wait again to block or task_output for progress.`;
+  }
+  return `${header}${body}`;
+}
+
 export function createTaskCreateTool(
   runtime?: BackgroundTaskRuntime,
 ): PilotDeckToolDefinition<TaskCreateInput, TaskCreateOutput> {
@@ -132,7 +163,7 @@ export function createTaskCreateTool(
     name: "task_create",
     aliases: ["TaskCreate"],
     description:
-      "Spawn a shell command as a detached background task. Returns immediately with a taskId; poll task_output / task_stop to manage it.",
+      "Spawn a shell command as a detached background task. Returns immediately with a taskId; it does not automatically push completion output back into the model context. For long-running tasks that should finish, call task_wait next. Use task_output for progress checks and task_stop for long-lived processes.",
     kind: "shell",
     inputSchema: {
       type: "object",
@@ -241,7 +272,7 @@ export function createTaskOutputTool(
     name: "task_output",
     aliases: ["TaskOutput"],
     description:
-      "Read newly-produced output for a background task (incremental polling). Use nextOffset for the next read. Stop polling when status is completed, failed, or cancelled and nextOffset >= totalBytes.",
+      "Read newly-produced output for a background task (incremental progress polling). Use task_wait when you need to block until a finite task completes. Use nextOffset for the next read. Stop polling when status is completed, failed, or cancelled and nextOffset >= totalBytes.",
     kind: "shell",
     inputSchema: {
       type: "object",
@@ -287,6 +318,102 @@ export function createTaskOutputTool(
       };
       return {
         content: [{ type: "text", text: formatTaskOutputText(data, requestedOffset) }],
+        data,
+      };
+    },
+  };
+}
+
+export function createTaskWaitTool(
+  runtime?: BackgroundTaskRuntime,
+): PilotDeckToolDefinition<TaskWaitInput, TaskWaitResult> {
+  return {
+    name: "task_wait",
+    aliases: ["TaskWait"],
+    description:
+      "Block until a background task finishes or timeoutMs elapses, then return the task status and output. Use this immediately after task_create for long-running commands that should eventually complete. It does not stop the task when timeoutMs elapses.",
+    kind: "shell",
+    inputSchema: {
+      type: "object",
+      required: ["taskId"],
+      additionalProperties: false,
+      properties: {
+        taskId: {
+          type: "string",
+          description: "The task id returned by task_create.",
+        },
+        timeoutMs: {
+          type: "integer",
+          description: "Maximum time to block in milliseconds. Defaults to 600000. Max 600000.",
+        },
+        offset: {
+          type: "integer",
+          description: "Byte offset to start reading output from after waiting. Defaults to 0.",
+        },
+        maxBytes: {
+          type: "integer",
+          description: "Maximum bytes to return in this read. Defaults to tool limit.",
+        },
+      },
+    },
+    maxResultBytes: 200_000,
+    isReadOnly: () => true,
+    isConcurrencySafe: () => true,
+    validateInput: async (input) => {
+      if (input.timeoutMs !== undefined && input.timeoutMs > MAX_TASK_WAIT_TIMEOUT_MS) {
+        return {
+          ok: false,
+          issues: [{ path: "timeoutMs", code: "invalid_schema", message: `timeoutMs must be <= ${MAX_TASK_WAIT_TIMEOUT_MS}.` }],
+        };
+      }
+      if (input.timeoutMs !== undefined && input.timeoutMs < 0) {
+        return {
+          ok: false,
+          issues: [{ path: "timeoutMs", code: "invalid_schema", message: "timeoutMs must be non-negative." }],
+        };
+      }
+      if (input.offset !== undefined && input.offset < 0) {
+        return {
+          ok: false,
+          issues: [{ path: "offset", code: "invalid_schema", message: "offset must be non-negative." }],
+        };
+      }
+      return { ok: true, input };
+    },
+    execute: async (input, context): Promise<PilotDeckToolExecutionOutput<TaskWaitResult>> => {
+      const rt = ensureRuntime(runtime);
+      const task = rt.get(input.taskId);
+      if (!task) {
+        throw new PilotDeckToolRuntimeError(
+          "invalid_tool_input",
+          `Unknown taskId: ${input.taskId}`,
+        );
+      }
+      const requestedOffset = input.offset ?? 0;
+      const waited = await rt.wait(input.taskId, {
+        timeoutMs: input.timeoutMs ?? DEFAULT_TASK_WAIT_TIMEOUT_MS,
+        abortSignal: context.abortSignal,
+      });
+      if (!waited) {
+        throw new PilotDeckToolRuntimeError(
+          "invalid_tool_input",
+          `Unknown taskId: ${input.taskId}`,
+        );
+      }
+      const slice = rt.getOutput(input.taskId, requestedOffset, input.maxBytes);
+      const data: TaskWaitResult = {
+        taskId: input.taskId,
+        content: slice.content,
+        nextOffset: slice.nextOffset,
+        totalBytes: slice.totalBytes,
+        truncated: slice.truncated,
+        status: waited.task.status,
+        exitCode: waited.task.exitCode,
+        waitedMs: waited.waitedMs,
+        timedOut: waited.timedOut,
+      };
+      return {
+        content: [{ type: "text", text: formatTaskWaitText(data, requestedOffset) }],
         data,
       };
     },
@@ -346,12 +473,14 @@ export function createTaskTools(options: CreateTaskToolsOptions): {
   create: ReturnType<typeof createTaskCreateTool>;
   list: ReturnType<typeof createTaskListTool>;
   output: ReturnType<typeof createTaskOutputTool>;
+  wait: ReturnType<typeof createTaskWaitTool>;
   stop: ReturnType<typeof createTaskStopTool>;
 } {
   return {
     create: createTaskCreateTool(options.runtime),
     list: createTaskListTool(options.runtime),
     output: createTaskOutputTool(options.runtime),
+    wait: createTaskWaitTool(options.runtime),
     stop: createTaskStopTool(options.runtime),
   };
 }

--- a/src/tool/index.ts
+++ b/src/tool/index.ts
@@ -201,6 +201,7 @@ export {
   createTaskListTool,
   createTaskOutputTool,
   createTaskStopTool,
+  createTaskWaitTool,
   createTaskTools,
   type CreateTaskToolsOptions,
   type TaskCreateInput,
@@ -211,6 +212,8 @@ export {
   type TaskOutputResult,
   type TaskStopInput,
   type TaskStopResult,
+  type TaskWaitInput,
+  type TaskWaitResult,
 } from "./builtin/taskTools.js";
 export {
   createTodoWriteTool,

--- a/src/tool/registry/createBuiltinRegistry.ts
+++ b/src/tool/registry/createBuiltinRegistry.ts
@@ -18,6 +18,7 @@ import {
   createTaskListTool,
   createTaskOutputTool,
   createTaskStopTool,
+  createTaskWaitTool,
 } from "../builtin/taskTools.js";
 import { createWebFetchTool, type CreateWebFetchToolOptions } from "../builtin/webFetch.js";
 import { createWebSearchTool, type CreateWebSearchToolOptions } from "../builtin/webSearch.js";
@@ -52,7 +53,7 @@ export type CreateBuiltinRegistryOptions = {
   webFetch?: CreateWebFetchToolOptions | false;
   /**
    * Background task tools (`task_create` / `task_list` / `task_output` /
-   * `task_stop`). **Opt-in** — pass `{ runtime }` to register; absent or
+   * `task_wait` / `task_stop`). **Opt-in** — pass `{ runtime }` to register; absent or
    * `false` keeps them out of the registry. Stand-alone runtimes that do
    * not provide a `BackgroundTaskRuntime` would otherwise see every call
    * fail with `unsupported_tool`.
@@ -114,6 +115,7 @@ export function createBuiltinRegistry(options?: CreateBuiltinRegistryOptions): T
     registry.register(createTaskCreateTool(runtime));
     registry.register(createTaskListTool(runtime));
     registry.register(createTaskOutputTool(runtime));
+    registry.register(createTaskWaitTool(runtime));
     registry.register(createTaskStopTool(runtime));
   }
   if (options?.structuredOutput !== false) {

--- a/tests/task/backgroundTaskRuntime.spec.ts
+++ b/tests/task/backgroundTaskRuntime.spec.ts
@@ -79,4 +79,28 @@ describe("BackgroundTaskRuntime completion notifications", () => {
     assert.equal(late.task.status, "completed");
     assert.equal(runtime.get(task.taskId)?.status, "completed");
   });
+
+  it("reports aborted waits without stopping the task", async () => {
+    const runtime = new BackgroundTaskRuntime();
+    const task = await runtime.start({
+      command: `${process.execPath} -e "setTimeout(() => { process.stdout.write('late') }, 80)"`,
+      cwd: process.cwd(),
+    });
+    const controller = new AbortController();
+    setTimeout(() => controller.abort(), 1).unref();
+
+    const aborted = await runtime.wait(task.taskId, {
+      timeoutMs: 1_000,
+      abortSignal: controller.signal,
+    });
+
+    assert.ok(aborted);
+    assert.equal(aborted.outcome, "aborted");
+    assert.equal(aborted.timedOut, true);
+    assert.equal(runtime.get(task.taskId)?.status, "running");
+
+    const late = await runtime.wait(task.taskId, { timeoutMs: 1_000 });
+    assert.ok(late);
+    assert.equal(late.task.status, "completed");
+  });
 });

--- a/tests/task/backgroundTaskRuntime.spec.ts
+++ b/tests/task/backgroundTaskRuntime.spec.ts
@@ -45,4 +45,38 @@ describe("BackgroundTaskRuntime completion notifications", () => {
     assert.equal(events[0]?.status, "cancelled");
     assert.equal(events[0]?.taskId, task.taskId);
   });
+
+  it("waits for a task to finish without polling", async () => {
+    const runtime = new BackgroundTaskRuntime();
+    const task = await runtime.start({
+      command: `${process.execPath} -e "setTimeout(() => { process.stdout.write('done') }, 25)"`,
+      cwd: process.cwd(),
+    });
+
+    const waited = await runtime.wait(task.taskId, { timeoutMs: 1_000 });
+
+    assert.ok(waited);
+    assert.equal(waited.task.status, "completed");
+    assert.equal(waited.task.exitCode, 0);
+    assert.equal(waited.timedOut, false);
+    assert.match(runtime.getOutput(task.taskId, 0).content, /done/u);
+  });
+
+  it("returns running on wait timeout without killing the task", async () => {
+    const runtime = new BackgroundTaskRuntime();
+    const task = await runtime.start({
+      command: `${process.execPath} -e "setTimeout(() => { process.stdout.write('late') }, 80)"`,
+      cwd: process.cwd(),
+    });
+
+    const early = await runtime.wait(task.taskId, { timeoutMs: 1 });
+    assert.ok(early);
+    assert.equal(early.task.status, "running");
+    assert.equal(early.timedOut, true);
+
+    const late = await runtime.wait(task.taskId, { timeoutMs: 1_000 });
+    assert.ok(late);
+    assert.equal(late.task.status, "completed");
+    assert.equal(runtime.get(task.taskId)?.status, "completed");
+  });
 });

--- a/tests/task/backgroundTaskRuntime.spec.ts
+++ b/tests/task/backgroundTaskRuntime.spec.ts
@@ -103,4 +103,35 @@ describe("BackgroundTaskRuntime completion notifications", () => {
     assert.ok(late);
     assert.equal(late.task.status, "completed");
   });
+
+  it("removes abort listeners after wait settles", async () => {
+    const runtime = new BackgroundTaskRuntime();
+    const task = await runtime.start({
+      command: `${process.execPath} -e "process.stdout.write('done')"`,
+      cwd: process.cwd(),
+    });
+    const controller = new AbortController();
+    let added = 0;
+    let removed = 0;
+    const addEventListener = controller.signal.addEventListener.bind(controller.signal);
+    const removeEventListener = controller.signal.removeEventListener.bind(controller.signal);
+    controller.signal.addEventListener = ((type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions) => {
+      if (type === "abort") added += 1;
+      return addEventListener(type, listener, options);
+    }) as AbortSignal["addEventListener"];
+    controller.signal.removeEventListener = ((type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions) => {
+      if (type === "abort") removed += 1;
+      return removeEventListener(type, listener, options);
+    }) as AbortSignal["removeEventListener"];
+
+    const waited = await runtime.wait(task.taskId, {
+      timeoutMs: 1_000,
+      abortSignal: controller.signal,
+    });
+
+    assert.ok(waited);
+    assert.equal(waited.outcome, "completed");
+    assert.equal(added, 1);
+    assert.equal(removed, 1);
+  });
 });

--- a/tests/tool/bash.spec.ts
+++ b/tests/tool/bash.spec.ts
@@ -38,7 +38,9 @@ describe("bash long-running guardrails", () => {
 
     assert.equal(result.type, "error");
     assert.equal(result.error.code, "invalid_tool_input");
+    assert.match(result.error.message, /timeout=600000 or less/u);
     assert.match(result.error.message, /task_create/u);
+    assert.match(result.error.message, /task_wait/u);
     assert.equal(ran, false);
   });
 
@@ -61,6 +63,7 @@ describe("bash long-running guardrails", () => {
       assert.equal(result.type, "error", command);
       assert.equal(result.error.code, "invalid_tool_input", command);
       assert.match(result.error.message, /task_create/u, command);
+      assert.match(result.error.message, /task_wait/u, command);
       assert.match(result.error.message, /task_output/u, command);
     }
   });

--- a/tests/tool/taskTools.spec.ts
+++ b/tests/tool/taskTools.spec.ts
@@ -158,4 +158,30 @@ describe("task_wait tool", () => {
     assert.equal(result.type, "error");
     assert.equal(result.error.code, "invalid_tool_input");
   });
+
+  it("returns tool_aborted when the wait is interrupted", async () => {
+    const backgroundTasks = new BackgroundTaskRuntime();
+    const runtime = createRuntime(backgroundTasks);
+    const controller = new AbortController();
+    const context = { ...createContext(), abortSignal: controller.signal };
+
+    const created = await runtime.execute({
+      id: "call-create",
+      name: "task_create",
+      input: { command: `${process.execPath} -e "setTimeout(() => {}, 10000)"` },
+    }, context);
+    const taskId = successData<TaskCreateOutput>(created).taskId;
+    setTimeout(() => controller.abort(), 1).unref();
+
+    const result = await runtime.execute({
+      id: "call-wait",
+      name: "task_wait",
+      input: { taskId, timeoutMs: 1_000 },
+    }, context);
+
+    assert.equal(result.type, "error");
+    assert.equal(result.error.code, "tool_aborted");
+    assert.equal(backgroundTasks.get(taskId)?.status, "running");
+    await backgroundTasks.stop(taskId, { graceMs: 1 });
+  });
 });

--- a/tests/tool/taskTools.spec.ts
+++ b/tests/tool/taskTools.spec.ts
@@ -1,0 +1,161 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { createDefaultPermissionContext, PermissionRuntime } from "../../src/permission/index.js";
+import { BackgroundTaskRuntime } from "../../src/task/runtime/BackgroundTaskRuntime.js";
+import {
+  createTaskTools,
+  type PilotDeckToolResult,
+  type PilotDeckToolRuntimeContext,
+  type TaskCreateOutput,
+  type TaskOutputResult,
+  type TaskWaitResult,
+} from "../../src/tool/index.js";
+import { ToolRuntime } from "../../src/tool/execution/ToolRuntime.js";
+import { ToolRegistry } from "../../src/tool/registry/ToolRegistry.js";
+
+function createContext(): PilotDeckToolRuntimeContext {
+  const cwd = process.cwd();
+  return {
+    sessionId: "session-1",
+    turnId: "turn-1",
+    cwd,
+    permissionMode: "bypassPermissions",
+    permissionContext: createDefaultPermissionContext({ cwd, mode: "bypassPermissions", canPrompt: false }),
+  };
+}
+
+function createRuntime(backgroundTasks: BackgroundTaskRuntime): ToolRuntime {
+  const registry = new ToolRegistry();
+  const tools = createTaskTools({ runtime: backgroundTasks });
+  registry.register(tools.create);
+  registry.register(tools.output);
+  registry.register(tools.wait);
+  registry.register(tools.stop);
+  return new ToolRuntime(registry, new PermissionRuntime());
+}
+
+function successData<T>(result: PilotDeckToolResult): T {
+  assert.equal(result.type, "success");
+  return result.data as T;
+}
+
+function firstText(result: PilotDeckToolResult): string {
+  assert.equal(result.type, "success");
+  const first = result.content[0];
+  assert.equal(first.type, "text");
+  return first.text;
+}
+
+describe("task_wait tool", () => {
+  it("waits for a successful background task and returns final output", async () => {
+    const backgroundTasks = new BackgroundTaskRuntime();
+    const runtime = createRuntime(backgroundTasks);
+    const context = createContext();
+
+    const created = await runtime.execute({
+      id: "call-create",
+      name: "task_create",
+      input: { command: `${process.execPath} -e "process.stdout.write('hello')"` },
+    }, context);
+    const taskId = successData<TaskCreateOutput>(created).taskId;
+
+    const waited = await runtime.execute({
+      id: "call-wait",
+      name: "task_wait",
+      input: { taskId, timeoutMs: 1_000 },
+    }, context);
+
+    const waitedData = successData<TaskWaitResult>(waited);
+    assert.equal(waitedData.status, "completed");
+    assert.equal(waitedData.exitCode, 0);
+    assert.equal(waitedData.timedOut, false);
+    assert.match(firstText(waited), /hello/u);
+    assert.match(firstText(waited), /Task finished; no further polling is needed/u);
+  });
+
+  it("returns failed status and output for a failing task", async () => {
+    const backgroundTasks = new BackgroundTaskRuntime();
+    const runtime = createRuntime(backgroundTasks);
+    const context = createContext();
+
+    const created = await runtime.execute({
+      id: "call-create",
+      name: "task_create",
+      input: { command: `${process.execPath} -e "process.stderr.write('bad'); process.exit(3)"` },
+    }, context);
+    const createdData = successData<TaskCreateOutput>(created);
+
+    const waited = await runtime.execute({
+      id: "call-wait",
+      name: "task_wait",
+      input: { taskId: createdData.taskId, timeoutMs: 1_000 },
+    }, context);
+
+    const waitedData = successData<TaskWaitResult>(waited);
+    assert.equal(waitedData.status, "failed");
+    assert.equal(waitedData.exitCode, 3);
+    assert.match(firstText(waited), /bad/u);
+  });
+
+  it("times out without stopping the task and can later read from an offset", async () => {
+    const backgroundTasks = new BackgroundTaskRuntime();
+    const runtime = createRuntime(backgroundTasks);
+    const context = createContext();
+
+    const created = await runtime.execute({
+      id: "call-create",
+      name: "task_create",
+      input: { command: `${process.execPath} -e "process.stdout.write('first'); setTimeout(() => { process.stdout.write('second') }, 80)"` },
+    }, context);
+    const taskId = successData<TaskCreateOutput>(created).taskId;
+
+    const early = await runtime.execute({
+      id: "call-wait-early",
+      name: "task_wait",
+      input: { taskId, timeoutMs: 1 },
+    }, context);
+    const earlyData = successData<TaskWaitResult>(early);
+    assert.equal(earlyData.status, "running");
+    assert.equal(earlyData.timedOut, true);
+    assert.match(firstText(early), /Task is still running/u);
+
+    let offset = earlyData.nextOffset;
+    for (let i = 0; i < 20 && offset === 0; i += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      const output = await runtime.execute({
+        id: `call-output-${i}`,
+        name: "task_output",
+        input: { taskId },
+      }, context);
+      const outputData = successData<TaskOutputResult>(output);
+      if (outputData.nextOffset > 0) {
+        assert.match(firstText(output), /first/u);
+        offset = outputData.nextOffset;
+      }
+    }
+    assert.ok(offset > 0, "expected first chunk to be available before final wait");
+
+    const later = await runtime.execute({
+      id: "call-wait-later",
+      name: "task_wait",
+      input: { taskId, timeoutMs: 1_000, offset },
+    }, context);
+    const laterData = successData<TaskWaitResult>(later);
+    assert.equal(laterData.status, "completed");
+    assert.match(firstText(later), /second/u);
+    assert.doesNotMatch(firstText(later), /first/u);
+  });
+
+  it("returns invalid_tool_input for unknown task ids", async () => {
+    const runtime = createRuntime(new BackgroundTaskRuntime());
+    const result = await runtime.execute({
+      id: "call-wait",
+      name: "task_wait",
+      input: { taskId: "missing", timeoutMs: 1 },
+    }, createContext());
+
+    assert.equal(result.type, "error");
+    assert.equal(result.error.code, "invalid_tool_input");
+  });
+});


### PR DESCRIPTION
## Summary
- Add a `task_wait` builtin tool so agents can block on background tasks until completion or timeout.
- Add a `BackgroundTaskRuntime.wait(...)` API that returns final status and output without killing still-running tasks on wait timeout.
- Update task/bash tool guidance so long-running but finite commands can use `task_create + task_wait` instead of manual sleep/polling.

## Details
- `task_wait` returns status, exit code, waited time, output slices, and next offset.
- Existing `task_create`, `task_output`, `task_stop`, and `task_list` wire shapes remain compatible.
- Foreground bash timeout validation still rejects values above the max, but now points users toward `timeout=600000` or `task_create + task_wait`.
- Protected context handling recognizes `task_wait` results.

## Tests
- `npm run build`
- `node --test --test-force-exit --test-timeout 60000 dist/tests/task/backgroundTaskRuntime.spec.js dist/tests/tool/taskTools.spec.js dist/tests/tool/bash.spec.js`

Note: a full `npm test` run had one unrelated pre-existing failure in `dist/tests/model/request/validateModelRequest.test.js` around Gemini tool schema metadata.
