### PR TITLE
fix: align token usage display

### DIFF
--- a/src/agent/loop/AgentLoop.ts
+++ b/src/agent/loop/AgentLoop.ts
@@ -1788,6 +1788,7 @@ export class AgentLoop {
         maxContextTokens,
         reservedOutputTokens: options.reservedOutputTokens,
         signal: input.abortSignal,
+        usePadding: true,
       });
       const usageTokens = tokensFromUsage(lastUsage);
       if (usageTokens === undefined || usageTokens <= snapshot.tokens) {
@@ -1796,6 +1797,7 @@ export class AgentLoop {
       return tokenAccounting.snapshotFromTokens(usageTokens, maxContextTokens, {
         reservedOutputTokens: options.reservedOutputTokens,
         usageTokens,
+        budgetTokens: snapshot.budgetTokens,
         source: snapshot.source,
         exact: snapshot.exact,
         estimatorError: snapshot.estimatorError,

--- a/src/cli/createLocalGateway.ts
+++ b/src/cli/createLocalGateway.ts
@@ -274,6 +274,8 @@ export function createLocalGateway(options: CreateLocalGatewayOptions = {}): Cre
       readWebSessionMessages(input, {
         projectRoot: input.projectKey ? input.projectKey : fallbackProjectRoot,
         pilotHome,
+        maxContextTokens: defaultRuntime.snapshot.config.agent.maxContextTokens,
+        maxOutputTokens: defaultRuntime.snapshot.config.agent.maxOutputTokens,
         now,
       }),
     readSubagentMessages: (input) =>

--- a/src/context/budget/TokenAccountingRuntime.ts
+++ b/src/context/budget/TokenAccountingRuntime.ts
@@ -100,6 +100,8 @@ export class TokenAccountingRuntime {
       source: counted.source,
       exact: counted.exact,
       estimatorError: counted.estimatorError,
+      displayTokens: counted.exact ? undefined : this.estimateRequestInput(request),
+      budgetTokens: options.usePadding ? this.estimateRequestInput(request, { usePadding: true }) : undefined,
     });
   }
 
@@ -112,6 +114,8 @@ export class TokenAccountingRuntime {
       exact?: boolean;
       estimatorError?: string;
       usageTokens?: number;
+      displayTokens?: number;
+      budgetTokens?: number;
     } = {},
   ): TokenBudgetSnapshot {
     return this.tokenBudget.snapshotFromTokens(tokens, maxContextTokens, metadata);

--- a/src/context/budget/TokenBudgetManager.ts
+++ b/src/context/budget/TokenBudgetManager.ts
@@ -11,6 +11,8 @@ export type TokenWarningState = "ok" | "warning" | "blocking";
 
 export type TokenBudgetSnapshot = {
   tokens: number;
+  displayTokens?: number;
+  budgetTokens?: number;
   estimateSource?: "estimator" | "usage";
   usageTokens?: number;
   maxContextTokens: number;
@@ -206,11 +208,14 @@ export class TokenBudgetManager {
       exact?: boolean;
       estimatorError?: string;
       usageTokens?: number;
+      displayTokens?: number;
+      budgetTokens?: number;
     } = {},
   ): TokenBudgetSnapshot {
+    const budgetTokens = options.budgetTokens !== undefined ? Math.max(options.budgetTokens, tokens) : tokens;
     const reserved = Math.max(0, Math.floor(options.reservedOutputTokens ?? 0));
     const promptBudget = effectiveInputContextTokens(maxContextTokens, reserved);
-    const ratio = promptBudget > 0 ? tokens / promptBudget : 0;
+    const ratio = promptBudget > 0 ? budgetTokens / promptBudget : 0;
     let state: TokenWarningState = "ok";
     if (ratio >= this.blockingRatio) {
       state = "blocking";
@@ -219,6 +224,8 @@ export class TokenBudgetManager {
     }
     return {
       tokens,
+      ...(options.displayTokens !== undefined && options.displayTokens !== tokens ? { displayTokens: options.displayTokens } : {}),
+      ...(budgetTokens !== tokens ? { budgetTokens } : {}),
       estimateSource: options.usageTokens !== undefined ? "usage" : "estimator",
       ...(options.usageTokens !== undefined ? { usageTokens: options.usageTokens } : {}),
       maxContextTokens: promptBudget,

--- a/src/gateway/client/InProcessGateway.ts
+++ b/src/gateway/client/InProcessGateway.ts
@@ -470,6 +470,19 @@ export class InProcessGateway implements Gateway {
             phase: telemetryContext.phase,
           });
           for (const gatewayEvent of mapAgentEvent(event, runId)) {
+            if (gatewayEvent.type === "context_budget") {
+              this.recordGatewayStatusMessage({
+                sessionKey: input.sessionKey,
+                turnId: runId,
+                projectKey: input.projectKey,
+                status: {
+                  event: "context_budget",
+                  kind: "status",
+                  text: "context_budget",
+                  detail: { ...gatewayEvent },
+                },
+              }).catch(() => {});
+            }
             this.recordActiveTurnEvent(input.sessionKey, gatewayEvent);
             queue.enqueue(gatewayEvent);
           }
@@ -1501,6 +1514,8 @@ export function mapAgentEvent(event: AgentEvent, runId: string): GatewayEvent[] 
       return [{
         type: "context_budget",
         used: event.snapshot.tokens,
+        displayUsed: event.snapshot.displayTokens,
+        budgetUsed: event.snapshot.budgetTokens,
         total: totalContextTokens,
         effectiveTotal: event.snapshot.effectiveContextTokens ?? event.snapshot.maxContextTokens,
         reservedOutputTokens,

--- a/src/gateway/protocol/types.ts
+++ b/src/gateway/protocol/types.ts
@@ -199,6 +199,8 @@ export type GatewayEvent =
   | {
       type: "context_budget";
       used: number;
+      displayUsed?: number;
+      budgetUsed?: number;
       total: number;
       effectiveTotal?: number;
       reservedOutputTokens?: number;

--- a/src/model/providers/google/response.ts
+++ b/src/model/providers/google/response.ts
@@ -25,7 +25,9 @@ export function parseGoogleResponse(raw: unknown, provider = "google"): Canonica
 export function normalizeGoogleUsage(raw: unknown): CanonicalUsage | undefined {
   const usage = asRecord(raw);
   const inputTokens = readNumber(usage.promptTokenCount);
-  const outputTokens = readNumber(usage.candidatesTokenCount) ?? readNumber(usage.responseTokenCount);
+  const responseTokens = readNumber(usage.candidatesTokenCount) ?? readNumber(usage.responseTokenCount);
+  const thinkingTokens = readNumber(usage.thoughtsTokenCount);
+  const outputTokens = sumDefined(responseTokens, thinkingTokens);
   const cacheReadTokens = readNumber(usage.cachedContentTokenCount);
   const totalTokens = readNumber(usage.totalTokenCount) ?? sumDefined(inputTokens, outputTokens, cacheReadTokens);
   const result: CanonicalUsage = {

--- a/src/model/response/normalizeUsage.ts
+++ b/src/model/response/normalizeUsage.ts
@@ -31,7 +31,11 @@ export function normalizeOpenAIUsage(raw: unknown): CanonicalUsage | undefined {
     readNumber(raw.total_cost) ??
     readNumber(raw.estimated_cost);
 
-  const details = isRecord(raw.prompt_tokens_details) ? raw.prompt_tokens_details : undefined;
+  const details = isRecord(raw.prompt_tokens_details)
+    ? raw.prompt_tokens_details
+    : isRecord(raw.input_tokens_details)
+      ? raw.input_tokens_details
+      : undefined;
   const cacheReadTokens = readNumber(details?.cached_tokens) ?? readNumber(raw.cache_read_input_tokens);
   const cacheWriteTokens = readNumber(details?.cache_write_tokens) ?? readNumber(raw.cache_creation_input_tokens);
 

--- a/src/web/client/protocol.ts
+++ b/src/web/client/protocol.ts
@@ -269,6 +269,7 @@ export type WebReadSessionMessagesResult = {
   messages: import("./webMessage.js").WebMessage[];
   nextCursor?: string;
   total?: number;
+  tokenUsage?: Record<string, unknown>;
   session: WebSessionInfo;
 };
 

--- a/src/web/server/readSessionMessages.ts
+++ b/src/web/server/readSessionMessages.ts
@@ -21,6 +21,7 @@ import {
   type CanonicalContentBlock,
   type CanonicalImageBlock,
   type CanonicalMessage,
+  type CanonicalUsage,
 } from "../../model/index.js";
 import { listProjectSessions, readTranscript, findLastCompactBoundaryIndex, type SessionInfo } from "../../session/index.js";
 import type { AgentTranscriptEntry } from "../../session/transcript/TranscriptEntry.js";
@@ -36,9 +37,13 @@ import type { WebMessage, WebMessageKind, WebMessageRole } from "../client/webMe
 export type ReadWebSessionMessagesOptions = {
   projectRoot: string;
   pilotHome: string;
+  maxContextTokens?: number;
+  maxOutputTokens?: number;
   /** Override clock for deterministic tests. */
   now?: () => Date;
 };
+
+const DEFAULT_HISTORY_CONTEXT_TOKENS = 200_000;
 
 export async function readWebSessionMessages(
   input: WebReadSessionMessagesInput,
@@ -120,6 +125,7 @@ export async function readWebSessionMessages(
         ? String(offset + slice.length)
         : undefined,
     total: allMessages.length,
+    tokenUsage: tokenUsageFromTranscript(entries, options),
     session: {
       sessionId: sessionInfo?.sessionId ?? input.sessionKey,
       sessionKey: input.sessionKey,
@@ -138,6 +144,110 @@ export async function readWebSessionMessages(
       forkedFromTurnId: sessionInfo?.forkedFromTurnId,
     },
   };
+}
+
+function tokenUsageFromTranscript(
+  entries: AgentTranscriptEntry[],
+  options: Pick<ReadWebSessionMessagesOptions, "maxContextTokens" | "maxOutputTokens">,
+): Record<string, unknown> | undefined {
+  const latestBudget = latestContextBudget(entries);
+  if (latestBudget) {
+    return latestBudget;
+  }
+  const latestTurn = latestTurnUsage(entries);
+  if (!latestTurn) {
+    return undefined;
+  }
+  const inputTokens = positiveNumber(latestTurn.inputTokens);
+  const outputTokens = positiveNumber(latestTurn.outputTokens) ?? 0;
+  const cacheReadTokens = positiveNumber(latestTurn.cacheReadTokens) ?? 0;
+  const cacheWriteTokens = positiveNumber(latestTurn.cacheWriteTokens) ?? 0;
+  const totalTokens = positiveNumber(latestTurn.totalTokens);
+  const used = inputTokens !== undefined
+    ? Math.ceil(inputTokens + cacheReadTokens + cacheWriteTokens)
+    : totalTokens !== undefined
+      ? Math.max(0, Math.ceil(totalTokens - outputTokens))
+      : undefined;
+  if (used === undefined || used <= 0) {
+    return undefined;
+  }
+  const total = positiveNumber(options.maxContextTokens) ?? DEFAULT_HISTORY_CONTEXT_TOKENS;
+  const reservedOutputTokens = positiveNumber(options.maxOutputTokens) ?? 0;
+  const effectiveTotal = Math.max(1, total - reservedOutputTokens);
+  return {
+    used,
+    total,
+    effectiveTotal,
+    reservedOutputTokens,
+    source: "history",
+    exact: true,
+    breakdown: {
+      input: inputTokens ?? 0,
+      cacheRead: cacheReadTokens,
+      cacheWrite: cacheWriteTokens,
+      output: outputTokens,
+      total: totalTokens ?? Math.ceil(used + outputTokens),
+    },
+  };
+}
+
+function latestContextBudget(entries: AgentTranscriptEntry[]): Record<string, unknown> | undefined {
+  for (let index = entries.length - 1; index >= 0; index -= 1) {
+    const entry = entries[index];
+    if (entry.type !== "agent_status_message" || entry.event !== "context_budget") {
+      continue;
+    }
+    const detail = isRecord(entry.detail) ? entry.detail : undefined;
+    if (!detail) {
+      continue;
+    }
+    const used = positiveNumber(detail.displayUsed) ?? positiveNumber(detail.used);
+    const total = positiveNumber(detail.total);
+    const effectiveTotal = positiveNumber(detail.effectiveTotal) ?? total;
+    if (used === undefined || total === undefined || effectiveTotal === undefined) {
+      continue;
+    }
+    return {
+      used,
+      ...(positiveNumber(detail.displayUsed) !== undefined ? { displayUsed: positiveNumber(detail.displayUsed) } : {}),
+      ...(positiveNumber(detail.budgetUsed) !== undefined ? { budgetUsed: positiveNumber(detail.budgetUsed) } : {}),
+      total,
+      effectiveTotal,
+      reservedOutputTokens: positiveNumber(detail.reservedOutputTokens) ?? 0,
+      ...(typeof detail.state === "string" ? { state: detail.state } : {}),
+      ...(typeof detail.ratio === "number" && Number.isFinite(detail.ratio) ? { ratio: detail.ratio } : {}),
+      source: "history",
+      exact: true,
+    };
+  }
+  return undefined;
+}
+
+function latestTurnUsage(entries: AgentTranscriptEntry[]): CanonicalUsage | undefined {
+  for (let index = entries.length - 1; index >= 0; index -= 1) {
+    const entry = entries[index];
+    if (entry.type === "turn_result" && hasPositiveUsage(entry.result.usage)) {
+      return entry.result.usage;
+    }
+  }
+  return undefined;
+}
+
+function hasPositiveUsage(usage: CanonicalUsage | undefined): boolean {
+  if (!usage) return false;
+  return positiveNumber(usage.inputTokens) !== undefined ||
+    positiveNumber(usage.outputTokens) !== undefined ||
+    positiveNumber(usage.cacheReadTokens) !== undefined ||
+    positiveNumber(usage.cacheWriteTokens) !== undefined ||
+    positiveNumber(usage.totalTokens) !== undefined;
+}
+
+function positiveNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 /**

--- a/tests/context/token-budget-manager.spec.ts
+++ b/tests/context/token-budget-manager.spec.ts
@@ -1,0 +1,15 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { TokenBudgetManager } from "../../src/context/budget/TokenBudgetManager.js";
+
+test("budget snapshot uses conservative budget tokens for ratio while preserving real tokens", () => {
+  const manager = new TokenBudgetManager({ warningRatio: 0.8, blockingRatio: 0.95 });
+
+  const snapshot = manager.snapshotFromTokens(100, 160, { budgetTokens: 140 });
+
+  assert.equal(snapshot.tokens, 100);
+  assert.equal(snapshot.budgetTokens, 140);
+  assert.equal(snapshot.ratio, 0.875);
+  assert.equal(snapshot.state, "warning");
+});

--- a/tests/model/normalizeUsage.spec.ts
+++ b/tests/model/normalizeUsage.spec.ts
@@ -1,0 +1,32 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { normalizeOpenAIUsage } from "../../src/model/response/normalizeUsage.js";
+import { normalizeGoogleUsage } from "../../src/model/providers/google/response.js";
+
+test("OpenAI Responses usage reads cached tokens from input token details", () => {
+  const usage = normalizeOpenAIUsage({
+    input_tokens: 100,
+    input_tokens_details: { cached_tokens: 40 },
+    output_tokens: 7,
+    total_tokens: 107,
+  });
+
+  assert.equal(usage?.inputTokens, 60);
+  assert.equal(usage?.outputTokens, 7);
+  assert.equal(usage?.cacheReadTokens, 40);
+  assert.equal(usage?.totalTokens, 107);
+});
+
+test("Gemini usage counts thoughts tokens as output consumption", () => {
+  const usage = normalizeGoogleUsage({
+    promptTokenCount: 9,
+    candidatesTokenCount: 0,
+    thoughtsTokenCount: 13,
+    totalTokenCount: 22,
+  });
+
+  assert.equal(usage?.inputTokens, 9);
+  assert.equal(usage?.outputTokens, 13);
+  assert.equal(usage?.totalTokens, 22);
+});

--- a/tests/web/read-session-status-i18n.spec.ts
+++ b/tests/web/read-session-status-i18n.spec.ts
@@ -51,3 +51,117 @@ test("history replay preserves agent status i18n metadata and user hint", async 
     await rm(pilotHome, { recursive: true, force: true });
   }
 });
+
+test("history token usage restores latest non-empty turn past latest empty turn result", async () => {
+  const projectRoot = await mkdtemp(join(tmpdir(), "pilotdeck-token-usage-project-"));
+  const pilotHome = await mkdtemp(join(tmpdir(), "pilotdeck-token-usage-home-"));
+  try {
+    const sessionKey = "web:s_token_usage_restore";
+    const storage = createAgentProjectSessionStorage({
+      projectRoot,
+      pilotHome,
+      sessionId: sessionKey,
+      now: () => new Date("2026-07-09T00:00:00.000Z"),
+    });
+    await storage.transcript.recordTurnResult(sessionKey, "turn-1", {
+      type: "success",
+      sessionId: sessionKey,
+      turnId: "turn-1",
+      stopReason: "completed",
+      usage: { inputTokens: 100, outputTokens: 5, cacheReadTokens: 40, totalTokens: 145 },
+      permissionDenials: [],
+      turns: 1,
+      startedAt: "2026-07-09T00:00:00.000Z",
+      completedAt: "2026-07-09T00:00:01.000Z",
+    });
+    await storage.transcript.recordTurnResult(sessionKey, "turn-2", {
+      type: "success",
+      sessionId: sessionKey,
+      turnId: "turn-2",
+      stopReason: "completed",
+      usage: { inputTokens: 25, outputTokens: 2, cacheReadTokens: 10, totalTokens: 37 },
+      permissionDenials: [],
+      turns: 1,
+      startedAt: "2026-07-09T00:00:02.000Z",
+      completedAt: "2026-07-09T00:00:03.000Z",
+    });
+    await storage.transcript.recordTurnResult(sessionKey, "turn-3", {
+      type: "error",
+      sessionId: sessionKey,
+      turnId: "turn-3",
+      stopReason: "model_error",
+      usage: {},
+      permissionDenials: [],
+      turns: 0,
+      startedAt: "2026-07-09T00:00:04.000Z",
+      completedAt: "2026-07-09T00:00:04.000Z",
+    });
+
+    const replay = await readWebSessionMessages(
+      { sessionKey },
+      { projectRoot, pilotHome, maxContextTokens: 1000 },
+    );
+
+    assert.equal(replay.tokenUsage?.used, 35);
+    assert.equal((replay.tokenUsage?.breakdown as { output?: number } | undefined)?.output, 2);
+    assert.equal(replay.tokenUsage?.total, 1000);
+  } finally {
+    await rm(projectRoot, { recursive: true, force: true });
+    await rm(pilotHome, { recursive: true, force: true });
+  }
+});
+
+test("history token usage prefers persisted context budget snapshot", async () => {
+  const projectRoot = await mkdtemp(join(tmpdir(), "pilotdeck-token-budget-project-"));
+  const pilotHome = await mkdtemp(join(tmpdir(), "pilotdeck-token-budget-home-"));
+  try {
+    const sessionKey = "web:s_token_budget_restore";
+    const storage = createAgentProjectSessionStorage({
+      projectRoot,
+      pilotHome,
+      sessionId: sessionKey,
+      now: () => new Date("2026-07-09T00:00:00.000Z"),
+    });
+    await storage.transcript.recordTurnResult(sessionKey, "turn-1", {
+      type: "success",
+      sessionId: sessionKey,
+      turnId: "turn-1",
+      stopReason: "completed",
+      usage: { inputTokens: 100, outputTokens: 5, totalTokens: 105 },
+      permissionDenials: [],
+      turns: 1,
+      startedAt: "2026-07-09T00:00:00.000Z",
+      completedAt: "2026-07-09T00:00:01.000Z",
+    });
+    await storage.transcript.recordAgentStatusMessage(sessionKey, "turn-1", {
+      event: "context_budget",
+      kind: "status",
+      text: "context_budget",
+      detail: {
+        type: "context_budget",
+        used: 80,
+        displayUsed: 60,
+        budgetUsed: 90,
+        total: 500,
+        effectiveTotal: 450,
+        reservedOutputTokens: 50,
+        ratio: 0.2,
+        state: "ok",
+      },
+    });
+
+    const replay = await readWebSessionMessages(
+      { sessionKey },
+      { projectRoot, pilotHome, maxContextTokens: 1000 },
+    );
+
+    assert.equal(replay.tokenUsage?.used, 60);
+    assert.equal(replay.tokenUsage?.displayUsed, 60);
+    assert.equal(replay.tokenUsage?.budgetUsed, 90);
+    assert.equal(replay.tokenUsage?.total, 500);
+    assert.equal(replay.tokenUsage?.effectiveTotal, 450);
+  } finally {
+    await rm(projectRoot, { recursive: true, force: true });
+    await rm(pilotHome, { recursive: true, force: true });
+  }
+});

--- a/ui/server/pilotdeck-bridge.js
+++ b/ui/server/pilotdeck-bridge.js
@@ -624,6 +624,8 @@ export function gatewayEventToFrames(event, sessionId, provider) {
                     text: 'token_budget',
                     tokenBudget: {
                         used: event.used,
+                        displayUsed: event.displayUsed,
+                        budgetUsed: event.budgetUsed,
                         total: event.total,
                         effectiveTotal: event.effectiveTotal,
                         reservedOutputTokens: event.reservedOutputTokens,
@@ -1131,6 +1133,8 @@ export async function runChatViaGateway(
             if (event && event.type === 'context_budget') {
                 state.tokenBudget = {
                     used: event.used,
+                    displayUsed: event.displayUsed,
+                    budgetUsed: event.budgetUsed,
                     total: event.total,
                     effectiveTotal: event.effectiveTotal,
                     reservedOutputTokens: event.reservedOutputTokens,
@@ -2206,6 +2210,8 @@ export function registerAlwaysOnNotificationForwarding(clients) {
                 const aoState = ensureSessionState(sessionKey, '', channelKey || 'web');
                 aoState.tokenBudget = {
                     used: event.used,
+                    displayUsed: event.displayUsed,
+                    budgetUsed: event.budgetUsed,
                     total: event.total,
                     effectiveTotal: event.effectiveTotal,
                     reservedOutputTokens: event.reservedOutputTokens,

--- a/ui/server/routes/messages.js
+++ b/ui/server/routes/messages.js
@@ -63,6 +63,7 @@ router.get('/:sessionId/messages', async (req, res) => {
       hasMore,
       offset,
       limit,
+      ...(result.tokenUsage ? { tokenUsage: result.tokenUsage } : {}),
     });
   } catch (error) {
     console.error('[messages] read_session_messages failed:', error);

--- a/ui/src/components/chat-v2/ComposerV2.tsx
+++ b/ui/src/components/chat-v2/ComposerV2.tsx
@@ -138,6 +138,7 @@ type ContextStatus = {
   known: boolean;
   used: number;
   total: number;
+  displayTotal: number;
   percent: number;
   usedLabel: string;
   totalLabel: string;
@@ -227,13 +228,17 @@ function formatTokenCount(value: number): string {
 }
 
 function getContextStatus(tokenBudget?: Record<string, unknown> | null): ContextStatus {
-  const used = readNumber(tokenBudget?.used) ?? 0;
+  const used = readNumber(tokenBudget?.displayUsed) ?? readNumber(tokenBudget?.used) ?? 0;
+  const budgetUsed = readNumber(tokenBudget?.budgetUsed) ?? readNumber(tokenBudget?.used) ?? used;
   const total = readNumber(tokenBudget?.total) ?? 0;
-  if (total <= 0) {
+  const effectiveTotal = readNumber(tokenBudget?.effectiveTotal);
+  const displayTotal = effectiveTotal && effectiveTotal > 0 ? effectiveTotal : total;
+  if (displayTotal <= 0) {
     return {
       known: false,
       used: 0,
       total: 0,
+      displayTotal: 0,
       percent: 0,
       usedLabel: '--',
       totalLabel: '--',
@@ -241,7 +246,7 @@ function getContextStatus(tokenBudget?: Record<string, unknown> | null): Context
     };
   }
 
-  const percent = Math.max(0, Math.min(999, Math.round((used / total) * 100)));
+  const percent = Math.max(0, Math.min(999, Math.round((budgetUsed / displayTotal) * 100)));
   const snapshotState = typeof tokenBudget?.state === 'string' ? tokenBudget.state : null;
   const tone = snapshotState === 'blocking'
     ? 'red'
@@ -256,9 +261,10 @@ function getContextStatus(tokenBudget?: Record<string, unknown> | null): Context
     known: true,
     used,
     total,
+    displayTotal,
     percent,
     usedLabel: formatTokenCount(used),
-    totalLabel: formatTokenCount(total),
+    totalLabel: formatTokenCount(displayTotal),
     tone,
   };
 }
@@ -837,9 +843,9 @@ export default function ComposerV2({
                               <div className="text-neutral-500 dark:text-neutral-400">
                                 {t('input.contextStatusUsed', {
                                   used: contextStatus.used.toLocaleString(),
-                                  total: contextStatus.total.toLocaleString(),
+                                  total: contextStatus.displayTotal.toLocaleString(),
                                   defaultValue:
-                                    `${contextStatus.used.toLocaleString()} tokens used out of ${contextStatus.total.toLocaleString()}.`,
+                                    `${contextStatus.used.toLocaleString()} tokens used out of ${contextStatus.displayTotal.toLocaleString()}.`,
                                 })}
                               </div>
                               <div className="mt-2 text-neutral-500 dark:text-neutral-400">


### PR DESCRIPTION
## Summary\n- show composer token progress from real input usage while keeping conservative budget state for compaction\n- normalize OpenAI Responses cached tokens and Gemini thought tokens\n- restore token progress from transcript history after reopening a session\n\n## Tests\n- npm run build\n- node --test --test-timeout 60000 dist/tests/model/normalizeUsage.spec.js dist/tests/web/read-session-status-i18n.spec.js dist/tests/web/tool-result-detail.spec.js