### PR TITLE
fix(model): resolve catalog apiKeyEnvVar when provider apiKey is absent

### DIFF
--- a/src/model/config/parseModelConfig.ts
+++ b/src/model/config/parseModelConfig.ts
@@ -104,7 +104,7 @@ function parseProvider(providerId: string, rawProvider: unknown, env?: Credentia
     id: providerId,
     protocol,
     url: rawUrl,
-    apiKey: resolveProviderApiKey(providerId, provider.apiKey, env),
+    apiKey: resolveProviderApiKey(providerId, provider.apiKey, env, catalogProvider?.apiKeyEnvVar),
     timeoutMs: readOptionalPositiveNumber(provider.timeoutMs, "timeoutMs"),
     headers: readStringRecord(provider.headers, "headers"),
     extraBody: isRecord(provider.extraBody) ? (provider.extraBody as Record<string, unknown>) : undefined,
@@ -113,11 +113,17 @@ function parseProvider(providerId: string, rawProvider: unknown, env?: Credentia
   };
 }
 
-function resolveProviderApiKey(providerId: string, value: unknown, env?: CredentialEnv): string {
+function resolveProviderApiKey(
+  providerId: string,
+  value: unknown,
+  env?: CredentialEnv,
+  catalogEnvVar?: string,
+): string {
   if (providerId === "ollama" && value === undefined) {
     return "ollama";
   }
-  return resolveApiKey(value, env);
+  const effectiveValue = value ?? (catalogEnvVar ? `\${${catalogEnvVar}}` : undefined);
+  return resolveApiKey(effectiveValue, env);
 }
 
 function resolveDefaultProviderUrl(


### PR DESCRIPTION
## Summary

- When a catalog provider (e.g. `anthropic`) is configured without an explicit `apiKey`, `parseModelConfig` now falls back to the catalog's `apiKeyEnvVar` to auto-resolve credentials from environment variables.
- Previously `apiKeyEnvVar` was defined in the catalog but never consumed at runtime, causing `missing_api_key` errors even when the declared env var (e.g. `ANTHROPIC_API_KEY`) was set.

## Changes

Single-file change in `src/model/config/parseModelConfig.ts`:

1. Pass `catalogProvider?.apiKeyEnvVar` into `resolveProviderApiKey`.
2. In `resolveProviderApiKey`, when `value` (user-configured `apiKey`) is absent and `catalogEnvVar` is available, construct a `${ENV_VAR}` reference for `resolveApiKey` to resolve.

All existing behavior is preserved:
- Explicit `apiKey` (literal or `${ENV}`) takes precedence.
- Non-catalog providers without `apiKey` still fail with `missing_api_key`.
- `ollama` special-case (`"ollama"`) is unchanged.

Closes #339

Made with [Cursor](https://cursor.com)