### PR TITLE
fix(feishu): preserve fields when saving config

### DIFF
--- a/ui/server/routes/gateway.js
+++ b/ui/server/routes/gateway.js
@@ -291,7 +291,9 @@ router.get('/feishu/qr-poll', async (req, res) => {
       // Auto-save to config
       const config = loadYaml();
       if (!config.adapters) config.adapters = {};
+      const previous = config.adapters.feishu ?? {};
       config.adapters.feishu = {
+        ...previous,
         enabled: true,
         appId,
         appSecret,
@@ -340,12 +342,14 @@ router.post('/feishu/save', async (req, res) => {
   try {
     const config = loadYaml();
     if (!config.adapters) config.adapters = {};
+    const previous = config.adapters.feishu ?? {};
     config.adapters.feishu = {
+      ...previous,
       enabled: true,
       appId,
       appSecret,
-      connectionMode: connectionMode || 'stream',
-      domainName: domainName || 'feishu',
+      connectionMode: connectionMode || previous.connectionMode || 'stream',
+      domainName: domainName || previous.domainName || 'feishu',
     };
     saveYaml(config);
 


### PR DESCRIPTION
Follow-up to #377.

## Summary
- Preserve existing Feishu fields such as `encryptKey` and `verifyToken` when saving config from QR/manual setup.
- Keep QR-created credentials forced to `connectionMode: stream`, because QR registration only returns `appId`/`appSecret`.
- Preserve previous manual `connectionMode`/`domainName` only when the manual save request omits them.

## Test
- `git diff --check -- ui/server/routes/gateway.js`