### PR TITLE
fix(weixin): single-source QR login and non-blocking Settings refresh

### DIFF
--- a/src/adapters/channel/protocol/ChannelRuntimeStatus.ts
+++ b/src/adapters/channel/protocol/ChannelRuntimeStatus.ts
@@ -17,6 +17,7 @@ export type ChannelRuntimeStatus = {
   message?: string;
   accountId?: string;
   error?: string;
+  qrUrl?: string;
 };
 
 export type ChannelRuntimeStatusUpdate = {
@@ -24,6 +25,7 @@ export type ChannelRuntimeStatusUpdate = {
   message?: string;
   accountId?: string;
   error?: string;
+  qrUrl?: string;
 };
 
 export type ChannelRuntimeStatusSnapshot = {
@@ -74,6 +76,7 @@ export function createChannelRuntimeStatusReporter(pilotHome: string): ChannelRu
           ...(update.message ? { message: update.message } : {}),
           ...(update.accountId ? { accountId: update.accountId } : {}),
           ...(update.error ? { error: update.error } : {}),
+          ...(update.qrUrl ? { qrUrl: update.qrUrl } : {}),
         },
       },
     };

--- a/src/adapters/channel/protocol/ChannelRuntimeStatus.ts
+++ b/src/adapters/channel/protocol/ChannelRuntimeStatus.ts
@@ -1,0 +1,84 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import type { GatewayChannelKey } from "../../../gateway/index.js";
+
+export type ChannelRuntimeState =
+  | "starting"
+  | "connected"
+  | "waiting_for_login"
+  | "expired"
+  | "failed"
+  | "stopped";
+
+export type ChannelRuntimeStatus = {
+  channelKey: GatewayChannelKey;
+  state: ChannelRuntimeState;
+  updatedAt: string;
+  message?: string;
+  accountId?: string;
+  error?: string;
+};
+
+export type ChannelRuntimeStatusUpdate = {
+  state: ChannelRuntimeState;
+  message?: string;
+  accountId?: string;
+  error?: string;
+};
+
+export type ChannelRuntimeStatusSnapshot = {
+  updatedAt: string;
+  channels: Record<string, ChannelRuntimeStatus>;
+};
+
+export type ChannelRuntimeStatusReporter = (
+  channelKey: GatewayChannelKey,
+  update: ChannelRuntimeStatusUpdate,
+) => void;
+
+export function channelRuntimeStatusPath(pilotHome: string): string {
+  return join(pilotHome, "channels", "runtime-status.json");
+}
+
+export function readChannelRuntimeStatusSnapshot(pilotHome: string): ChannelRuntimeStatusSnapshot {
+  const path = channelRuntimeStatusPath(pilotHome);
+  if (!existsSync(path)) {
+    return { updatedAt: new Date(0).toISOString(), channels: {} };
+  }
+
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf8")) as Partial<ChannelRuntimeStatusSnapshot>;
+    return {
+      updatedAt: typeof parsed.updatedAt === "string" ? parsed.updatedAt : new Date(0).toISOString(),
+      channels: parsed.channels && typeof parsed.channels === "object" ? parsed.channels : {},
+    };
+  } catch {
+    return { updatedAt: new Date(0).toISOString(), channels: {} };
+  }
+}
+
+export function createChannelRuntimeStatusReporter(pilotHome: string): ChannelRuntimeStatusReporter {
+  const path = channelRuntimeStatusPath(pilotHome);
+
+  return (channelKey, update) => {
+    const now = new Date().toISOString();
+    const snapshot = readChannelRuntimeStatusSnapshot(pilotHome);
+    const next: ChannelRuntimeStatusSnapshot = {
+      updatedAt: now,
+      channels: {
+        ...snapshot.channels,
+        [channelKey]: {
+          channelKey,
+          state: update.state,
+          updatedAt: now,
+          ...(update.message ? { message: update.message } : {}),
+          ...(update.accountId ? { accountId: update.accountId } : {}),
+          ...(update.error ? { error: update.error } : {}),
+        },
+      },
+    };
+
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, `${JSON.stringify(next, null, 2)}\n`, "utf8");
+  };
+}

--- a/src/adapters/channel/protocol/types.ts
+++ b/src/adapters/channel/protocol/types.ts
@@ -1,6 +1,7 @@
 import type { ChannelAttachment, Gateway, GatewayChannelKey } from "../../../gateway/index.js";
 import type { CronResultDelivery } from "../../../cron/index.js";
 import type { PilotConfig } from "../../../pilot/index.js";
