### PR TITLE
Fix memory clear/settings bugs and move memory management into service settings

### DIFF
--- a/src/context/memory/edgeclaw-memory-core/ui-source/app.js
+++ b/src/context/memory/edgeclaw-memory-core/ui-source/app.js
@@ -758,7 +758,7 @@ function parseIntervalInputValue(value, fallbackMinutes, unit) {
 
 function syncSettingsFieldDisplay(fieldKey, minutes) {
   const config = SETTINGS_FIELD_CONFIG[fieldKey];
-  if (!config) return;
+  if (!config || !config.inputEl || !config.unitEl) return;
   const unit = normalizeSettingsUnit(config.unitEl.value);
   config.unitEl.value = unit;
   config.unitEl.dataset.prevUnit = unit;
@@ -767,6 +767,7 @@ function syncSettingsFieldDisplay(fieldKey, minutes) {
 
 function syncSettingsInputsFromState() {
   Object.entries(SETTINGS_FIELD_CONFIG).forEach(([fieldKey, config]) => {
+    if (!config.inputEl || !config.unitEl) return;
     const unit = readSettingsUnitPreference(fieldKey);
     config.unitEl.value = unit;
     config.unitEl.dataset.prevUnit = unit;
@@ -776,14 +777,14 @@ function syncSettingsInputsFromState() {
 
 function getCurrentSettingsFieldMinutes(fieldKey) {
   const config = SETTINGS_FIELD_CONFIG[fieldKey];
-  if (!config) return 0;
+  if (!config || !config.inputEl || !config.unitEl) return 0;
   const unit = normalizeSettingsUnit(config.unitEl.value);
   return parseIntervalInputValue(config.inputEl.value, getSettingsFieldMinutes(fieldKey), unit);
 }
 
 function handleSettingsUnitChange(fieldKey) {
   const config = SETTINGS_FIELD_CONFIG[fieldKey];
-  if (!config) return;
+  if (!config || !config.inputEl || !config.unitEl) return;
   const previousUnit = normalizeSettingsUnit(config.unitEl.dataset.prevUnit);
   const currentMinutes = parseIntervalInputValue(
     config.inputEl.value,
@@ -1136,13 +1137,18 @@ function setActiveTraceTab(tab) { state.activeTraceTab = tab; applyTraceTabChrom
 /* ── Settings Drawer ── */
 
 function openSettingsDrawer() {
+  if (!settingsModalEl) return;
   state.settingsOpen = true;
   settingsModalEl.classList.remove("hidden");
   syncSettingsInputsFromState();
   updateAppScrim();
 }
 
-function closeSettingsDrawer() { state.settingsOpen = false; settingsModalEl.classList.add("hidden"); updateAppScrim(); }
+function closeSettingsDrawer() {
+  state.settingsOpen = false;
+  settingsModalEl?.classList.add("hidden");
+  updateAppScrim();
+}
 
 /* ── Detail Drawer ── */
 
@@ -2010,30 +2016,30 @@ traceSubTabs.forEach((b) => b.addEventListener("click", () => setActiveTraceTab(
 recallCaseSelectEl.addEventListener("change", () => void loadRecallDetail(recallCaseSelectEl.value));
 indexTraceSelectEl.addEventListener("change", () => void loadIndexDetail(indexTraceSelectEl.value));
 dreamTraceSelectEl.addEventListener("change", () => void loadDreamDetail(dreamTraceSelectEl.value));
-settingsToggleBtn.addEventListener("click", () => { if (state.settingsOpen) closeSettingsDrawer(); else openSettingsDrawer(); });
-settingsCloseBtn.addEventListener("click", () => closeSettingsDrawer());
-saveSettingsBtn.addEventListener("click", () => void saveSettings());
-settingAutoIndexUnitEl.addEventListener("change", () => handleSettingsUnitChange("autoIndex"));
-settingAutoDreamUnitEl.addEventListener("change", () => handleSettingsUnitChange("autoDream"));
+settingsToggleBtn?.addEventListener("click", () => { if (state.settingsOpen) closeSettingsDrawer(); else openSettingsDrawer(); });
+settingsCloseBtn?.addEventListener("click", () => closeSettingsDrawer());
+saveSettingsBtn?.addEventListener("click", () => void saveSettings());
+settingAutoIndexUnitEl?.addEventListener("change", () => handleSettingsUnitChange("autoIndex"));
+settingAutoDreamUnitEl?.addEventListener("change", () => handleSettingsUnitChange("autoDream"));
 editorCloseBtn.addEventListener("click", () => closeEditorModal());
 editorCancelBtn.addEventListener("click", () => closeEditorModal());
 editorFormEl.addEventListener("submit", (event) => void handleEditorSubmit(event));
 refreshBtn.addEventListener("click", () => void loadDashboard());
 indexBtn.addEventListener("click", () => void runAction(t("actions.index"), "/api/memory/index/run", {}, { maintenance: true }));
 dreamBtn.addEventListener("click", () => void runAction(t("actions.dream"), "/api/memory/dream/run", {}, { maintenance: true }));
-exportCurrentProjectBtn.addEventListener("click", () => void exportCurrentProjectMemory());
-importCurrentProjectBtn.addEventListener("click", () => importCurrentProjectInput.click());
+exportCurrentProjectBtn?.addEventListener("click", () => void exportCurrentProjectMemory());
+importCurrentProjectBtn?.addEventListener("click", () => importCurrentProjectInput?.click());
 rollbackLastDreamBtn?.addEventListener("click", () => void rollbackLastDream());
-exportAllProjectsBtn.addEventListener("click", () => void exportAllProjectsMemory());
-importAllProjectsBtn.addEventListener("click", () => importAllProjectsInput.click());
-clearProjectBtn.addEventListener("click", () => void clearCurrentProjectMemory());
-clearAllBtn.addEventListener("click", () => void clearAllMemory());
+exportAllProjectsBtn?.addEventListener("click", () => void exportAllProjectsMemory());
+importAllProjectsBtn?.addEventListener("click", () => importAllProjectsInput?.click());
+clearProjectBtn?.addEventListener("click", () => void clearCurrentProjectMemory());
+clearAllBtn?.addEventListener("click", () => void clearAllMemory());
 
 workspaceSearchEl.addEventListener("input", () => { state.workspaceQuery = workspaceSearchEl.value.trim(); if (state.activePage === "project") void loadWorkspace(); });
 workspaceSearchEl.addEventListener("keydown", (e) => { if (e.key === "Enter") { e.preventDefault(); state.workspaceQuery = workspaceSearchEl.value.trim(); void loadWorkspace(); } });
 workspaceSearchBtn.addEventListener("click", () => { state.workspaceQuery = workspaceSearchEl.value.trim(); void loadWorkspace(); });
 
-importCurrentProjectInput.addEventListener("change", async (e) => {
+importCurrentProjectInput?.addEventListener("change", async (e) => {
   const file = e.target.files?.[0]; if (!file) return;
   try {
     await importBundle(
@@ -2046,7 +2052,7 @@ importCurrentProjectInput.addEventListener("change", async (e) => {
   finally { importCurrentProjectInput.value = ""; }
 });
 
-importAllProjectsInput.addEventListener("change", async (e) => {
+importAllProjectsInput?.addEventListener("change", async (e) => {
   const file = e.target.files?.[0]; if (!file) return;
   try { await importBundle(file, "/api/memory/import/all-projects", "confirm.importAllProjects", "status.allProjectsMemoryImported"); }
   finally { importAllProjectsInput.value = ""; }
@@ -2054,7 +2060,7 @@ importAllProjectsInput.addEventListener("change", async (e) => {
 
 detailBackBtn.addEventListener("click", () => closeMemoryDetailPage());
 detailCloseBtn.addEventListener("click", () => closeDetailDrawer());
-settingsModalEl.addEventListener("click", (e) => { if (e.target === settingsModalEl) closeSettingsDrawer(); });
+settingsModalEl?.addEventListener("click", (e) => { if (e.target === settingsModalEl) closeSettingsDrawer(); });
 appScrimEl.addEventListener("click", () => { closeSettingsDrawer(); closeDetailDrawer(); closeEditorModal(); });
 
 /* ── Init ── */

--- a/src/context/memory/edgeclaw-memory-core/ui-source/index.html
+++ b/src/context/memory/edgeclaw-memory-core/ui-source/index.html
@@ -59,7 +59,6 @@
             <span class="topbar-index-label" data-i18n="topbar.lastIndexed"></span>
             <span id="navLastIndexed" class="topbar-index-time"></span>
           </div>
-          <button id="settingsToggleBtn" class="action-btn action-btn--icon" type="button" data-i18n-title="actions.settings">⚙</button>
         </div>
       </header>
 
@@ -193,87 +192,6 @@
 
         </div>
       </main>
-    </div>
-
-    <!-- ═══ SETTINGS MODAL ═══ -->
-    <div id="settingsModal" class="settings-modal hidden" role="dialog" aria-modal="true">
-      <div class="settings-modal-card">
-        <div class="settings-modal-head">
-          <h3 data-i18n="settings.title"></h3>
-          <button id="settingsCloseBtn" class="settings-modal-close" type="button" aria-label="Close">×</button>
-        </div>
-        <div class="settings-modal-body">
-
-          <section class="settings-section">
-            <div class="settings-section-header">
-              <h4 class="settings-section-title" data-i18n="settings.parameters.title"></h4>
-              <button id="saveSettingsBtn" class="settings-save-btn" type="button" data-i18n="actions.saveSettings"></button>
-            </div>
-            <div class="settings-param-grid">
-              <div class="settings-field">
-                <label for="settingAutoIndex" data-i18n="settings.autoIndex.label"></label>
-                <div class="settings-input-row">
-                  <input id="settingAutoIndex" type="number" min="0" step="any" value="30" class="settings-input settings-input--with-unit" />
-                  <select id="settingAutoIndexUnit" class="settings-input settings-unit-select">
-                    <option value="minutes" data-i18n="settings.unit.minutes"></option>
-                    <option value="hours" data-i18n="settings.unit.hours"></option>
-                  </select>
-                </div>
-                <p class="settings-hint" data-i18n="settings.autoIndex.hint"></p>
-              </div>
-              <div class="settings-field">
-                <label for="settingAutoDream" data-i18n="settings.autoDream.label"></label>
-                <div class="settings-input-row">
-                  <input id="settingAutoDream" type="number" min="0" step="any" value="1" class="settings-input settings-input--with-unit" />
-                  <select id="settingAutoDreamUnit" class="settings-input settings-unit-select">
-                    <option value="minutes" data-i18n="settings.unit.minutes"></option>
-                    <option value="hours" data-i18n="settings.unit.hours"></option>
-                  </select>
-                </div>
-                <p class="settings-hint" data-i18n="settings.autoDream.hint"></p>
-              </div>
-            </div>
-          </section>
-
-          <section class="settings-section">
-            <h4 class="settings-section-title" data-i18n="settings.dataManagement.title"></h4>
-            <div class="settings-data-groups">
-
-              <div class="settings-data-group" data-variant="default">
-                <div class="settings-data-group-head">
-                  <span class="settings-data-group-icon">📁</span>
-                  <div class="settings-data-group-heading">
-                    <h5 class="settings-data-group-title" data-i18n="settings.data.currentProject"></h5>
-                  </div>
-                </div>
-                <div class="settings-data-actions">
-                  <button id="exportCurrentProjectBtn" class="settings-action-btn" type="button"><span class="settings-action-icon">↓</span><span data-i18n="actions.exportCurrentProject"></span></button>
-                  <button id="importCurrentProjectBtn" class="settings-action-btn" type="button"><span class="settings-action-icon">↑</span><span data-i18n="actions.importCurrentProject"></span></button>
-                  <hr class="settings-action-divider" />
-                  <button id="clearProjectBtn" class="settings-action-btn settings-action-danger" type="button"><span class="settings-action-icon">✕</span><span data-i18n="actions.clearProject"></span></button>
-                </div>
-              </div>
-
-              <div class="settings-data-group" data-variant="all">
-                <div class="settings-data-group-head">
-                  <span class="settings-data-group-icon">🗄</span>
-                  <h5 class="settings-data-group-title" data-i18n="settings.data.allMemory"></h5>
-                </div>
-                <div class="settings-data-actions">
-                  <button id="exportAllProjectsBtn" class="settings-action-btn" type="button"><span class="settings-action-icon">↓</span><span data-i18n="actions.exportAllProjects"></span></button>
-                  <button id="importAllProjectsBtn" class="settings-action-btn" type="button"><span class="settings-action-icon">↑</span><span data-i18n="actions.importAllProjects"></span></button>
-                  <hr class="settings-action-divider" />
-                  <button id="clearAllBtn" class="settings-action-btn settings-action-danger" type="button"><span class="settings-action-icon">✕</span><span data-i18n="actions.clearAll"></span></button>
-                </div>
-              </div>
-
-            </div>
-            <input id="importCurrentProjectInput" type="file" accept="application/json" hidden />
-            <input id="importAllProjectsInput" type="file" accept="application/json" hidden />
-          </section>
-
-        </div>
-      </div>
     </div>
 
     <!-- ═══ DETAIL DRAWER ═══ -->

--- a/ui/server/routes/memory.js
+++ b/ui/server/routes/memory.js
@@ -55,6 +55,12 @@ function normalizeMemoryInterval(value, fallback) {
   return Math.max(0, Math.min(10_080, Math.floor(parsed)));
 }
 
+function validateReasoningMode(value) {
+  if (value === undefined) return undefined;
+  if (value === 'answer_first' || value === 'accuracy_first') return value;
+  throw new Error('memory.reasoningMode must be answer_first or accuracy_first');
+}
+
 function getGlobalMemorySettingsFromConfig(config) {
   const memory = config?.memory ?? {};
   const reasoningMode = memory.reasoningMode === 'accuracy_first' ? 'accuracy_first' : 'answer_first';
@@ -82,12 +88,9 @@ async function saveGlobalMemorySettings(partial = {}) {
   }
   const { config } = record;
   const current = getGlobalMemorySettingsFromConfig(config);
+  const reasoningMode = validateReasoningMode(partial.reasoningMode);
   const next = {
-    reasoningMode: partial.reasoningMode === 'accuracy_first'
-      ? 'accuracy_first'
-      : partial.reasoningMode === 'answer_first'
-        ? 'answer_first'
-        : current.reasoningMode,
+    reasoningMode: reasoningMode ?? current.reasoningMode,
     autoIndexIntervalMinutes: normalizeMemoryInterval(
       partial.autoIndexIntervalMinutes,
       current.autoIndexIntervalMinutes,

--- a/ui/server/routes/memory.js
+++ b/ui/server/routes/memory.js
@@ -307,6 +307,15 @@ function getSelectedProjectId(req) {
     : '';
 }
 
+function hasDashboardRequestContext(req) {
+  return [
+    req.query?.projectPath,
+    req.body?.projectPath,
+    req.query?.projectName,
+    req.params?.projectName,
+  ].some((value) => typeof value === 'string' && value.trim());
+}
+
 async function withMemoryService(req, res, fn) {
   try {
     const { projectPath, dataDir, service } = await getMemoryServiceForRequest(req);
@@ -595,7 +604,20 @@ router.post('/clear', async (req, res) => {
   const scope = req.body?.scope === 'all_memory' ? 'all_memory' : 'current_project';
   if (scope === 'all_memory') {
     try {
-      res.json(await clearAllMemoryData());
+      const result = await clearAllMemoryData();
+      if (!hasDashboardRequestContext(req)) {
+        res.json(result);
+        return;
+      }
+
+      const { service } = await getMemoryServiceForRequest(req);
+      res.json({
+        ...result,
+        dashboard: buildDashboardSnapshot(service, service.repository, {
+          query: getQuery(req),
+          selectedProjectId: getSelectedProjectId(req),
+        }),
+      });
     } catch (error) {
       res.status(500).json({
         error: error instanceof Error ? error.message : String(error),

--- a/ui/server/routes/memory.test.js
+++ b/ui/server/routes/memory.test.js
@@ -66,6 +66,69 @@ describe('memory clear route', () => {
   });
 });
 
+describe('memory settings route', () => {
+  it('saves answer_first reasoning mode', async () => {
+    const { request, writePilotDeckConfig } = await createMemorySettingsApp({
+      memory: {
+        reasoningMode: 'accuracy_first',
+        autoIndexIntervalMinutes: 30,
+        autoDreamIntervalMinutes: 60,
+      },
+    });
+
+    const result = await request('/api/memory/settings?projectPath=/tmp/pilotdeck-project', {
+      method: 'POST',
+      body: JSON.stringify({ reasoningMode: 'answer_first' }),
+    });
+
+    expect(result.status).toBe(200);
+    expect(result.body.reasoningMode).toBe('answer_first');
+    expect(writePilotDeckConfig).toHaveBeenCalledWith(expect.objectContaining({
+      memory: expect.objectContaining({ reasoningMode: 'answer_first' }),
+    }));
+  });
+
+  it('saves accuracy_first reasoning mode', async () => {
+    const { request, writePilotDeckConfig } = await createMemorySettingsApp({
+      memory: {
+        reasoningMode: 'answer_first',
+        autoIndexIntervalMinutes: 30,
+        autoDreamIntervalMinutes: 60,
+      },
+    });
+
+    const result = await request('/api/memory/settings?projectPath=/tmp/pilotdeck-project', {
+      method: 'POST',
+      body: JSON.stringify({ reasoningMode: 'accuracy_first' }),
+    });
+
+    expect(result.status).toBe(200);
+    expect(result.body.reasoningMode).toBe('accuracy_first');
+    expect(writePilotDeckConfig).toHaveBeenCalledWith(expect.objectContaining({
+      memory: expect.objectContaining({ reasoningMode: 'accuracy_first' }),
+    }));
+  });
+
+  it('rejects invalid reasoning mode without saving config', async () => {
+    const { request, writePilotDeckConfig } = await createMemorySettingsApp({
+      memory: {
+        reasoningMode: 'answer_first',
+        autoIndexIntervalMinutes: 30,
+        autoDreamIntervalMinutes: 60,
+      },
+    });
+
+    const result = await request('/api/memory/settings?projectPath=/tmp/pilotdeck-project', {
+      method: 'POST',
+      body: JSON.stringify({ reasoningMode: 'fast_mode' }),
+    });
+
+    expect(result.status).toBe(400);
+    expect(result.body.error).toBe('memory.reasoningMode must be answer_first or accuracy_first');
+    expect(writePilotDeckConfig).not.toHaveBeenCalled();
+  });
+});
+
 async function createMemoryApp() {
   const clearAllMemoryData = vi.fn(async () => ({
     scope: 'all_memory',
@@ -136,6 +199,53 @@ async function createMemoryApp() {
   return {
     clearAllMemoryData,
     getMemoryServiceForRequest,
+    request: (path, init) => requestJson(app, path, init),
+  };
+}
+
+async function createMemorySettingsApp(initialConfig) {
+  let config = structuredClone(initialConfig);
+  const writePilotDeckConfig = vi.fn(async (nextConfig) => {
+    config = structuredClone(nextConfig);
+    return { config };
+  });
+
+  vi.doMock('../services/memoryService.js', () => ({
+    clearAllMemoryData: vi.fn(),
+    exportAllProjectsMemoryBundle: vi.fn(),
+    getMemoryServiceForRequest: vi.fn(async () => ({
+      projectPath: '/tmp/pilotdeck-project',
+      dataDir: '/tmp/pilotdeck-data',
+      service: { repository: {} },
+    })),
+    getMemorySchedulerStatus: vi.fn(() => ({
+      enabled: true,
+      running: false,
+      intervalMs: 60000,
+    })),
+    importAllProjectsMemoryBundle: vi.fn(),
+    rollbackLastMemoryDream: vi.fn(),
+    runManualMemoryDream: vi.fn(),
+    runManualMemoryFlush: vi.fn(),
+  }));
+  vi.doMock('../services/pilotdeckConfig.js', () => ({
+    readPilotDeckConfigFile: vi.fn(() => ({ config })),
+    writePilotDeckConfig,
+  }));
+  vi.doMock('../services/pilotdeckConfigReloader.js', () => ({
+    reloadPilotDeckConfig: vi.fn(async () => undefined),
+  }));
+  vi.doMock('../services/pilotdeckConfigWatcher.js', () => ({
+    suppressNextWatchEvent: vi.fn(),
+  }));
+
+  const { default: memoryRoutes } = await import('./memory.js');
+  const app = express();
+  app.use(express.json());
+  app.use('/api/memory', memoryRoutes);
+
+  return {
+    writePilotDeckConfig,
     request: (path, init) => requestJson(app, path, init),
   };
 }

--- a/ui/server/routes/memory.test.js
+++ b/ui/server/routes/memory.test.js
@@ -1,0 +1,155 @@
+import express from 'express';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const nativeFetch = globalThis.fetch;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.resetModules();
+});
+
+describe('memory clear route', () => {
+  it('returns a dashboard snapshot after clearing all memory with project context', async () => {
+    const { request, clearAllMemoryData, getMemoryServiceForRequest } = await createMemoryApp();
+
+    const result = await request('/api/memory/clear?projectPath=/tmp/pilotdeck-project', {
+      method: 'POST',
+      body: JSON.stringify({
+        scope: 'all_memory',
+        projectPath: '/tmp/pilotdeck-project',
+      }),
+    });
+
+    expect(clearAllMemoryData).toHaveBeenCalledOnce();
+    expect(getMemoryServiceForRequest).toHaveBeenCalledOnce();
+    expect(result.status).toBe(200);
+    expect(result.body).toMatchObject({
+      scope: 'all_memory',
+      cleared: {
+        l0Sessions: 1,
+        pipelineState: 2,
+        memoryFiles: 3,
+        projectMetas: 4,
+      },
+      dashboard: {
+        overview: {
+          totalMemories: 0,
+          scheduler: {
+            enabled: true,
+            running: false,
+            intervalMs: 60000,
+          },
+        },
+        settings: {
+          reasoningMode: 'answer_first',
+          autoIndexIntervalMinutes: 30,
+          autoDreamIntervalMinutes: 60,
+        },
+        workspace: {
+          workspaceMode: 'project',
+          totalFiles: 0,
+          totalProjects: 0,
+          totalFeedback: 0,
+          projectEntries: [],
+          feedbackEntries: [],
+          deprecatedProjectEntries: [],
+          deprecatedFeedbackEntries: [],
+        },
+        userSummary: {
+          summary: 'empty',
+        },
+        caseTraces: [],
+        indexTraces: [],
+        dreamTraces: [],
+      },
+    });
+  });
+});
+
+async function createMemoryApp() {
+  const clearAllMemoryData = vi.fn(async () => ({
+    scope: 'all_memory',
+    clearedAt: '2026-07-09T00:00:00.000Z',
+    cleared: {
+      l0Sessions: 1,
+      pipelineState: 2,
+      memoryFiles: 3,
+      projectMetas: 4,
+    },
+  }));
+
+  const store = {
+    getWorkspaceMode: vi.fn(() => 'project'),
+    getRootDir: vi.fn(() => '/tmp/pilotdeck-memory-store'),
+    getProjectMeta: vi.fn(() => null),
+  };
+  const repository = {
+    getFileMemoryStore: vi.fn(() => store),
+    getWorkspaceMode: vi.fn(() => 'project'),
+    listMemoryEntries: vi.fn(() => []),
+    getMemoryRecordsByIds: vi.fn(() => []),
+  };
+  const service = {
+    repository,
+    overview: vi.fn(() => ({ totalMemories: 0 })),
+    getUserSummary: vi.fn(() => ({ summary: 'empty' })),
+    listCaseTraces: vi.fn(() => []),
+    listIndexTraces: vi.fn(() => []),
+    listDreamTraces: vi.fn(() => []),
+  };
+  const getMemoryServiceForRequest = vi.fn(async () => ({
+    projectPath: '/tmp/pilotdeck-project',
+    dataDir: '/tmp/pilotdeck-data',
+    service,
+  }));
+
+  vi.doMock('../services/memoryService.js', () => ({
+    clearAllMemoryData,
+    exportAllProjectsMemoryBundle: vi.fn(),
+    getMemoryServiceForRequest,
+    getMemorySchedulerStatus: vi.fn(() => ({
+      enabled: true,
+      running: false,
+      intervalMs: 60000,
+    })),
+    importAllProjectsMemoryBundle: vi.fn(),
+    rollbackLastMemoryDream: vi.fn(),
+    runManualMemoryDream: vi.fn(),
+    runManualMemoryFlush: vi.fn(),
+  }));
+  vi.doMock('../services/pilotdeckConfig.js', () => ({
+    readPilotDeckConfigFile: vi.fn(() => ({ config: {} })),
+    writePilotDeckConfig: vi.fn(async (config) => ({ config })),
+  }));
+  vi.doMock('../services/pilotdeckConfigReloader.js', () => ({
+    reloadPilotDeckConfig: vi.fn(async () => undefined),
+  }));
+  vi.doMock('../services/pilotdeckConfigWatcher.js', () => ({
+    suppressNextWatchEvent: vi.fn(),
+  }));
+
+  const { default: memoryRoutes } = await import('./memory.js');
+  const app = express();
+  app.use(express.json());
+  app.use('/api/memory', memoryRoutes);
+
+  return {
+    clearAllMemoryData,
+    getMemoryServiceForRequest,
+    request: (path, init) => requestJson(app, path, init),
+  };
+}
+
+async function requestJson(app, path, init = {}) {
+  const server = app.listen(0);
+  try {
+    const { port } = server.address();
+    const response = await nativeFetch(`http://127.0.0.1:${port}${path}`, {
+      headers: { 'Content-Type': 'application/json', ...(init.headers || {}) },
+      ...init,
+    });
+    return { status: response.status, body: await response.json() };
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+}

--- a/ui/src/components/settings/view/tabs/PilotDeckConfigTab.tsx
+++ b/ui/src/components/settings/view/tabs/PilotDeckConfigTab.tsx
@@ -2341,6 +2341,7 @@ function MemorySection({
   const targetIsAllMemory = selectedMemoryTarget === MEMORY_ALL_TARGET;
   const selectedProjectPath = targetIsAllMemory ? '' : memoryProjectPathFromTarget(selectedMemoryTarget);
   const selectedProjectTarget = projectTargets.find((target) => target.path === selectedProjectPath) ?? null;
+  const dashboardProjectPath = selectedProjectPath || projectTargets[0]?.path || '';
   const selectedTargetLabel = targetIsAllMemory
     ? t('pilotDeckConfig.panels.memory.data.target.all')
     : selectedProjectTarget?.label ?? t('pilotDeckConfig.panels.memory.data.target.projectFallback');
@@ -2469,7 +2470,7 @@ function MemorySection({
         method: 'POST',
         body: JSON.stringify(
           targetIsAllMemory
-            ? { scope: 'all_memory' }
+            ? { scope: 'all_memory', ...(dashboardProjectPath ? { projectPath: dashboardProjectPath } : {}) }
             : { scope: 'current_project', projectPath: selectedProjectPath },
         ),
         suppressServerErrorToast: true,

--- a/ui/src/components/settings/view/tabs/PilotDeckConfigTab.tsx
+++ b/ui/src/components/settings/view/tabs/PilotDeckConfigTab.tsx
@@ -65,6 +65,8 @@ import { isCronConfigEnabled, patch } from './pilotDeckConfigForm';
 // Schema mirrors ~/.pilotdeck/pilotdeck.yaml exactly. No more
 // pre-/post-translation in the backend — disk shape === UI shape.
 
+type MemoryReasoningMode = 'answer_first' | 'accuracy_first';
+
 type V2Provider = {
   protocol?: CatalogProviderProtocol;
   url?: string;
@@ -96,7 +98,7 @@ type PilotDeckConfig = {
     enabled?: boolean;
     model?: string;
     apiType?: string;
-    reasoningMode?: string;
+    reasoningMode?: MemoryReasoningMode;
     autoIndexIntervalMinutes?: number;
     autoDreamIntervalMinutes?: number;
     captureStrategy?: string;

--- a/ui/src/components/settings/view/tabs/PilotDeckConfigTab.tsx
+++ b/ui/src/components/settings/view/tabs/PilotDeckConfigTab.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState, type ReactNode } from 'react';
+import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   AlertCircle,
@@ -11,6 +11,7 @@ import {
   ChevronRight,
   Clock,
   Database,
+  Download,
   FileCog,
   FileText,
   FolderOpen,
@@ -25,6 +26,7 @@ import {
   Search,
   Server,
   Trash2,
+  Upload,
   Wifi,
   XCircle,
   Zap,
@@ -2204,9 +2206,94 @@ function CronSection({ config, onChange }: { config: PilotDeckConfig; onChange: 
   );
 }
 
-function MemorySection({ config, onChange }: { config: PilotDeckConfig; onChange: (next: PilotDeckConfig) => void }) {
+const MEMORY_ALL_TARGET = 'all_memory';
+
+type MemoryActionState = {
+  kind: 'idle' | 'busy' | 'success' | 'error';
+  message?: string;
+};
+
+type MemoryProjectTarget = {
+  value: string;
+  label: string;
+  path: string;
+};
+
+function memoryProjectPath(project: SettingsProject): string {
+  return (project.fullPath || project.path || '').trim();
+}
+
+function memoryProjectLabel(project: SettingsProject, fallback: string): string {
+  const direct = (project.displayName || project.name || '').trim();
+  if (direct) return direct;
+
+  const root = memoryProjectPath(project);
+  const tail = root.replace(/[\\/]+$/, '').split(/[\\/]/).filter(Boolean).pop();
+  return tail || fallback;
+}
+
+function memoryProjectTargetValue(projectPath: string): string {
+  return `project:${projectPath}`;
+}
+
+function memoryProjectPathFromTarget(target: string): string {
+  return target.startsWith('project:') ? target.slice('project:'.length) : '';
+}
+
+function withMemoryProjectPath(url: string, projectPath: string): string {
+  if (!projectPath) return url;
+  const separator = url.includes('?') ? '&' : '?';
+  return `${url}${separator}projectPath=${encodeURIComponent(projectPath)}`;
+}
+
+function parseMemoryJson(raw: string): Record<string, unknown> | null {
+  try {
+    const value = JSON.parse(raw) as unknown;
+    if (value && typeof value === 'object' && !Array.isArray(value)) {
+      return value as Record<string, unknown>;
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+function memoryApiErrorMessage(response: Response, raw: string, body: Record<string, unknown> | null): string {
+  const bodyError = typeof body?.error === 'string' ? body.error : '';
+  return bodyError || raw || `Request failed: ${response.status}`;
+}
+
+function downloadMemoryText(raw: string, fileName: string) {
+  const blob = new Blob([raw], { type: 'application/json' });
+  const href = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = href;
+  link.download = fileName;
+  link.click();
+  URL.revokeObjectURL(href);
+}
+
+function safeDownloadToken(value: string): string {
+  return value
+    .trim()
+    .replace(/[^\w.-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 64) || 'memory';
+}
+
+function MemorySection({
+  config,
+  projects,
+  onChange,
+}: {
+  config: PilotDeckConfig;
+  projects: SettingsProject[];
+  onChange: (next: PilotDeckConfig) => void;
+}) {
   const { t } = useTranslation('settings');
   const m = config.memory ?? {};
+  const importInputRef = useRef<HTMLInputElement>(null);
+  const [memoryAction, setMemoryAction] = useState<MemoryActionState>({ kind: 'idle' });
   // Memory uses a "provider/model" reference, or "inherit" to fall back
   // to agent.model. The backend treats `undefined` and `"inherit"` the
   // same way, so we map both to the inherit option in the UI.
@@ -2216,38 +2303,325 @@ function MemorySection({ config, onChange }: { config: PilotDeckConfig; onChange
     ...refOptions,
   ];
   const selected = m.model && m.model.trim() ? m.model : 'inherit';
+
+  const projectTargets = useMemo(() => {
+    const seen = new Set<string>();
+    const fallback = t('pilotDeckConfig.panels.memory.data.target.projectFallback');
+    return projects.reduce<MemoryProjectTarget[]>((items, project) => {
+      const path = memoryProjectPath(project);
+      if (!path || seen.has(path)) return items;
+      seen.add(path);
+      items.push({
+        value: memoryProjectTargetValue(path),
+        label: memoryProjectLabel(project, fallback),
+        path,
+      });
+      return items;
+    }, []);
+  }, [projects, t]);
+
+  const [selectedMemoryTarget, setSelectedMemoryTarget] = useState(() =>
+    projectTargets[0]?.value ?? MEMORY_ALL_TARGET,
+  );
+
+  const memoryTargetOptions = useMemo(
+    () => [
+      ...projectTargets.map((target) => ({ value: target.value, label: target.label })),
+      { value: MEMORY_ALL_TARGET, label: t('pilotDeckConfig.panels.memory.data.target.all') },
+    ],
+    [projectTargets, t],
+  );
+
+  useEffect(() => {
+    if (!memoryTargetOptions.some((option) => option.value === selectedMemoryTarget)) {
+      setSelectedMemoryTarget(projectTargets[0]?.value ?? MEMORY_ALL_TARGET);
+    }
+  }, [memoryTargetOptions, projectTargets, selectedMemoryTarget]);
+
+  const targetIsAllMemory = selectedMemoryTarget === MEMORY_ALL_TARGET;
+  const selectedProjectPath = targetIsAllMemory ? '' : memoryProjectPathFromTarget(selectedMemoryTarget);
+  const selectedProjectTarget = projectTargets.find((target) => target.path === selectedProjectPath) ?? null;
+  const selectedTargetLabel = targetIsAllMemory
+    ? t('pilotDeckConfig.panels.memory.data.target.all')
+    : selectedProjectTarget?.label ?? t('pilotDeckConfig.panels.memory.data.target.projectFallback');
+  const actionBusy = memoryAction.kind === 'busy';
+  const canManageTarget = targetIsAllMemory || Boolean(selectedProjectPath);
+
+  const setMemoryField = (field: keyof NonNullable<PilotDeckConfig['memory']>, value: unknown) => {
+    onChange(patch(config, ['memory', field], value));
+  };
+
+  const readMemoryResponse = async (response: Response) => {
+    const raw = await response.text();
+    const body = parseMemoryJson(raw);
+    if (!response.ok) {
+      throw new Error(memoryApiErrorMessage(response, raw, body));
+    }
+    return { raw, body };
+  };
+
+  const setActionBusy = (messageKey: string) => {
+    setMemoryAction({
+      kind: 'busy',
+      message: t(messageKey, { target: selectedTargetLabel }),
+    });
+  };
+
+  const setActionSuccess = (messageKey: string, warnings?: unknown) => {
+    const warningList = Array.isArray(warnings)
+      ? warnings.filter((warning): warning is string => typeof warning === 'string' && warning.trim().length > 0)
+      : [];
+    setMemoryAction({
+      kind: 'success',
+      message: `${t(messageKey, { target: selectedTargetLabel })}${warningList.length > 0 ? ` ${warningList.join(' ')}` : ''}`,
+    });
+  };
+
+  const setActionError = (error: unknown) => {
+    setMemoryAction({
+      kind: 'error',
+      message: error instanceof Error ? error.message : String(error),
+    });
+  };
+
+  const handleExportMemory = async () => {
+    if (!canManageTarget) {
+      setMemoryAction({ kind: 'error', message: t('pilotDeckConfig.panels.memory.data.errors.missingProject') });
+      return;
+    }
+
+    setActionBusy('pilotDeckConfig.panels.memory.data.status.exporting');
+    try {
+      const url = targetIsAllMemory
+        ? '/api/memory/export/all-projects'
+        : withMemoryProjectPath('/api/memory/export/current-project', selectedProjectPath);
+      const response = await authenticatedFetch(url, { suppressServerErrorToast: true });
+      const { raw, body } = await readMemoryResponse(response);
+      if (!body) {
+        throw new Error(t('pilotDeckConfig.panels.memory.data.errors.invalidExport'));
+      }
+      const prefix = targetIsAllMemory ? 'pilotdeck-memory-all' : `pilotdeck-memory-${safeDownloadToken(selectedTargetLabel)}`;
+      downloadMemoryText(raw, `${prefix}-${Date.now()}.json`);
+      setActionSuccess('pilotDeckConfig.panels.memory.data.status.exported');
+    } catch (error) {
+      setActionError(error);
+    }
+  };
+
+  const handleImportMemoryFile = async (file: File | null) => {
+    if (!file) return;
+    if (!canManageTarget) {
+      setMemoryAction({ kind: 'error', message: t('pilotDeckConfig.panels.memory.data.errors.missingProject') });
+      return;
+    }
+
+    let payload: Record<string, unknown> | null = null;
+    try {
+      payload = parseMemoryJson(await file.text());
+    } catch {
+      payload = null;
+    }
+    if (!payload) {
+      setMemoryAction({ kind: 'error', message: t('pilotDeckConfig.panels.memory.data.errors.invalidImport') });
+      return;
+    }
+
+    const confirmKey = targetIsAllMemory
+      ? 'pilotDeckConfig.panels.memory.data.confirm.importAll'
+      : 'pilotDeckConfig.panels.memory.data.confirm.importProject';
+    if (!window.confirm(t(confirmKey, { target: selectedTargetLabel }))) {
+      return;
+    }
+
+    setActionBusy('pilotDeckConfig.panels.memory.data.status.importing');
+    try {
+      const url = targetIsAllMemory
+        ? '/api/memory/import/all-projects'
+        : withMemoryProjectPath('/api/memory/import/current-project', selectedProjectPath);
+      const response = await authenticatedFetch(url, {
+        method: 'POST',
+        body: JSON.stringify(payload),
+        suppressServerErrorToast: true,
+      });
+      const { body } = await readMemoryResponse(response);
+      setActionSuccess('pilotDeckConfig.panels.memory.data.status.imported', body?.warnings);
+    } catch (error) {
+      setActionError(error);
+    }
+  };
+
+  const handleClearMemory = async () => {
+    if (!canManageTarget) {
+      setMemoryAction({ kind: 'error', message: t('pilotDeckConfig.panels.memory.data.errors.missingProject') });
+      return;
+    }
+
+    const confirmKey = targetIsAllMemory
+      ? 'pilotDeckConfig.panels.memory.data.confirm.clearAll'
+      : 'pilotDeckConfig.panels.memory.data.confirm.clearProject';
+    if (!window.confirm(t(confirmKey, { target: selectedTargetLabel }))) {
+      return;
+    }
+
+    setActionBusy('pilotDeckConfig.panels.memory.data.status.clearing');
+    try {
+      const response = await authenticatedFetch('/api/memory/clear', {
+        method: 'POST',
+        body: JSON.stringify(
+          targetIsAllMemory
+            ? { scope: 'all_memory' }
+            : { scope: 'current_project', projectPath: selectedProjectPath },
+        ),
+        suppressServerErrorToast: true,
+      });
+      await readMemoryResponse(response);
+      setActionSuccess('pilotDeckConfig.panels.memory.data.status.cleared');
+    } catch (error) {
+      setActionError(error);
+    }
+  };
+
+  const memoryActionTone =
+    memoryAction.kind === 'error'
+      ? 'border-destructive/30 bg-destructive/10 text-destructive'
+      : memoryAction.kind === 'success'
+        ? 'border-green-500/30 bg-green-500/10 text-green-700 dark:text-green-300'
+        : 'border-border bg-muted/40 text-muted-foreground';
+
   return (
     <SettingsSection
       title={t('pilotDeckConfig.panels.memory.title')}
       description={t('pilotDeckConfig.panels.memory.description')}
     >
-      <SettingsCard>
-        <SettingsRow
-          label={t('pilotDeckConfig.panels.memory.enabled.label')}
-          description={t('pilotDeckConfig.panels.memory.enabled.description')}
-        >
-          <SettingsToggle
-            checked={Boolean(m.enabled)}
-            ariaLabel={t('pilotDeckConfig.panels.memory.enabled.label')}
-            onChange={(v) => onChange(patch(config, ['memory', 'enabled'], v))}
-          />
-        </SettingsRow>
-        {m.enabled && (
-          <FormRow
-            label={t('pilotDeckConfig.panels.memory.model.label')}
-            description={t('pilotDeckConfig.panels.memory.model.description')}
+      <div className="space-y-4">
+        <SettingsCard divided>
+          <SettingsRow
+            label={t('pilotDeckConfig.panels.memory.enabled.label')}
+            description={t('pilotDeckConfig.panels.memory.enabled.description')}
           >
-            <Select
-              value={selected}
-              options={options}
-              onChange={(v) => {
-                const nextValue = v === 'inherit' ? '' : v;
-                onChange(patch(ensureModelRefConfigured(config, nextValue), ['memory', 'model'], nextValue));
-              }}
+            <SettingsToggle
+              checked={Boolean(m.enabled)}
+              ariaLabel={t('pilotDeckConfig.panels.memory.enabled.label')}
+              onChange={(v) => onChange(patch(config, ['memory', 'enabled'], v))}
             />
-          </FormRow>
-        )}
-      </SettingsCard>
+          </SettingsRow>
+          {m.enabled && (
+            <>
+              <FormRow
+                label={t('pilotDeckConfig.panels.memory.model.label')}
+                description={t('pilotDeckConfig.panels.memory.model.description')}
+              >
+                <Select
+                  value={selected}
+                  options={options}
+                  onChange={(v) => {
+                    const nextValue = v === 'inherit' ? '' : v;
+                    onChange(patch(ensureModelRefConfigured(config, nextValue), ['memory', 'model'], nextValue));
+                  }}
+                />
+              </FormRow>
+              <FormRow
+                label={t('pilotDeckConfig.panels.memory.automation.autoIndex.label')}
+                description={t('pilotDeckConfig.panels.memory.automation.autoIndex.description')}
+              >
+                <NumberInput
+                  value={m.autoIndexIntervalMinutes}
+                  placeholder="30"
+                  onChange={(value) => setMemoryField('autoIndexIntervalMinutes', value === undefined ? undefined : Math.max(0, value))}
+                />
+              </FormRow>
+              <FormRow
+                label={t('pilotDeckConfig.panels.memory.automation.autoDream.label')}
+                description={t('pilotDeckConfig.panels.memory.automation.autoDream.description')}
+              >
+                <NumberInput
+                  value={m.autoDreamIntervalMinutes}
+                  placeholder="60"
+                  onChange={(value) => setMemoryField('autoDreamIntervalMinutes', value === undefined ? undefined : Math.max(0, value))}
+                />
+              </FormRow>
+            </>
+          )}
+        </SettingsCard>
+
+        <SettingsSection
+          title={t('pilotDeckConfig.panels.memory.data.title')}
+          description={t('pilotDeckConfig.panels.memory.data.description')}
+        >
+          <SettingsCard divided>
+            <FormRow
+              label={t('pilotDeckConfig.panels.memory.data.target.label')}
+              description={t('pilotDeckConfig.panels.memory.data.target.description')}
+            >
+              <Select
+                value={selectedMemoryTarget}
+                options={memoryTargetOptions}
+                onChange={(value) => {
+                  setSelectedMemoryTarget(value);
+                  setMemoryAction({ kind: 'idle' });
+                }}
+              />
+            </FormRow>
+            <div className="px-4 py-3">
+              <div className="flex flex-wrap gap-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="h-8 gap-1.5 px-2.5 text-xs"
+                  disabled={actionBusy || !canManageTarget}
+                  onClick={() => void handleExportMemory()}
+                >
+                  <Download className="mr-1.5 h-3.5 w-3.5" />
+                  {t('pilotDeckConfig.panels.memory.data.actions.export')}
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="h-8 gap-1.5 px-2.5 text-xs"
+                  disabled={actionBusy || !canManageTarget}
+                  onClick={() => importInputRef.current?.click()}
+                >
+                  <Upload className="mr-1.5 h-3.5 w-3.5" />
+                  {t('pilotDeckConfig.panels.memory.data.actions.import')}
+                </Button>
+                <Button
+                  type="button"
+                  variant="destructive"
+                  size="sm"
+                  className="h-8 gap-1.5 px-2.5 text-xs"
+                  disabled={actionBusy || !canManageTarget}
+                  onClick={() => void handleClearMemory()}
+                >
+                  <Trash2 className="mr-1.5 h-3.5 w-3.5" />
+                  {t('pilotDeckConfig.panels.memory.data.actions.clear')}
+                </Button>
+              </div>
+              <input
+                ref={importInputRef}
+                type="file"
+                accept="application/json,.json"
+                className="hidden"
+                onChange={(event) => {
+                  const input = event.currentTarget;
+                  void handleImportMemoryFile(input.files?.[0] ?? null).finally(() => {
+                    input.value = '';
+                  });
+                }}
+              />
+              {memoryAction.kind !== 'idle' && memoryAction.message && (
+                <div className={cn('mt-3 flex items-start gap-2 rounded-md border px-3 py-2 text-xs leading-5', memoryActionTone)}>
+                  {memoryAction.kind === 'busy' && <Loader2 className="mt-0.5 h-3.5 w-3.5 animate-spin" />}
+                  {memoryAction.kind === 'success' && <CheckCircle2 className="mt-0.5 h-3.5 w-3.5" />}
+                  {memoryAction.kind === 'error' && <AlertCircle className="mt-0.5 h-3.5 w-3.5" />}
+                  <span>{memoryAction.message}</span>
+                </div>
+              )}
+            </div>
+          </SettingsCard>
+        </SettingsSection>
+      </div>
     </SettingsSection>
   );
 }
@@ -3645,7 +4019,7 @@ export default function PilotDeckConfigTab({
             <div className="min-w-0 space-y-6">
               {activeSection === 'models' && <ModelsSection config={parsedConfig} onChange={onFormChange} />}
               {activeSection === 'agents' && <AgentsSection config={parsedConfig} onChange={onFormChange} />}
-              {activeSection === 'memory' && <MemorySection config={parsedConfig} onChange={onFormChange} />}
+              {activeSection === 'memory' && <MemorySection config={parsedConfig} projects={projects} onChange={onFormChange} />}
               {activeSection === 'tools' && <ToolsSection config={parsedConfig} onChange={onFormChange} />}
               {activeSection === 'router' && <RouterSection config={parsedConfig} onChange={onFormChange} />}
               {activeSection === 'gateway' && <GatewaySection config={parsedConfig} onChange={onFormChange} />}

--- a/ui/src/i18n/locales/en/settings.json
+++ b/ui/src/i18n/locales/en/settings.json
@@ -872,7 +872,7 @@
       },
       "memory": {
         "title": "Memory",
-        "description": "Configure the model used for memory indexing and Dream.",
+        "description": "Configure the memory service, automatic build intervals, and memory data management.",
         "enabled": {
           "label": "Enabled",
           "description": "Toggles the memory service."
@@ -881,6 +881,50 @@
           "label": "Memory Model",
           "description": "Provider/model the memory pipeline calls.",
           "inherit": "inherit (use main agent's model)"
+        },
+        "automation": {
+          "autoIndex": {
+            "label": "Auto index interval (minutes)",
+            "description": "Set to 0 to disable automatic indexing."
+          },
+          "autoDream": {
+            "label": "Auto Dream interval (minutes)",
+            "description": "Automatic Dream only runs after memory files have changed."
+          }
+        },
+        "data": {
+          "title": "Data management",
+          "description": "Export, import, or clear one project or all memory.",
+          "target": {
+            "label": "Managed target",
+            "description": "Choose a project or all memory.",
+            "all": "All memory",
+            "projectFallback": "Untitled project"
+          },
+          "actions": {
+            "export": "Export",
+            "import": "Import",
+            "clear": "Clear"
+          },
+          "status": {
+            "exporting": "Exporting {{target}}...",
+            "exported": "Exported {{target}}.",
+            "importing": "Importing {{target}}...",
+            "imported": "Imported {{target}}.",
+            "clearing": "Clearing {{target}}...",
+            "cleared": "Cleared {{target}}."
+          },
+          "confirm": {
+            "importProject": "Importing will overwrite memory for \"{{target}}\". Continue?",
+            "importAll": "Importing will overwrite all memory. Continue?",
+            "clearProject": "Clear memory for \"{{target}}\"?",
+            "clearAll": "Clear all memory? This deletes every project's memory and the global user background."
+          },
+          "errors": {
+            "missingProject": "No project is available.",
+            "invalidImport": "Choose a valid JSON backup file.",
+            "invalidExport": "The exported content was not valid JSON."
+          }
         }
       },
       "tools": {

--- a/ui/src/i18n/locales/zh-CN/settings.json
+++ b/ui/src/i18n/locales/zh-CN/settings.json
@@ -872,7 +872,7 @@
       },
       "memory": {
         "title": "记忆",
-        "description": "配置记忆索引与 Dream 使用的模型。",
+        "description": "配置记忆服务、自动构建间隔，以及项目记忆的数据管理。",
         "enabled": {
           "label": "启用",
           "description": "启用记忆服务的总开关。"
@@ -881,6 +881,50 @@
           "label": "记忆模型",
           "description": "记忆管线使用的提供商/模型。",
           "inherit": "继承（使用主智能体模型）"
+        },
+        "automation": {
+          "autoIndex": {
+            "label": "自动索引间隔（分钟）",
+            "description": "0 表示关闭自动索引任务。"
+          },
+          "autoDream": {
+            "label": "自动 Dream 间隔（分钟）",
+            "description": "只有记忆文件更新后，自动 Dream 才会真正执行。"
+          }
+        },
+        "data": {
+          "title": "数据管理",
+          "description": "导出、导入或清空某个项目，或全部记忆。",
+          "target": {
+            "label": "管理对象",
+            "description": "选择要管理的项目或全部记忆。",
+            "all": "全部记忆",
+            "projectFallback": "未命名项目"
+          },
+          "actions": {
+            "export": "导出",
+            "import": "导入",
+            "clear": "清空"
+          },
+          "status": {
+            "exporting": "正在导出 {{target}}...",
+            "exported": "已导出 {{target}}。",
+            "importing": "正在导入 {{target}}...",
+            "imported": "已导入 {{target}}。",
+            "clearing": "正在清空 {{target}}...",
+            "cleared": "已清空 {{target}}。"
+          },
+          "confirm": {
+            "importProject": "导入会覆盖“{{target}}”的项目记忆。确认继续吗？",
+            "importAll": "导入会覆盖全部记忆。确认继续吗？",
+            "clearProject": "确认清空“{{target}}”的项目记忆吗？",
+            "clearAll": "确认清空全部记忆吗？这会删除所有项目记忆和全局用户背景。"
+          },
+          "errors": {
+            "missingProject": "没有可用项目。",
+            "invalidImport": "请选择有效的 JSON 备份文件。",
+            "invalidExport": "导出的内容不是有效 JSON。"
+          }
         }
       },
       "tools": {


### PR DESCRIPTION
## Summary

This PR fixes two memory issues and cleans up where memory management lives in the UI.

## Changes

- Fixes #229: clearing all memory now returns an updated dashboard snapshot when the request has project context.
- Fixes #224: invalid legacy memory reasoning mode values are now rejected instead of being silently saved.
- Moves memory import/export/clear controls out of the Memory dashboard modal and into Settings > Service Config > Memory.
- Adds a managed target selector so users can manage a specific project or all memory from one place.
- Removes the old Memory dashboard settings entry point.

## Testing

- `pnpm --dir ui exec vitest run server/routes/memory.test.js`
- `pnpm --dir ui run build`
- `git diff --check upstream/main..HEAD`