### PR TITLE
fix(model): handle catalog api key env fallback

### DIFF
--- a/src/model/config/parseModelConfig.ts
+++ b/src/model/config/parseModelConfig.ts
@@ -122,7 +122,11 @@ function resolveProviderApiKey(
   if (providerId === "ollama" && value === undefined) {
     return "ollama";
   }
-  const effectiveValue = value ?? (catalogEnvVar ? `\${${catalogEnvVar}}` : undefined);
+  const hasBlankString = typeof value === "string" && value.trim().length === 0;
+  const hasConfigValue = value !== undefined && value !== null && !hasBlankString;
+  const effectiveValue = hasConfigValue
+    ? value
+    : catalogEnvVar ? `\${${catalogEnvVar}}` : value;
   return resolveApiKey(effectiveValue, env);
 }
 

--- a/tests/model/config/parseModelConfig.spec.ts
+++ b/tests/model/config/parseModelConfig.spec.ts
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseModelConfig } from "../../../src/model/config/parseModelConfig.js";
+
+test("catalog provider resolves api key from default env var when apiKey is omitted", () => {
+  const config = parseModelConfig({
+    providers: {
+      openai: {
+        models: { "gpt-4o-mini": {} },
+      },
+    },
+  }, { env: { OPENAI_API_KEY: " sk-env " } });
+
+  assert.equal(config.providers.openai.apiKey, "sk-env");
+});
+
+test("catalog provider resolves api key from default env var when apiKey is blank", () => {
+  const config = parseModelConfig({
+    providers: {
+      google: {
+        apiKey: "  ",
+        models: { "gemini-2.0-flash": {} },
+      },
+    },
+  }, { env: { GEMINI_API_KEY: " gemini-env " } });
+
+  assert.equal(config.providers.google.apiKey, "gemini-env");
+});


### PR DESCRIPTION
Follow-up/replacement for OpenBMB/PilotDeck#397.\n\nThis includes the original catalog apiKeyEnvVar fallback and fixes the UI-generated blank apiKey case, so catalog providers can resolve OPENAI_API_KEY, GEMINI_API_KEY, etc. even when saved configs contain apiKey: ''.\n\nValidation:\n- CI=true pnpm exec tsc -p tsconfig.json --noEmit\n- CI=true pnpm run build\n- node --test --test-timeout 60000 dist/tests/model/config/parseModelConfig.spec.js