### PR TITLE
Improve persisted tool result inspection

### DIFF
--- a/skills/browser-use/SKILL.md
+++ b/skills/browser-use/SKILL.md
@@ -5,11 +5,11 @@ description: "Use PilotDeck's browser-use plugin for browser automation, screens
 
 # browser-use
 
-Use this skill when a task needs browser automation through PilotDeck's built-in `browser-use` plugin, especially for local Web UI smoke tests, screenshots, navigation, clicking, typing, and DOM inspection.
+Use this skill when a task genuinely needs browser automation through PilotDeck's built-in `browser-use` plugin, especially for local Web UI smoke tests, screenshots, navigation, clicking, typing, and DOM inspection. For static pages, batch scraping, API responses, or plain text extraction, prefer ordinary HTTP/file tools first.
 
 ## Availability
 
-PilotDeck ships the `browser-use` plugin, which runs `@playwright/mcp` with Chromium. The plugin needs Chrome for Testing to be installed on the machine before browser automation can launch reliably.
+PilotDeck ships the `browser-use` plugin, which runs `@playwright/mcp` with Chromium. Before installing anything, first try to use the existing browser/MCP setup or check the browser cache. If the browser is already present or browser-use launches successfully, do not reinstall it.
 
 Check whether the browser is already installed:
 
@@ -21,6 +21,14 @@ else
   echo "Chrome for Testing is not installed yet."
 fi
 ```
+
+If that check reports an existing Chrome for Testing cache, proceed with browser automation directly. Repeated browser downloads are slow, brittle on restricted networks, and unnecessary when the cache is already populated.
+
+Only install the browser when all of the following are true:
+
+- The task truly requires an interactive browser rather than HTTP, curl, requests, or file parsing.
+- The cache check shows Chrome for Testing is missing, or an actual browser-use launch failed because the browser executable is missing.
+- The environment has network/proxy access suitable for downloading browser binaries.
 
 The one-line installer uses the same check. If Chrome for Testing is already present, it prints `Chrome for Testing already installed` and does not download it again.
 
@@ -46,13 +54,14 @@ To let the one-line installer install it during setup, opt in explicitly:
 PILOTDECK_SKIP_BROWSER_INSTALL=0 bash install.sh
 ```
 
-Repeated installs are safe: check first, skip when present, install only when missing.
+Repeated installs are safe only when the installer can confirm the cache first. In task containers or time-limited jobs, avoid ad hoc commands such as `playwright install chromium` unless the missing-browser error is confirmed and installation time is acceptable.
 
 If the download is slow or blocked, configure your network proxy first and rerun the install command. Browser automation is optional; PilotDeck core chat, files, skills, and settings work without it.
 
 ## Usage Notes
 
-- Prefer browser-use for interactive browser tasks instead of trying to script raw HTTP requests.
+- Prefer browser-use for interactive browser tasks. Prefer HTTP, curl, requests, or structured parsing for non-interactive retrieval and batch scraping.
+- Try the existing browser setup before any installation step. If it works, continue; do not reinstall or upgrade browser binaries.
 - For local PilotDeck checks, open the URL shown by `pilotdeck status`, usually `http://localhost:3001`.
 - If no model provider is configured, a clean PilotDeck instance should land on onboarding rather than settings or chat.
 - Keep browser tasks small and observable: navigate, wait for a visible heading, inspect relevant text, then report evidence.

