### PR TITLE
fix(router): remove deprecated autoOrchestrate model override fields

### DIFF
--- a/src/router/RouterRuntime.ts
+++ b/src/router/RouterRuntime.ts
@@ -504,17 +504,7 @@ export function createRouterRuntime(
       if (orchestrated.applied) {
         mutations = { ...mutations, ...orchestrated.mutations };
         decision.orchestrating = true;
-        if (config.autoOrchestrate.mainAgentModel) {
-          decision.provider = config.autoOrchestrate.mainAgentModel.provider;
-          decision.model = config.autoOrchestrate.mainAgentModel.model;
-        }
       }
-    }
-
-    if (!input.isMainAgent && config.autoOrchestrate?.subagentModel) {
-      decision.provider = config.autoOrchestrate.subagentModel.provider;
-      decision.model = config.autoOrchestrate.subagentModel.model;
-      mutations = { ...mutations, subagentModelOverride: true };
     }
 
     if (scenarioOutcome.subagentModelHint || decision.isSubagent) {

--- a/src/router/config/parseRouterConfig.ts
+++ b/src/router/config/parseRouterConfig.ts
@@ -447,18 +447,16 @@ function parseAutoOrchestrate(
     return undefined;
   }
   const enabled = typeof raw.enabled === "boolean" ? raw.enabled : true;
-  const mainAgentModel = optionalRef(
-    raw.mainAgentModel,
-    "router.autoOrchestrate.mainAgentModel",
-    modelConfig,
-    diagnostics,
-  );
-  const subagentModel = optionalRef(
-    raw.subagentModel,
-    "router.autoOrchestrate.subagentModel",
-    modelConfig,
-    diagnostics,
-  );
+  for (const deprecated of ["mainAgentModel", "subagentModel"] as const) {
+    if (raw[deprecated] !== undefined) {
+      diagnostics.push({
+        code: "ROUTER_AUTO_ORCHESTRATE_DEPRECATED_FIELD",
+        severity: "warning",
+        path: `router.autoOrchestrate.${deprecated}`,
+        message: `router.autoOrchestrate.${deprecated} is deprecated and ignored.`,
+      });
+    }
+  }
   let triggerTiers: string[] = [...DEFAULT_TRIGGER_TIERS];
   if (raw.triggerTiers !== undefined) {
     if (Array.isArray(raw.triggerTiers) && raw.triggerTiers.every((entry) => typeof entry === "string")) {
@@ -550,8 +548,6 @@ function parseAutoOrchestrate(
 
   return {
     enabled,
-    mainAgentModel,
-    subagentModel,
     triggerTiers,
     allowedTools,
     blockedTools,

--- a/src/router/config/schema.ts
+++ b/src/router/config/schema.ts
@@ -41,9 +41,6 @@ export type RouterTokenSaverConfig = {
 
 export type RouterAutoOrchestrateConfig = {
   enabled: boolean;
-  mainAgentModel?: RouterModelRef;
-  /** Force subagents spawned during orchestration to use this model instead of the tier-resolved one. */
-  subagentModel?: RouterModelRef;
   skillExtensionId?: string;
   /** Inline orchestration prompt injected when skillExtensionId is absent. */
   orchestrationPrompt?: string;

--- a/src/router/protocol/decision.ts
+++ b/src/router/protocol/decision.ts
@@ -17,7 +17,6 @@ export type RouterMutationsLog = {
   orchestrationActivated?: { tier: string; continued: boolean };
   asyncAgentLaunchedRewritten?: boolean;
   subagentTagStripped?: boolean;
-  subagentModelOverride?: boolean;
   mediaCapabilityRerouted?: {
     required: import("../../model/protocol/multimodal.js").InputModality[];
     from: string;

--- a/ui/src/hooks/useRouterSettings.ts
+++ b/ui/src/hooks/useRouterSettings.ts
@@ -45,7 +45,6 @@ export type CCRConfig = {
     autoOrchestrate?: {
       enabled: boolean;
       triggerTiers: string[];
-      mainAgentModel: string;
       skillPath?: string;
       slimSystemPrompt?: boolean;
     };


### PR DESCRIPTION
## Summary

- Remove residual `autoOrchestrate.mainAgentModel` and `autoOrchestrate.subagentModel` config fields from schema, parser, and runtime
- These fields were confirmed by the router designer as deprecated — when autoOrchestrate activates, the tier-resolved model is used for the main agent, and subagent requests are independently classified by the tokenSaver judge
- The parser now emits a deprecation **warning** (not fatal) for existing configs that still contain these fields, so legacy configs load without errors
- Also removes the now-unused `subagentModelOverride` mutation flag and the `mainAgentModel` field from the UI type

## Test plan

- [x] `npx tsc --noEmit` passes with zero errors
- [ ] Verify a config with residual `autoOrchestrate.mainAgentModel` / `subagentModel` fields loads successfully with deprecation warnings (not fatal)
- [ ] Verify autoOrchestrate still triggers correctly using the tier-resolved model when `triggerTiers` match
- [ ] Verify subagent requests are still independently classified by the tokenSaver judge

Closes #248

Made with [Cursor](https://cursor.com)