### PR TITLE
Require opt-in Node.js fallback mirrors

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,8 @@ curl -fsSL https://raw.githubusercontent.com/OpenBMB/PilotDeck/main/install.sh |
   NPM_CONFIG_REGISTRY=https://registry.npmmirror.com bash
 ```
 
+You can also keep the official Node.js host as the primary source and opt in to one or more trusted fallback mirrors with `PILOTDECK_NODE_DIST_FALLBACK_MIRRORS`.
+
 ```bash
 pilotdeck            # starts the server at http://localhost:3001
 pilotdeck status     # check runtime status

--- a/README.zh.md
+++ b/README.zh.md
@@ -308,6 +308,8 @@ curl -fsSL https://raw.githubusercontent.com/OpenBMB/PilotDeck/main/install.sh |
   NPM_CONFIG_REGISTRY=https://registry.npmmirror.com bash
 ```
 
+如果希望优先使用官方 Node.js 下载地址，也可以通过 `PILOTDECK_NODE_DIST_FALLBACK_MIRRORS` 显式设置一个或多个可信的备用镜像。
+
 ```bash
 pilotdeck            # 在 http://localhost:3001 启动服务
 pilotdeck status     # 查看运行状态

--- a/install.sh
+++ b/install.sh
@@ -17,7 +17,7 @@ NODE_INSTALL_VERSION="${PILOTDECK_NODE_VERSION:-22}"
 NODE_FALLBACK_VERSION="${PILOTDECK_NODE_FALLBACK_VERSION:-22.13.0}"
 NODE_DIRECT_INSTALL_ROOT="$HOME/.local/share/pilotdeck-node"
 NODE_DIST_MIRROR="${PILOTDECK_NODE_DIST_MIRROR:-https://nodejs.org/dist}"
-NODE_DIST_FALLBACK_MIRRORS="${PILOTDECK_NODE_DIST_FALLBACK_MIRRORS:-https://npmmirror.com/mirrors/node}"
+NODE_DIST_FALLBACK_MIRRORS="${PILOTDECK_NODE_DIST_FALLBACK_MIRRORS:-}"
 APT_UPDATED=0
 # 1 = repo was (re)cloned or its HEAD changed; drives whether we reinstall/rebuild.
 REPO_CHANGED=1
@@ -445,7 +445,7 @@ install_node_tarball() {
 
   if [[ "$downloaded" != "1" ]]; then
     rm -rf "$tmp_dir"
-    fail "$(L "Could not download Node.js. Check your network/proxy, or set PILOTDECK_NODE_DIST_MIRROR / PILOTDECK_NODE_DIST_FALLBACK_MIRRORS to a reachable Node.js mirror such as https://npmmirror.com/mirrors/node." "无法下载 Node.js。请检查网络/代理，或将 PILOTDECK_NODE_DIST_MIRROR / PILOTDECK_NODE_DIST_FALLBACK_MIRRORS 设置为可访问的 Node.js 镜像，例如 https://npmmirror.com/mirrors/node。")"
+    fail "$(L "Could not download Node.js. Check your network/proxy, or explicitly set PILOTDECK_NODE_DIST_MIRROR / PILOTDECK_NODE_DIST_FALLBACK_MIRRORS to a trusted reachable Node.js mirror." "无法下载 Node.js。请检查网络/代理，或显式将 PILOTDECK_NODE_DIST_MIRROR / PILOTDECK_NODE_DIST_FALLBACK_MIRRORS 设置为可信且可访问的 Node.js 镜像。")"
   fi
 
   mkdir -p "$install_root"


### PR DESCRIPTION
## Summary
- remove the default third-party Node.js fallback mirror added in #394
- keep retry support through explicit `PILOTDECK_NODE_DIST_FALLBACK_MIRRORS` configuration
- document how to opt in to trusted fallback mirrors while keeping the official Node.js host primary

## Validation
- bash -n install.sh
- git diff --check -- README.md README.zh.md install.sh
- simulated primary mirror failure and explicit fallback success