### PR TITLE
fix: expand plugin MCP placeholders consistently

### DIFF
--- a/src/mcp/runtime/parsePluginMcpServers.ts
+++ b/src/mcp/runtime/parsePluginMcpServers.ts
@@ -38,11 +38,12 @@ export function parsePluginMcpServers(
       continue;
     }
     const v = value as Record<string, unknown>;
-    if (typeof v.command === "string" && v.command.length > 0) {
+    const command = typeof v.command === "string" ? expandMcpString(v.command) : undefined;
+    if (command && command.length > 0) {
       servers.push({
         id,
         transport: "stdio",
-        command: v.command,
+        command,
         args: Array.isArray(v.args)
           ? (v.args.filter((a): a is string => typeof a === "string").map(expandMcpString))
           : undefined,
@@ -52,7 +53,11 @@ export function parsePluginMcpServers(
       });
       continue;
     }
-    const url = typeof v.url === "string" ? v.url : typeof v.httpUrl === "string" ? v.httpUrl : undefined;
+    const url = typeof v.url === "string"
+      ? expandMcpString(v.url)
+      : typeof v.httpUrl === "string"
+        ? expandMcpString(v.httpUrl)
+        : undefined;
     if (url) {
       servers.push({
         id,

--- a/tests/mcp/expand-placeholders.spec.ts
+++ b/tests/mcp/expand-placeholders.spec.ts
@@ -80,6 +80,37 @@ test("parsePluginMcpServers expands ${env:*} in stdio env", () => {
   }
 });
 
+test("parsePluginMcpServers expands ${env:*} in stdio command before transport detection", () => {
+  process.env.PILOTDECK_TEST_COMMAND = "node";
+  try {
+    const { servers, diagnostics } = parsePluginMcpServers({
+      myServer: {
+        command: "${env:PILOTDECK_TEST_COMMAND}",
+      },
+    });
+    assert.equal(diagnostics.length, 0);
+    assert.equal(servers.length, 1);
+    const s = servers[0]!;
+    assert.equal(s.transport, "stdio");
+    if (s.transport === "stdio") {
+      assert.equal(s.command, "node");
+    }
+  } finally {
+    delete process.env.PILOTDECK_TEST_COMMAND;
+  }
+});
+
+test("parsePluginMcpServers drops empty expanded stdio command", () => {
+  delete process.env.__PILOTDECK_NONEXISTENT_COMMAND__;
+  const { servers, diagnostics } = parsePluginMcpServers({
+    myServer: {
+      command: "${env:__PILOTDECK_NONEXISTENT_COMMAND__}",
+    },
+  });
+  assert.equal(servers.length, 0);
+  assert.equal(diagnostics[0]?.message, "no recognized transport (need command or url)");
+});
+
 test("parsePluginMcpServers expands ${userHome} in stdio cwd", () => {
   const { servers } = parsePluginMcpServers({
     myServer: {


### PR DESCRIPTION
Follow-up for OpenBMB/PilotDeck#404.

This branch includes the placeholder expansion work from #404 plus an additional fix for remaining parity gaps:

- expands stdio `command` before transport detection, so `${env:MCP_COMMAND}` and `${userHome}/bin/server` work like user/project `mcp.json`
- expands streamable HTTP `url` before transport detection

Validation:

- `npm run build`
- `node --test --test-force-exit --test-timeout 60000 dist/tests/mcp/expand-placeholders.spec.js`
