### PR TITLE
Improve model error guidance

### DIFF
--- a/src/adapters/channel/feishu/FeishuChannel.ts
+++ b/src/adapters/channel/feishu/FeishuChannel.ts
@@ -551,7 +551,7 @@ export class FeishuChannel implements ChannelAdapter {
           type: "agent_status",
           event: "channel_submit_failed",
           detail: createVisibleErrorStatusDetail({
-            message: "处理消息时发生错误，请重试。",
+            message: "Failed to process this message. Please retry.",
             code: "channel_submit_failed",
             userHint: "PilotDeck failed before this IM turn could finish. Retry the message; if it repeats, check the channel and gateway logs.",
             scope: "channel",

--- a/src/adapters/channel/webhook/WebhookChannel.ts
+++ b/src/adapters/channel/webhook/WebhookChannel.ts
@@ -286,12 +286,12 @@ export class WebhookChannel implements ChannelAdapter {
       this.logger?.error?.(`webhook: submitTurn error: ${e}`);
       const statusEvent = createWebhookStatusEvent({
         event: "channel_submit_failed",
-        message: "处理消息时发生错误，请重试。",
+        message: "Failed to process this message. Please retry.",
         code: "channel_submit_failed",
         scope: "channel",
         userHint: "PilotDeck failed before this webhook turn could finish. Retry the delivery; if it repeats, check webhook and gateway logs.",
       });
-      replyText = renderWebhookEvent(statusEvent) ?? "处理消息时发生错误，请重试。";
+      replyText = renderWebhookEvent(statusEvent) ?? "Failed to process this message. Please retry.";
     }
 
     const finalText = replyText.trim();

--- a/src/adapters/channel/weixin/WeixinChannel.ts
+++ b/src/adapters/channel/weixin/WeixinChannel.ts
@@ -678,7 +678,7 @@ export class WeixinChannel implements ChannelAdapter {
         type: "agent_status",
         event: "channel_submit_failed",
         detail: createVisibleErrorStatusDetail({
-          message: "处理消息时发生错误，请重试。",
+          message: "Failed to process this message. Please retry.",
           code: "channel_submit_failed",
           userHint: "PilotDeck failed before this IM turn could finish. Retry the message; if it repeats, check the channel and gateway logs.",
           scope: "channel",

--- a/src/agent/loop/AgentLoop.ts
+++ b/src/agent/loop/AgentLoop.ts
@@ -10,6 +10,7 @@ import {
   REQUEST_TOO_LARGE_PATTERN,
   type CanonicalMessage,
   type CanonicalModelError,
+  ModelProviderError,
   type CanonicalModelRequest,
   type CanonicalToolSchema,
   type CanonicalUsage,
@@ -59,6 +60,7 @@ import { repairToolName } from "../../model/streaming/repairToolName.js";
 import {
   createAgentStatusDetail,
   createVisibleErrorStatusDetail,
+  type AgentStatusI18nDescriptor,
 } from "../../status/agentStatus.js";
 
 const TOOL_EVENT_PUMP_INTERVAL_MS = 500;
@@ -520,7 +522,8 @@ export class AgentLoop {
           yield { type: "turn_completed", sessionId: input.sessionId, turnId: input.turnId, result };
           return { result, messages };
         }
-        const stopFailureMsg = error instanceof Error ? error.message : String(error);
+        const modelError = error instanceof ModelProviderError ? error.error : undefined;
+        const stopFailureMsg = modelError?.message ?? (error instanceof Error ? error.message : String(error));
         await this.dispatchLifecycle(input, "StopFailure", { error: stopFailureMsg });
         yield { type: "stop_failure", sessionId: input.sessionId, turnId: input.turnId, error: stopFailureMsg };
         const result = this.createTurnResult(input, {
@@ -531,7 +534,7 @@ export class AgentLoop {
           turns: turnCount,
           startedAt,
           finalMessage,
-          errors: [agentError("agent_model_error", stopFailureMsg)],
+          errors: [agentError("agent_model_error", stopFailureMsg, modelError, modelError?.userHint)],
         });
         const abortStatus = createAbortStatus();
         if (abortStatus) {
@@ -539,6 +542,7 @@ export class AgentLoop {
         } else {
           yield await emitStatus(createModelRequestFailedStatus({
             error: result.errors![0]!,
+            modelError,
           }));
         }
         yield { type: "turn_failed", sessionId: input.sessionId, turnId: input.turnId, error: result.errors![0]! };
@@ -2779,22 +2783,117 @@ function createModelRequestFailedStatus(args: {
   error: ReturnType<typeof agentError>;
   modelError?: CanonicalModelError;
 }): AgentStatusMessage {
-  const text = args.error.message || "The model request failed, so this turn has stopped.";
+  const providerMessage = args.error.message || args.modelError?.message || "The model request failed, so this turn has stopped.";
+  const text = formatModelRequestFailureMessage(providerMessage, args.modelError);
+  const action = modelFailureAction(args.modelError);
   return {
     event: "model_request_failed",
     kind: "error",
     text,
     detail: createAgentTurnErrorDetail({
       message: text,
+      messageI18n: {
+        key: "chat:agentStatus.modelRequestFailed.message",
+        params: { providerMessage },
+      },
       code: args.error.code,
-      userHint: args.error.userHint ?? args.modelError?.userHint ?? defaultModelFailureHint(args.modelError),
+      userHint: action.userHint,
+      userHintI18n: action.userHintI18n,
       detail: {
         provider: args.modelError?.provider,
+        protocol: args.modelError?.protocol,
         status: args.modelError?.status,
         modelErrorCode: args.modelError?.code,
         retryable: args.modelError?.retryable,
+        providerMessage,
+        settingsFix: args.modelError?.settingsFix,
+        fixTarget: action.fixTarget,
       },
     }),
+  };
+}
+
+export function formatModelRequestFailureMessage(providerMessage: string, error: CanonicalModelError | undefined): string {
+  const cleanMessage = providerMessage.trim() || "The model request failed.";
+  const action = modelFailureAction(error);
+  return `${cleanMessage}\n\n${action.shortAction}`;
+}
+
+export function modelFailureAction(error: CanonicalModelError | undefined): {
+  shortAction: string;
+  userHint: string;
+  userHintI18n: AgentStatusI18nDescriptor;
+  fixTarget: "settings" | "provider" | "network" | "prompt" | "retry";
+} {
+  if (!error) {
+    const hint = "Check Settings → Model Provider and verify the selected provider, base URL, API key, model name, and timeoutMs. If the provider is slow or the network is unstable, increase timeoutMs or check provider status.";
+    return modelFailureActionResult(hint, "settings", "settingsDefault");
+  }
+
+  const providerLabel = error.provider ? ` provider "${error.provider}"` : " provider";
+  const modelLabel = error.model ? ` model "${error.model}"` : " selected model";
+
+  if (error.status === 401 || error.status === 403 || error.code === "auth_error") {
+    const hint = `Update the API key or access permissions for${providerLabel} in Settings → Model Provider, or run pilotdeck setup.`;
+    return modelFailureActionResult(hint, "settings", "auth", { provider: error.provider ?? "the provider" });
+  }
+  if (error.code === "model_not_found") {
+    const hint = `Choose a valid${modelLabel} for${providerLabel} in Settings → Model Provider, or add it under model.providers.<id>.models in pilotdeck.yaml.`;
+    return modelFailureActionResult(hint, "settings", "modelNotFound", { provider: error.provider ?? "the provider", model: error.model });
+  }
+  if (error.code === "timeout") {
+    const hint = `Increase timeoutMs for${providerLabel} in Settings → Model Provider → Advanced, or check local network/proxy and provider status.`;
+    return modelFailureActionResult(hint, "network", "timeout", { provider: error.provider ?? "the provider" });
+  }
+  if (error.status === 429 || error.code === "rate_limit_error") {
+    const hint = `Wait for the provider rate limit to reset, reduce concurrency, or switch to another provider/model in Settings.`;
+    return modelFailureActionResult(hint, "provider", "rateLimit");
+  }
+  if (error.code === "billing") {
+    const hint = `Top up billing/quota on the provider API side, or switch to another provider/model in Settings.`;
+    return modelFailureActionResult(hint, "provider", "billing");
+  }
+  if (error.code === "prompt_too_long" || error.code === "context_overflow") {
+    const hint = "Run /compact, start a new session, remove large attachments, or switch to a larger-context model in Settings.";
+    return modelFailureActionResult(hint, "prompt", "contextOverflow");
+  }
+  if (error.code === "payload_too_large" || error.code === "request_too_large") {
+    const hint = "Reduce attachments/context size, run /compact, or start a new session before retrying.";
+    return modelFailureActionResult(hint, "prompt", "payloadTooLarge");
+  }
+  if (error.code === "max_output_reached") {
+    const hint = "Increase max output tokens in Settings → Model Provider, or ask the agent to split the answer into smaller parts.";
+    return modelFailureActionResult(hint, "settings", "maxOutput");
+  }
+  if (error.code === "image_too_large") {
+    const hint = "Resize or remove large images, then retry.";
+    return modelFailureActionResult(hint, "prompt", "imageTooLarge");
+  }
+  if (error.retryable || error.code === "server_error" || error.code === "overloaded_error") {
+    const hint = `Retry later, check provider API status, or switch to another provider/model in Settings if it repeats.`;
+    return modelFailureActionResult(hint, "provider", "providerRetry");
+  }
+
+  const hint = `Check Settings → Model Provider for base URL/API key/model and timeoutMs. If settings look correct, check local network/proxy and provider API status/logs.`;
+  return modelFailureActionResult(hint, "settings", "settingsDefault");
+}
+
+function modelFailureActionResult(
+  hint: string,
+  fixTarget: "settings" | "provider" | "network" | "prompt" | "retry",
+  key: string,
+  params: Record<string, unknown> = {},
+): {
+  shortAction: string;
+  userHint: string;
+  userHintI18n: AgentStatusI18nDescriptor;
+  fixTarget: "settings" | "provider" | "network" | "prompt" | "retry";
+} {
+  return {
+    shortAction: `Action: ${hint}`,
+    userHint: hint,
+    userHintI18n: { key: `chat:agentStatus.modelRequestFailed.actions.${key}`, params },
+    fixTarget,
   };
 }
 
@@ -2810,8 +2909,10 @@ function createToolCallRecoveryExhaustedStatus(args: {
     text,
     detail: createAgentTurnErrorDetail({
       message: text,
+      messageI18n: { key: "chat:agentStatus.toolCallRecoveryExhausted.message", params: { message: text } },
       code: args.error.code,
-      userHint: args.error.userHint ?? "Retry with a shorter prompt or ask the agent to split large tool inputs into smaller steps.",
+      userHint: args.error.userHint ?? "Retry with a shorter prompt, ask the agent to split large tool inputs into smaller steps, or switch to a model with stronger tool-calling support in Settings → Model Provider.",
+      userHintI18n: { key: "chat:agentStatus.toolCallRecoveryExhausted.hint" },
       detail: {
         attempts: args.attempts,
         reason: args.reason,
@@ -2832,7 +2933,7 @@ function createToolErrorLoopStatus(args: {
     detail: createAgentTurnErrorDetail({
       message: text,
       code: args.error.code,
-      userHint: args.error.userHint ?? "Try changing the request, granting the required permission, or switching to a more capable model.",
+      userHint: args.error.userHint ?? "Change the request to avoid repeating the same failing tool call, grant any required permission, or switch to a model with stronger tool-calling support in Settings → Model Provider.",
       detail: {
         repeatedFailures: args.repeatedFailures,
       },
@@ -2891,8 +2992,10 @@ function createEmptyResponseStatus(args: {
     text,
     detail: createAgentTurnErrorDetail({
       message: text,
+      messageI18n: { key: "chat:agentStatus.emptyResponse.message" },
       code: "model_empty_response_exhausted",
-      userHint: "Increase max output tokens or retry with a shorter prompt.",
+      userHint: "Increase max output tokens in Settings → Model Provider, retry with a shorter prompt, or check whether this provider/model supports the requested output format.",
+      userHintI18n: { key: "chat:agentStatus.emptyResponse.hint" },
       detail: {
         provider: args.provider,
         model: args.model,
@@ -2913,8 +3016,10 @@ function createMaxTurnsStatus(args: {
     text,
     detail: createAgentTurnErrorDetail({
       message: text,
+      messageI18n: { key: "chat:agentStatus.maxTurns.message", params: { maxTurns: args.maxTurns } },
       code: args.error.code,
-      userHint: args.error.userHint ?? "Increase maxTurns or split the task into smaller steps and try again.",
+      userHint: args.error.userHint ?? "Increase maxTurns in local config if this task legitimately needs more agent steps, or split the task into smaller prompts and try again.",
+      userHintI18n: { key: "chat:agentStatus.maxTurns.hint" },
       detail: {
         maxTurns: args.maxTurns,
       },
@@ -2932,9 +3037,11 @@ function createMaxOutputRecoveryExhaustedStatus(args: {
     text,
     detail: createAgentTurnErrorDetail({
       message: text,
+      messageI18n: { key: "chat:agentStatus.maxOutputRecoveryExhausted.message" },
       severity: "warning",
       code: "max_output_recovery_exhausted",
-      userHint: "Increase max output tokens or split the task into smaller steps.",
+      userHint: "Increase max output tokens in Settings → Model Provider, or ask the agent to split the answer into smaller parts.",
+      userHintI18n: { key: "chat:agentStatus.maxOutputRecoveryExhausted.hint" },
       detail: {
         attempts: args.attempts,
       },
@@ -2950,6 +3057,7 @@ function createStructuredOutputCompletedStatus(): AgentStatusMessage {
     text,
     detail: createAgentTurnStatusDetail({
       message: text,
+      messageI18n: { key: "chat:agentStatus.structuredOutputCompleted.message" },
       code: "structured_output_completed",
     }),
   };
@@ -2963,9 +3071,11 @@ function createContentFilterStopStatus(): AgentStatusMessage {
     text,
     detail: createAgentTurnErrorDetail({
       message: text,
+      messageI18n: { key: "chat:agentStatus.contentFilter.message" },
       severity: "warning",
       code: "content_filter_stop",
-      userHint: "Retry with a narrower request or adjust the prompt to avoid filtered content.",
+      userHint: "Retry with a narrower request or adjust the prompt to avoid filtered content; if this seems wrong, check the provider API policy/status for the selected model.",
+      userHintI18n: { key: "chat:agentStatus.contentFilter.hint" },
     }),
   };
 }
@@ -2978,9 +3088,11 @@ function createUnknownFinishReasonStatus(): AgentStatusMessage {
     text,
     detail: createAgentTurnErrorDetail({
       message: text,
+      messageI18n: { key: "chat:agentStatus.unknownFinishReason.message" },
       severity: "warning",
       code: "unknown_finish_reason",
-      userHint: "Retry the turn; if it repeats, check the provider stream and gateway logs.",
+      userHint: "Retry the turn; if it repeats, check provider API status/logs for stream finish reasons and verify the selected provider/model in Settings → Model Provider.",
+      userHintI18n: { key: "chat:agentStatus.unknownFinishReason.hint" },
     }),
   };
 }
@@ -2993,8 +3105,10 @@ function createTurnAbortedStatus(args: { reason?: string }): AgentStatusMessage 
     text,
     detail: createAgentTurnStatusDetail({
       message: text,
+      messageI18n: { key: "chat:agentStatus.turnAborted.message" },
       code: "turn_aborted",
-      userHint: "Retry when you are ready to continue.",
+      userHint: "Retry when you are ready to continue. If this was unexpected, check whether you clicked Stop, switched sessions during a run, or lost the gateway connection.",
+      userHintI18n: { key: "chat:agentStatus.turnAborted.hint" },
       detail: {
         reason: args.reason,
       },
@@ -3011,8 +3125,10 @@ function createFinishReasonStatus(finishReason: string | undefined, assistantTex
 
 function createAgentTurnErrorDetail(input: {
   message: string;
+  messageI18n?: AgentStatusI18nDescriptor;
   code: string;
   userHint: string;
+  userHintI18n?: AgentStatusI18nDescriptor;
   severity?: "error" | "warning";
   detail?: Record<string, unknown>;
 }): Record<string, unknown> {
@@ -3025,8 +3141,10 @@ function createAgentTurnErrorDetail(input: {
 
 function createAgentTurnStatusDetail(input: {
   message: string;
+  messageI18n?: AgentStatusI18nDescriptor;
   code: string;
   userHint?: string;
+  userHintI18n?: AgentStatusI18nDescriptor;
   detail?: Record<string, unknown>;
 }): Record<string, unknown> {
   return createAgentStatusDetail({

--- a/src/model/errors/normalizeModelError.ts
+++ b/src/model/errors/normalizeModelError.ts
@@ -196,7 +196,7 @@ function resolveUserHint(
   switch (code) {
     case "billing":
       return {
-        userHint: "API account balance exhausted or quota depleted.",
+        userHint: `API account balance exhausted or quota depleted${provider ? ` for provider \"${provider}\"` : ""}. Top up provider billing or switch provider/model in Settings.`,
         settingsFix: {
           description: "Top up credits or switch to a different provider.",
           configPath: "model.provider",
@@ -204,7 +204,7 @@ function resolveUserHint(
       };
     case "auth_error":
       return {
-        userHint: "API key rejected by the provider. Verify the key is valid and not expired.",
+        userHint: `API key rejected${provider ? ` by provider \"${provider}\"` : " by the provider"}. Update the key in Settings → Model Provider or run pilotdeck setup.`,
         settingsFix: {
           description: "Reconfigure API key via setup.",
           command: "pilotdeck setup",
@@ -212,7 +212,7 @@ function resolveUserHint(
       };
     case "model_not_found":
       return {
-        userHint: "The requested model does not exist or your account lacks access.",
+        userHint: `The requested model does not exist or your account lacks access${provider ? ` on provider \"${provider}\"` : ""}. Select a valid model in Settings → Model Provider or add it under model.providers.<id>.models in pilotdeck.yaml.`,
         settingsFix: {
           description: "Switch to a valid model.",
           configPath: "model.default",
@@ -221,7 +221,7 @@ function resolveUserHint(
     case "context_overflow":
     case "prompt_too_long":
       return {
-        userHint: "Input exceeds the model context window. Try /compact to compress history or /new for a fresh session.",
+        userHint: "Input exceeds the model context window. Run /compact, start a new session with /new, remove large attachments, or switch to a larger-context model in Settings.",
       };
     case "image_too_large":
       return {
@@ -230,23 +230,23 @@ function resolveUserHint(
     case "payload_too_large":
     case "request_too_large":
       return {
-        userHint: "Request payload too large. Try /compact to reduce context, or start a new session with /new.",
+        userHint: "Request payload too large. Remove attachments, run /compact, start a new session with /new, or reduce the prompt size before retrying.",
       };
     case "rate_limit_error":
       return {
-        userHint: "Rate limited by the provider. The request will be retried automatically after a short wait.",
+        userHint: "Rate limited by the provider. Wait for the limit to reset, reduce concurrent requests, or switch provider/model in Settings.",
       };
     case "overloaded_error":
       return {
-        userHint: "Provider is temporarily overloaded. Retrying with backoff.",
+        userHint: "Provider is temporarily overloaded. Retry later, check provider API status, or switch provider/model in Settings if it repeats.",
       };
     case "max_output_reached":
       return {
-        userHint: "Model output hit the token limit. The system will attempt to resume automatically.",
+        userHint: "Model output hit the token limit. Increase max output tokens in Settings → Model Provider or ask the agent to split the answer into smaller parts.",
       };
     case "timeout":
       return {
-        userHint: "Request timed out. For large prompts, try increasing provider.timeoutMs in config or use streaming mode.",
+        userHint: `Request timed out${provider ? ` for provider \"${provider}\"` : ""}. Increase provider.timeoutMs in Settings → Model Provider → Advanced, or check local network/proxy and provider status.`,
         settingsFix: {
           description: "Increase request timeout for this provider.",
           configPath: "model.providers.<id>.timeoutMs",
@@ -254,7 +254,7 @@ function resolveUserHint(
       };
     case "server_error":
       return {
-        userHint: "Provider returned a server error. Retrying automatically.",
+        userHint: "Provider returned a server error. Check provider API status/logs, retry later, or switch provider/model in Settings if it repeats.",
       };
     default:
       return {};

--- a/src/model/protocol/errors.ts
+++ b/src/model/protocol/errors.ts
@@ -118,7 +118,7 @@ export const USAGE_LIMIT_PATTERN =
   /usage limit|quota|limit exceeded|key limit exceeded/i;
 
 export const NETWORK_TIMEOUT_PATTERN =
-  /fetch failed|terminated|socket hang up|ETIMEDOUT|ECONNRESET|ECONNREFUSED|network error|request timeout|client disconnected/i;
+  /fetch failed|terminated|socket hang up|ETIMEDOUT|ECONNRESET|ECONNREFUSED|network error|request timeout|stream idle timeout|no data received|client disconnected/i;
 
 export class ModelConfigError extends Error {
   readonly name = "ModelConfigError";

--- a/src/status/agentStatus.ts
+++ b/src/status/agentStatus.ts
@@ -16,12 +16,19 @@ export type AgentStatusSource =
 
 export type AgentStatusSeverity = "info" | "warning" | "error";
 
+export type AgentStatusI18nDescriptor = {
+  key: string;
+  params?: Record<string, unknown>;
+};
+
 export type AgentStatusDetailInput = {
   message: string;
+  messageI18n?: AgentStatusI18nDescriptor;
   code?: string;
   severity?: AgentStatusSeverity;
   visible?: boolean;
   userHint?: string;
+  userHintI18n?: AgentStatusI18nDescriptor;
   scope: AgentStatusScope;
   source: AgentStatusSource;
   detail?: Record<string, unknown>;
@@ -48,10 +55,12 @@ export type AgentStatusHttpErrorBody = {
 export function createAgentStatusDetail(input: AgentStatusDetailInput): Record<string, unknown> {
   return pruneUndefined({
     message: input.message,
+    messageI18n: input.messageI18n,
     code: input.code,
     severity: input.severity,
     visible: input.visible ?? true,
     userHint: input.userHint,
+    userHintI18n: input.userHintI18n,
     scope: input.scope,
     source: input.source,
     ...(input.detail ?? {}),

--- a/src/web/client/webMessage.ts
+++ b/src/web/client/webMessage.ts
@@ -107,6 +107,8 @@ export type WebMessage = {
   requestId?: string;
   ok?: boolean;
   text?: string;
+  contentI18n?: { key: string; params?: Record<string, unknown> };
+  userHintI18n?: { key: string; params?: Record<string, unknown> };
   images?: Array<{
     data: string;
     name?: string;
@@ -452,10 +454,14 @@ export function applyWebGatewayEvent(
         role: kind === "error" ? "error" : "system",
         kind,
         text,
+        ...(isI18nDescriptor(detail.messageI18n) ? { contentI18n: detail.messageI18n } : {}),
+        ...(isI18nDescriptor(detail.userHintI18n) ? { userHintI18n: detail.userHintI18n } : {}),
         payload: {
           event: event.event,
           detail,
           ...(typeof detail.userHint === "string" ? { userHint: detail.userHint } : {}),
+          ...(isI18nDescriptor(detail.messageI18n) ? { contentI18n: detail.messageI18n } : {}),
+          ...(isI18nDescriptor(detail.userHintI18n) ? { userHintI18n: detail.userHintI18n } : {}),
         },
         source: "live",
       };
@@ -514,6 +520,12 @@ function defaultNewId(): string {
     return c.randomUUID();
   }
   return `web-${Math.random().toString(36).slice(2)}-${Date.now().toString(36)}`;
+}
+
+function isI18nDescriptor(value: unknown): value is { key: string; params?: Record<string, unknown> } {
+  return typeof value === "object"
+    && value !== null
+    && typeof (value as { key?: unknown }).key === "string";
 }
 
 function isErrorAgentStatusEvent(event: WebGatewayEvent & { type: "agent_status" }): boolean {

--- a/src/web/server/readSessionMessages.ts
+++ b/src/web/server/readSessionMessages.ts
@@ -846,6 +846,8 @@ function injectAgentStatusMessages(
       role: entry.kind === "error" ? "error" : "system",
       kind: entry.kind,
       text: entry.text,
+      ...(isI18nDescriptor(entry.detail?.messageI18n) ? { contentI18n: entry.detail.messageI18n } : {}),
+      ...(isI18nDescriptor(entry.detail?.userHintI18n) ? { userHintI18n: entry.detail.userHintI18n } : {}),
       payload: { event: entry.event, ...(entry.detail ? { detail: entry.detail } : {}) },
       source: "history",
     });
@@ -863,6 +865,12 @@ function injectAgentStatusMessages(
     }
     allMessages.splice(insertAt, 0, statusMsg);
   }
+}
+
+function isI18nDescriptor(value: unknown): value is { key: string; params?: Record<string, unknown> } {
+  return typeof value === "object"
+    && value !== null
+    && typeof (value as { key?: unknown }).key === "string";
 }
 
 function readToolResultErrorCode(raw: unknown): string | undefined {

--- a/tests/model/model-error-guidance.spec.ts
+++ b/tests/model/model-error-guidance.spec.ts
@@ -1,0 +1,101 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { formatModelRequestFailureMessage, modelFailureAction } from "../../src/agent/loop/AgentLoop.js";
+import { normalizeModelError } from "../../src/model/errors/normalizeModelError.js";
+import type { CanonicalModelError } from "../../src/model/protocol/errors.js";
+
+test("model request failure preserves provider raw message before action guidance", () => {
+  const providerMessage = "No such model: typo-model";
+  const error = normalizeModelError(
+    "modelbest-openai",
+    "openai",
+    { error: { message: providerMessage, code: "model_not_found" } },
+    404,
+  );
+
+  const formatted = formatModelRequestFailureMessage(providerMessage, error);
+
+  assert.ok(formatted.startsWith(providerMessage), formatted);
+  assert.match(formatted, /Action:/);
+  assert.match(formatted, /Settings → Model Provider/);
+  assert.match(formatted, /pilotdeck\.yaml/);
+});
+
+test("model_not_found guidance points users to local model settings", () => {
+  const error = normalizeModelError(
+    "modelbest-openai",
+    "openai",
+    { error: { message: "The model `does-not-exist` does not exist" } },
+    404,
+  );
+
+  assert.equal(error.code, "model_not_found");
+  assert.match(error.userHint ?? "", /Select a valid model/);
+  assert.match(error.userHint ?? "", /Settings → Model Provider/);
+  assert.equal(error.settingsFix?.configPath, "model.default");
+
+  const action = modelFailureAction(error);
+  assert.equal(action.fixTarget, "settings");
+  assert.match(action.userHint, /valid/);
+  assert.match(action.userHint, /pilotdeck\.yaml/);
+  assert.equal(action.userHintI18n.key, "chat:agentStatus.modelRequestFailed.actions.modelNotFound");
+  assert.equal(action.userHintI18n.params?.provider, "modelbest-openai");
+});
+
+test("stream idle timeout is classified as timeout with network and timeoutMs guidance", () => {
+  const error = normalizeModelError(
+    "modelbest-openai",
+    "openai",
+    new Error("Stream idle timeout: no data received for 30000ms"),
+  );
+
+  assert.equal(error.code, "timeout");
+  assert.match(error.userHint ?? "", /timeoutMs/);
+  assert.match(error.userHint ?? "", /network|proxy|provider status/i);
+
+  const action = modelFailureAction(error);
+  assert.equal(action.fixTarget, "network");
+  assert.match(action.userHint, /timeoutMs/);
+  assert.match(action.userHint, /network|proxy|provider status/i);
+});
+
+test("billing and rate limit guidance distinguish provider-side fixes", () => {
+  const billing = normalizeModelError(
+    "modelbest-openai",
+    "openai",
+    { error: { message: "insufficient balance, please top up your account" } },
+    402,
+  );
+  const rateLimit = normalizeModelError(
+    "modelbest-openai",
+    "openai",
+    { error: { message: "rate limit exceeded, retry later" } },
+    429,
+  );
+
+  assert.equal(billing.code, "billing");
+  assert.equal(modelFailureAction(billing).fixTarget, "provider");
+  assert.match(modelFailureAction(billing).userHint, /Top up billing\/quota/);
+
+  assert.equal(rateLimit.code, "rate_limit_error");
+  assert.equal(modelFailureAction(rateLimit).fixTarget, "provider");
+  assert.match(modelFailureAction(rateLimit).userHint, /rate limit/);
+  assert.match(modelFailureAction(rateLimit).userHint, /reduce concurrency|switch/);
+});
+
+test("unknown provider errors still give actionable settings and provider checks", () => {
+  const action = modelFailureAction({
+    provider: "custom",
+    protocol: "openai",
+    code: "weird_provider_code",
+    message: "provider said something unexpected",
+    retryable: false,
+    raw: {},
+  } satisfies CanonicalModelError);
+
+  assert.equal(action.fixTarget, "settings");
+  assert.match(action.userHint, /base URL\/API key\/model/);
+  assert.match(action.userHint, /timeoutMs/);
+  assert.match(action.userHint, /provider API status\/logs/);
+});

--- a/tests/web/read-session-status-i18n.spec.ts
+++ b/tests/web/read-session-status-i18n.spec.ts
@@ -1,0 +1,53 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { createAgentProjectSessionStorage } from "../../src/session/storage/ProjectSessionStorage.js";
+import { readWebSessionMessages } from "../../src/web/server/readSessionMessages.js";
+
+test("history replay preserves agent status i18n metadata and user hint", async () => {
+  const projectRoot = await mkdtemp(join(tmpdir(), "pilotdeck-status-i18n-project-"));
+  const pilotHome = await mkdtemp(join(tmpdir(), "pilotdeck-status-i18n-home-"));
+  try {
+    const sessionKey = "web:s_status_i18n";
+    const storage = createAgentProjectSessionStorage({
+      projectRoot,
+      pilotHome,
+      sessionId: sessionKey,
+      now: () => new Date("2026-07-09T00:00:00.000Z"),
+    });
+    await storage.transcript.recordAgentStatusMessage(sessionKey, "turn-1", {
+      event: "model_request_failed",
+      kind: "error",
+      text: "Provider raw error\n\nAction: Check Settings.",
+      detail: {
+        message: "Provider raw error\n\nAction: Check Settings.",
+        messageI18n: {
+          key: "chat:agentStatus.modelRequestFailed.message",
+          params: { providerMessage: "Provider raw error" },
+        },
+        userHint: "Check Settings.",
+        userHintI18n: { key: "chat:agentStatus.modelRequestFailed.actions.settingsDefault" },
+        severity: "error",
+        visible: true,
+      },
+    });
+
+    const replay = await readWebSessionMessages({ sessionKey }, { projectRoot, pilotHome });
+    const message = replay.messages.find((item) => item.kind === "error");
+
+    assert.ok(message, "expected replayed error status message");
+    assert.equal(message.text, "Provider raw error\n\nAction: Check Settings.");
+    assert.deepEqual(message.contentI18n, {
+      key: "chat:agentStatus.modelRequestFailed.message",
+      params: { providerMessage: "Provider raw error" },
+    });
+    assert.deepEqual(message.userHintI18n, { key: "chat:agentStatus.modelRequestFailed.actions.settingsDefault" });
+    assert.equal((message.payload as { detail?: { userHint?: string } }).detail?.userHint, "Check Settings.");
+  } finally {
+    await rm(projectRoot, { recursive: true, force: true });
+    await rm(pilotHome, { recursive: true, force: true });
+  }
+});

--- a/ui/server/pilotdeck-bridge.js
+++ b/ui/server/pilotdeck-bridge.js
@@ -687,9 +687,11 @@ export function gatewayEventToFrames(event, sessionId, provider) {
                         ...base,
                         kind: 'error',
                         content: detail.message || 'The model returned empty content repeatedly, so this turn has stopped. Try again later or increase max output tokens.',
+                        contentI18n: detail.messageI18n,
                         code: event.event,
                         recoverable: false,
                         userHint: detail.userHint,
+                        userHintI18n: detail.userHintI18n,
                     }),
                 ];
             }
@@ -699,9 +701,11 @@ export function gatewayEventToFrames(event, sessionId, provider) {
                         ...base,
                         kind: 'error',
                         content: detail.message || 'Reached the maximum number of turns, so this turn has stopped. Increase maxTurns or split the task into smaller steps and try again.',
+                        contentI18n: detail.messageI18n,
                         code: event.event,
                         recoverable: false,
                         userHint: detail.userHint,
+                        userHintI18n: detail.userHintI18n,
                     }),
                 ];
             }
@@ -711,9 +715,11 @@ export function gatewayEventToFrames(event, sessionId, provider) {
                         ...base,
                         kind: 'error',
                         content: detail.message || 'Agent execution stopped before producing a complete response. Please retry or adjust the task.',
+                        contentI18n: detail.messageI18n,
                         code: event.event,
                         recoverable: false,
                         userHint: detail.userHint,
+                        userHintI18n: detail.userHintI18n,
                     }),
                 ];
             }
@@ -723,9 +729,11 @@ export function gatewayEventToFrames(event, sessionId, provider) {
                         ...base,
                         kind: 'status',
                         content: detail.message || 'This turn ended before producing a standard assistant response.',
+                        contentI18n: detail.messageI18n,
                         code: event.event,
                         recoverable: false,
                         userHint: detail.userHint,
+                        userHintI18n: detail.userHintI18n,
                     }),
                 ];
             }

--- a/ui/server/pilotdeck-bridge.test.js
+++ b/ui/server/pilotdeck-bridge.test.js
@@ -32,7 +32,9 @@ describe('gatewayEventToFrames agent status errors', () => {
             event: 'model_request_failed',
             detail: {
                 message: 'Provider rejected the request.',
+                messageI18n: { key: 'chat:agentStatus.modelRequestFailed.message', params: { providerMessage: 'Provider rejected the request.' } },
                 userHint: 'Check provider settings.',
+                userHintI18n: { key: 'chat:agentStatus.modelRequestFailed.actions.settingsDefault' },
                 visible: true,
             },
         }, 'web:s_test', 'pilotdeck');
@@ -41,8 +43,10 @@ describe('gatewayEventToFrames agent status errors', () => {
         expect(frames[0]).toMatchObject({
             kind: 'error',
             content: 'Provider rejected the request.',
+            contentI18n: { key: 'chat:agentStatus.modelRequestFailed.message', params: { providerMessage: 'Provider rejected the request.' } },
             code: 'model_request_failed',
             userHint: 'Check provider settings.',
+            userHintI18n: { key: 'chat:agentStatus.modelRequestFailed.actions.settingsDefault' },
         });
     });
 

--- a/ui/server/routes/messages.js
+++ b/ui/server/routes/messages.js
@@ -243,11 +243,24 @@ function mapWebMessageToNormalized(message, sessionId) {
         payload: message.payload,
       });
     case 'status':
-      return createNormalizedMessage({ ...base, kind: 'status', text: message.text || '' });
+      return createNormalizedMessage({
+        ...base,
+        kind: 'status',
+        text: message.text || '',
+        ...(message.contentI18n ? { contentI18n: message.contentI18n } : {}),
+        ...(message.userHintI18n ? { userHintI18n: message.userHintI18n } : {}),
+      });
     case 'complete':
       return createNormalizedMessage({ ...base, kind: 'complete' });
     case 'error':
-      return createNormalizedMessage({ ...base, kind: 'error', content: message.text || '' });
+      return createNormalizedMessage({
+        ...base,
+        kind: 'error',
+        content: message.text || '',
+        ...(message.payload?.detail?.userHint ? { userHint: message.payload.detail.userHint } : {}),
+        ...(message.contentI18n ? { contentI18n: message.contentI18n } : {}),
+        ...(message.userHintI18n ? { userHintI18n: message.userHintI18n } : {}),
+      });
     case 'interrupted':
       return createNormalizedMessage({ ...base, kind: 'interrupted', content: message.text || '' });
     case 'compact_boundary': {

--- a/ui/src/components/chat/hooks/useChatMessages.ts
+++ b/ui/src/components/chat/hooks/useChatMessages.ts
@@ -216,6 +216,8 @@ function convertSingleMessage(
         content: msg.content || 'Unknown error',
         timestamp: msg.timestamp,
         ...(msg.userHint ? { userHint: msg.userHint } : {}),
+        ...(msg.contentI18n ? { contentI18n: msg.contentI18n } : {}),
+        ...(msg.userHintI18n ? { userHintI18n: msg.userHintI18n } : {}),
       };
 
     case 'interactive_prompt':

--- a/ui/src/components/chat/view/subcomponents/MessageComponent.tsx
+++ b/ui/src/components/chat/view/subcomponents/MessageComponent.tsx
@@ -52,6 +52,11 @@ type InteractiveOption = {
 
 type PermissionGrantState = 'idle' | 'granted' | 'error';
 
+type I18nDescriptor = {
+  key?: unknown;
+  params?: unknown;
+};
+
 const stringifyMessageContent = (content: unknown): string => {
   if (typeof content === 'string') return content;
   if (content === undefined || content === null) return '';
@@ -61,6 +66,20 @@ const stringifyMessageContent = (content: unknown): string => {
     return String(content);
   }
 };
+
+function translateDescriptor(
+  t: ReturnType<typeof useTranslation>['t'],
+  descriptor: unknown,
+  fallback: string,
+): string {
+  if (!descriptor || typeof descriptor !== 'object') return fallback;
+  const { key, params } = descriptor as I18nDescriptor;
+  if (typeof key !== 'string' || !key.trim()) return fallback;
+  const interpolation = params && typeof params === 'object' && !Array.isArray(params)
+    ? params as Record<string, unknown>
+    : {};
+  return t(key, { ...interpolation, defaultValue: fallback });
+}
 
 function cleanToolUseErrorContent(content: unknown): string {
   return stringifyMessageContent(content)
@@ -132,7 +151,9 @@ const MessageComponent = memo(({ message, prevMessage, createDiff, onFileOpen, o
   const [isExpanded, setIsExpanded] = useState(false);
   const permissionSuggestion = getPilotDeckPermissionSuggestion(message, provider);
   const [permissionGrantState, setPermissionGrantState] = useState<PermissionGrantState>('idle');
-  const messageContent = stringifyMessageContent(message.content);
+  const rawMessageContent = stringifyMessageContent(message.content);
+  const messageContent = translateDescriptor(t, message.contentI18n, rawMessageContent);
+  const userHintContent = translateDescriptor(t, message.userHintI18n, stringifyMessageContent(message.userHint));
   const messageImages = Array.isArray(message.images)
     ? message.images.filter((image) => image && typeof image.data === 'string')
     : [];
@@ -801,12 +822,12 @@ const MessageComponent = memo(({ message, prevMessage, createDiff, onFileOpen, o
                   );
                 })()}
 
-                {message.type === 'error' && message.userHint && (
+                {message.type === 'error' && userHintContent && (
                   <div className="mt-2 flex items-start gap-2 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 dark:border-amber-800/50 dark:bg-amber-950/30">
                     <svg className="mt-0.5 h-4 w-4 flex-shrink-0 text-amber-500 dark:text-amber-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z" />
                     </svg>
-                    <span className="text-xs text-amber-700 dark:text-amber-300">{String(message.userHint)}</span>
+                    <span className="text-xs text-amber-700 dark:text-amber-300">{userHintContent}</span>
                   </div>
                 )}
               </div>

--- a/ui/src/i18n/locales/en/chat.json
+++ b/ui/src/i18n/locales/en/chat.json
@@ -452,5 +452,54 @@
       "thinking": "Thinking",
       "executingTool": "Executing {{toolName}}"
     }
+  },
+  "agentStatus": {
+    "modelRequestFailed": {
+      "message": "{{providerMessage}}\n\nSee the suggested action below.",
+      "actions": {
+        "settingsDefault": "Check Settings → Model Provider and verify the selected provider, base URL, API key, model name, and timeoutMs. If the provider is slow or the network is unstable, increase timeoutMs or check provider status.",
+        "auth": "Update the API key or access permissions for {{provider}} in Settings → Model Provider, or run pilotdeck setup.",
+        "modelNotFound": "Choose a valid model for {{provider}} in Settings → Model Provider, or add it under model.providers.<id>.models in pilotdeck.yaml.",
+        "timeout": "Increase timeoutMs for {{provider}} in Settings → Model Provider → Advanced, or check local network/proxy and provider status.",
+        "rateLimit": "Wait for the provider rate limit to reset, reduce concurrency, or switch to another provider/model in Settings.",
+        "billing": "Top up billing/quota on the provider API side, or switch to another provider/model in Settings.",
+        "contextOverflow": "Run /compact, start a new session, remove large attachments, or switch to a larger-context model in Settings.",
+        "payloadTooLarge": "Reduce attachments/context size, run /compact, or start a new session before retrying.",
+        "maxOutput": "Increase max output tokens in Settings → Model Provider, or ask the agent to split the answer into smaller parts.",
+        "imageTooLarge": "Resize or remove large images, then retry.",
+        "providerRetry": "Retry later, check provider API status, or switch to another provider/model in Settings if it repeats."
+      }
+    },
+    "emptyResponse": {
+      "message": "The model returned empty content repeatedly, so this turn has stopped. Try again later or increase max output tokens.",
+      "hint": "Increase max output tokens in Settings → Model Provider, retry with a shorter prompt, or check whether this provider/model supports the requested output format."
+    },
+    "maxTurns": {
+      "message": "Reached the maximum number of turns ({{maxTurns}}), so this turn has stopped. Increase maxTurns or split the task into smaller steps and try again.",
+      "hint": "Increase maxTurns in local config if this task legitimately needs more agent steps, or split the task into smaller prompts and try again."
+    },
+    "maxOutputRecoveryExhausted": {
+      "message": "Output token recovery was exhausted, so the visible response may be incomplete. Increase max output tokens or split the task into smaller steps and try again.",
+      "hint": "Increase max output tokens in Settings → Model Provider, or ask the agent to split the answer into smaller parts."
+    },
+    "structuredOutputCompleted": {
+      "message": "Structured output was returned, so this turn has completed."
+    },
+    "contentFilter": {
+      "message": "The response may be incomplete because the model stopped due to content filtering.",
+      "hint": "Retry with a narrower request or adjust the prompt to avoid filtered content; if this seems wrong, check the provider API policy/status for the selected model."
+    },
+    "unknownFinishReason": {
+      "message": "The model stream ended without a normal finish reason, so the response may be incomplete.",
+      "hint": "Retry the turn; if it repeats, check provider API status/logs for stream finish reasons and verify the selected provider/model in Settings → Model Provider."
+    },
+    "turnAborted": {
+      "message": "This turn was aborted before completion.",
+      "hint": "Retry when you are ready to continue. If this was unexpected, check whether you clicked Stop, switched sessions during a run, or lost the gateway connection."
+    },
+    "toolCallRecoveryExhausted": {
+      "message": "{{message}}",
+      "hint": "Retry with a shorter prompt, ask the agent to split large tool inputs into smaller steps, or switch to a model with stronger tool-calling support in Settings → Model Provider."
+    }
   }
 }

--- a/ui/src/i18n/locales/zh-CN/chat.json
+++ b/ui/src/i18n/locales/zh-CN/chat.json
@@ -440,5 +440,54 @@
       "thinking": "思考中",
       "executingTool": "正在执行 {{toolName}}"
     }
+  },
+  "agentStatus": {
+    "modelRequestFailed": {
+      "message": "{{providerMessage}}\n\n请查看下方建议操作。",
+      "actions": {
+        "settingsDefault": "请在“设置 → 模型 Provider”中检查当前 provider、Base URL、API Key、模型名称和 timeoutMs。若 provider 响应慢或网络不稳定，请增大 timeoutMs 或检查 provider 状态。",
+        "auth": "请在“设置 → 模型 Provider”中更新 {{provider}} 的 API Key 或访问权限，或运行 pilotdeck setup。",
+        "modelNotFound": "请在“设置 → 模型 Provider”中为 {{provider}} 选择有效模型，或在 pilotdeck.yaml 的 model.providers.<id>.models 下添加该模型。",
+        "timeout": "请在“设置 → 模型 Provider → 高级”中增大 {{provider}} 的 timeoutMs，或检查本机网络、代理和 provider 状态。",
+        "rateLimit": "请等待 provider 限流窗口恢复、减少并发请求，或在设置中切换 provider/model。",
+        "billing": "请在 provider API 侧充值或恢复 quota，或在设置中切换 provider/model。",
+        "contextOverflow": "请运行 /compact、开启新会话、移除大型附件，或在设置中切换到更大上下文模型。",
+        "payloadTooLarge": "请减少附件/上下文大小，运行 /compact，或开启新会话后重试。",
+        "maxOutput": "请在“设置 → 模型 Provider”中增加最大输出 token，或让 agent 将回答拆成更小部分。",
+        "imageTooLarge": "请缩小或移除大型图片后重试。",
+        "providerRetry": "请稍后重试、检查 provider API 状态，若反复出现则在设置中切换 provider/model。"
+      }
+    },
+    "emptyResponse": {
+      "message": "模型连续返回空内容，本轮已停止。请稍后重试或增加最大输出 token。",
+      "hint": "请在“设置 → 模型 Provider”中增加最大输出 token，使用更短 prompt 重试，或确认该 provider/model 是否支持请求的输出格式。"
+    },
+    "maxTurns": {
+      "message": "已达到最大轮数（{{maxTurns}}），本轮已停止。请增加 maxTurns，或把任务拆成更小步骤后重试。",
+      "hint": "如果任务确实需要更多 agent 步数，请在本地配置中增加 maxTurns；否则请把任务拆成更小 prompt 后重试。"
+    },
+    "maxOutputRecoveryExhausted": {
+      "message": "输出 token 恢复已耗尽，可见回复可能不完整。请增加最大输出 token，或把任务拆成更小步骤后重试。",
+      "hint": "请在“设置 → 模型 Provider”中增加最大输出 token，或让 agent 将回答拆成更小部分。"
+    },
+    "structuredOutputCompleted": {
+      "message": "已返回结构化输出，本轮已完成。"
+    },
+    "contentFilter": {
+      "message": "模型因内容过滤停止，回复可能不完整。",
+      "hint": "请缩小请求范围或调整 prompt 以避开过滤内容；如果你认为这是误判，请检查所选模型的 provider API 策略/状态。"
+    },
+    "unknownFinishReason": {
+      "message": "模型流结束时没有正常 finish reason，因此回复可能不完整。",
+      "hint": "请重试；若反复出现，请检查 provider API 状态/日志中的 stream finish reason，并确认“设置 → 模型 Provider”中的 provider/model。"
+    },
+    "turnAborted": {
+      "message": "本轮在完成前已中止。",
+      "hint": "准备好后可重试。如果这不是预期行为，请检查是否点击了停止、运行中切换了会话，或 gateway 连接丢失。"
+    },
+    "toolCallRecoveryExhausted": {
+      "message": "{{message}}",
+      "hint": "请用更短 prompt 重试，让 agent 把大型工具输入拆成更小步骤，或在“设置 → 模型 Provider”中切换到工具调用能力更强的模型。"
+    }
   }
 }

--- a/ui/src/stores/useSessionStore.ts
+++ b/ui/src/stores/useSessionStore.ts
@@ -52,6 +52,8 @@ export interface NormalizedMessage {
   // kind-specific fields (flat for simplicity)
   role?: 'user' | 'assistant';
   content?: string;
+  contentI18n?: { key: string; params?: Record<string, unknown> };
+  userHintI18n?: { key: string; params?: Record<string, unknown> };
   images?: string[];
   attachments?: Array<{
     kind?: 'file' | 'document-selection';


### PR DESCRIPTION
## Summary
- preserve provider raw model errors while appending actionable recovery guidance
- classify common provider failures into settings/provider/network/prompt fix targets
- add i18n-ready agent status metadata and localized Web UI rendering for error guidance

## Tests
- npm run build
- node --test --test-reporter=spec dist/tests/model/model-error-guidance.spec.js
- npm --workspace ui test -- server/pilotdeck-bridge.test.js
- npx tsc -p tsconfig.json --noEmit
- git diff --check