### PR TITLE
Add Node.js mirror fallback to installer

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -17,6 +17,7 @@ NODE_INSTALL_VERSION="${PILOTDECK_NODE_VERSION:-22}"
 NODE_FALLBACK_VERSION="${PILOTDECK_NODE_FALLBACK_VERSION:-22.13.0}"
 NODE_DIRECT_INSTALL_ROOT="$HOME/.local/share/pilotdeck-node"
 NODE_DIST_MIRROR="${PILOTDECK_NODE_DIST_MIRROR:-https://nodejs.org/dist}"
+NODE_DIST_FALLBACK_MIRRORS="${PILOTDECK_NODE_DIST_FALLBACK_MIRRORS:-https://npmmirror.com/mirrors/node}"
 APT_UPDATED=0
 # 1 = repo was (re)cloned or its HEAD changed; drives whether we reinstall/rebuild.
 REPO_CHANGED=1
@@ -400,18 +401,35 @@ install_node_tarball() {
   local install_root
   local node_dir
   local tmp_dir
+  local mirrors
+  local mirror
+  local downloaded=0
 
   platform="$(node_tarball_platform)" || fail "$(L "Unsupported platform for direct Node.js download. Please install Node.js 22 manually." "当前平台不支持直接下载 Node.js。请手动安装 Node.js 22。")"
   tarball="node-v${NODE_FALLBACK_VERSION}-${platform}.tar.xz"
-  url="${NODE_DIST_MIRROR%/}/v${NODE_FALLBACK_VERSION}/${tarball}"
   install_root="$NODE_DIRECT_INSTALL_ROOT"
   node_dir="$install_root/node-v${NODE_FALLBACK_VERSION}-${platform}"
   tmp_dir="$(mktemp -d)"
 
-  warn "$(L "Downloading Node.js ${NODE_FALLBACK_VERSION} from ${url}" "正在从 ${url} 下载 Node.js ${NODE_FALLBACK_VERSION}")"
-  if ! run_with_timeout 180 curl -fL "$url" -o "$tmp_dir/$tarball"; then
+  mirrors="$NODE_DIST_MIRROR"
+  if [[ -n "$NODE_DIST_FALLBACK_MIRRORS" ]]; then
+    mirrors="$mirrors $NODE_DIST_FALLBACK_MIRRORS"
+  fi
+
+  for mirror in $mirrors; do
+    url="${mirror%/}/v${NODE_FALLBACK_VERSION}/${tarball}"
+    warn "$(L "Downloading Node.js ${NODE_FALLBACK_VERSION} from ${url}" "正在从 ${url} 下载 Node.js ${NODE_FALLBACK_VERSION}")"
+    if run_with_timeout 180 curl -fL "$url" -o "$tmp_dir/$tarball"; then
+      downloaded=1
+      NODE_DIST_MIRROR="${mirror%/}"
+      break
+    fi
+    warn "$(L "Node.js download failed from ${mirror}; trying the next mirror if available." "从 ${mirror} 下载 Node.js 失败;如果还有镜像,将尝试下一个。")"
+  done
+
+  if [[ "$downloaded" != "1" ]]; then
     rm -rf "$tmp_dir"
-    fail "$(L "Could not download Node.js. Check your network/proxy, or set PILOTDECK_NODE_DIST_MIRROR to a reachable Node.js mirror such as https://npmmirror.com/mirrors/node." "无法下载 Node.js。请检查网络/代理，或将 PILOTDECK_NODE_DIST_MIRROR 设置为可访问的 Node.js 镜像，例如 https://npmmirror.com/mirrors/node。")"
+    fail "$(L "Could not download Node.js. Check your network/proxy, or set PILOTDECK_NODE_DIST_MIRROR / PILOTDECK_NODE_DIST_FALLBACK_MIRRORS to a reachable Node.js mirror such as https://npmmirror.com/mirrors/node." "无法下载 Node.js。请检查网络/代理，或将 PILOTDECK_NODE_DIST_MIRROR / PILOTDECK_NODE_DIST_FALLBACK_MIRRORS 设置为可访问的 Node.js 镜像，例如 https://npmmirror.com/mirrors/node。")"
   fi
 
   mkdir -p "$install_root"


### PR DESCRIPTION
## Summary
- add a configurable fallback mirror list for direct Node.js downloads
- retry Node.js tarball downloads against the fallback mirror when the default dist host fails
- update the failure message to mention both primary and fallback mirror variables

## Validation
- bash -n install.sh
- simulated primary download failure and fallback success with a stub curl/tarball
- verified the installer workaround on jinan40 succeeds when using the npm mirror manually before this patch