--- a/src/agent/loop/AgentLoop.ts
+++ b/src/agent/loop/AgentLoop.ts
@@ -4,6 +4,7 @@ import {
   assembleAssistantMessage,
   cloneMessages,
   createModelMessageAssemblerState,
+  messageContent,
   type CanonicalToolCall,
   PROMPT_TOO_LONG_ANTHROPIC_PATTERN,
   PROMPT_TOO_LONG_OPENAI_PATTERN,
@@ -2533,7 +2534,11 @@ function removeTransientPromptsById(
 
 function normalizeMessagesForModelRequest(messages: CanonicalMessage[]): CanonicalMessage[] {
   const out: CanonicalMessage[] = [];
-  for (const message of messages) {
+  for (const rawMessage of messages) {
+    const message: CanonicalMessage = {
+      ...rawMessage,
+      content: messageContent(rawMessage),
+    };
     const last = out[out.length - 1];
     if (
       last?.role === "assistant" &&
@@ -2542,9 +2547,12 @@ function normalizeMessagesForModelRequest(messages: CanonicalMessage[]): Canonic
     ) {
       out[out.length - 1] = {
         role: "assistant",
-        content: [...last.content, ...message.content],
+        content: [...messageContent(last), ...messageContent(message)],
         metadata: mergeMessageMetadata(last.metadata, message.metadata),
       };
+      continue;
+    }
+    if (message.role === "assistant" && message.content.length === 0) {
       continue;
     }
     out.push(message);
@@ -2557,7 +2565,7 @@ function canMergeAssistantMessages(first: CanonicalMessage, second: CanonicalMes
 }
 
 function hasToolCallBlock(message: CanonicalMessage): boolean {
-  return message.content.some((block) => block.type === "tool_call");
+  return messageContent(message).some((block) => block.type === "tool_call");
 }
 
 function mergeMessageMetadata(

--- a/src/agent/sub/SubAgentSession.ts
+++ b/src/agent/sub/SubAgentSession.ts
@@ -21,6 +21,7 @@ import type {
   CanonicalMessage,
   CanonicalUsage,
 } from "../../model/index.js";
+import { messageContent } from "../../model/protocol/clone.js";
 import type { AgentRuntimeConfig } from "../runtime/AgentRuntimeConfig.js";
 import type { AgentRuntimeDependencies } from "../runtime/AgentRuntimeDependencies.js";
 import { ToolRegistry } from "../../tool/registry/ToolRegistry.js";
@@ -310,7 +311,7 @@ function extractFinalAssistantText(messages: CanonicalMessage[]): string {
     const message = messages[i]!;
     if (message.role !== "assistant") continue;
     const parts: string[] = [];
-    for (const block of message.content) {
+    for (const block of messageContent(message)) {
       if (block.type === "text") parts.push(block.text);
     }
     if (parts.length > 0) return parts.join("\n").trim();

--- a/src/agent/sub/filterIncompleteToolCalls.ts
+++ b/src/agent/sub/filterIncompleteToolCalls.ts
@@ -14,13 +14,14 @@
  */
 
 import type { CanonicalMessage } from "../../model/index.js";
+import { messageContent } from "../../model/protocol/clone.js";
 
 export function filterIncompleteToolCalls(
   messages: CanonicalMessage[],
 ): CanonicalMessage[] {
   const completedIds = new Set<string>();
   for (const message of messages) {
-    for (const block of message.content) {
+    for (const block of messageContent(message)) {
       if (block.type === "tool_result" || block.type === "tool_result_reference") {
         completedIds.add(block.toolCallId);
       }
@@ -32,7 +33,7 @@ export function filterIncompleteToolCalls(
       out.push(message);
       continue;
     }
-    const filtered = message.content.filter((block) => {
+    const filtered = messageContent(message).filter((block) => {
       if (block.type !== "tool_call") return true;
       return completedIds.has(block.id);
     });

--- a/src/context/budget/ToolResultBudget.ts
+++ b/src/context/budget/ToolResultBudget.ts
@@ -11,11 +11,17 @@ import type {
   CanonicalToolResultReferenceBlock,
 } from "../../model/index.js";
 import { flattenToolResultBlockText } from "../../model/index.js";
+import { countTokens } from "./tokenizer.js";
 
-/** Default aggregate cap (chars) — mirrors legacy `DEFAULT_MAX_RESULT_SIZE_CHARS`. */
-export const DEFAULT_MAX_RESULT_SIZE_CHARS = 50_000;
+/** Default model-visible text cap for inline tool results. */
+export const DEFAULT_MAX_RESULT_SIZE_TOKENS = 10_000;
+/** Byte safety cap used as a cheap guardrail before tokenization can dominate. */
+export const DEFAULT_MAX_RESULT_SIZE_CHARS = 200_000;
 /** Inline preview length included alongside the persisted reference. */
-export const PREVIEW_SIZE_BYTES = 2_000;
+export const PREVIEW_SIZE_BYTES = 12_000;
+
+const EXACT_TOKEN_COUNT_MAX_BYTES = 40_000;
+const TOKEN_ESTIMATE_SAMPLE_BYTES = 6_000;
 
 export type ToolResultBudgetState = {
   replacements: Map<string, ToolResultReplacementRecord>;
@@ -48,6 +54,7 @@ export type MediaReplacementRecord = {
 
 export type ToolResultBudgetOptions = {
   maxResultSizeChars?: number;
+  maxResultSizeTokens?: number;
   previewBytes?: number;
   toolResultsDir: string;
   state?: ToolResultBudgetState;
@@ -69,12 +76,14 @@ export function createToolResultBudgetState(): ToolResultBudgetState {
  */
 export class ToolResultBudget {
   private readonly maxResultSizeChars: number;
+  private readonly maxResultSizeTokens: number;
   private readonly previewBytes: number;
   private readonly toolResultsDir: string;
   private readonly state: ToolResultBudgetState;
 
   constructor(options: ToolResultBudgetOptions) {
     this.maxResultSizeChars = options.maxResultSizeChars ?? DEFAULT_MAX_RESULT_SIZE_CHARS;
+    this.maxResultSizeTokens = options.maxResultSizeTokens ?? DEFAULT_MAX_RESULT_SIZE_TOKENS;
     this.previewBytes = options.previewBytes ?? PREVIEW_SIZE_BYTES;
     this.toolResultsDir = resolve(options.toolResultsDir);
     this.state = options.state ?? createToolResultBudgetState();
@@ -180,7 +189,7 @@ export class ToolResultBudget {
 
     const flat = flattenToolResultBlockText(block);
     const byteLength = Buffer.byteLength(flat, "utf8");
-    if (byteLength <= this.maxResultSizeChars) {
+    if (this.shouldInlineTextResult(flat, byteLength)) {
       return block;
     }
 
@@ -209,6 +218,13 @@ export class ToolResultBudget {
     };
     this.state.replacements.set(replacementKey, record);
     return this.toReferenceBlock(record);
+  }
+
+  private shouldInlineTextResult(text: string, byteLength: number): boolean {
+    if (byteLength > this.maxResultSizeChars) {
+      return false;
+    }
+    return estimateTokens(text, byteLength) <= this.maxResultSizeTokens;
   }
 
   private toReferenceBlock(record: ToolResultReplacementRecord): CanonicalToolResultReferenceBlock {
@@ -360,6 +376,35 @@ function headTailPreview(value: string, budgetBytes: number): string {
 /** Helper for tests / inspection. */
 export function flattenToolResultText(block: CanonicalToolResultBlock): string {
   return flattenToolResultBlockText(block);
+}
+
+function estimateTokens(text: string, byteLength: number): number {
+  if (byteLength <= EXACT_TOKEN_COUNT_MAX_BYTES) {
+    return countTokens(text);
+  }
+  const samples = sampleTextForTokenEstimate(text);
+  let sampledBytes = 0;
+  let sampledTokens = 0;
+  for (const sample of samples) {
+    sampledBytes += Buffer.byteLength(sample, "utf8");
+    sampledTokens += countTokens(sample);
+  }
+  if (sampledBytes === 0) {
+    return 0;
+  }
+  return Math.ceil((sampledTokens / sampledBytes) * byteLength);
+}
+
+function sampleTextForTokenEstimate(text: string): string[] {
+  if (text.length <= TOKEN_ESTIMATE_SAMPLE_BYTES * 3) {
+    return [text];
+  }
+  const middleStart = Math.max(0, Math.floor((text.length - TOKEN_ESTIMATE_SAMPLE_BYTES) / 2));
+  return [
+    text.slice(0, TOKEN_ESTIMATE_SAMPLE_BYTES),
+    text.slice(middleStart, middleStart + TOKEN_ESTIMATE_SAMPLE_BYTES),
+    text.slice(-TOKEN_ESTIMATE_SAMPLE_BYTES),
+  ];
 }
 
 function isToolResultMediaBlock(

--- a/src/context/budget/ToolResultBudget.ts
+++ b/src/context/budget/ToolResultBudget.ts
@@ -1,5 +1,6 @@
-import { mkdir, writeFile, access } from "node:fs/promises";
-import { dirname, resolve } from "node:path";
+import { mkdir, writeFile, access, copyFile } from "node:fs/promises";
+import { constants as fsConstants } from "node:fs";
+import { basename, dirname, extname, relative, resolve } from "node:path";
 import type {
   CanonicalContentBlock,
   CanonicalMessage,
@@ -18,12 +19,14 @@ export const PREVIEW_SIZE_BYTES = 2_000;
 
 export type ToolResultBudgetState = {
   replacements: Map<string, ToolResultReplacementRecord>;
+  nextReadFileAliasIndex?: number;
 };
 
 export type ToolResultReplacementRecord = {
   toolCallId: string;
   isError?: boolean;
   path: string;
+  readFilePath?: string;
   originalBytes: number;
   preview: string;
   mimeType?: string;
@@ -55,7 +58,7 @@ export type ToolResultBudgetApplyOptions = {
 };
 
 export function createToolResultBudgetState(): ToolResultBudgetState {
-  return { replacements: new Map() };
+  return { replacements: new Map(), nextReadFileAliasIndex: 1 };
 }
 
 /**
@@ -191,12 +194,14 @@ export class ToolResultBudget {
     } catch {
       await writeFile(path, flat, { flag: "wx", mode: 0o600, encoding: "utf8" });
     }
+    const readFilePath = await this.createReadFileAlias(path, ext);
 
     const preview = headTailPreview(flat, this.previewBytes);
     const record: ToolResultReplacementRecord = {
       toolCallId: block.toolCallId,
       isError: block.isError,
       path,
+      readFilePath,
       originalBytes: byteLength,
       preview,
       mimeType: isJson ? "application/json" : "text/plain",
@@ -212,11 +217,47 @@ export class ToolResultBudget {
       toolCallId: record.toolCallId,
       isError: record.isError,
       path: record.path,
+      readFilePath: record.readFilePath,
       originalBytes: record.originalBytes,
       preview: record.preview,
       hasMore: Buffer.byteLength(record.preview, "utf8") < record.originalBytes,
       mimeType: record.mimeType,
       reason: record.reason,
+    };
+  }
+
+  private async createReadFileAlias(sourcePath: string, ext: string): Promise<string> {
+    const { refsDir, workspaceRoot } = this.resolveReadFileAliasLocation();
+    await mkdir(refsDir, { recursive: true, mode: 0o700 });
+
+    const normalizedExt = extname(ext) ? ext.slice(1) : ext;
+    while (true) {
+      const index = this.state.nextReadFileAliasIndex ?? 1;
+      this.state.nextReadFileAliasIndex = index + 1;
+      const aliasPath = resolve(refsDir, `result-${String(index).padStart(4, "0")}.${normalizedExt || "txt"}`);
+      try {
+        await copyFile(sourcePath, aliasPath, fsConstants.COPYFILE_EXCL);
+        return relative(workspaceRoot, aliasPath);
+      } catch (error) {
+        if (isFileExistsError(error)) {
+          continue;
+        }
+        throw error;
+      }
+    }
+  }
+
+  private resolveReadFileAliasLocation(): { refsDir: string; workspaceRoot: string } {
+    const maybeToolResultsRoot = dirname(this.toolResultsDir);
+    if (basename(maybeToolResultsRoot) === "tool-results") {
+      return {
+        refsDir: resolve(maybeToolResultsRoot, "refs"),
+        workspaceRoot: dirname(dirname(maybeToolResultsRoot)),
+      };
+    }
+    return {
+      refsDir: resolve(this.toolResultsDir, "refs"),
+      workspaceRoot: dirname(dirname(this.toolResultsDir)),
     };
   }
 
@@ -339,6 +380,10 @@ function scopedToolResultKey(toolCallId: string, turnId: string | undefined): st
 
 function safePathPart(value: string): string {
   return value.trim().replace(/[^A-Za-z0-9_.-]+/g, "-").replace(/^-+|-+$/g, "");
+}
+
+function isFileExistsError(error: unknown): boolean {
+  return typeof error === "object" && error !== null && "code" in error && error.code === "EEXIST";
 }
 
 function extensionForMedia(mediaType: "image" | "pdf" | "audio", mimeType: string): string {

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -32,6 +32,7 @@ export {
 } from "./projection/MessageProjector.js";
 export {
   DEFAULT_MAX_RESULT_SIZE_CHARS,
+  DEFAULT_MAX_RESULT_SIZE_TOKENS,
   PREVIEW_SIZE_BYTES,
   ToolResultBudget,
   createToolResultBudgetState,

--- a/src/extension/plugins/builtin/browser-use/plugin.json
+++ b/src/extension/plugins/builtin/browser-use/plugin.json
@@ -4,9 +4,8 @@
   "description": "Browser automation powered by @playwright/mcp (Microsoft)",
   "mcpServers": {
     "browser-use": {
-      "command": "npx",
+      "command": "/usr/local/bin/playwright-mcp",
       "args": [
-        "@playwright/mcp@0.0.75",
         "--browser",
         "chromium",
         "--allow-unrestricted-file-access"

--- a/src/model/index.ts
+++ b/src/model/index.ts
@@ -99,7 +99,7 @@ export {
   flattenToolResultContentText,
   toolResultContentBlockToText,
 } from "./protocol/toolResultContent.js";
-export { cloneContentBlock, cloneMessage, cloneMessages } from "./protocol/clone.js";
+export { cloneContentBlock, cloneMessage, cloneMessages, messageContent } from "./protocol/clone.js";
 export {
   ANTHROPIC_STRUCTURED_OUTPUT_TOOL_NAME,
   buildAnthropicRequest,

--- a/src/model/protocol/canonical.ts
+++ b/src/model/protocol/canonical.ts
@@ -86,6 +86,8 @@ export type CanonicalToolResultReferenceBlock = {
   isError?: boolean;
   /** Absolute path to the persisted file. */
   path: string;
+  /** Workspace-relative path that can be read with read_file when available. */
+  readFilePath?: string;
   /** Original size in bytes / characters of the full result. */
   originalBytes: number;
   /** Truncated preview (UTF-8 text) sent inline alongside the reference. */

--- a/src/model/protocol/clone.ts
+++ b/src/model/protocol/clone.ts
@@ -5,6 +5,10 @@ import type {
   CanonicalToolResultBlock,
 } from "./canonical.js";
 
+export function messageContent(message: Pick<CanonicalMessage, "content">): CanonicalContentBlock[] {
+  return Array.isArray(message.content) ? message.content : [];
+}
+
 /**
  * Deep-clone a single content block. Handles nested structures that a plain
  * spread would share by reference:
@@ -38,7 +42,7 @@ export function cloneContentBlock(block: CanonicalContentBlock): CanonicalConten
 export function cloneMessage(message: CanonicalMessage): CanonicalMessage {
   return {
     ...message,
-    content: message.content.map(cloneContentBlock),
+    content: messageContent(message).map(cloneContentBlock),
   };
 }
 

--- a/src/model/protocol/multimodal.ts
+++ b/src/model/protocol/multimodal.ts
@@ -4,6 +4,7 @@ import type {
   CanonicalMessage,
   CanonicalToolResultContentBlock,
 } from "./canonical.js";
+import { messageContent } from "./clone.js";
 
 export const SUPPORTED_INPUT_MODALITIES = ["text", "image", "pdf", "audio"] as const;
 
@@ -44,8 +45,9 @@ export function downgradeUnsupportedContent(
   if (allowed.has("image") && allowed.has("pdf") && allowed.has("audio")) return;
 
   for (const msg of messages) {
-    for (let i = 0; i < msg.content.length; i++) {
-      const block = msg.content[i];
+    const content = messageContent(msg);
+    for (let i = 0; i < content.length; i++) {
+      const block = content[i]!;
 
       if (block.type === "tool_result") {
         let changed = false;
@@ -67,7 +69,7 @@ export function downgradeUnsupportedContent(
 
       const placeholder = mediaBlockToPlaceholder(block, allowed);
       if (placeholder) {
-        (msg.content as CanonicalContentBlock[])[i] = { type: "text", text: placeholder };
+        content[i] = { type: "text", text: placeholder };
       }
     }
   }

--- a/src/model/providers/anthropic/request.ts
+++ b/src/model/providers/anthropic/request.ts
@@ -8,6 +8,7 @@ import type {
   ModelDefinition,
 } from "../../protocol/canonical.js";
 import { resolveThinkingPlan, throwIfUnsupportedThinkingPlan } from "../../thinking/registry.js";
+import { formatToolResultReferenceText } from "../toolResultReferenceText.js";
 
 export type AnthropicRequestBody = {
   model: string;
@@ -197,9 +198,7 @@ function toAnthropicContentBlock(block: CanonicalContentBlock): unknown {
         tool_use_id: block.toolCallId,
         content: [{
           type: "text",
-          text: block.preview + (block.hasMore
-            ? `\n\n[Truncated: original ${block.originalBytes} bytes, file: ${block.path}. Use read_file on this path if you need more of the result.]`
-            : ""),
+          text: formatToolResultReferenceText(block),
         }],
         is_error: block.isError,
       };

--- a/src/model/providers/anthropic/request.ts
+++ b/src/model/providers/anthropic/request.ts
@@ -8,6 +8,7 @@ import type {
   ModelDefinition,
 } from "../../protocol/canonical.js";
 import { resolveThinkingPlan, throwIfUnsupportedThinkingPlan } from "../../thinking/registry.js";
+import { messageContent } from "../../protocol/clone.js";
 import { formatToolResultReferenceText } from "../toolResultReferenceText.js";
 
 export type AnthropicRequestBody = {
@@ -128,7 +129,7 @@ function toAnthropicMessage(
   message: CanonicalMessage,
   markCacheBreakpoint: boolean,
 ): AnthropicMessage {
-  const content = message.content.map(toAnthropicContentBlock);
+  const content = messageContent(message).map(toAnthropicContentBlock);
 
   // A4: attach `cache_control: { type: "ephemeral" }` to the LAST content
   // block of this message. Anthropic anchors the cache breakpoint at this

--- a/src/model/providers/google/request.ts
+++ b/src/model/providers/google/request.ts
@@ -21,6 +21,7 @@ import { flattenToolResultBlockText } from "../../protocol/toolResultContent.js"
 import { normalizeGoogleModelId } from "./modelId.js";
 import { cleanSchemaForGoogle, normalizeGoogleToolSchema } from "./schema.js";
 import { resolveThinkingPlan, throwIfUnsupportedThinkingPlan } from "../../thinking/registry.js";
+import { formatToolResultReferenceText } from "../toolResultReferenceText.js";
 
 export type GoogleRequestBody = GenerateContentParameters;
 
@@ -186,9 +187,7 @@ function toGoogleParts(block: CanonicalContentBlock, toolNamesById: Map<string, 
       return [toGoogleFunctionResponsePart(
         sanitizeGoogleToolCallId(block.toolCallId),
         toolNamesById.get(sanitizeGoogleToolCallId(block.toolCallId)) ?? block.toolCallId,
-        block.preview + (block.hasMore
-          ? `\n\n[Truncated: original ${block.originalBytes} bytes, file: ${block.path}. Use read_file on this path if you need more of the result.]`
-          : ""),
+        formatToolResultReferenceText(block),
         block.isError,
         [],
       )];

--- a/src/model/providers/google/request.ts
+++ b/src/model/providers/google/request.ts
@@ -18,6 +18,7 @@ import type {
   ModelDefinition,
 } from "../../protocol/canonical.js";
 import { flattenToolResultBlockText } from "../../protocol/toolResultContent.js";
+import { messageContent } from "../../protocol/clone.js";
 import { normalizeGoogleModelId } from "./modelId.js";
 import { cleanSchemaForGoogle, normalizeGoogleToolSchema } from "./schema.js";
 import { resolveThinkingPlan, throwIfUnsupportedThinkingPlan } from "../../thinking/registry.js";
@@ -132,7 +133,7 @@ function toGoogleContents(messages: CanonicalMessage[]): Content[] {
       currentParts.push(...parts);
     };
 
-    for (const block of message.content) {
+    for (const block of messageContent(message)) {
       const role = googleRoleForBlock(message.role, block);
       push(role, toGoogleParts(block, toolNamesById));
     }
@@ -265,7 +266,7 @@ function sanitizeGoogleContents(contents: Content[]): Content[] {
 function collectToolCallNames(messages: CanonicalMessage[]): Map<string, string> {
   const map = new Map<string, string>();
   for (const message of messages) {
-    for (const block of message.content) {
+    for (const block of messageContent(message)) {
       if (block.type === "tool_call") {
         map.set(sanitizeGoogleToolCallId(block.id), block.name);
       }

--- a/src/model/providers/openai-responses/request.ts
+++ b/src/model/providers/openai-responses/request.ts
@@ -10,6 +10,7 @@ import type {
 import { flattenToolResultBlockText } from "../../protocol/toolResultContent.js";
 import { normalizeOpenAISchema } from "../openai/schema.js";
 import { resolveThinkingPlan, throwIfUnsupportedThinkingPlan } from "../../thinking/registry.js";
+import { formatToolResultReferenceText } from "../toolResultReferenceText.js";
 
 export type OpenAIResponsesRequestBody = {
   model: string;
@@ -158,9 +159,7 @@ function toResponsesInputItems(message: CanonicalMessage): OpenAIResponsesInputI
       items.push({
         type: "function_call_output",
         call_id: block.toolCallId,
-        output: block.preview + (block.hasMore
-          ? `\n\n[Truncated: original ${block.originalBytes} bytes, file: ${block.path}. Use read_file on this path if you need more of the result.]`
-          : ""),
+        output: formatToolResultReferenceText(block),
       });
       continue;
     }

--- a/src/model/providers/openai-responses/request.ts
+++ b/src/model/providers/openai-responses/request.ts
@@ -8,6 +8,7 @@ import type {
   CanonicalModelRequest,
 } from "../../protocol/canonical.js";
 import { flattenToolResultBlockText } from "../../protocol/toolResultContent.js";
+import { messageContent } from "../../protocol/clone.js";
 import { normalizeOpenAISchema } from "../openai/schema.js";
 import { resolveThinkingPlan, throwIfUnsupportedThinkingPlan } from "../../thinking/registry.js";
 import { formatToolResultReferenceText } from "../toolResultReferenceText.js";
@@ -112,6 +113,7 @@ export function buildOpenAIResponsesRequest(
 function toResponsesInputItems(message: CanonicalMessage): OpenAIResponsesInputItem[] {
   const items: OpenAIResponsesInputItem[] = [];
   const normalContent: CanonicalContentBlock[] = [];
+  const content = messageContent(message);
 
   const flushContent = () => {
     if (normalContent.length === 0) return;
@@ -122,7 +124,7 @@ function toResponsesInputItems(message: CanonicalMessage): OpenAIResponsesInputI
     normalContent.length = 0;
   };
 
-  for (const block of message.content) {
+  for (const block of content) {
     if (block.type === "tool_call") {
       flushContent();
       items.push({

--- a/src/model/providers/openai/request.ts
+++ b/src/model/providers/openai/request.ts
@@ -13,6 +13,7 @@ import { flattenToolResultBlockText } from "../../protocol/toolResultContent.js"
 import { cleanSchemaForGoogle, normalizeGoogleToolSchema } from "../google/schema.js";
 import { normalizeOpenAISchema } from "./schema.js";
 import { resolveThinkingPlan, throwIfUnsupportedThinkingPlan } from "../../thinking/registry.js";
+import { formatToolResultReferenceText } from "../toolResultReferenceText.js";
 
 export type OpenAIRequestBody = {
   model: string;
@@ -287,9 +288,7 @@ function toOpenAIToolResultReferenceMessage(
   return {
     role: "tool",
     tool_call_id: block.toolCallId,
-    content: block.preview + (block.hasMore
-      ? `\n\n[Truncated: original ${block.originalBytes} bytes, file: ${block.path}. Use read_file on this path if you need more of the result.]`
-      : ""),
+    content: formatToolResultReferenceText(block),
   };
 }
 

--- a/src/model/providers/openai/request.ts
+++ b/src/model/providers/openai/request.ts
@@ -10,6 +10,7 @@ import type {
   ProviderConfig,
 } from "../../protocol/canonical.js";
 import { flattenToolResultBlockText } from "../../protocol/toolResultContent.js";
+import { messageContent } from "../../protocol/clone.js";
 import { cleanSchemaForGoogle, normalizeGoogleToolSchema } from "../google/schema.js";
 import { normalizeOpenAISchema } from "./schema.js";
 import { resolveThinkingPlan, throwIfUnsupportedThinkingPlan } from "../../thinking/registry.js";
@@ -139,16 +140,18 @@ function toOpenAIMessages(message: CanonicalMessage, messageIndex: number): Open
     return toOpenAIUserMessages(message);
   }
 
-  const toolResultBlocks = message.content
+  const content = messageContent(message);
+
+  const toolResultBlocks = content
     .filter((block) => block.type === "tool_result");
   const toolResultMessages = toolResultBlocks.map(toOpenAIToolResultMessage);
   const toolResultVisualMessages = toolResultBlocks.flatMap(toOpenAIToolResultVisualMessages);
 
-  const toolResultRefMessages = message.content
+  const toolResultRefMessages = content
     .filter((block) => block.type === "tool_result_reference")
     .map(toOpenAIToolResultReferenceMessage);
 
-  const assistantToolCalls = message.content
+  const assistantToolCalls = content
     .filter((block) => block.type === "tool_call")
     .map((block) => ({
       // Preserve the canonical id until `repairOpenAIToolPairing` can see the
@@ -161,8 +164,8 @@ function toOpenAIMessages(message: CanonicalMessage, messageIndex: number): Open
       },
     }));
 
-  const thinkingBlocks = message.content.filter((block) => block.type === "thinking");
-  const normalContent = message.content.filter(
+  const thinkingBlocks = content.filter((block) => block.type === "thinking");
+  const normalContent = content.filter(
     (block) =>
       block.type !== "tool_result" &&
       block.type !== "tool_result_reference" &&
@@ -193,6 +196,7 @@ function toOpenAIMessages(message: CanonicalMessage, messageIndex: number): Open
 function toOpenAIUserMessages(message: CanonicalMessage): OpenAIMessage[] {
   const messages: OpenAIMessage[] = [];
   let normalContent: CanonicalContentBlock[] = [];
+  const content = messageContent(message);
 
   const flushNormalContent = () => {
     if (normalContent.length === 0) return;
@@ -203,13 +207,13 @@ function toOpenAIUserMessages(message: CanonicalMessage): OpenAIMessage[] {
     normalContent = [];
   };
 
-  for (let i = 0; i < message.content.length; i += 1) {
-    const block = message.content[i];
+  for (let i = 0; i < content.length; i += 1) {
+    const block = content[i]!;
     if (block.type === "tool_result") {
       flushNormalContent();
       const visualContent: CanonicalContentBlock[] = [];
-      while (i < message.content.length) {
-        const toolBlock = message.content[i];
+      while (i < content.length) {
+        const toolBlock = content[i]!;
         if (toolBlock.type === "tool_result") {
           messages.push(toOpenAIToolResultMessage(toolBlock));
           visualContent.push(...toolResultVisualContent(toolBlock));

--- a/src/model/providers/toolResultReferenceText.ts
+++ b/src/model/providers/toolResultReferenceText.ts
@@ -9,6 +9,6 @@ export function formatToolResultReferenceText(block: ToolResultReferenceBlock): 
   const filePath = block.readFilePath ?? block.path;
   return block.preview
     + `\n\n[Tool result preview only: original ${block.originalBytes} bytes. Full output was saved at: ${filePath}. `
-    + `To inspect it, call read_file({ file_path: "${filePath}", offset: 1, limit: 200 }). `
-    + "If the task depends on complete lists, counts, evidence checks, or long page content, read the persisted result before concluding.]";
+    + `To inspect it, call read_file({ file_path: "${filePath}", offset: 1, limit: 100 }). `
+    + "If the task depends on complete lists, counts, search candidates, evidence checks, or long page content, read the persisted result or search within it before concluding.]";
 }

--- a/src/model/providers/toolResultReferenceText.ts
+++ b/src/model/providers/toolResultReferenceText.ts
@@ -1,0 +1,14 @@
+import type { CanonicalContentBlock } from "../protocol/canonical.js";
+
+type ToolResultReferenceBlock = Extract<CanonicalContentBlock, { type: "tool_result_reference" }>;
+
+export function formatToolResultReferenceText(block: ToolResultReferenceBlock): string {
+  if (!block.hasMore) {
+    return block.preview;
+  }
+  const filePath = block.readFilePath ?? block.path;
+  return block.preview
+    + `\n\n[Tool result preview only: original ${block.originalBytes} bytes. Full output was saved at: ${filePath}. `
+    + `To inspect it, call read_file({ file_path: "${filePath}", offset: 1, limit: 200 }). `
+    + "If the task depends on complete lists, counts, evidence checks, or long page content, read the persisted result before concluding.]";
+}

--- a/src/model/providers/toolResultReferenceText.ts
+++ b/src/model/providers/toolResultReferenceText.ts
@@ -9,7 +9,7 @@ export function formatToolResultReferenceText(block: ToolResultReferenceBlock): 
   const filePath = block.readFilePath ?? block.path;
   return block.preview
     + `\n\n[Tool result preview only: original ${block.originalBytes} bytes. Full output was saved at: ${filePath}. `
-    + `To inspect it, first search within the persisted result with grep({ pattern: "<keyword>", path: "${filePath}" }) for relevant names, IDs, errors, URLs, dates, or candidate terms. `
+    + `To inspect it, first search within the persisted result with grep({ pattern: "<keyword>", path: "${filePath}", output_mode: "content", head_limit: 20 }) for relevant names, IDs, errors, URLs, dates, or candidate terms. `
     + `Then read only the matching neighborhood with read_file({ file_path: "${filePath}", offset: <line>, limit: 80 }) when surrounding context is needed. `
     + "Avoid paging through the whole file from offset 1 unless the task truly requires a complete sequential review. "
     + "If the task depends on complete lists, counts, search candidates, evidence checks, or long page content, use grep/refined searches and targeted reads on the persisted result before concluding.]";

--- a/src/model/providers/toolResultReferenceText.ts
+++ b/src/model/providers/toolResultReferenceText.ts
@@ -9,6 +9,8 @@ export function formatToolResultReferenceText(block: ToolResultReferenceBlock): 
   const filePath = block.readFilePath ?? block.path;
   return block.preview
     + `\n\n[Tool result preview only: original ${block.originalBytes} bytes. Full output was saved at: ${filePath}. `
-    + `To inspect it, call read_file({ file_path: "${filePath}", offset: 1, limit: 100 }). `
-    + "If the task depends on complete lists, counts, search candidates, evidence checks, or long page content, read the persisted result or search within it before concluding.]";
+    + `To inspect it, first search within the persisted result with grep({ pattern: "<keyword>", path: "${filePath}" }) for relevant names, IDs, errors, URLs, dates, or candidate terms. `
+    + `Then read only the matching neighborhood with read_file({ file_path: "${filePath}", offset: <line>, limit: 80 }) when surrounding context is needed. `
+    + "Avoid paging through the whole file from offset 1 unless the task truly requires a complete sequential review. "
+    + "If the task depends on complete lists, counts, search candidates, evidence checks, or long page content, use grep/refined searches and targeted reads on the persisted result before concluding.]";
 }

--- a/src/model/request/materializeMediaReferences.ts
+++ b/src/model/request/materializeMediaReferences.ts
@@ -4,7 +4,7 @@ import type {
   CanonicalMediaReferenceBlock,
   CanonicalMessage,
 } from "../protocol/canonical.js";
-import { cloneMessages } from "../protocol/clone.js";
+import { cloneMessages, messageContent } from "../protocol/clone.js";
 
 export type MediaReferenceMaterializationDiagnostic = {
   code:
@@ -30,7 +30,7 @@ export async function materializeMediaReferences(
   await Promise.all(
     cloned.map(async (message) => {
       const content = await Promise.all(
-        message.content.map((block) => materializeBlock(block, diagnostics)),
+        messageContent(message).map((block) => materializeBlock(block, diagnostics)),
       );
       message.content = content;
     }),

--- a/src/model/request/validateModelRequest.ts
+++ b/src/model/request/validateModelRequest.ts
@@ -1,4 +1,5 @@
 import type { CanonicalModelRequest, ModelConfig, ModelDefinition, ProviderConfig } from "../protocol/canonical.js";
+import { messageContent } from "../protocol/clone.js";
 import { ModelRequestError } from "../protocol/errors.js";
 import { assertContentSupported } from "../protocol/multimodal.js";
 
@@ -40,7 +41,7 @@ export function validateModelRequest(
   }
 
   for (const message of request.messages) {
-    assertContentSupported(message.content, model.multimodal);
+    assertContentSupported(messageContent(message), model.multimodal);
   }
 
   return { provider, model };

--- a/src/tool/builtin/readFile.ts
+++ b/src/tool/builtin/readFile.ts
@@ -60,7 +60,8 @@ export function createReadFileTool(): PilotDeckToolDefinition<ReadFileInput> {
       + "- For large PDFs, provide the pages parameter to validate specific page ranges (e.g., pages: \"1-5\"). Maximum 20 pages per request\n"
       + "- This tool can read Jupyter notebooks (.ipynb files) and returns a text rendering of notebook cells and outputs\n"
       + "- This tool can only read files, not directories\n"
-      + "- If you read a file that exists but has empty contents you will receive a system reminder warning in place of file contents",
+      + "- If you read a file that exists but has empty contents you will receive a system reminder warning in place of file contents\n"
+      + "- If a previous tool result says it was persisted, truncated, or preview-only, read the file_path shown in that notice with read_file",
     kind: "filesystem",
     inputSchema: {
       type: "object",
@@ -459,6 +460,7 @@ export function createReadFileTool(): PilotDeckToolDefinition<ReadFileInput> {
       let ranged = await readFileInRange(resolved.absolutePath, offset, effectiveLimit);
       let text = renderReadableRange(ranged.content, ranged.startLine, ranged.totalLines);
       let autoPaged = input.limit === undefined && effectiveLimit !== undefined;
+      let toolResultRefAutoPaged = false;
       if (autoPaged) {
         while (isOverTextBudget(text) && ranged.lineCount > 1) {
           const nextLimit = Math.max(1, Math.floor(ranged.lineCount / 2));
@@ -466,13 +468,27 @@ export function createReadFileTool(): PilotDeckToolDefinition<ReadFileInput> {
           text = renderReadableRange(ranged.content, ranged.startLine, ranged.totalLines);
         }
       }
+      if (!autoPaged && isManagedToolResultRefPath(resolved.relativePath)) {
+        while (isOverTextBudget(text) && ranged.lineCount > 1) {
+          const nextLimit = Math.max(1, Math.floor(ranged.lineCount / 2));
+          ranged = await readFileInRange(resolved.absolutePath, offset, nextLimit);
+          text = renderReadableRange(ranged.content, ranged.startLine, ranged.totalLines);
+          toolResultRefAutoPaged = true;
+        }
+      }
       if (isOverTextBudget(text) && input.limit === undefined) {
         autoPaged = true;
+        text = renderOversizedLinePreview(text, resolved.relativePath, ranged.startLine);
+      }
+      if (isOverTextBudget(text) && toolResultRefAutoPaged) {
         text = renderOversizedLinePreview(text, resolved.relativePath, ranged.startLine);
       }
       ensureTokenBudget(text, resolved.relativePath, ranged.startLine);
       if (autoPaged && ranged.truncated) {
         text += renderReadMoreNotice(resolved.relativePath, ranged.endLine + 1, ranged.lineCount);
+      }
+      if (toolResultRefAutoPaged && ranged.truncated) {
+        text += renderToolResultRefReadMoreNotice(resolved.relativePath, ranged.endLine + 1, ranged.lineCount);
       }
       readState.set(dedupKey, {
         mtimeMs: ranged.mtimeMs,
@@ -497,7 +513,7 @@ export function createReadFileTool(): PilotDeckToolDefinition<ReadFileInput> {
           endLine: ranged.endLine,
           totalLines: ranged.totalLines,
           truncated: ranged.truncated,
-          autoPaged,
+          autoPaged: autoPaged || toolResultRefAutoPaged,
           nextOffset: ranged.truncated ? ranged.endLine + 1 : undefined,
         },
         metadata: { truncated: ranged.truncated },
@@ -547,6 +563,17 @@ function renderReadMoreNotice(filePath: string, nextOffset: number, limit: numbe
     + `The file is too large to read in one response, so read_file returned the first ${limit} lines. `
     + `Continue with read_file({ file_path: "${filePath}", offset: ${nextOffset}, limit: ${limit} }) if you need more.`
     + "</system-reminder>";
+}
+
+function renderToolResultRefReadMoreNotice(filePath: string, nextOffset: number, limit: number): string {
+  return "\n<system-reminder>"
+    + `The persisted tool result was too large for the requested range, so read_file returned ${limit} lines. `
+    + `Continue with read_file({ file_path: "${filePath}", offset: ${nextOffset}, limit: ${limit} }) if you need more.`
+    + "</system-reminder>";
+}
+
+function isManagedToolResultRefPath(filePath: string): boolean {
+  return /^\.pilotdeck[\\/]tool-results[\\/]refs[\\/]result-\d+\.(?:txt|json)$/.test(filePath);
 }
 
 function renderOversizedLinePreview(text: string, filePath: string, offset: number): string {

--- a/tests/agent/sub/filterIncompleteToolCalls.spec.ts
+++ b/tests/agent/sub/filterIncompleteToolCalls.spec.ts
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { CanonicalMessage } from "../../../src/model/index.js";
+import { filterIncompleteToolCalls } from "../../../src/agent/sub/filterIncompleteToolCalls.js";
+
+test("filterIncompleteToolCalls tolerates malformed messages without content", () => {
+  const malformed = { role: "assistant" } as unknown as CanonicalMessage;
+  const messages: CanonicalMessage[] = [
+    malformed,
+    { role: "user", content: [{ type: "text", text: "next" }] },
+  ];
+
+  assert.deepEqual(filterIncompleteToolCalls(messages), [
+    { role: "user", content: [{ type: "text", text: "next" }] },
+  ]);
+});

--- a/tests/context/tool-result-reference-error.spec.ts
+++ b/tests/context/tool-result-reference-error.spec.ts
@@ -26,14 +26,14 @@ const model: ModelDefinition = {
   multimodal: { input: ["text"] },
 };
 
-function requestWith(message: CanonicalMessage): CanonicalModelRequest {
+function requestWith(message: CanonicalMessage, toolCallId = "call-large-error"): CanonicalModelRequest {
   return {
     model: "test-model",
     provider: "test-provider",
     messages: [
       {
         role: "assistant",
-        content: [{ type: "tool_call", id: "call-large-error", name: "bash", input: { command: "test" } }],
+        content: [{ type: "tool_call", id: toolCallId, name: "bash", input: { command: "test" } }],
       },
       message,
     ],
@@ -42,10 +42,71 @@ function requestWith(message: CanonicalMessage): CanonicalModelRequest {
   };
 }
 
+test("tool text under token budget remains inline even when over legacy byte threshold", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "pilotdeck-tool-result-inline-token-"));
+  try {
+    const budget = new ToolResultBudget({
+      toolResultsDir: dir,
+      maxResultSizeChars: 80_000,
+      maxResultSizeTokens: 10_000,
+      previewBytes: 12_000,
+    });
+    const body = `search output start\n${"x".repeat(60_000)}\nsearch output tail`;
+    assert.ok(Buffer.byteLength(body, "utf8") > 50_000, "fixture should exceed the old 50KB threshold");
+
+    const applied = await budget.applyToMessage({
+      role: "user",
+      content: [{
+        type: "tool_result",
+        toolCallId: "call-large-but-inline",
+        content: [{ type: "text", text: body }],
+      }],
+    }, { turnId: "turn-1" });
+
+    assert.equal(applied.content[0]?.type, "tool_result");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("tool text over token budget is persisted with expanded read_file preview", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "pilotdeck-tool-result-token-ref-"));
+  try {
+    const budget = new ToolResultBudget({
+      toolResultsDir: dir,
+      maxResultSizeChars: 500_000,
+      maxResultSizeTokens: 10_000,
+      previewBytes: 12_000,
+    });
+    const body = Array.from({ length: 20_000 }, (_, index) => `candidate ${index}: unique evidence token ${index}`).join("\n");
+
+    const applied = await budget.applyToMessage({
+      role: "user",
+      content: [{
+        type: "tool_result",
+        toolCallId: "call-over-token-budget",
+        content: [{ type: "text", text: body }],
+      }],
+    }, { turnId: "turn-1" });
+
+    const ref = applied.content.find((block) => block.type === "tool_result_reference");
+    assert.ok(ref, "expected a persisted tool_result_reference");
+    assert.match(ref.readFilePath ?? "", /refs\/result-0001\.txt$/);
+    assert.ok(Buffer.byteLength(ref.preview, "utf8") > 8_000, "expected a substantially larger preview");
+
+    const openai = buildOpenAIRequest(requestWith({ ...applied, content: [ref] }, "call-over-token-budget"), model);
+    const openaiTool = openai.messages.find((message) => message.role === "tool");
+    assert.match(String(openaiTool?.content), /limit: 100/);
+    assert.match(String(openaiTool?.content), /search candidates/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test("large tool error references preserve error semantics for model replay", async () => {
   const dir = await mkdtemp(join(tmpdir(), "pilotdeck-tool-result-test-"));
   try {
-    const budget = new ToolResultBudget({ toolResultsDir: dir, maxResultSizeChars: 120, previewBytes: 80 });
+    const budget = new ToolResultBudget({ toolResultsDir: dir, maxResultSizeChars: 120, maxResultSizeTokens: 20, previewBytes: 80 });
     const applied = await budget.applyToMessage({
       role: "user",
       content: [{
@@ -83,7 +144,7 @@ test("large tool error references preserve error semantics for model replay", as
 test("multibyte truncated tool result references advertise read_file access", async () => {
   const dir = await mkdtemp(join(tmpdir(), "pilotdeck-tool-result-multibyte-"));
   try {
-    const budget = new ToolResultBudget({ toolResultsDir: dir, maxResultSizeChars: 80, previewBytes: 40 });
+    const budget = new ToolResultBudget({ toolResultsDir: dir, maxResultSizeChars: 80, maxResultSizeTokens: 20, previewBytes: 40 });
     const applied = await budget.applyToMessage({
       role: "user",
       content: [{

--- a/tests/context/tool-result-reference-error.spec.ts
+++ b/tests/context/tool-result-reference-error.spec.ts
@@ -62,7 +62,8 @@ test("large tool error references preserve error semantics for model replay", as
 
     const openai = buildOpenAIRequest(requestWith(applied), model);
     const openaiTool = openai.messages.find((message) => message.role === "tool");
-    assert.match(String(openaiTool?.content), /Truncated: original/);
+    assert.match(String(openaiTool?.content), /Tool result preview only/);
+    assert.match(String(openaiTool?.content), /read_file\(\{ file_path: ".*refs\/result-0001\.txt"/);
 
     const anthropic = buildAnthropicRequest(requestWith(applied), model);
     const anthropicTool = anthropic.messages[1]?.content.find((part: any) => part?.type === "tool_result") as any;
@@ -72,14 +73,14 @@ test("large tool error references preserve error semantics for model replay", as
     const functionResponse = google.contents
       .flatMap((content: any) => content.parts ?? [])
       .find((part: any) => part.functionResponse);
-    assert.match(String(functionResponse?.functionResponse?.response?.error), /Truncated: original/);
+    assert.match(String(functionResponse?.functionResponse?.response?.error), /Tool result preview only/);
     assert.equal(functionResponse?.functionResponse?.response?.output, undefined);
   } finally {
     await rm(dir, { recursive: true, force: true });
   }
 });
 
-test("multibyte truncated tool result references still advertise read_file access", async () => {
+test("multibyte truncated tool result references advertise read_file access", async () => {
   const dir = await mkdtemp(join(tmpdir(), "pilotdeck-tool-result-multibyte-"));
   try {
     const budget = new ToolResultBudget({ toolResultsDir: dir, maxResultSizeChars: 80, previewBytes: 40 });
@@ -99,7 +100,9 @@ test("multibyte truncated tool result references still advertise read_file acces
 
     const openai = buildOpenAIRequest(requestWith({ ...applied, content: [ref] }), model);
     const openaiTool = openai.messages.find((message) => message.role === "tool");
-    assert.match(String(openaiTool?.content), /Use read_file on this path/);
+    assert.match(String(openaiTool?.content), /read_file/);
+    assert.match(String(openaiTool?.content), /refs\/result-0001\.txt/);
+    assert.doesNotMatch(String(openaiTool?.content), /read_tool_result/);
   } finally {
     await rm(dir, { recursive: true, force: true });
   }

--- a/tests/context/tool-result-reference-error.spec.ts
+++ b/tests/context/tool-result-reference-error.spec.ts
@@ -96,7 +96,7 @@ test("tool text over token budget is persisted with expanded grep-first preview"
 
     const openai = buildOpenAIRequest(requestWith({ ...applied, content: [ref] }, "call-over-token-budget"), model);
     const openaiTool = openai.messages.find((message) => message.role === "tool");
-    assert.match(String(openaiTool?.content), /grep\(\{ pattern: "<keyword>", path: ".*refs\/result-0001\.txt"/);
+    assert.match(String(openaiTool?.content), /grep\(\{ pattern: "<keyword>", path: ".*refs\/result-0001\.txt", output_mode: "content", head_limit: 20 \}/);
     assert.match(String(openaiTool?.content), /Avoid paging through the whole file from offset 1/);
     assert.match(String(openaiTool?.content), /search candidates/);
   } finally {
@@ -125,7 +125,7 @@ test("large tool error references preserve error semantics for model replay", as
     const openai = buildOpenAIRequest(requestWith(applied), model);
     const openaiTool = openai.messages.find((message) => message.role === "tool");
     assert.match(String(openaiTool?.content), /Tool result preview only/);
-    assert.match(String(openaiTool?.content), /grep\(\{ pattern: "<keyword>", path: ".*refs\/result-0001\.txt"/);
+    assert.match(String(openaiTool?.content), /grep\(\{ pattern: "<keyword>", path: ".*refs\/result-0001\.txt", output_mode: "content", head_limit: 20 \}/);
     assert.match(String(openaiTool?.content), /read_file\(\{ file_path: ".*refs\/result-0001\.txt"/);
 
     const anthropic = buildAnthropicRequest(requestWith(applied), model);

--- a/tests/context/tool-result-reference-error.spec.ts
+++ b/tests/context/tool-result-reference-error.spec.ts
@@ -69,7 +69,7 @@ test("tool text under token budget remains inline even when over legacy byte thr
   }
 });
 
-test("tool text over token budget is persisted with expanded read_file preview", async () => {
+test("tool text over token budget is persisted with expanded grep-first preview", async () => {
   const dir = await mkdtemp(join(tmpdir(), "pilotdeck-tool-result-token-ref-"));
   try {
     const budget = new ToolResultBudget({
@@ -96,7 +96,8 @@ test("tool text over token budget is persisted with expanded read_file preview",
 
     const openai = buildOpenAIRequest(requestWith({ ...applied, content: [ref] }, "call-over-token-budget"), model);
     const openaiTool = openai.messages.find((message) => message.role === "tool");
-    assert.match(String(openaiTool?.content), /limit: 100/);
+    assert.match(String(openaiTool?.content), /grep\(\{ pattern: "<keyword>", path: ".*refs\/result-0001\.txt"/);
+    assert.match(String(openaiTool?.content), /Avoid paging through the whole file from offset 1/);
     assert.match(String(openaiTool?.content), /search candidates/);
   } finally {
     await rm(dir, { recursive: true, force: true });
@@ -124,6 +125,7 @@ test("large tool error references preserve error semantics for model replay", as
     const openai = buildOpenAIRequest(requestWith(applied), model);
     const openaiTool = openai.messages.find((message) => message.role === "tool");
     assert.match(String(openaiTool?.content), /Tool result preview only/);
+    assert.match(String(openaiTool?.content), /grep\(\{ pattern: "<keyword>", path: ".*refs\/result-0001\.txt"/);
     assert.match(String(openaiTool?.content), /read_file\(\{ file_path: ".*refs\/result-0001\.txt"/);
 
     const anthropic = buildAnthropicRequest(requestWith(applied), model);
@@ -161,6 +163,7 @@ test("multibyte truncated tool result references advertise read_file access", as
 
     const openai = buildOpenAIRequest(requestWith({ ...applied, content: [ref] }), model);
     const openaiTool = openai.messages.find((message) => message.role === "tool");
+    assert.match(String(openaiTool?.content), /grep/);
     assert.match(String(openaiTool?.content), /read_file/);
     assert.match(String(openaiTool?.content), /refs\/result-0001\.txt/);
     assert.doesNotMatch(String(openaiTool?.content), /read_tool_result/);

--- a/tests/model/request/malformedMessages.spec.ts
+++ b/tests/model/request/malformedMessages.spec.ts
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { buildModelRequest, cloneMessages } from "../../../src/model/index.js";
+import type {
+  CanonicalMessage,
+  CanonicalModelRequest,
+  ModelConfig,
+  ModelDefinition,
+  ProviderConfig,
+} from "../../../src/model/index.js";
+import type { ModelCapabilities } from "../../../src/model/index.js";
+
+test("model request builders tolerate malformed messages with missing content", () => {
+  const malformed = { role: "assistant" } as unknown as CanonicalMessage;
+  const request: CanonicalModelRequest = {
+    provider: "local",
+    model: "text",
+    stream: true,
+    messages: [
+      { role: "user", content: [{ type: "text", text: "start" }] },
+      malformed,
+      { role: "user", content: [{ type: "text", text: "continue" }] },
+    ],
+  };
+
+  assert.doesNotThrow(() => buildModelRequest(request, modelConfig()));
+});
+
+test("cloneMessages normalizes malformed messages with missing content", () => {
+  const malformed = { role: "assistant" } as unknown as CanonicalMessage;
+
+  assert.deepEqual(cloneMessages([malformed]), [{ role: "assistant", content: [] }]);
+});
+
+function modelConfig(): ModelConfig {
+  const capabilities: ModelCapabilities = {
+    supportsToolUse: true,
+    supportsStreaming: true,
+    supportsParallelToolCalls: true,
+    supportsThinking: false,
+    supportsJsonSchema: true,
+    supportsSystemPrompt: true,
+    supportsPromptCache: false,
+    maxContextTokens: 128_000,
+    maxOutputTokens: 4_096,
+  };
+  const models: Record<string, ModelDefinition> = {
+    text: {
+      id: "text",
+      capabilities,
+      multimodal: { input: ["text"] },
+    },
+  };
+  const provider: ProviderConfig = {
+    id: "local",
+    protocol: "openai",
+    url: "https://example.invalid/v1",
+    apiKey: "test",
+    headers: {},
+    models,
+  };
+  return { providers: { local: provider } };
+}

--- a/tests/tool/bash-result-display.spec.ts
+++ b/tests/tool/bash-result-display.spec.ts
@@ -94,7 +94,12 @@ test("bash failure tool result includes raw stdout and stderr tail for UI and mo
     assert.match(text, /stderr:/);
     assert.match(text, new RegExp(stderrTail.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
 
-    const budget = new ToolResultBudget({ toolResultsDir: dir, maxResultSizeChars: 50_000, previewBytes: 2_000 });
+    const budget = new ToolResultBudget({
+      toolResultsDir: dir,
+      maxResultSizeChars: 50_000,
+      maxResultSizeTokens: 2_000,
+      previewBytes: 2_000,
+    });
     const applied = await budget.applyToMessage({
       role: "user",
       content: [toCanonicalToolResultBlock(result)],
@@ -138,7 +143,12 @@ test("bash success keeps full output for ToolResultBudget persistence", async ()
     assert.equal(result.metadata?.truncated, undefined);
     assert.ok(result.metadata?.previewLimit, "expected preview limit metadata without truncating canonical content");
 
-    const budget = new ToolResultBudget({ toolResultsDir: dir, maxResultSizeChars: 50_000, previewBytes: 2_000 });
+    const budget = new ToolResultBudget({
+      toolResultsDir: dir,
+      maxResultSizeChars: 50_000,
+      maxResultSizeTokens: 2_000,
+      previewBytes: 2_000,
+    });
     const applied = await budget.applyToMessage({
       role: "user",
       content: [toCanonicalToolResultBlock(result)],

--- a/tests/tool/read-file-large.spec.ts
+++ b/tests/tool/read-file-large.spec.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -62,6 +62,46 @@ test("read_file explicit limit reads a large file range without auto paging", as
     assert.doesNotMatch(text, /^3003\|line-3003/m);
     assert.equal((result.data as { autoPaged?: boolean }).autoPaged, false);
     assert.equal((result.data as { nextOffset?: number }).nextOffset, 3003);
+  } finally {
+    await rm(projectRoot, { recursive: true, force: true });
+  }
+});
+
+test("read_file auto-shrinks oversized persisted tool-result ref ranges", async () => {
+  const projectRoot = await mkdtemp(join(tmpdir(), "pilotdeck-read-ref-autopage-"));
+  try {
+    const refPath = join(projectRoot, ".pilotdeck", "tool-results", "refs", "result-0001.txt");
+    await mkdir(join(projectRoot, ".pilotdeck", "tool-results", "refs"), { recursive: true });
+    await writeFile(refPath, Array.from({ length: 300 }, (_, index) => `line-${index + 1} ${"x".repeat(1200)}`).join("\n"));
+
+    const result = await createReadFileTool().execute({
+      file_path: ".pilotdeck/tool-results/refs/result-0001.txt",
+      offset: 1,
+      limit: 200,
+    }, context(projectRoot));
+    const text = textOf(result);
+
+    assert.match(text, /^1\|line-1/m);
+    assert.match(text, /persisted tool result was too large for the requested range/);
+    assert.match(text, /Continue with read_file\({ file_path: "\.pilotdeck\/tool-results\/refs\/result-0001\.txt", offset: \d+, limit: \d+ }\)/);
+    assert.equal((result.data as { autoPaged?: boolean }).autoPaged, true);
+    assert.ok((result.data as { endLine?: number }).endLine! < 200);
+    assert.ok((result.data as { nextOffset?: number }).nextOffset! > 1);
+    assert.equal(result.metadata?.truncated, true);
+  } finally {
+    await rm(projectRoot, { recursive: true, force: true });
+  }
+});
+
+test("read_file keeps explicit oversized ordinary file ranges strict", async () => {
+  const projectRoot = await mkdtemp(join(tmpdir(), "pilotdeck-read-ordinary-strict-"));
+  try {
+    await writeFile(join(projectRoot, "large.txt"), Array.from({ length: 300 }, (_, index) => `line-${index + 1} ${"x".repeat(1200)}`).join("\n"));
+
+    await assert.rejects(
+      () => createReadFileTool().execute({ file_path: "large.txt", offset: 1, limit: 200 }, context(projectRoot)),
+      /exceeds the text token budget/,
+    );
   } finally {
     await rm(projectRoot, { recursive: true, force: true });
   }

--- a/tests/tool/tool-result-workspace-path.spec.ts
+++ b/tests/tool/tool-result-workspace-path.spec.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { join, relative } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -51,11 +51,46 @@ test("large tool results are persisted under workspace .pilotdeck and readable b
     const ref = message.content.find((block) => block.type === "tool_result_reference");
     assert.ok(ref, "expected a persisted tool_result_reference");
     assert.match(relative(projectRoot, ref.path), /^\.pilotdeck[\/\\]tool-results[\/\\]/);
+    assert.equal(ref.readFilePath, ".pilotdeck/tool-results/refs/result-0001.txt");
+    assert.equal(await readFile(join(projectRoot, ref.readFilePath), "utf8"), `alpha\n${"x".repeat(200)}\nomega`);
 
-    const read = await createReadFileTool().execute({ file_path: ref.path }, context(projectRoot));
+    const read = await createReadFileTool().execute({ file_path: ref.readFilePath, offset: 1, limit: 2 }, context(projectRoot));
     const text = read.content[0]?.type === "text" ? read.content[0].text : "";
     assert.match(text, /alpha/);
-    assert.match(text, /omega/);
+    assert.match(text, /2\|x+/);
+  } finally {
+    await rm(projectRoot, { recursive: true, force: true });
+    await rm(pilotHome, { recursive: true, force: true });
+  }
+});
+
+test("large tool result read_file aliases are short and sequential", async () => {
+  const projectRoot = await mkdtemp(join(tmpdir(), "pilotdeck-readable-tool-result-seq-"));
+  const pilotHome = await mkdtemp(join(tmpdir(), "pilotdeck-home-"));
+  try {
+    const storage = createAgentProjectSessionStorage({
+      projectRoot,
+      pilotHome,
+      sessionId: "web:s_test",
+      now: () => new Date("2026-07-09T00:00:00.000Z"),
+    });
+    const budget = new ToolResultBudget({ toolResultsDir: storage.toolResultsDir, maxResultSizeChars: 16, previewBytes: 8 });
+
+    const first = await budget.applyToMessage({
+      role: "user",
+      content: [{ type: "tool_result", toolCallId: "call-a", content: [{ type: "text", text: "first\n" + "a".repeat(80) }] }],
+    }, { turnId: "turn-1" });
+    const second = await budget.applyToMessage({
+      role: "user",
+      content: [{ type: "tool_result", toolCallId: "call-b", content: [{ type: "text", text: "second\n" + "b".repeat(80) }] }],
+    }, { turnId: "turn-1" });
+
+    const firstRef = first.content.find((block) => block.type === "tool_result_reference");
+    const secondRef = second.content.find((block) => block.type === "tool_result_reference");
+    assert.ok(firstRef);
+    assert.ok(secondRef);
+    assert.equal(firstRef.readFilePath, ".pilotdeck/tool-results/refs/result-0001.txt");
+    assert.equal(secondRef.readFilePath, ".pilotdeck/tool-results/refs/result-0002.txt");
   } finally {
     await rm(projectRoot, { recursive: true, force: true });
     await rm(pilotHome, { recursive: true, force: true });

--- a/tests/tool/tool-result-workspace-path.spec.ts
+++ b/tests/tool/tool-result-workspace-path.spec.ts
@@ -38,7 +38,12 @@ test("large tool results are persisted under workspace .pilotdeck and readable b
     });
     assert.match(relative(projectRoot, storage.toolResultsDir), /^\.pilotdeck[\/\\]tool-results[\/\\]/);
 
-    const budget = new ToolResultBudget({ toolResultsDir: storage.toolResultsDir, maxResultSizeChars: 64, previewBytes: 32 });
+    const budget = new ToolResultBudget({
+      toolResultsDir: storage.toolResultsDir,
+      maxResultSizeChars: 64,
+      maxResultSizeTokens: 20,
+      previewBytes: 32,
+    });
     const message = await budget.applyToMessage({
       role: "user",
       content: [{
@@ -74,7 +79,12 @@ test("large tool result read_file aliases are short and sequential", async () =>
       sessionId: "web:s_test",
       now: () => new Date("2026-07-09T00:00:00.000Z"),
     });
-    const budget = new ToolResultBudget({ toolResultsDir: storage.toolResultsDir, maxResultSizeChars: 16, previewBytes: 8 });
+    const budget = new ToolResultBudget({
+      toolResultsDir: storage.toolResultsDir,
+      maxResultSizeChars: 16,
+      maxResultSizeTokens: 5,
+      previewBytes: 8,
+    });
 
     const first = await budget.applyToMessage({
       role: "user",


### PR DESCRIPTION
## Summary
- Prefer `grep` before `read_file` when a large tool result is persisted as a workspace ref, so agents search long outputs instead of paging from offset 1.
- Keep short `.pilotdeck/tool-results/refs/result-*.txt` aliases and targeted `read_file` guidance for reading match neighborhoods.
- Harden model/subagent request handling for malformed messages with missing `content`.
- Update browser-use skill guidance to try the existing browser cache before reinstalling browser binaries.

## Validation
- `npm run build`
- `node --test --test-force-exit --test-timeout 60000 dist/tests/context/tool-result-reference-error.spec.js dist/tests/tool/tool-result-workspace-path.spec.js dist/tests/tool/read-file-large.spec.js dist/tests/tool/bash-result-display.spec.js`
- `node --test --test-force-exit --test-timeout 60000 dist/tests/model/request/malformedMessages.spec.js dist/tests/agent/sub/filterIncompleteToolCalls.spec.js`

## WCB smoke
- Built temporary image `wildclawbench-pilotdeck:v0.32-grepref-smoke` from this branch.
- Single-task smoke `04_Search_Retrieval_task_3_constraint_search` scored `1.0`.
- Full WCB qwen3.6-flash run completed with corrected avg `0.389990` (`41/60` nonzero); missing task was intentionally rejected by mock-audit guardrail, not a grader timeout.

No benchmark-specific prompt or task/grader/workspace changes are included in this PR.