+import type { ChannelRuntimeStatusReporter } from "./ChannelRuntimeStatus.js";
 
 export type ChannelLogger = {
   info?(message: string, metadata?: Record<string, unknown>): void;
@@ -12,6 +13,7 @@ export type ChannelStartDeps = {
   gateway: Gateway;
   config?: PilotConfig;
   logger?: ChannelLogger;
+  reportChannelStatus?: ChannelRuntimeStatusReporter;
 };
 
 export type ChannelHandle = {

--- a/src/adapters/channel/weixin/WeixinChannel.ts
+++ b/src/adapters/channel/weixin/WeixinChannel.ts
@@ -133,6 +133,7 @@ export class WeixinChannel implements ChannelAdapter {
   private attachmentStore: ImAttachmentStore;
   private loginRecoveryTimer: ReturnType<typeof setTimeout> | null = null;
   private loginRecoveryPromise: Promise<void> | null = null;
+  private currentLoginQrUrl: string | undefined;
 
   constructor(options: WeixinChannelOptions = {}) {
     this.credentialsPath = options.credentialsPath ?? CREDENTIALS_PATH;
@@ -266,6 +267,7 @@ export class WeixinChannel implements ChannelAdapter {
     }
 
     this.logger?.info?.("weixin: no credentials found, starting QR login...");
+    this.currentLoginQrUrl = undefined;
     this.reportStatus("waiting_for_login", "微信等待扫码登录");
     console.log("\n╔══════════════════════════════════════════════╗");
     console.log("║  微信 iLink 登录 — 请用微信扫描二维码        ║");
@@ -284,6 +286,8 @@ export class WeixinChannel implements ChannelAdapter {
       const result: LoginResult = await this.login({
         onQRCode: (url) => {
           if (this.isStaleGeneration(generation)) return;
+          this.currentLoginQrUrl = url;
+          this.reportStatus("waiting_for_login", "微信等待扫码登录", { qrUrl: url });
           console.log(`[weixin] 扫码登录链接:\n${url}\n`);
         },
         onStatusChange: (status) => {
@@ -296,7 +300,9 @@ export class WeixinChannel implements ChannelAdapter {
           };
           console.log(`[weixin] ${labels[status] ?? status}`);
           if (status === "waiting" || status === "scanned" || status === "refreshing") {
-            this.reportStatus("waiting_for_login", `weixin: ${labels[status] ?? status}`);
+            this.reportStatus("waiting_for_login", `weixin: ${labels[status] ?? status}`, {
+              qrUrl: this.currentLoginQrUrl,
+            });
           }
         },
       });
@@ -308,12 +314,14 @@ export class WeixinChannel implements ChannelAdapter {
         accountId: result.accountId,
       };
       this.saveCredentials(creds);
+      this.currentLoginQrUrl = undefined;
       console.log(`[weixin] 登录成功! accountId: ${result.accountId}\n`);
       this.logger?.info?.(`weixin: login successful, accountId=${result.accountId}`);
       this.startPollingWithCredentials(creds);
     } catch (e) {
       if (this.isStaleGeneration(generation)) return;
       const message = formatWeixinError(e);
+      this.currentLoginQrUrl = undefined;
       this.logger?.error?.(`weixin: QR login failed: ${e}`);
       console.error(`[weixin] 登录失败: ${e}`);
       this.reportStatus("failed", "weixin: QR login failed", { error: message });
@@ -328,7 +336,7 @@ export class WeixinChannel implements ChannelAdapter {
   private reportStatus(
     state: "starting" | "connected" | "waiting_for_login" | "expired" | "failed" | "stopped",
     message: string,
-    details: { accountId?: string; error?: string } = {},
+    details: { accountId?: string; error?: string; qrUrl?: string } = {},
   ): void {
     this.reportChannelStatus?.(this.channelKey, { state, message, ...details });
   }

--- a/src/adapters/channel/weixin/WeixinChannel.ts
+++ b/src/adapters/channel/weixin/WeixinChannel.ts
@@ -7,6 +7,7 @@ import type { ClientOptions, GetUpdatesResp, WeixinMessage, LoginResult } from "
 import type { CronResultDelivery } from "../../../cron/index.js";
 import type { ChannelAttachment, Gateway, GatewayChannelKey, GatewayOutboundAttachment } from "../../../gateway/index.js";
 import type { ChannelAdapter, ChannelHandle, ChannelLogger, ChannelStartDeps } from "../protocol/ChannelAdapter.js";
+import type { ChannelRuntimeStatusReporter } from "../protocol/ChannelRuntimeStatus.js";
 import { executeChannelCommand } from "../protocol/ChannelCommandRegistry.js";
 import {
   formatImAttachmentFallback,
@@ -112,9 +113,12 @@ export class WeixinChannel implements ChannelAdapter {
 
   private gateway?: Gateway;
   private logger?: ChannelLogger;
+  private reportChannelStatus?: ChannelRuntimeStatusReporter;
   private client?: WeixinIlinkClient;
   private loopAbort = new AbortController();
+  private startGeneration = 0;
   private pollPromise: Promise<void> | null = null;
+  private loginPromise: Promise<void> | null = null;
   private activeChats = new Set<string>();
   private activeLiveReplies = new Map<string, ImLiveReplyController<void>>();
   private readonly elicitation = new ImElicitationHelper();
@@ -147,25 +151,31 @@ export class WeixinChannel implements ChannelAdapter {
   async start(deps: ChannelStartDeps): Promise<ChannelHandle> {
     this.gateway = deps.gateway;
     this.logger = deps.logger;
+    this.reportChannelStatus = deps.reportChannelStatus;
+    this.startGeneration++;
     this.loopAbort = new AbortController();
 
-    const creds = await this.ensureLoggedIn();
+    const creds = this.loadCredentials();
     if (creds) {
+      this.logger?.info?.(`weixin: loaded saved credentials (account: ${creds.accountId})`);
       this.startPollingWithCredentials(creds);
     } else {
-      this.startLoginRecoveryWatcher();
+      this.startQrLoginInBackground(this.startGeneration);
     }
 
     return {
       stop: async (reason?: string) => {
         this.logger?.info?.(`weixin: stopping (${reason ?? "no reason"})`);
+        this.startGeneration++;
         this.loopAbort.abort();
         this.clearLoginRecoveryTimer();
         this.saveCursor();
         try { await this.pollPromise; } catch { /* ignore */ }
         try { await this.loginRecoveryPromise; } catch { /* ignore */ }
         this.pollPromise = null;
+        this.loginPromise = null;
         this.loginRecoveryPromise = null;
+        this.reportStatus("stopped", "weixin: stopped");
       },
     };
   }
@@ -188,6 +198,7 @@ export class WeixinChannel implements ChannelAdapter {
     this.loopAbort = new AbortController();
     this.pollPromise = this.pollLoop();
     this.logger?.info?.("weixin: connected, poll loop started");
+    this.reportStatus("connected", "weixin: connected", { accountId: creds.accountId });
   }
 
   private startLoginRecoveryWatcher(): void {
@@ -248,24 +259,35 @@ export class WeixinChannel implements ChannelAdapter {
     this.loginRecoveryTimer = null;
   }
 
-  private async ensureLoggedIn(): Promise<SavedCredentials | null> {
-    const saved = this.loadCredentials();
-    if (saved) {
-      this.logger?.info?.(`weixin: loaded saved credentials (account: ${saved.accountId})`);
-      return saved;
+  private startQrLoginInBackground(generation: number): void {
+    if (this.loginPromise) {
+      this.logger?.warn?.("weixin: QR login already running");
+      return;
     }
 
     this.logger?.info?.("weixin: no credentials found, starting QR login...");
+    this.reportStatus("waiting_for_login", "微信等待扫码登录");
     console.log("\n╔══════════════════════════════════════════════╗");
     console.log("║  微信 iLink 登录 — 请用微信扫描二维码        ║");
     console.log("╚══════════════════════════════════════════════╝\n");
+    console.log("[weixin] 等待扫码登录；PilotDeck Web UI 已可继续使用。\n");
 
+    this.loginPromise = this.runQrLogin(generation).finally(() => {
+      if (this.startGeneration === generation) {
+        this.loginPromise = null;
+      }
+    });
+  }
+
+  private async runQrLogin(generation: number): Promise<void> {
     try {
       const result: LoginResult = await this.login({
         onQRCode: (url) => {
+          if (this.isStaleGeneration(generation)) return;
           console.log(`[weixin] 扫码登录链接:\n${url}\n`);
         },
         onStatusChange: (status) => {
+          if (this.isStaleGeneration(generation)) return;
           const labels: Record<string, string> = {
             waiting: "等待扫码...",
             scanned: "已扫码，等待确认...",
@@ -273,8 +295,12 @@ export class WeixinChannel implements ChannelAdapter {
             refreshing: "刷新中...",
           };
           console.log(`[weixin] ${labels[status] ?? status}`);
+          if (status === "waiting" || status === "scanned" || status === "refreshing") {
+            this.reportStatus("waiting_for_login", `weixin: ${labels[status] ?? status}`);
+          }
         },
       });
+      if (this.isStaleGeneration(generation)) return;
 
       const creds: SavedCredentials = {
         baseUrl: result.baseUrl,
@@ -284,12 +310,27 @@ export class WeixinChannel implements ChannelAdapter {
       this.saveCredentials(creds);
       console.log(`[weixin] 登录成功! accountId: ${result.accountId}\n`);
       this.logger?.info?.(`weixin: login successful, accountId=${result.accountId}`);
-      return creds;
+      this.startPollingWithCredentials(creds);
     } catch (e) {
+      if (this.isStaleGeneration(generation)) return;
+      const message = formatWeixinError(e);
       this.logger?.error?.(`weixin: QR login failed: ${e}`);
       console.error(`[weixin] 登录失败: ${e}`);
-      return null;
+      this.reportStatus("failed", "weixin: QR login failed", { error: message });
+      this.startLoginRecoveryWatcher();
     }
+  }
+
+  private isStaleGeneration(generation: number): boolean {
+    return this.loopAbort.signal.aborted || this.startGeneration !== generation;
+  }
+
+  private reportStatus(
+    state: "starting" | "connected" | "waiting_for_login" | "expired" | "failed" | "stopped",
+    message: string,
+    details: { accountId?: string; error?: string } = {},
+  ): void {
+    this.reportChannelStatus?.(this.channelKey, { state, message, ...details });
   }
 
   private async pollLoop(): Promise<void> {
@@ -302,6 +343,7 @@ export class WeixinChannel implements ChannelAdapter {
           this.logger?.error?.("weixin: session expired (errcode -14), need re-login");
           console.error("[weixin] Session 过期，请删除凭证文件并重启以重新扫码登录:");
           console.error(`[weixin]   rm ${this.credentialsPath}`);
+          this.reportStatus("expired", "微信登录已过期，请重新扫码登录");
           await this.notifyActiveChats(WEIXIN_SESSION_EXPIRED_TEXT);
           break;
         }

--- a/src/cli/pilotdeck.ts
+++ b/src/cli/pilotdeck.ts
@@ -251,6 +251,15 @@ async function main(argv = process.argv.slice(2)): Promise<void> {
 
     let serverRef: Awaited<ReturnType<typeof startPilotDeckServer>> | undefined;
 
+    async function hotStartWeixinChannel(): Promise<void> {
+      if (!serverRef) return;
+      const savedWeixin = await channelStatePersistence.load<WeixinSessionMapperState>("weixin");
+      await serverRef.hotStartChannel(new WeixinChannel({
+        mapper: savedWeixin ? new WeixinSessionMapper(savedWeixin) : undefined,
+        onStateChange: (state) => channelStatePersistence.save("weixin", state),
+      }));
+    }
+
     async function handleAdapterHotReload(config: (typeof snapshot)["config"]): Promise<void> {
       if (!serverRef) return;
       const parts: string[] = [];
@@ -274,11 +283,7 @@ async function main(argv = process.argv.slice(2)): Promise<void> {
 
       const wCfg = config.adapters?.weixin;
       if (wCfg?.enabled === true) {
-        const savedWeixin = await channelStatePersistence.load<WeixinSessionMapperState>("weixin");
-        await serverRef.hotStartChannel(new WeixinChannel({
-          mapper: savedWeixin ? new WeixinSessionMapper(savedWeixin) : undefined,
-          onStateChange: (state) => channelStatePersistence.save("weixin", state),
-        }));
+        await hotStartWeixinChannel();
         parts.push("weixin=started");
       }
 
@@ -381,6 +386,20 @@ async function main(argv = process.argv.slice(2)): Promise<void> {
       config: snapshot.config,
     });
     serverRef = server;
+    (
+      gateway as {
+        setPrepareWeixinLogin?: (
+          handler: () => Promise<{ requested: boolean; requestedAt: string; reason?: "unsupported" }>
+        ) => void;
+      }
+    ).setPrepareWeixinLogin?.(async () => {
+      const requestedAt = new Date().toISOString();
+      if (!serverRef) {
+        return { requested: false, requestedAt, reason: "unsupported" };
+      }
+      await hotStartWeixinChannel();
+      return { requested: true, requestedAt };
+    });
     bindServer(server);
     deferredBroadcast = (name, payload) => server.broadcastNotification(name, payload);
     console.log(`PilotDeck server listening: ${server.url}`);

--- a/src/cli/pilotdeckServer.ts
+++ b/src/cli/pilotdeckServer.ts
@@ -5,7 +5,11 @@ import { WeixinChannel } from "../adapters/index.js";
 import { QQChannel } from "../adapters/index.js";
 import type { Gateway } from "../gateway/index.js";
 import { startGatewayServer, type GatewayServer } from "../gateway/index.js";
-import type { PilotConfig } from "../pilot/index.js";
+import { resolvePilotHome, type PilotConfig } from "../pilot/index.js";
+import {
+  createChannelRuntimeStatusReporter,
+  type ChannelRuntimeStatusReporter,
+} from "../adapters/channel/protocol/ChannelRuntimeStatus.js";
 
 export type StartPilotDeckServerOptions = {
   gateway: Gateway;
@@ -42,12 +46,26 @@ export async function startPilotDeckServer(options: StartPilotDeckServerOptions)
     warn: (msg: string) => console.warn(msg),
     error: (msg: string) => console.error(msg),
   };
-  const baseDeps = { gateway: options.gateway, config: options.config, logger: consoleLogger };
+  const reportChannelStatus = createSafeChannelStatusReporter(
+    createChannelRuntimeStatusReporter(resolvePilotHome(process.env)),
+    consoleLogger,
+  );
+  const baseDeps = {
+    gateway: options.gateway,
+    config: options.config,
+    logger: consoleLogger,
+    reportChannelStatus,
+  };
 
   const runningHandles = new Map<string, ChannelHandle>();
   const runningChannels = new Map<string, ChannelAdapter>();
+  const channelStarts = new Map<string, Promise<void>>();
 
   async function startAndTrack(ch: ChannelAdapter): Promise<void> {
+    reportChannelStatus(ch.channelKey, {
+      state: "starting",
+      message: `${ch.channelKey}: starting in background`,
+    });
     const existing = runningHandles.get(ch.channelKey);
     if (existing) {
       await existing.stop("hot-reload").catch(() => {});
@@ -57,20 +75,6 @@ export async function startPilotDeckServer(options: StartPilotDeckServerOptions)
     const handle = await ch.start(baseDeps);
     runningHandles.set(ch.channelKey, handle);
     runningChannels.set(ch.channelKey, ch);
-  }
-
-  if (options.feishu) await startAndTrack(options.feishu);
-  if (options.weixin) await startAndTrack(options.weixin);
-  if (options.qq) await startAndTrack(options.qq);
-
-  if (options.channels?.length) {
-    await Promise.all(
-      options.channels.map((ch) =>
-        startAndTrack(ch).catch((e) => {
-          console.error(`[adapters] channel ${ch.channelKey} start failed: ${e}`);
-        }),
-      ),
-    );
   }
 
   const gwServer = await startGatewayServer({
@@ -83,9 +87,41 @@ export async function startPilotDeckServer(options: StartPilotDeckServerOptions)
       : undefined,
   });
 
+  function startChannelInBackground(channel: ChannelAdapter): Promise<void> {
+    const start = startAndTrack(channel)
+      .then(() => {
+        consoleLogger.info(`[adapters] channel ${channel.channelKey} startup task completed`);
+      })
+      .catch((e: unknown) => {
+        const message = e instanceof Error ? e.message : String(e);
+        consoleLogger.error(`[adapters] channel ${channel.channelKey} start failed: ${message}`);
+        reportChannelStatus(channel.channelKey, {
+          state: "failed",
+          message: `${channel.channelKey}: startup failed`,
+          error: message,
+        });
+      })
+      .finally(() => {
+        channelStarts.delete(channel.channelKey);
+      });
+    channelStarts.set(channel.channelKey, start);
+    return start;
+  }
+
+  const startupChannels = [
+    ...(options.feishu ? [options.feishu] : []),
+    ...(options.weixin ? [options.weixin] : []),
+    ...(options.qq ? [options.qq] : []),
+    ...(options.channels ?? []),
+  ];
+  for (const channel of startupChannels) {
+    void startChannelInBackground(channel);
+  }
+
   return Object.assign(gwServer, {
-    async hotStartChannel(channel: ChannelAdapter) {
-      await startAndTrack(channel);
+    hotStartChannel(channel: ChannelAdapter) {
+      void startChannelInBackground(channel);
+      return Promise.resolve();
     },
     async deliverCronResult(delivery: CronResultDelivery) {
       const channel = runningChannels.get(delivery.originChannelKey ?? delivery.channelKey);
@@ -93,4 +129,21 @@ export async function startPilotDeckServer(options: StartPilotDeckServerOptions)
       return channel.deliverCronResult(delivery);
     },
   });
+}
+
+function createSafeChannelStatusReporter(
+  reporter: ChannelRuntimeStatusReporter,
+  logger: { warn(message: string): void },
+): ChannelRuntimeStatusReporter {
+  return (channelKey, update) => {
+    try {
+      reporter(channelKey, update);
+    } catch (error) {
+      logger.warn(
+        `[adapters] failed to write runtime status for ${channelKey}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+  };
 }

--- a/src/gateway/client/InProcessGateway.ts
+++ b/src/gateway/client/InProcessGateway.ts
@@ -32,6 +32,7 @@ import type {
   ListSessionsInput,
   ListSessionsResult,
   NewSessionInput,
+  PrepareWeixinLoginResult,
   AlwaysOnApplyInput,
   AlwaysOnApplyResult,
   AlwaysOnRerunPlanInput,
@@ -114,6 +115,7 @@ export type InProcessGatewayOptions = {
    * the PilotConfigStore + ProjectRuntimeRegistry lifecycle.
    */
   reloadConfig?: () => Promise<ReloadConfigResult>;
+  prepareWeixinLogin?: () => Promise<PrepareWeixinLoginResult>;
   /**
    * Pluggable extension/MCP reload handler wired by `createLocalGateway`.
    * Unlike `reloadConfig`, this does not depend on `pilotdeck.yaml` changing.
@@ -749,6 +751,17 @@ export class InProcessGateway implements Gateway {
     return this.options.reloadConfig();
   }
 
+  async prepareWeixinLogin(): Promise<PrepareWeixinLoginResult> {
+    if (!this.options.prepareWeixinLogin) {
+      return {
+        requested: false,
+        requestedAt: new Date().toISOString(),
+        reason: "unsupported",
+      };
+    }
+    return this.options.prepareWeixinLogin();
+  }
+
   async reloadExtensions(input?: import("../protocol/types.js").ReloadExtensionsInput): Promise<import("../protocol/types.js").ReloadExtensionsResult> {
     if (!this.options.reloadExtensions) {
       return { reloaded: false, reason: "unsupported" };
@@ -766,6 +779,10 @@ export class InProcessGateway implements Gateway {
 
   setAlwaysOnRerunPlan(handler: InProcessGatewayOptions["alwaysOnRerunPlan"]): void {
     (this.options as { alwaysOnRerunPlan?: InProcessGatewayOptions["alwaysOnRerunPlan"] }).alwaysOnRerunPlan = handler;
+  }
+
+  setPrepareWeixinLogin(handler: InProcessGatewayOptions["prepareWeixinLogin"]): void {
+    (this.options as { prepareWeixinLogin?: InProcessGatewayOptions["prepareWeixinLogin"] }).prepareWeixinLogin = handler;
   }
 
   // -------------------------------------------------------------------

--- a/src/gateway/client/RemoteGateway.ts
+++ b/src/gateway/client/RemoteGateway.ts
@@ -12,6 +12,7 @@ import type {
   ListSessionsInput,
   ListSessionsResult,
   NewSessionInput,
+  PrepareWeixinLoginResult,
   ReloadConfigResult,
   ReloadExtensionsInput,
   ReloadExtensionsResult,
@@ -155,6 +156,10 @@ export class RemoteGateway implements Gateway {
 
   async reloadConfig(): Promise<ReloadConfigResult> {
     return parseReloadConfigResult(await this.client.request("reload_config", {}));
+  }
+
+  async prepareWeixinLogin(): Promise<PrepareWeixinLoginResult> {
+    return (await this.client.request("prepare_weixin_login", {})) as PrepareWeixinLoginResult;
   }
 
   async reloadExtensions(input: ReloadExtensionsInput = {}): Promise<ReloadExtensionsResult> {

--- a/src/gateway/index.ts
+++ b/src/gateway/index.ts
@@ -42,6 +42,7 @@ export type {
   ListSessionsInput,
   ListSessionsResult,
   NewSessionInput,
+  PrepareWeixinLoginResult,
   ReloadConfigResult,
   TurnUsage,
 } from "./protocol/index.js";

--- a/src/gateway/protocol/frames.ts
+++ b/src/gateway/protocol/frames.ts
@@ -41,6 +41,7 @@ export type WsGatewayMethod =
   | "list_projects"
   | "describe_project"
   | "reload_config"
+  | "prepare_weixin_login"
   | "reload_extensions"
   | "skill_list"
   | "skill_read"

--- a/src/gateway/protocol/index.ts
+++ b/src/gateway/protocol/index.ts
@@ -16,6 +16,7 @@ export type {
   ListSessionsInput,
   ListSessionsResult,
   NewSessionInput,
+  PrepareWeixinLoginResult,
   ReloadConfigResult,
   TurnUsage,
 } from "./types.js";

--- a/src/gateway/protocol/types.ts
+++ b/src/gateway/protocol/types.ts
@@ -330,6 +330,12 @@ export type ReloadConfigResult = {
   reason?: "unsupported" | "unchanged";
 };
 
+export type PrepareWeixinLoginResult = {
+  requested: boolean;
+  requestedAt: string;
+  reason?: "unsupported";
+};
+
 export type ReloadExtensionsInput = {
   projectKey?: string;
   changedPaths?: string[];
@@ -429,6 +435,13 @@ export interface Gateway {
    * capability) may leave it undefined.
    */
   reloadConfig?(): Promise<ReloadConfigResult>;
+
+  /**
+   * Ask the gateway host to start or restart the Weixin channel so it can
+   * generate a runtime QR code. The host owns channel construction; UI/server
+   * callers must not invoke `weixin-ilink.loginWithQR()` directly.
+   */
+  prepareWeixinLogin?(): Promise<PrepareWeixinLoginResult>;
 
   /**
    * Trigger a plugin/skill/MCP extension reload without waiting for the file

--- a/src/gateway/server/GatewayWsConnection.ts
+++ b/src/gateway/server/GatewayWsConnection.ts
@@ -226,6 +226,15 @@ export class GatewayWsConnection {
           return this.options.gateway.reloadConfig();
         }
         return Promise.resolve({ reloaded: false, reason: "unsupported" });
+      case "prepare_weixin_login":
+        if (this.options.gateway.prepareWeixinLogin) {
+          return this.options.gateway.prepareWeixinLogin();
+        }
+        return Promise.resolve({
+          requested: false,
+          requestedAt: new Date().toISOString(),
+          reason: "unsupported",
+        });
       case "reload_extensions":
         if (this.options.gateway.reloadExtensions) {
           return this.options.gateway.reloadExtensions(frame.params as never);

--- a/tests/gateway/background-channel-start.spec.ts
+++ b/tests/gateway/background-channel-start.spec.ts
@@ -1,0 +1,41 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { startPilotDeckServer } from "../../src/cli/pilotdeckServer.js";
+import type { ChannelAdapter } from "../../src/adapters/index.js";
+import type { Gateway } from "../../src/gateway/index.js";
+
+test("startPilotDeckServer listens before a background channel finishes starting", async (t) => {
+  const pilotHome = await mkdtemp(join(tmpdir(), "pilotdeck-channel-start-"));
+  const previousPilotHome = process.env.PILOT_HOME;
+  process.env.PILOT_HOME = pilotHome;
+  t.after(async () => {
+    if (previousPilotHome === undefined) {
+      delete process.env.PILOT_HOME;
+    } else {
+      process.env.PILOT_HOME = previousPilotHome;
+    }
+    await rm(pilotHome, { recursive: true, force: true });
+  });
+
+  const stuckChannel: ChannelAdapter = {
+    channelKey: "test",
+    start: async () => new Promise(() => undefined),
+  };
+
+  const server = await startPilotDeckServer({
+    gateway: {} as Gateway,
+    port: 0,
+    channels: [stuckChannel],
+  });
+  t.after(async () => {
+    await server.close();
+  });
+
+  const response = await fetch(`${server.url}/health`);
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), { ok: true });
+});

--- a/tests/gateway/weixin-nonblocking-login.spec.ts
+++ b/tests/gateway/weixin-nonblocking-login.spec.ts
@@ -21,7 +21,10 @@ test("WeixinChannel.start returns while QR login is waiting", async (t) => {
   const updates: Array<{ channelKey: GatewayChannelKey; update: ChannelRuntimeStatusUpdate }> = [];
   const channel = new WeixinChannel({
     credentialsPath: join(tempDir, "weixin-credentials.json"),
-    loginWithQR: async () => new Promise(() => undefined),
+    loginWithQR: async ({ onQRCode }) => {
+      onQRCode?.("https://wechat.example/qr");
+      return new Promise(() => undefined);
+    },
   });
 
   const handle = await Promise.race([
@@ -38,6 +41,13 @@ test("WeixinChannel.start returns while QR login is waiting", async (t) => {
       entry.channelKey === "weixin" && entry.update.state === "waiting_for_login"
     ),
   );
+  assert.ok(
+    updates.some((entry) =>
+      entry.channelKey === "weixin"
+      && entry.update.state === "waiting_for_login"
+      && entry.update.qrUrl === "https://wechat.example/qr"
+    ),
+  );
 
   await (handle as Awaited<ReturnType<WeixinChannel["start"]>>).stop("test");
 });
@@ -52,10 +62,12 @@ test("channel runtime status reporter persists the latest channel state", async 
   report("weixin", {
     state: "waiting_for_login",
     message: "微信等待扫码登录",
+    qrUrl: "https://wechat.example/qr",
   });
 
   const snapshot = readChannelRuntimeStatusSnapshot(pilotHome);
   assert.equal(snapshot.channels.weixin.channelKey, "weixin");
   assert.equal(snapshot.channels.weixin.state, "waiting_for_login");
   assert.equal(snapshot.channels.weixin.message, "微信等待扫码登录");
+  assert.equal(snapshot.channels.weixin.qrUrl, "https://wechat.example/qr");
 });

--- a/tests/gateway/weixin-nonblocking-login.spec.ts
+++ b/tests/gateway/weixin-nonblocking-login.spec.ts
@@ -1,0 +1,61 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { WeixinChannel } from "../../src/adapters/index.js";
+import {
+  createChannelRuntimeStatusReporter,
+  readChannelRuntimeStatusSnapshot,
+  type ChannelRuntimeStatusUpdate,
+} from "../../src/adapters/channel/protocol/ChannelRuntimeStatus.js";
+import type { Gateway, GatewayChannelKey } from "../../src/gateway/index.js";
+
+test("WeixinChannel.start returns while QR login is waiting", async (t) => {
+  const tempDir = await mkdtemp(join(tmpdir(), "pilotdeck-weixin-start-"));
+  t.after(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  const updates: Array<{ channelKey: GatewayChannelKey; update: ChannelRuntimeStatusUpdate }> = [];
+  const channel = new WeixinChannel({
+    credentialsPath: join(tempDir, "weixin-credentials.json"),
+    loginWithQR: async () => new Promise(() => undefined),
+  });
+
+  const handle = await Promise.race([
+    channel.start({
+      gateway: {} as Gateway,
+      reportChannelStatus: (channelKey, update) => updates.push({ channelKey, update }),
+    }),
+    new Promise<"timeout">((resolve) => setTimeout(() => resolve("timeout"), 100)),
+  ]);
+
+  assert.notEqual(handle, "timeout");
+  assert.ok(
+    updates.some((entry) =>
+      entry.channelKey === "weixin" && entry.update.state === "waiting_for_login"
+    ),
+  );
+
+  await (handle as Awaited<ReturnType<WeixinChannel["start"]>>).stop("test");
+});
+
+test("channel runtime status reporter persists the latest channel state", async (t) => {
+  const pilotHome = await mkdtemp(join(tmpdir(), "pilotdeck-channel-status-"));
+  t.after(async () => {
+    await rm(pilotHome, { recursive: true, force: true });
+  });
+
+  const report = createChannelRuntimeStatusReporter(pilotHome);
+  report("weixin", {
+    state: "waiting_for_login",
+    message: "微信等待扫码登录",
+  });
+
+  const snapshot = readChannelRuntimeStatusSnapshot(pilotHome);
+  assert.equal(snapshot.channels.weixin.channelKey, "weixin");
+  assert.equal(snapshot.channels.weixin.state, "waiting_for_login");
+  assert.equal(snapshot.channels.weixin.message, "微信等待扫码登录");
+});

--- a/tests/gateway/weixin-settings-runtime-flow.spec.ts
+++ b/tests/gateway/weixin-settings-runtime-flow.spec.ts
@@ -1,0 +1,76 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+test("UI weixin QR route only reads runtime status", () => {
+  const source = readFileSync(join(process.cwd(), "ui/server/routes/gateway.js"), "utf8");
+  const routeStart = source.indexOf("router.get('/weixin/qr'");
+  const routeEnd = source.indexOf("router.post('/weixin/disable'");
+
+  assert.ok(routeStart >= 0, "expected /weixin/qr route to exist");
+  assert.ok(routeEnd > routeStart, "expected weixin route section to be bounded");
+
+  const weixinRouteSection = source.slice(routeStart, routeEnd);
+  assert.doesNotMatch(weixinRouteSection, /loginWithQR/);
+  assert.doesNotMatch(weixinRouteSection, /weixin-ilink/);
+  assert.doesNotMatch(weixinRouteSection, /_weixinLogin/);
+  assert.match(weixinRouteSection, /runtime\?\.state === 'waiting_for_login' && runtime\.qrUrl/);
+});
+
+test("UI weixin QR begin route delegates to gateway prepare RPC", () => {
+  const source = readFileSync(join(process.cwd(), "ui/server/routes/gateway.js"), "utf8");
+  const routeStart = source.indexOf("router.post('/weixin/qr-begin'");
+  const routeEnd = source.indexOf("router.get('/weixin/qr'");
+
+  assert.ok(routeStart >= 0, "expected /weixin/qr-begin route to exist");
+  assert.ok(routeEnd > routeStart, "expected begin route to be before read-only QR route");
+
+  const beginRouteSection = source.slice(routeStart, routeEnd);
+  assert.match(beginRouteSection, /config\.adapters\.weixin = \{ \.\.\.previous, enabled: true \}/);
+  assert.match(beginRouteSection, /gw\.prepareWeixinLogin/);
+  assert.match(beginRouteSection, /requestedAt/);
+  assert.doesNotMatch(beginRouteSection, /loginWithQR/);
+  assert.doesNotMatch(beginRouteSection, /weixin-ilink/);
+  assert.doesNotMatch(beginRouteSection, /_weixinLogin/);
+});
+
+test("Gateway settings keeps existing status rendered during silent refresh", () => {
+  const source = readFileSync(
+    join(process.cwd(), "ui/src/components/settings/view/tabs/GatewaySettingsTab.tsx"),
+    "utf8",
+  );
+
+  assert.match(source, /if \(loading && !status\)/);
+  assert.doesNotMatch(source, /if \(loading \|\| !status\)/);
+  assert.match(source, /void fetch_\(\{ showLoading: true \}\)/);
+  assert.match(source, /setInterval\(\(\) => \{\s*void fetch_\(\);/s);
+});
+
+test("Gateway settings starts weixin QR by begin route and ignores stale runtime errors", () => {
+  const source = readFileSync(
+    join(process.cwd(), "ui/src/components/settings/view/tabs/GatewaySettingsTab.tsx"),
+    "utf8",
+  );
+
+  assert.match(source, /authenticatedFetch\('\/api\/gateway\/weixin\/qr-begin', \{ method: 'POST' \}\)/);
+  assert.doesNotMatch(source, /authenticatedFetch\('\/api\/gateway\/weixin\/qr'\)/);
+  assert.match(source, /requestedAtRef/);
+  assert.match(source, /isWeixinRuntimeCurrent/);
+  assert.match(source, /WEIXIN_QR_PREPARE_TIMEOUT_MS/);
+});
+
+test("Gateway protocol exposes prepare_weixin_login RPC", () => {
+  const frames = readFileSync(join(process.cwd(), "src/gateway/protocol/frames.ts"), "utf8");
+  const wsConnection = readFileSync(join(process.cwd(), "src/gateway/server/GatewayWsConnection.ts"), "utf8");
+  const remoteGateway = readFileSync(join(process.cwd(), "src/gateway/client/RemoteGateway.ts"), "utf8");
+  const inProcessGateway = readFileSync(join(process.cwd(), "src/gateway/client/InProcessGateway.ts"), "utf8");
+  const pilotdeck = readFileSync(join(process.cwd(), "src/cli/pilotdeck.ts"), "utf8");
+
+  assert.match(frames, /"prepare_weixin_login"/);
+  assert.match(wsConnection, /case "prepare_weixin_login"/);
+  assert.match(remoteGateway, /request\("prepare_weixin_login", \{\}\)/);
+  assert.match(inProcessGateway, /prepareWeixinLogin/);
+  assert.match(pilotdeck, /setPrepareWeixinLogin/);
+  assert.match(pilotdeck, /hotStartWeixinChannel/);
+});

--- a/ui/server/routes/gateway.js
+++ b/ui/server/routes/gateway.js
@@ -57,6 +57,16 @@ function loadChannelRuntimeStatus() {
   }
 }
 
+function loadWeixinCredentials() {
+  try {
+    if (!existsSync(WEIXIN_CREDS)) return null;
+    const raw = JSON.parse(readFileSync(WEIXIN_CREDS, 'utf-8'));
+    return raw.accountId ? { accountId: raw.accountId } : null;
+  } catch {
+    return null;
+  }
+}
+
 function saveYaml(config) {
   mkdirSync(dirname(PILOTDECK_YAML), { recursive: true });
   suppressNextWatchEvent();
@@ -134,15 +144,7 @@ router.get('/status', (_req, res) => {
     const runtimeStatus = loadChannelRuntimeStatus();
     const weixinRuntime = runtimeStatus.weixin ?? null;
 
-    let weixinCredentials = null;
-    try {
-      if (existsSync(WEIXIN_CREDS)) {
-        const raw = JSON.parse(readFileSync(WEIXIN_CREDS, 'utf-8'));
-        if (raw.accountId) {
-          weixinCredentials = { accountId: raw.accountId };
-        }
-      }
-    } catch { /* ignore */ }
+    const weixinCredentials = loadWeixinCredentials();
 
     res.json({
       feishu: {
@@ -397,85 +399,76 @@ router.post('/feishu/disable', async (_req, res) => {
 
 // ─── Weixin ──────────────────────────────────────────────────────────────────
 
-router.get('/weixin/qr', async (_req, res) => {
+router.post('/weixin/qr-begin', async (_req, res) => {
+  const requestedAt = new Date().toISOString();
   try {
-    const { loginWithQR } = await import('weixin-ilink');
+    const config = loadYaml();
+    if (!config.adapters) config.adapters = {};
+    const previous = config.adapters.weixin ?? {};
+    if (previous.enabled !== true) {
+      config.adapters.weixin = { ...previous, enabled: true };
+      saveYaml(config);
+      const record = readPilotDeckConfigFile();
+      await reloadPilotDeckConfig(record.config);
+    }
 
-    let qrUrl = null;
-    let resolved = false;
-
-    const loginPromise = loginWithQR({
-      onQRCode: (url) => {
-        qrUrl = url;
-        if (!resolved) {
-          resolved = true;
-          res.json({ ok: true, qrUrl: url });
-        }
-      },
-      onStatusChange: () => {},
-    });
-
-    // Store the login promise so /weixin/qr-poll can check it
-    _req.app.locals._weixinLoginPromise = loginPromise;
-    _req.app.locals._weixinLoginResolved = false;
-
-    loginPromise
-      .then((result) => {
-        _req.app.locals._weixinLoginResult = {
-          ok: true,
-          accountId: result.accountId,
-          baseUrl: result.baseUrl,
-          botToken: result.botToken,
-        };
-        _req.app.locals._weixinLoginResolved = true;
-
-        // Auto-save credentials
-        mkdirSync(PILOT_HOME, { recursive: true });
-        writeFileSync(WEIXIN_CREDS, JSON.stringify({
-          baseUrl: result.baseUrl,
-          botToken: result.botToken,
-          accountId: result.accountId,
-        }, null, 2), 'utf-8');
-
-        // Enable in config
-        const config = loadYaml();
-        if (!config.adapters) config.adapters = {};
-        config.adapters.weixin = { enabled: true };
-        saveYaml(config);
-      })
-      .catch((err) => {
-        _req.app.locals._weixinLoginResult = {
-          ok: false,
-          error: err.message || String(err),
-        };
-        _req.app.locals._weixinLoginResolved = true;
+    const gw = await getPilotDeckGateway();
+    if (!gw?.prepareWeixinLogin) {
+      return res.json({
+        ok: false,
+        requestedAt,
+        error: '当前 gateway 不支持准备微信扫码登录，请重启 PilotDeck 后重试',
       });
+    }
 
-    // Fallback: if QR URL wasn't ready in 15s
-    setTimeout(() => {
-      if (!resolved) {
-        resolved = true;
-        res.json({ ok: false, error: '获取二维码超时' });
-      }
-    }, 15_000);
+    const result = await gw.prepareWeixinLogin();
+    if (!result?.requested) {
+      return res.json({
+        ok: false,
+        requestedAt: result?.requestedAt || requestedAt,
+        error: '微信后台通道无法启动，请确认 PilotDeck gateway 正在运行',
+      });
+    }
+
+    res.json({ ok: true, requestedAt: result.requestedAt || requestedAt });
   } catch (error) {
-    res.json({ ok: false, error: error.message || 'weixin-ilink 模块加载失败' });
+    res.json({ ok: false, requestedAt, error: error.message || '请求微信后台通道准备二维码失败' });
+  }
+});
+
+router.get('/weixin/qr', (_req, res) => {
+  try {
+    const runtime = loadChannelRuntimeStatus().weixin;
+    if (runtime?.state === 'waiting_for_login' && runtime.qrUrl) {
+      return res.json({ ok: true, qrUrl: runtime.qrUrl, runtime });
+    }
+    return res.json({
+      ok: false,
+      error: '微信通道尚未生成二维码，请稍后刷新或重启通道',
+      runtime: runtime ?? null,
+    });
+  } catch (error) {
+    res.json({ ok: false, error: error.message || '读取微信通道运行时状态失败' });
   }
 });
 
 router.get('/weixin/qr-poll', (_req, res) => {
-  const resolved = _req.app.locals._weixinLoginResolved;
-  const result = _req.app.locals._weixinLoginResult;
+  const runtime = loadChannelRuntimeStatus().weixin;
+  const credentials = loadWeixinCredentials();
 
-  if (resolved && result) {
-    // Clear state
-    _req.app.locals._weixinLoginPromise = null;
-    _req.app.locals._weixinLoginResult = null;
-    _req.app.locals._weixinLoginResolved = false;
-    return res.json(result);
+  if (credentials || runtime?.state === 'connected') {
+    return res.json({ ok: true, accountId: credentials?.accountId ?? runtime?.accountId ?? null });
   }
 
-  res.json({ pending: true });
+  if (runtime?.state === 'failed' || runtime?.state === 'expired' || runtime?.state === 'stopped') {
+    return res.json({
+      ok: false,
+      error: runtime.error || runtime.message || '微信登录未完成',
+      runtime,
+    });
+  }
+
+  res.json({ pending: true, qrUrl: runtime?.qrUrl ?? null, runtime: runtime ?? null });
 });
 
 router.post('/weixin/disable', async (_req, res) => {

--- a/ui/server/routes/gateway.js
+++ b/ui/server/routes/gateway.js
@@ -13,6 +13,7 @@ const router = express.Router();
 const PILOT_HOME = process.env.PILOT_HOME || join(homedir(), '.pilotdeck');
 const PILOTDECK_YAML = process.env.PILOTDECK_CONFIG_PATH || join(PILOT_HOME, 'pilotdeck.yaml');
 const WEIXIN_CREDS = join(PILOT_HOME, 'weixin-credentials.json');
+const CHANNEL_RUNTIME_STATUS = join(PILOT_HOME, 'channels', 'runtime-status.json');
 
 const FEISHU_TOKEN_URL = 'https://open.feishu.cn/open-apis/auth/v3/tenant_access_token/internal';
 const LARK_TOKEN_URL = 'https://open.larksuite.com/open-apis/auth/v3/tenant_access_token/internal';
@@ -44,6 +45,16 @@ function loadYaml() {
     if (!existsSync(PILOTDECK_YAML)) return {};
     return parseYaml(readFileSync(PILOTDECK_YAML, 'utf-8')) ?? {};
   } catch { return {}; }
+}
+
+function loadChannelRuntimeStatus() {
+  try {
+    if (!existsSync(CHANNEL_RUNTIME_STATUS)) return {};
+    const parsed = JSON.parse(readFileSync(CHANNEL_RUNTIME_STATUS, 'utf-8'));
+    return parsed?.channels && typeof parsed.channels === 'object' ? parsed.channels : {};
+  } catch {
+    return {};
+  }
 }
 
 function saveYaml(config) {
@@ -120,6 +131,8 @@ router.get('/status', (_req, res) => {
     const wecom = config.adapters?.wecom ?? {};
     const wecomExtra = wecom.extra ?? {};
     const weixinEnabled = config.adapters?.weixin?.enabled === true;
+    const runtimeStatus = loadChannelRuntimeStatus();
+    const weixinRuntime = runtimeStatus.weixin ?? null;
 
     let weixinCredentials = null;
     try {
@@ -143,6 +156,7 @@ router.get('/status', (_req, res) => {
         enabled: weixinEnabled,
         hasCredentials: !!weixinCredentials,
         accountId: weixinCredentials?.accountId || null,
+        runtime: weixinRuntime,
       },
       wecom: {
         enabled: wecom.enabled === true,

--- a/ui/src/components/settings/view/tabs/GatewaySettingsTab.tsx
+++ b/ui/src/components/settings/view/tabs/GatewaySettingsTab.tsx
@@ -34,6 +34,7 @@ type GatewayStatus = {
       message?: string;
       accountId?: string;
       error?: string;
+      qrUrl?: string;
       updatedAt?: string;
     } | null;
   };
@@ -51,25 +52,29 @@ type GatewayStatus = {
 
 type TestResult = { ok: boolean; message?: string; error?: string } | null;
 type WeComAccessPolicy = 'open' | 'allowlist' | 'disabled';
+type FetchGatewayStatusOptions = { showLoading?: boolean };
+type RefreshGatewayStatus = (options?: FetchGatewayStatusOptions) => Promise<GatewayStatus | null>;
 
 function useGatewayStatus() {
   const [status, setStatus] = useState<GatewayStatus | null>(null);
   const [loading, setLoading] = useState(true);
 
-  const fetch_ = useCallback(async () => {
-    setLoading(true);
+  const fetch_ = useCallback<RefreshGatewayStatus>(async ({ showLoading = false } = {}) => {
+    if (showLoading) setLoading(true);
     try {
       const res = await authenticatedFetch('/api/gateway/status');
       const data = await res.json();
       setStatus(data);
+      return data;
     } catch {
-      setStatus(null);
+      if (showLoading) setStatus(null);
+      return null;
     } finally {
-      setLoading(false);
+      if (showLoading) setLoading(false);
     }
   }, []);
 
-  useEffect(() => { void fetch_(); }, [fetch_]);
+  useEffect(() => { void fetch_({ showLoading: true }); }, [fetch_]);
 
   useEffect(() => {
     const state = status?.weixin?.runtime?.state;
@@ -441,12 +446,38 @@ function FeishuSection({ status, onSaved }: { status: GatewayStatus['feishu']; o
 
 // ─── Weixin Section ──────────────────────────────────────────────────────────
 
-function WeixinSection({ status, onSaved }: { status: GatewayStatus['weixin']; onSaved: () => void }) {
+const WEIXIN_QR_PREPARE_TIMEOUT_MS = 30_000;
+
+function isWeixinRuntimeCurrent(
+  runtime: GatewayStatus['weixin']['runtime'] | undefined | null,
+  requestedAt: string | null,
+): boolean {
+  if (!requestedAt) return true;
+  if (!runtime?.updatedAt) return false;
+  const runtimeUpdatedAt = Date.parse(runtime.updatedAt);
+  const requestStartedAt = Date.parse(requestedAt);
+  return Number.isFinite(runtimeUpdatedAt)
+    && Number.isFinite(requestStartedAt)
+    && runtimeUpdatedAt >= requestStartedAt;
+}
+
+function readWeixinRuntimeQr(
+  status: GatewayStatus['weixin'] | undefined | null,
+  requestedAt: string | null = null,
+): string | null {
+  if (!status?.enabled || status.runtime?.state !== 'waiting_for_login') return null;
+  if (!isWeixinRuntimeCurrent(status.runtime, requestedAt)) return null;
+  return status.runtime.qrUrl ?? null;
+}
+
+function WeixinSection({ status, refreshStatus }: { status: GatewayStatus['weixin']; refreshStatus: RefreshGatewayStatus }) {
   const { t } = useTranslation('settings');
   const [phase, setPhase] = useState<'idle' | 'loading-qr' | 'scanning' | 'success' | 'error'>('idle');
   const [qrUrl, setQrUrl] = useState<string | null>(null);
   const [error, setError] = useState('');
   const pollRef = useRef<number | null>(null);
+  const prepareTimeoutRef = useRef<number | null>(null);
+  const requestedAtRef = useRef<string | null>(null);
   const runtimeState = status.enabled ? status.runtime?.state : undefined;
   const runtimeLabel =
     runtimeState === 'waiting_for_login'
@@ -471,46 +502,128 @@ function WeixinSection({ status, onSaved }: { status: GatewayStatus['weixin']; o
           ? 'green'
           : 'muted';
 
-  useEffect(() => {
-    return () => {
-      if (pollRef.current) clearInterval(pollRef.current);
-    };
+  const clearPoll = useCallback(() => {
+    if (pollRef.current) {
+      clearInterval(pollRef.current);
+      pollRef.current = null;
+    }
   }, []);
+
+  const clearPrepareTimeout = useCallback(() => {
+    if (prepareTimeoutRef.current) {
+      clearTimeout(prepareTimeoutRef.current);
+      prepareTimeoutRef.current = null;
+    }
+  }, []);
+
+  const clearLoginTimers = useCallback(() => {
+    clearPoll();
+    clearPrepareTimeout();
+  }, [clearPoll, clearPrepareTimeout]);
+
+  const beginStatusPoll = useCallback(() => {
+    clearLoginTimers();
+    pollRef.current = window.setInterval(async () => {
+      const latest = await refreshStatus();
+      const next = latest?.weixin;
+      if (!next) return;
+
+      const nextRuntimeState = next.enabled ? next.runtime?.state : undefined;
+      const requestStartedAt = requestedAtRef.current;
+      const nextQrUrl = readWeixinRuntimeQr(next, requestStartedAt);
+      if (nextQrUrl) {
+        clearPrepareTimeout();
+        setQrUrl(nextQrUrl);
+        setPhase('scanning');
+      }
+
+      if (next.hasCredentials || nextRuntimeState === 'connected') {
+        clearLoginTimers();
+        setPhase('success');
+        return;
+      }
+
+      if (
+        (nextRuntimeState === 'failed' || nextRuntimeState === 'expired' || nextRuntimeState === 'stopped')
+        && isWeixinRuntimeCurrent(next.runtime, requestStartedAt)
+      ) {
+        clearLoginTimers();
+        setError(next.runtime?.error || next.runtime?.message || t('gateway.weixin.noRuntimeQr'));
+        setPhase('error');
+      }
+    }, 2000);
+  }, [clearLoginTimers, clearPrepareTimeout, refreshStatus, t]);
+
+  const showQrAndPoll = useCallback((url: string) => {
+    clearPrepareTimeout();
+    setQrUrl(url);
+    setPhase('scanning');
+    beginStatusPoll();
+  }, [beginStatusPoll, clearPrepareTimeout]);
+
+  useEffect(() => clearLoginTimers, [clearLoginTimers]);
+
+  useEffect(() => {
+    if (phase !== 'loading-qr' && phase !== 'scanning') return;
+
+    const requestStartedAt = requestedAtRef.current;
+    const nextQrUrl = readWeixinRuntimeQr(status, requestStartedAt);
+    if (nextQrUrl && nextQrUrl !== qrUrl) {
+      clearPrepareTimeout();
+      setQrUrl(nextQrUrl);
+      setPhase('scanning');
+    }
+
+    if (status.hasCredentials || runtimeState === 'connected') {
+      clearLoginTimers();
+      setPhase('success');
+      return;
+    }
+
+    if (
+      (runtimeState === 'failed' || runtimeState === 'expired' || runtimeState === 'stopped')
+      && isWeixinRuntimeCurrent(status.runtime, requestStartedAt)
+    ) {
+      clearLoginTimers();
+      setError(status.runtime?.error || status.runtime?.message || t('gateway.weixin.noRuntimeQr'));
+      setPhase('error');
+    }
+  }, [clearLoginTimers, clearPrepareTimeout, phase, qrUrl, runtimeState, status, t]);
 
   const startQRLogin = async () => {
     setPhase('loading-qr');
     setError('');
     setQrUrl(null);
+    requestedAtRef.current = null;
+    clearLoginTimers();
     try {
-      const res = await authenticatedFetch('/api/gateway/weixin/qr');
+      const currentQrUrl = readWeixinRuntimeQr(status);
+      if (currentQrUrl) {
+        showQrAndPoll(currentQrUrl);
+        return;
+      }
+
+      const refreshed = await refreshStatus();
+      const refreshedQrUrl = readWeixinRuntimeQr(refreshed?.weixin);
+      if (refreshedQrUrl) {
+        showQrAndPoll(refreshedQrUrl);
+        return;
+      }
+
+      const res = await authenticatedFetch('/api/gateway/weixin/qr-begin', { method: 'POST' });
       const data = await res.json();
       if (!data.ok) {
         setPhase('error');
-        setError(data.error || 'Failed to get QR code');
+        setError(data.error || t('gateway.weixin.qrPreparing'));
         return;
       }
-      setQrUrl(data.qrUrl);
-      setPhase('scanning');
-
-      // Start polling for login result
-      pollRef.current = window.setInterval(async () => {
-        try {
-          const pollRes = await authenticatedFetch('/api/gateway/weixin/qr-poll');
-          const pollData = await pollRes.json();
-          if (pollData.pending) return;
-          if (pollRef.current) clearInterval(pollRef.current);
-          pollRef.current = null;
-          if (pollData.ok) {
-            setPhase('success');
-            onSaved();
-          } else {
-            setPhase('error');
-            setError(pollData.error || 'Login failed');
-          }
-        } catch {
-          // Network error, keep polling
-        }
-      }, 2000);
+      requestedAtRef.current = data.requestedAt || new Date().toISOString();
+      beginStatusPoll();
+      prepareTimeoutRef.current = window.setTimeout(() => {
+        clearPoll();
+        setError(t('gateway.weixin.qrPreparing'));
+        setPhase('error');
+      }, WEIXIN_QR_PREPARE_TIMEOUT_MS);
     } catch (err: any) {
       setPhase('error');
       setError(err.message);
@@ -519,8 +632,9 @@ function WeixinSection({ status, onSaved }: { status: GatewayStatus['weixin']; o
 
   const handleDisable = async () => {
     try {
+      clearLoginTimers();
       await authenticatedFetch('/api/gateway/weixin/disable', { method: 'POST' });
-      onSaved();
+      void refreshStatus();
     } catch { /* ignore */ }
   };
 
@@ -605,7 +719,8 @@ function WeixinSection({ status, onSaved }: { status: GatewayStatus['weixin']; o
                   variant="ghost"
                   size="sm"
                   onClick={() => {
-                    if (pollRef.current) { clearInterval(pollRef.current); pollRef.current = null; }
+                    clearLoginTimers();
+                    requestedAtRef.current = null;
                     setPhase('idle');
                   }}
                 >
@@ -1012,10 +1127,18 @@ export default function GatewaySettingsTab() {
   const { t } = useTranslation('settings');
   const { status, loading, refresh } = useGatewayStatus();
 
-  if (loading || !status) {
+  if (loading && !status) {
     return (
       <div className="flex items-center justify-center py-16">
         <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (!status) {
+    return (
+      <div className="flex items-center justify-center py-16 text-xs text-muted-foreground">
+        {t('gateway.loadFailed')}
       </div>
     );
   }
@@ -1026,7 +1149,7 @@ export default function GatewaySettingsTab() {
         {t('gateway.description')}
       </p>
       <FeishuSection status={status.feishu} onSaved={refresh} />
-      <WeixinSection status={status.weixin} onSaved={refresh} />
+      <WeixinSection status={status.weixin} refreshStatus={refresh} />
       <WeComSection status={status.wecom} onSaved={refresh} />
     </div>
   );

--- a/ui/src/components/settings/view/tabs/GatewaySettingsTab.tsx
+++ b/ui/src/components/settings/view/tabs/GatewaySettingsTab.tsx
@@ -29,6 +29,13 @@ type GatewayStatus = {
     enabled: boolean;
     hasCredentials: boolean;
     accountId: string | null;
+    runtime?: {
+      state: 'starting' | 'connected' | 'waiting_for_login' | 'expired' | 'failed' | 'stopped';
+      message?: string;
+      accountId?: string;
+      error?: string;
+      updatedAt?: string;
+    } | null;
   };
   wecom: {
     enabled: boolean;
@@ -63,6 +70,15 @@ function useGatewayStatus() {
   }, []);
 
   useEffect(() => { void fetch_(); }, [fetch_]);
+
+  useEffect(() => {
+    const state = status?.weixin?.runtime?.state;
+    if (state !== 'starting' && state !== 'waiting_for_login') return undefined;
+    const timer = window.setInterval(() => {
+      void fetch_();
+    }, 3000);
+    return () => window.clearInterval(timer);
+  }, [fetch_, status?.weixin?.runtime?.state]);
 
   return { status, loading, refresh: fetch_ };
 }
@@ -431,6 +447,29 @@ function WeixinSection({ status, onSaved }: { status: GatewayStatus['weixin']; o
   const [qrUrl, setQrUrl] = useState<string | null>(null);
   const [error, setError] = useState('');
   const pollRef = useRef<number | null>(null);
+  const runtimeState = status.enabled ? status.runtime?.state : undefined;
+  const runtimeLabel =
+    runtimeState === 'waiting_for_login'
+      ? t('gateway.weixin.waitingForLogin')
+      : runtimeState === 'starting'
+        ? t('gateway.weixin.starting')
+        : runtimeState === 'expired'
+          ? t('gateway.weixin.expired')
+          : runtimeState === 'failed'
+            ? t('gateway.weixin.failed')
+            : null;
+  const statusText = runtimeLabel
+    ?? (status.enabled && status.hasCredentials
+      ? `${t('gateway.connected')}${status.accountId ? ` · ${status.accountId}` : ''}`
+      : t('gateway.notConfigured'));
+  const badgeTone =
+    runtimeState === 'waiting_for_login' || runtimeState === 'starting'
+      ? 'amber'
+      : runtimeState === 'expired' || runtimeState === 'failed'
+        ? 'red'
+        : status.enabled
+          ? 'green'
+          : 'muted';
 
   useEffect(() => {
     return () => {
@@ -496,17 +535,31 @@ function WeixinSection({ status, onSaved }: { status: GatewayStatus['weixin']; o
               <div>
                 <div className="text-[13px] font-medium text-foreground">{t('gateway.weixin.label')}</div>
                 <div className="text-xs text-muted-foreground">
-                  {status.enabled && status.hasCredentials
-                    ? `${t('gateway.connected')}${status.accountId ? ` · ${status.accountId}` : ''}`
-                    : t('gateway.notConfigured')}
+                  {statusText}
                 </div>
               </div>
             </div>
             <div className="flex items-center gap-2">
               {status.enabled && (
-                <span className="inline-flex items-center gap-1 rounded-full bg-green-500/10 px-2 py-0.5 text-[11px] font-medium text-green-600 dark:text-green-400">
-                  <span className="h-1.5 w-1.5 rounded-full bg-green-500" />
-                  {t('gateway.enabled')}
+                <span
+                  className={cn(
+                    'inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-medium',
+                    badgeTone === 'amber' && 'bg-amber-500/10 text-amber-700 dark:text-amber-400',
+                    badgeTone === 'red' && 'bg-red-500/10 text-red-700 dark:text-red-400',
+                    badgeTone === 'green' && 'bg-green-500/10 text-green-600 dark:text-green-400',
+                    badgeTone === 'muted' && 'bg-muted text-muted-foreground',
+                  )}
+                >
+                  <span
+                    className={cn(
+                      'h-1.5 w-1.5 rounded-full',
+                      badgeTone === 'amber' && 'bg-amber-500',
+                      badgeTone === 'red' && 'bg-red-500',
+                      badgeTone === 'green' && 'bg-green-500',
+                      badgeTone === 'muted' && 'bg-muted-foreground',
+                    )}
+                  />
+                  {runtimeLabel ?? t('gateway.enabled')}
                 </span>
               )}
             </div>

--- a/ui/src/i18n/locales/en/settings.json
+++ b/ui/src/i18n/locales/en/settings.json
@@ -1153,6 +1153,7 @@
     "connected": "Connected",
     "notConfigured": "Not configured",
     "enabled": "Enabled",
+    "loadFailed": "Unable to load IM channel status. Try again later.",
     "edit": "Edit",
     "setup": "Set Up",
     "testConnection": "Test Connection",
@@ -1187,7 +1188,9 @@
       "waitingForLogin": "WeChat waiting for QR login",
       "starting": "WeChat channel is starting",
       "expired": "WeChat login expired; scan again",
-      "failed": "WeChat channel failed to start"
+      "failed": "WeChat channel failed to start",
+      "qrPreparing": "The WeChat background channel is preparing a QR code. Try again shortly.",
+      "noRuntimeQr": "No QR code is available. Make sure the WeChat channel is enabled and waiting for login."
     },
     "wecom": {
       "title": "Enterprise WeChat / WeCom",

--- a/ui/src/i18n/locales/en/settings.json
+++ b/ui/src/i18n/locales/en/settings.json
@@ -1183,7 +1183,11 @@
       "relogin": "Re-login",
       "loadingQr": "Generating QR code…",
       "scanPrompt": "Open WeChat and scan the QR code to log in",
-      "loginSuccess": "Login successful — credentials saved"
+      "loginSuccess": "Login successful — credentials saved",
+      "waitingForLogin": "WeChat waiting for QR login",
+      "starting": "WeChat channel is starting",
+      "expired": "WeChat login expired; scan again",
+      "failed": "WeChat channel failed to start"
     },
     "wecom": {
       "title": "Enterprise WeChat / WeCom",

--- a/ui/src/i18n/locales/zh-CN/settings.json
+++ b/ui/src/i18n/locales/zh-CN/settings.json
@@ -1147,6 +1147,7 @@
     "connected": "已连接",
     "notConfigured": "未配置",
     "enabled": "已启用",
+    "loadFailed": "无法加载 IM 通道状态，请稍后重试",
     "edit": "编辑",
     "setup": "配置",
     "testConnection": "测试连接",
@@ -1181,7 +1182,9 @@
       "waitingForLogin": "微信等待扫码登录",
       "starting": "微信通道正在启动",
       "expired": "微信登录已过期，请重新扫码",
-      "failed": "微信通道启动失败"
+      "failed": "微信通道启动失败",
+      "qrPreparing": "微信后台通道正在准备二维码，请稍后再试",
+      "noRuntimeQr": "当前没有可用二维码，请确认微信通道已启用并正在等待登录"
     },
     "wecom": {
       "title": "企业微信 WeCom",

--- a/ui/src/i18n/locales/zh-CN/settings.json
+++ b/ui/src/i18n/locales/zh-CN/settings.json
@@ -1177,7 +1177,11 @@
       "relogin": "重新登录",
       "loadingQr": "正在生成二维码…",
       "scanPrompt": "请打开微信扫描二维码登录",
-      "loginSuccess": "登录成功 — 凭据已保存"
+      "loginSuccess": "登录成功 — 凭据已保存",
+      "waitingForLogin": "微信等待扫码登录",
+      "starting": "微信通道正在启动",
+      "expired": "微信登录已过期，请重新扫码",
+      "failed": "微信通道启动失败"
     },
     "wecom": {
       "title": "企业微信 WeCom",


### PR DESCRIPTION
## Summary

- Make `WeixinChannel` the single source of QR login — the UI server no longer calls `weixin-ilink.loginWithQR()` directly, eliminating the dual-login race condition.
- Add `prepare_weixin_login` gateway RPC so the Settings page can trigger a backend channel start/restart without importing `weixin-ilink`.
- Fix Settings auto-refresh unmounting the QR code: `useGatewayStatus` now does silent refresh (no full-page loading spinner) once initial data is loaded.
- Write `qrUrl` into `runtime-status.json` from `WeixinChannel.onQRCode`, so the UI reads the QR code from runtime state instead of maintaining its own login task.
- Use `requestedAt` timestamp to ignore stale `failed/expired` runtime errors from previous attempts.

## Test plan

- [x] `npm test` — 58 tests pass (includes new regression tests for begin route, runtime QR persistence, stale error filtering, and protocol RPC exposure)
- [x] `npm --workspace ui run build` — succeeds
- [ ] Manual: start PilotDeck with `adapters.weixin.enabled: false`, click WeChat QR login in Settings → should show "preparing" then display QR code
- [ ] Manual: with an old `failed` runtime state, click QR login again → should restart the channel, not show the stale error
- [ ] Manual: QR code stays visible during 3-second auto-refresh cycles (no unmount/remount)


Made with [Cursor](https://cursor.com)