### PR TITLE
fix: use resolvePilotHome instead of os.homedir in command discovery

### DIFF
--- a/ui/server/routes/commands.js
+++ b/ui/server/routes/commands.js
@@ -759,7 +759,7 @@ Custom commands can be created in:
       workdir = effectiveProjectPath;
       dir = path.join('.pilotdeck', 'skills');
     } else {
-      workdir = path.join(os.homedir(), '.pilotdeck');
+      workdir = resolvePilotHome(process.env);
       dir = 'skills';
     }
     const installPath = path.join(workdir, dir, slug);
@@ -885,7 +885,7 @@ Custom commands can be created in:
 router.post('/list', async (req, res) => {
   try {
     const { projectPath } = req.body;
-    const homeDir = os.homedir();
+    const pilotHome = resolvePilotHome(process.env);
 
     const customCommandSources = [];
 
@@ -899,8 +899,8 @@ router.post('/list', async (req, res) => {
       customCommandSources.push(...projectCommands, ...projectSkills);
     }
 
-    const userCommandsDir = path.join(homeDir, '.pilotdeck', 'commands');
-    const userSkillsDir = path.join(homeDir, '.pilotdeck', 'skills');
+    const userCommandsDir = path.join(pilotHome, 'commands');
+    const userSkillsDir = path.join(pilotHome, 'skills');
     const [userCommands, userSkills] = await Promise.all([
       scanCommandsDirectory(userCommandsDir, userCommandsDir, 'user'),
       scanSkillsDirectory(userSkillsDir, 'user'),

--- a/ui/server/routes/commands.js
+++ b/ui/server/routes/commands.js
@@ -1100,9 +1100,10 @@ router.post('/execute', async (req, res) => {
     // Security: validate commandPath is within allowed directories.
     {
       const resolvedPath = path.resolve(commandPath);
+      const pilotHome = resolvePilotHome(process.env);
       const allowedBases = [
-        path.resolve(path.join(os.homedir(), '.pilotdeck', 'commands')),
-        path.resolve(path.join(os.homedir(), '.pilotdeck', 'skills')),
+        path.resolve(path.join(pilotHome, 'commands')),
+        path.resolve(path.join(pilotHome, 'skills')),
       ];
       if (context?.projectPath) {
         allowedBases.push(

--- a/ui/server/routes/commands.test.js
+++ b/ui/server/routes/commands.test.js
@@ -1,0 +1,95 @@
+import express from 'express';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const nativeFetch = globalThis.fetch;
+const tempDirs = [];
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.resetModules();
+  delete process.env.PILOT_HOME;
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('commands routes', () => {
+  it('executes user commands discovered under custom PILOT_HOME', async () => {
+    const pilotHome = mkdtempSync(join(tmpdir(), 'pilotdeck-commands-route-'));
+    tempDirs.push(pilotHome);
+    process.env.PILOT_HOME = pilotHome;
+
+    const commandsDir = join(pilotHome, 'commands');
+    mkdirSync(commandsDir, { recursive: true });
+    const commandPath = join(commandsDir, 'hello.md');
+    writeFileSync(commandPath, '---\ndescription: Says hello\n---\nHello $1', 'utf8');
+
+    const { request } = await createCommandsApp();
+
+    const result = await request('/api/commands/execute', {
+      method: 'POST',
+      body: JSON.stringify({
+        commandName: '/hello',
+        commandPath,
+        args: ['PilotDeck'],
+      }),
+    });
+
+    expect(result.status).toBe(200);
+    expect(result.body).toMatchObject({
+      type: 'custom',
+      command: '/hello',
+      content: 'Hello PilotDeck',
+    });
+  });
+});
+
+async function createCommandsApp() {
+  vi.doMock('../../shared/modelConstants.js', () => ({
+    CODEX_MODELS: [],
+    CURSOR_MODELS: [],
+  }));
+  vi.doMock('../utils/claude-runtime-config.js', () => ({
+    getClaudeRuntimeModelConfig: vi.fn(() => ({})),
+    getClaudeRuntimeModelValues: vi.fn(() => []),
+  }));
+  vi.doMock('../services/pilotdeckConfig.js', () => ({
+    readPilotDeckConfigFile: vi.fn(() => ({ config: {} })),
+    resolveModel: vi.fn((model) => model),
+  }));
+  vi.doMock('../turnkey-slash.js', () => ({
+    executeTurnkeySlashCommand: vi.fn(async () => ({})),
+  }));
+  vi.doMock('../../../src/adapters/channel/protocol/ChannelCommandRegistry.js', () => ({
+    getRegisteredCommands: vi.fn(() => []),
+  }));
+  vi.doMock('../../../src/cli/commands/chatSearch.js', () => ({
+    runChatSearchFormatted: vi.fn(async () => ({ result: {}, text: '' })),
+  }));
+
+  const { default: commandsRoutes } = await import('./commands.js');
+  const app = express();
+  app.use(express.json());
+  app.use('/api/commands', commandsRoutes);
+
+  return {
+    request: (path, init) => requestJson(app, path, init),
+  };
+}
+
+async function requestJson(app, path, init = {}) {
+  const server = app.listen(0);
+  try {
+    const { port } = server.address();
+    const response = await nativeFetch(`http://127.0.0.1:${port}${path}`, {
+      headers: { 'Content-Type': 'application/json', ...(init.headers || {}) },
+      ...init,
+    });
+    return { status: response.status, body: await response.json() };
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+}


### PR DESCRIPTION
## Summary

- Fix `/api/commands/list` route using `os.homedir()` instead of `resolvePilotHome()` for user skill/command discovery, causing the command palette to ignore `PILOT_HOME`.
- Fix `/skill_install` handler using `os.homedir()` for user-scope installs, diverging from `SkillManager` and `/api/skills/*` which correctly honor `PILOT_HOME`.

Closes #344

## Test plan

- [ ] Set `PILOT_HOME` to a non-default directory and create a skill under `$PILOT_HOME/skills/test_skill/SKILL.md`
- [ ] Verify `/api/commands/list` returns `/test_skill` in the command list
- [ ] Verify `/api/commands/list` does NOT return stale skills from `~/.pilotdeck/skills/` when `PILOT_HOME` points elsewhere
- [ ] Verify `/skill_install` installs to `$PILOT_HOME/skills/` (not `~/.pilotdeck/skills/`) when `PILOT_HOME` is set

Made with [Cursor](https://cursor.com)