### PR TITLE
Allow task waits in read-only modes

### DIFF
--- a/src/tool/askModeConstraints.ts
+++ b/src/tool/askModeConstraints.ts
@@ -19,6 +19,9 @@ export const ASK_MODE_ALLOWED_TOOLS = new Set([
   "agent",
   "execute_code",
   "bash",
+  "task_list",
+  "task_output",
+  "task_wait",
 ]);
 
 export const ASK_MODE_DESCRIPTION_SUFFIX: Record<string, string> = {

--- a/src/tool/planModeConstraints.ts
+++ b/src/tool/planModeConstraints.ts
@@ -22,6 +22,9 @@ export const PLAN_MODE_ALLOWED_TOOLS = new Set([
   "structured_output",
   "agent",
   "bash",
+  "task_list",
+  "task_output",
+  "task_wait",
   "write_file",
   "edit_file",
 ]);

--- a/tests/tool/taskTools.spec.ts
+++ b/tests/tool/taskTools.spec.ts
@@ -14,14 +14,15 @@ import {
 import { ToolRuntime } from "../../src/tool/execution/ToolRuntime.js";
 import { ToolRegistry } from "../../src/tool/registry/ToolRegistry.js";
 
-function createContext(): PilotDeckToolRuntimeContext {
+function createContext(mode: "bypassPermissions" | "plan" | "default" = "bypassPermissions"): PilotDeckToolRuntimeContext {
   const cwd = process.cwd();
   return {
     sessionId: "session-1",
     turnId: "turn-1",
     cwd,
-    permissionMode: "bypassPermissions",
-    permissionContext: createDefaultPermissionContext({ cwd, mode: "bypassPermissions", canPrompt: false }),
+    permissionMode: mode,
+    runMode: mode === "default" ? "ask" : undefined,
+    permissionContext: createDefaultPermissionContext({ cwd, mode, canPrompt: false }),
   };
 }
 
@@ -183,5 +184,25 @@ describe("task_wait tool", () => {
     assert.equal(result.error.code, "tool_aborted");
     assert.equal(backgroundTasks.get(taskId)?.status, "running");
     await backgroundTasks.stop(taskId, { graceMs: 1 });
+  });
+
+  it("allows read-only waits in plan and ask modes", async () => {
+    for (const mode of ["plan", "default"] as const) {
+      const backgroundTasks = new BackgroundTaskRuntime();
+      const runtime = createRuntime(backgroundTasks);
+      const task = await backgroundTasks.start({
+        command: `${process.execPath} -e "process.stdout.write('${mode}')"`,
+        cwd: process.cwd(),
+      });
+
+      const result = await runtime.execute({
+        id: `call-wait-${mode}`,
+        name: "task_wait",
+        input: { taskId: task.taskId, timeoutMs: 1_000 },
+      }, createContext(mode));
+
+      assert.equal(result.type, "success", mode);
+      assert.match(firstText(result), new RegExp(mode, "u"));
+    }
   });
 });


### PR DESCRIPTION
## Summary
- allow read-only background task inspection tools in plan mode
- allow the same task inspection tools in ask mode
- add regression coverage for task_wait in plan and ask modes

## Tests
- npm run build && node --test --test-timeout 60000 dist/tests/tool/taskTools.spec.js