### PR TITLE
fix: improve session title generation and display

### DIFF
--- a/src/agent/turn/TurnRunner.ts
+++ b/src/agent/turn/TurnRunner.ts
@@ -60,9 +60,13 @@ type PendingSessionTitle = {
   cleanup: () => void;
   completed: boolean;
   title: string | null;
+  /** Settles when the title generation finishes (success, failure, or timeout). */
+  promise: Promise<void>;
 };
 
 export class TurnRunner {
+  private pendingSessionTitle: PendingSessionTitle | undefined;
+
   constructor(
     private readonly loop: AgentLoop,
     private readonly transcript: AgentTranscriptWriter,
@@ -275,14 +279,17 @@ export class TurnRunner {
     }
     const metadataStore = this.turnDependencies.metadataStore;
     const generateTitle = this.turnDependencies.sessionTitleGenerator;
-    if (!metadataStore || !generateTitle || options.messages.length > 0) {
+    if (!metadataStore || !generateTitle) {
       return undefined;
     }
     const snapshot = metadataStore.getSnapshot();
     if (snapshot.title || snapshot.aiTitle) {
       return undefined;
     }
-    const text = firstHumanText(acceptedMessages);
+    if (this.pendingSessionTitle && !this.pendingSessionTitle.completed) {
+      return this.pendingSessionTitle;
+    }
+    const text = allHumanText([...options.messages, ...acceptedMessages]);
     if (!text) {
       return undefined;
     }
@@ -294,21 +301,28 @@ export class TurnRunner {
       cleanup,
       completed: false,
       title: null,
-    };
-    void generateTitle({
-      text,
-      sessionId: options.sessionId,
-      turnId: options.turnId,
-      signal: controller.signal,
-    })
-      .then((title) => {
-        pending.title = title;
+      promise: generateTitle({
+        text,
+        sessionId: options.sessionId,
+        turnId: options.turnId,
+        signal: controller.signal,
       })
-      .catch(() => {})
-      .finally(() => {
-        pending.completed = true;
-        cleanup();
-      });
+        .then(async (title) => {
+          pending.title = title;
+          if (title) {
+            const snap = metadataStore.getSnapshot();
+            if (!snap.title && !snap.aiTitle) {
+              await metadataStore.saveAiTitle(title, options.turnId);
+            }
+          }
+        })
+        .catch(() => {})
+        .finally(() => {
+          pending.completed = true;
+          cleanup();
+        }),
+    };
+    this.pendingSessionTitle = pending;
     return pending;
   }
 
@@ -320,9 +334,9 @@ export class TurnRunner {
       return;
     }
     if (!pending.completed) {
-      pending.controller.abort("turn_completed");
-      pending.cleanup();
-      return;
+      // The title generation has its own timeout (SESSION_TITLE_TIMEOUT_MS).
+      // Wait for it to settle instead of discarding immediately.
+      await pending.promise;
     }
     if (!pending.title) {
       return;
@@ -374,7 +388,8 @@ function inputToPromptText(input: AgentInput): string {
     .join("\n");
 }
 
-function firstHumanText(messages: CanonicalMessage[]): string | null {
+function allHumanText(messages: CanonicalMessage[]): string | null {
+  const parts: string[] = [];
   for (const message of messages) {
     if (message.role !== "user" || message.metadata?.synthetic) {
       continue;
@@ -385,10 +400,10 @@ function firstHumanText(messages: CanonicalMessage[]): string | null {
       .join("\n")
       .trim();
     if (text) {
-      return text;
+      parts.push(text);
     }
   }
-  return null;
+  return parts.length > 0 ? parts.join("\n") : null;
 }
 
 function linkAbortSignal(

--- a/src/session/title/SessionTitleGenerator.ts
+++ b/src/session/title/SessionTitleGenerator.ts
@@ -3,7 +3,7 @@ import type { PilotAgentModelSelection } from "../../pilot/config/types.js";
 
 export const SESSION_TITLE_MAX_INPUT_CHARS = 1200;
 export const SESSION_TITLE_MAX_OUTPUT_CHARS = 80;
-export const SESSION_TITLE_TIMEOUT_MS = 15_000;
+export const SESSION_TITLE_TIMEOUT_MS = 30_000;
 
 const SESSION_TITLE_SYSTEM_PROMPT = `Generate a concise, sentence-case title (3-7 words) that captures the main topic or goal of this coding session. The title should be clear enough that the user recognizes the session in a list. Use sentence case: capitalize only the first word and proper nouns.
 
@@ -61,7 +61,7 @@ export function createSessionTitleGenerator(
               content: [{ type: "text", text: prompt }],
             },
           ],
-          maxOutputTokens: 1000,
+          maxOutputTokens: 4096,
           temperature: 0,
           metadata: {
             purpose: "session_title_generation",

--- a/ui/src/hooks/useProjectsState.ts
+++ b/ui/src/hooks/useProjectsState.ts
@@ -437,6 +437,29 @@ export function useProjectsState({
     setProjects((prevProjects) => applyProjectsSocketUpdate(prevProjects, updatedProjects));
 
     if (skipSelectedReplacement) {
+      // Still sync display-only fields (title, summary) so the header
+      // title updates immediately when aiTitle is written, without
+      // triggering a full chat reload.
+      if (selectedProject && selectedSession) {
+        const updatedProject = updatedProjects.find(
+          (p) => p.name === selectedProject.name,
+        );
+        const updatedSession = updatedProject
+          ? getProjectSessions(updatedProject).find((s) => s.id === selectedSession.id)
+          : undefined;
+        if (updatedSession) {
+          const displayKeys: Array<keyof ProjectSession> = ['title', 'summary', 'name'];
+          const patch: Partial<ProjectSession> = {};
+          for (const key of displayKeys) {
+            if (updatedSession[key] !== undefined && updatedSession[key] !== selectedSession[key]) {
+              (patch as Record<string, unknown>)[key] = updatedSession[key];
+            }
+          }
+          if (Object.keys(patch).length > 0) {
+            setSelectedSession({ ...selectedSession, ...patch });
+          }
+        }
+      }
       return;
     }
 


### PR DESCRIPTION
## Summary

- **Fix title loss on fast turns**: When the agent loop finished before the title LLM call, the title was permanently discarded. Now `flushReadySessionTitle` awaits the pending promise (bounded by 30s timeout) instead of aborting immediately.
- **Eager title write**: Title is written to transcript as soon as the LLM returns, so the UI can update before the agent loop finishes.
- **Retry on subsequent messages**: Removed the first-message-only restriction. If no `aiTitle` exists, any turn will trigger title generation using all user messages as context.
- **Prevent duplicate LLM calls**: Added instance-level `pendingSessionTitle` to reuse in-flight requests across turns.
- **Increased timeout and output budget**: `SESSION_TITLE_TIMEOUT_MS` 15s -> 30s, `maxOutputTokens` 1000 -> 4096, to accommodate thinking models.
- **Header title sync during streaming**: Patch display-only fields (`title`, `summary`, `name`) onto `selectedSession` even when full replacement is skipped, so the header title updates immediately.

## Test plan

- [ ] Start a new session, send a message, verify sidebar title updates to AI-generated title within seconds
- [ ] Verify header title updates at the same time as sidebar (no delay until turn ends)
- [ ] Send a second message in a session that failed to generate a title on the first attempt; verify title generation retries
- [ ] Send messages rapidly; verify no duplicate title generation LLM calls
- [ ] Resume a session that already has an `aiTitle`; verify no title generation is triggered

Made with [Cursor](https://cursor.com)