### PR TITLE
feat(ui): split cron into dedicated module

### DIFF
--- a/ui/server/index.js
+++ b/ui/server/index.js
@@ -584,6 +584,43 @@ app.get('/api/always-on/cron-jobs', authenticateToken, async (_req, res) => {
     }
 });
 
+app.post('/api/always-on/cron-jobs', authenticateToken, async (req, res) => {
+    try {
+        const message = typeof req.body?.message === 'string' ? req.body.message.trim() : '';
+        const projectKey = typeof req.body?.projectKey === 'string' ? req.body.projectKey : '';
+        const schedule = req.body?.schedule;
+        const timezone = typeof req.body?.timezone === 'string' && req.body.timezone.trim()
+            ? req.body.timezone.trim()
+            : undefined;
+
+        if (!message) {
+            res.status(400).json({ error: 'Cron message is required.' });
+            return;
+        }
+        if (!projectKey) {
+            res.status(400).json({ error: 'Cron projectKey is required.' });
+            return;
+        }
+        if (!schedule || typeof schedule !== 'object') {
+            res.status(400).json({ error: 'Cron schedule is required.' });
+            return;
+        }
+
+        const gateway = await getPilotDeckGateway();
+        const result = await gateway.cronCreate({
+            message,
+            projectKey,
+            schedule,
+            timezone,
+            channelKey: 'web',
+        });
+        res.json(result);
+    } catch (error) {
+        console.error('[always-on-cron-create] failed:', error);
+        res.status(500).json({ error: error?.message || 'cron create failed' });
+    }
+});
+
 app.post('/api/always-on/cron-jobs/:taskId/run-now', authenticateToken, async (req, res) => {
     try {
         const gateway = await getPilotDeckGateway();

--- a/ui/server/projects.js
+++ b/ui/server/projects.js
@@ -516,6 +516,7 @@ async function getProjectCronJobsOverview(projectName) {
                 cron: isCron ? task.schedule.expression : '',
                 prompt: task.message || '',
                 createdAt: task.createdAt,
+                nextRunAt: task.nextRunAt,
                 recurring: isCron,
                 permanent: isCron,
                 manualOnly: false,

--- a/ui/src/components/app-shell/MainAreaV2.tsx
+++ b/ui/src/components/app-shell/MainAreaV2.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import {
   BarChart3,
   Bot,
+  Clock,
   Database,
   Folder,
   PanelLeftOpen,
@@ -40,6 +41,7 @@ const TABS: Tab[] = [
   { id: 'dashboard', labelKey: 'tabs.dashboard', icon: BarChart3 },
   { id: 'memory',    labelKey: 'tabs.memory',    icon: Database },
   { id: 'always-on', labelKey: 'tabs.alwaysOn',  icon: Radio },
+  { id: 'cron',      labelKey: 'tabs.cron',      icon: Clock },
 ];
 
 const ALWAYS_ON_EVENT_BADGE_POLL_INTERVAL_MS = 15_000;

--- a/ui/src/components/main-content-v2/AlwaysOnV2.tsx
+++ b/ui/src/components/main-content-v2/AlwaysOnV2.tsx
@@ -17,7 +17,7 @@ type PlanDetailTarget = {
 
 const SUB_TABS: { id: AlwaysOnSubTab; labelKey: string; defaultLabel: string; icon: typeof BarChart3 }[] = [
   { id: 'dashboard', labelKey: 'tabs.dashboard', defaultLabel: 'Dashboard', icon: BarChart3 },
-  { id: 'plans-cron', labelKey: 'tabs.plansCron', defaultLabel: 'Plans & Cron Jobs', icon: ListChecks },
+  { id: 'plans', labelKey: 'tabs.plans', defaultLabel: 'Plans', icon: ListChecks },
 ];
 
 type AlwaysOnV2Props = {
@@ -88,7 +88,7 @@ export default function AlwaysOnV2({
             projectDisplayName={planDetail.projectDisplayName}
             runId={planDetail.sourceRunId}
             projectKey={planDetail.projectKey}
-            backLabel={t('dashboard.runDetail.backToPlans', { defaultValue: 'Back to Plans & Cron Jobs' })}
+            backLabel={t('dashboard.runDetail.backToPlans', { defaultValue: 'Back to Plans' })}
             onBack={() => setPlanDetail(null)}
             onOpenExecutionSession={onOpenExecutionSession}
           />

--- a/ui/src/components/main-content-v2/CronV2.test.tsx
+++ b/ui/src/components/main-content-v2/CronV2.test.tsx
@@ -1,0 +1,241 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { CronJobOverview, Project } from '../../types/app';
+import CronV2 from './CronV2';
+
+const apiMock = vi.hoisted(() => ({
+  projects: vi.fn(),
+  allCronJobs: vi.fn(),
+  cronCreate: vi.fn(),
+  cronDelete: vi.fn(),
+  cronRunNow: vi.fn(),
+  cronStop: vi.fn(),
+}));
+
+vi.mock('../../utils/api', () => ({
+  api: apiMock,
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, options?: Record<string, unknown>) => (
+      typeof options?.defaultValue === 'string' ? options.defaultValue : _key
+    ),
+  }),
+}));
+
+const project: Project = {
+  name: 'general',
+  displayName: 'General',
+  fullPath: '/project/general',
+};
+
+function jsonResponse<T>(body: T, ok = true): Response {
+  return {
+    ok,
+    status: ok ? 200 : 400,
+    json: vi.fn(async () => body),
+  } as unknown as Response;
+}
+
+function makeJob(overrides: Partial<CronJobOverview>): CronJobOverview {
+  return {
+    id: 'job-1',
+    projectKey: '/project/general',
+    cron: '0 * * * *',
+    prompt: 'Run hourly report',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    recurring: true,
+    manualOnly: false,
+    status: 'scheduled',
+    ...overrides,
+  };
+}
+
+function setup(jobs: CronJobOverview[]) {
+  apiMock.projects.mockResolvedValue(jsonResponse([project]));
+  apiMock.allCronJobs.mockResolvedValue(jsonResponse({ jobs }));
+  apiMock.cronCreate.mockResolvedValue(jsonResponse({ task: { taskId: 'created-task' } }));
+  apiMock.cronRunNow.mockResolvedValue(jsonResponse({ triggered: true }));
+  apiMock.cronStop.mockResolvedValue(jsonResponse({ stopped: true }));
+  apiMock.cronDelete.mockResolvedValue(jsonResponse({ deleted: true }));
+
+  return render(<CronV2 />);
+}
+
+describe('CronV2', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('loads active cron jobs and groups them by project', async () => {
+    setup([
+      makeJob({
+        id: 'job-1',
+        prompt: 'Run hourly report',
+        projectKey: '/project/general',
+        nextRunAt: '2026-01-01T01:00:00.000Z',
+      }),
+      makeJob({ id: 'job-2', prompt: 'Unassigned check', projectKey: null }),
+      makeJob({ id: 'job-3', prompt: 'Completed old job', status: 'completed' }),
+    ]);
+
+    await screen.findByText('General');
+    expect(screen.getAllByText('Next Run').length).toBeGreaterThan(0);
+    expect(screen.getByText('Run hourly report')).toBeTruthy();
+    expect(screen.getByText(formatExpectedTime('2026-01-01T01:00:00.000Z'))).toBeTruthy();
+    expect(screen.getByText('Unassigned')).toBeTruthy();
+    expect(screen.getByText('Unassigned check')).toBeTruthy();
+    expect(screen.queryByText('Completed old job')).toBeNull();
+  });
+
+  it('shows cron sub-navigation and defaults to the task list', async () => {
+    setup([makeJob({ prompt: 'Visible list task' })]);
+
+    expect(screen.getByRole('button', { name: 'Task List' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Create Task' })).toBeTruthy();
+    await screen.findByText('Visible list task');
+  });
+
+  it('creates a one-time cron task and refreshes the list', async () => {
+    setup([]);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create Task' }));
+    await screen.findByText('Create Cron Task');
+
+    fireEvent.change(screen.getByLabelText('Prompt'), {
+      target: { value: 'Run a focused review' },
+    });
+    fireEvent.change(screen.getByLabelText('Workspace'), {
+      target: { value: '/project/general' },
+    });
+    fireEvent.change(screen.getByLabelText('Date'), {
+      target: { value: '2099-01-01' },
+    });
+    fireEvent.change(screen.getByLabelText('Time'), {
+      target: { value: '10:00' },
+    });
+    fireEvent.click(screen.getAllByRole('button', { name: 'Create Task' }).at(-1)!);
+
+    await waitFor(() => {
+      expect(apiMock.cronCreate).toHaveBeenCalledWith(expect.objectContaining({
+        message: 'Run a focused review',
+        projectKey: '/project/general',
+        schedule: expect.objectContaining({ type: 'once' }),
+      }));
+      expect(apiMock.allCronJobs).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it('creates a recurring cron task', async () => {
+    setup([]);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create Task' }));
+    await screen.findByText('Create Cron Task');
+    fireEvent.change(screen.getByLabelText('Prompt'), {
+      target: { value: 'Daily digest' },
+    });
+    fireEvent.change(screen.getByLabelText('Workspace'), {
+      target: { value: '/project/general' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Recurring' }));
+    fireEvent.change(screen.getByLabelText('Time'), {
+      target: { value: '08:30' },
+    });
+    fireEvent.change(screen.getByLabelText('Timezone'), {
+      target: { value: 'Asia/Shanghai' },
+    });
+    fireEvent.click(screen.getAllByRole('button', { name: 'Create Task' }).at(-1)!);
+
+    await waitFor(() => {
+      expect(apiMock.cronCreate).toHaveBeenCalledWith(expect.objectContaining({
+        message: 'Daily digest',
+        projectKey: '/project/general',
+        timezone: 'Asia/Shanghai',
+        schedule: {
+          type: 'cron',
+          expression: '30 8 * * *',
+          timezone: 'Asia/Shanghai',
+        },
+      }));
+    });
+  });
+
+  it('validates required create fields before calling the API', async () => {
+    setup([]);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create Task' }));
+    await screen.findByText('Create Cron Task');
+    fireEvent.click(screen.getAllByRole('button', { name: 'Create Task' }).at(-1)!);
+
+    await screen.findByText('Prompt is required.');
+    expect(apiMock.cronCreate).not.toHaveBeenCalled();
+  });
+
+  it('runs a scheduled cron job immediately and refreshes', async () => {
+    setup([makeJob({ id: 'job-run', prompt: 'Run this now', status: 'scheduled' })]);
+
+    await screen.findByText('Run this now');
+    fireEvent.click(screen.getByRole('button', { name: /Run Now/ }));
+
+    await waitFor(() => {
+      expect(apiMock.cronRunNow).toHaveBeenCalledWith('job-run');
+      expect(apiMock.allCronJobs).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it('stops a running cron job and refreshes', async () => {
+    setup([makeJob({ id: 'job-stop', prompt: 'Stop this job', status: 'running' })]);
+
+    await screen.findByText('Stop this job');
+    fireEvent.click(screen.getByRole('button', { name: /Stop/ }));
+
+    await waitFor(() => {
+      expect(apiMock.cronStop).toHaveBeenCalledWith('job-stop');
+      expect(apiMock.allCronJobs).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it('deletes a cron job and refreshes', async () => {
+    setup([makeJob({ id: 'job-delete', prompt: 'Delete this job' })]);
+
+    await screen.findByText('Delete this job');
+    fireEvent.click(screen.getByTitle('Delete'));
+
+    await waitFor(() => {
+      expect(apiMock.cronDelete).toHaveBeenCalledWith('job-delete');
+      expect(apiMock.allCronJobs).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it('shows an empty state when there are no active cron jobs', async () => {
+    setup([makeJob({ id: 'job-complete', prompt: 'Past job', status: 'completed' })]);
+
+    await screen.findByText('No active cron jobs found.');
+    expect(screen.queryByText('Past job')).toBeNull();
+  });
+
+  it('renders a placeholder when next run time is missing', async () => {
+    setup([makeJob({ id: 'job-missing-next-run', prompt: 'Missing next run' })]);
+
+    await screen.findByText('Missing next run');
+    expect(screen.getByText('—')).toBeTruthy();
+  });
+});
+
+function formatExpectedTime(iso: string): string {
+  return new Date(Date.parse(iso)).toLocaleString([], {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  });
+}

--- a/ui/src/components/main-content-v2/CronV2.tsx
+++ b/ui/src/components/main-content-v2/CronV2.tsx
@@ -1,0 +1,709 @@
+import { useCallback, useEffect, useMemo, useState, type FormEvent } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  AlertCircle,
+  CalendarClock,
+  ChevronDown,
+  ChevronRight,
+  Clock,
+  ListChecks,
+  Loader2,
+  Play,
+  PlusCircle,
+  RefreshCw,
+  Square,
+  Trash2,
+} from 'lucide-react';
+import type { CronJobOverview, CronJobsOverviewResponse, Project } from '../../types/app';
+import { cn } from '../../lib/utils.js';
+import { api } from '../../utils/api';
+
+const POLL_INTERVAL_MS = 15_000;
+
+type CronSubTab = 'list' | 'create';
+type ScheduleKind = 'once' | 'cron';
+
+const SUB_TABS: { id: CronSubTab; labelKey: string; defaultLabel: string; icon: typeof ListChecks }[] = [
+  { id: 'list', labelKey: 'cron.tabs.list', defaultLabel: 'Task List', icon: ListChecks },
+  { id: 'create', labelKey: 'cron.tabs.create', defaultLabel: 'Create Task', icon: PlusCircle },
+];
+
+const COL = {
+  title: 'min-w-0 flex-1 max-w-[420px]',
+  createdAt: 'w-[150px] shrink-0',
+  nextRunAt: 'w-[150px] shrink-0',
+  status: 'w-[140px] shrink-0',
+  actions: 'w-[180px] shrink-0',
+} as const;
+
+const CRON_STATUS_STYLE: Record<'scheduled' | 'running', string> = {
+  scheduled: 'bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300',
+  running: 'bg-indigo-100 text-indigo-700 dark:bg-indigo-900/40 dark:text-indigo-300',
+};
+
+const CRON_STATUS_LABEL: Record<'scheduled' | 'running', { key: string; defaultValue: string }> = {
+  scheduled: { key: 'cron.status.scheduled', defaultValue: 'Scheduled' },
+  running: { key: 'cron.status.running', defaultValue: 'Running' },
+};
+
+type ProjectGroup = {
+  displayName: string;
+  items: CronJobOverview[];
+};
+
+function getBrowserTimezone(): string {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
+  } catch {
+    return 'UTC';
+  }
+}
+
+function formatDateTimeLocal(date: Date): string {
+  const pad = (value: number) => String(value).padStart(2, '0');
+  return [
+    date.getFullYear(),
+    '-',
+    pad(date.getMonth() + 1),
+    '-',
+    pad(date.getDate()),
+    'T',
+    pad(date.getHours()),
+    ':',
+    pad(date.getMinutes()),
+  ].join('');
+}
+
+function formatDateLocal(date: Date): string {
+  return formatDateTimeLocal(date).slice(0, 10);
+}
+
+function formatTimeLocal(date: Date): string {
+  return formatDateTimeLocal(date).slice(11, 16);
+}
+
+function buildDailyCronExpression(time: string): string {
+  const [hour = '0', minute = '0'] = time.split(':');
+  return `${Number(minute)} ${Number(hour)} * * *`;
+}
+
+function formatAbsoluteTime(iso: string | number): string {
+  const parsed = typeof iso === 'number' ? iso : Date.parse(iso);
+  if (Number.isNaN(parsed)) return '';
+  return new Date(parsed).toLocaleString([], {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  });
+}
+
+export default function CronV2() {
+  const { t } = useTranslation('alwaysOn');
+  const [subTab, setSubTab] = useState<CronSubTab>('list');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [projects, setProjects] = useState<Project[]>([]);
+  const [jobs, setJobs] = useState<CronJobOverview[]>([]);
+  const [collapsedProjects, setCollapsedProjects] = useState<Set<string>>(new Set());
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const [projectsRes, jobsRes] = await Promise.all([
+        api.projects(),
+        api.allCronJobs(),
+      ]);
+
+      if (!projectsRes.ok) throw new Error(`Projects: HTTP ${projectsRes.status}`);
+      if (!jobsRes.ok) throw new Error(`Cron jobs: HTTP ${jobsRes.status}`);
+
+      const projectsPayload = await projectsRes.json() as Project[];
+      const jobsPayload = await jobsRes.json() as CronJobsOverviewResponse;
+      setProjects(Array.isArray(projectsPayload) ? projectsPayload : []);
+      setJobs(Array.isArray(jobsPayload.jobs) ? jobsPayload.jobs : []);
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : String(caught));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+    const timer = window.setInterval(() => void refresh(), POLL_INTERVAL_MS);
+    return () => window.clearInterval(timer);
+  }, [refresh]);
+
+  const grouped = useMemo(() => {
+    const projectMap = new Map<string, Project>();
+    const projectKeyToName = new Map<string, string>();
+    for (const project of projects) {
+      projectMap.set(project.name, project);
+      projectKeyToName.set(project.name, project.name);
+      if (project.fullPath) projectKeyToName.set(project.fullPath, project.name);
+    }
+
+    const result = new Map<string, ProjectGroup>();
+    for (const job of jobs) {
+      if (job.status !== 'scheduled' && job.status !== 'running') continue;
+
+      const projectName = job.projectKey
+        ? (projectKeyToName.get(job.projectKey) || job.projectKey)
+        : '__unassigned__';
+      const project = projectMap.get(projectName);
+      const displayName = project?.displayName || (projectName === '__unassigned__'
+        ? t('cron.unassigned', { defaultValue: 'Unassigned' })
+        : projectName);
+
+      if (!result.has(projectName)) {
+        result.set(projectName, { displayName, items: [] });
+      }
+      result.get(projectName)!.items.push(job);
+    }
+
+    for (const group of result.values()) {
+      group.items.sort((left, right) => {
+        const leftTime = Date.parse(left.createdAt) || 0;
+        const rightTime = Date.parse(right.createdAt) || 0;
+        return rightTime - leftTime;
+      });
+    }
+
+    return result;
+  }, [jobs, projects, t]);
+
+  const totalItems = useMemo(() => {
+    let count = 0;
+    for (const group of grouped.values()) count += group.items.length;
+    return count;
+  }, [grouped]);
+
+  const toggleProject = (key: string) => {
+    setCollapsedProjects((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  };
+
+  return (
+    <div className="flex h-full flex-col bg-white dark:bg-neutral-950">
+      <div className="flex shrink-0 gap-1 border-b border-neutral-200 px-8 pt-4 dark:border-neutral-800">
+        {SUB_TABS.map((tab) => {
+          const Icon = tab.icon;
+          const isActive = subTab === tab.id;
+          return (
+            <button
+              key={tab.id}
+              type="button"
+              onClick={() => setSubTab(tab.id)}
+              className={cn(
+                'inline-flex items-center gap-1.5 border-b-2 px-3 pb-2 text-[13px] font-medium transition-colors',
+                isActive
+                  ? 'border-blue-500 text-blue-600 dark:border-blue-400 dark:text-blue-400'
+                  : 'border-transparent text-neutral-500 hover:text-neutral-700 dark:text-neutral-400 dark:hover:text-neutral-200',
+              )}
+            >
+              <Icon className="h-3.5 w-3.5" strokeWidth={1.75} />
+              {t(tab.labelKey, { defaultValue: tab.defaultLabel })}
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        {subTab === 'list' ? (
+          <CronListView
+            t={t}
+            loading={loading}
+            error={error}
+            grouped={grouped}
+            totalItems={totalItems}
+            collapsedProjects={collapsedProjects}
+            onRefresh={refresh}
+            onToggleProject={toggleProject}
+          />
+        ) : (
+          <CronCreateView
+            t={t}
+            projects={projects}
+            onCreated={async () => {
+              await refresh();
+              setSubTab('list');
+            }}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function CronListView({
+  t,
+  loading,
+  error,
+  grouped,
+  totalItems,
+  collapsedProjects,
+  onRefresh,
+  onToggleProject,
+}: {
+  t: (key: string, opts?: Record<string, string>) => string;
+  loading: boolean;
+  error: string | null;
+  grouped: Map<string, ProjectGroup>;
+  totalItems: number;
+  collapsedProjects: Set<string>;
+  onRefresh: () => Promise<void>;
+  onToggleProject: (key: string) => void;
+}) {
+  return (
+    <div className="w-full space-y-5 px-8 py-5">
+      <div className="flex items-start justify-between">
+        <div>
+          <h2 className="text-[20px] font-semibold tracking-tight text-neutral-900 dark:text-neutral-100">
+            {t('cron.title', { defaultValue: 'Cron' })}
+          </h2>
+          <p className="mt-0.5 text-[13px] text-neutral-500 dark:text-neutral-400">
+            {t('cron.subtitle', { defaultValue: 'Scheduled cron jobs across projects.' })}
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => void onRefresh()}
+          disabled={loading}
+          className="inline-flex h-8 items-center gap-1.5 rounded-md border border-neutral-200 px-2.5 text-xxs text-neutral-600 transition hover:bg-neutral-50 disabled:opacity-50 dark:border-neutral-800 dark:text-neutral-300 dark:hover:bg-neutral-900"
+        >
+          <RefreshCw className={cn('h-3.5 w-3.5', loading && 'animate-spin')} strokeWidth={1.75} />
+          <span>{t('actions.refresh', { defaultValue: 'Refresh' })}</span>
+        </button>
+      </div>
+
+      {error ? (
+        <div className="flex items-center gap-2 text-xxs text-red-500">
+          <AlertCircle className="h-3.5 w-3.5" strokeWidth={1.75} />
+          <span>{error}</span>
+        </div>
+      ) : null}
+
+      {loading && totalItems === 0 ? (
+        <div className="flex items-center gap-2 py-8 text-[13px] text-neutral-500 dark:text-neutral-400">
+          <Loader2 className="h-3.5 w-3.5 animate-spin" strokeWidth={1.75} />
+          <span>{t('cron.loading', { defaultValue: 'Loading cron jobs...' })}</span>
+        </div>
+      ) : totalItems === 0 && !loading ? (
+        <div className="py-8 text-center text-[13px] text-neutral-500 dark:text-neutral-400">
+          <Clock className="mx-auto mb-2 h-8 w-8 text-neutral-300 dark:text-neutral-600" strokeWidth={1.25} />
+          {t('cron.empty', { defaultValue: 'No active cron jobs found.' })}
+        </div>
+      ) : (
+        <div className="space-y-4">
+          {[...grouped.entries()].map(([projectKey, group]) => {
+            const isCollapsed = collapsedProjects.has(projectKey);
+            return (
+              <div
+                key={projectKey}
+                className="overflow-hidden rounded-xl border border-neutral-200 bg-white dark:border-neutral-800 dark:bg-neutral-950"
+              >
+                <button
+                  type="button"
+                  onClick={() => onToggleProject(projectKey)}
+                  className="flex w-full items-center gap-2 px-5 py-3 text-left transition-colors hover:bg-neutral-50 dark:hover:bg-neutral-900"
+                >
+                  {isCollapsed ? (
+                    <ChevronRight className="h-4 w-4 shrink-0 text-neutral-400" strokeWidth={1.75} />
+                  ) : (
+                    <ChevronDown className="h-4 w-4 shrink-0 text-neutral-400" strokeWidth={1.75} />
+                  )}
+                  <span className="text-[13px] font-semibold text-neutral-900 dark:text-neutral-100">
+                    {group.displayName}
+                  </span>
+                  <span className="ml-auto text-xxs tabular-nums text-neutral-400 dark:text-neutral-500">
+                    {group.items.length}
+                  </span>
+                </button>
+
+                {!isCollapsed && (
+                  <>
+                    <ColumnHeaders t={t} />
+                    <div className="divide-y divide-neutral-100 dark:divide-neutral-900">
+                      {group.items.map((job) => (
+                        <CronJobRow
+                          key={job.id}
+                          job={job}
+                          t={t}
+                          onRefresh={onRefresh}
+                        />
+                      ))}
+                    </div>
+                  </>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function CronCreateView({
+  t,
+  projects,
+  onCreated,
+}: {
+  t: (key: string, opts?: Record<string, string>) => string;
+  projects: Project[];
+  onCreated: () => Promise<void>;
+}) {
+  const defaultRunAt = useMemo(() => new Date(Date.now() + 60 * 60 * 1000), []);
+  const [message, setMessage] = useState('');
+  const [projectKey, setProjectKey] = useState('');
+  const [scheduleKind, setScheduleKind] = useState<ScheduleKind>('once');
+  const [scheduleDate, setScheduleDate] = useState(formatDateLocal(defaultRunAt));
+  const [scheduleTime, setScheduleTime] = useState(formatTimeLocal(defaultRunAt));
+  const [timezone, setTimezone] = useState(getBrowserTimezone);
+  const [submitting, setSubmitting] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+
+  const resetForm = () => {
+    setMessage('');
+    setProjectKey('');
+    setScheduleKind('once');
+    const nextDefault = new Date(Date.now() + 60 * 60 * 1000);
+    setScheduleDate(formatDateLocal(nextDefault));
+    setScheduleTime(formatTimeLocal(nextDefault));
+    setTimezone(getBrowserTimezone());
+  };
+
+  const validate = () => {
+    if (!message.trim()) {
+      return t('cron.create.validation.messageRequired', { defaultValue: 'Prompt is required.' });
+    }
+    if (!projectKey) {
+      return t('cron.create.validation.workspaceRequired', { defaultValue: 'Workspace is required.' });
+    }
+    if (!scheduleTime) {
+      return t('cron.create.validation.timeRequired', { defaultValue: 'Time is required.' });
+    }
+    if (!timezone.trim()) {
+      return t('cron.create.validation.timezoneRequired', { defaultValue: 'Timezone is required.' });
+    }
+    if (scheduleKind === 'once') {
+      if (!scheduleDate) {
+        return t('cron.create.validation.dateRequired', { defaultValue: 'Date is required.' });
+      }
+      const parsed = new Date(`${scheduleDate}T${scheduleTime}`);
+      if (Number.isNaN(parsed.getTime()) || parsed.getTime() <= Date.now()) {
+        return t('cron.create.validation.runAtFuture', { defaultValue: 'Run time must be in the future.' });
+      }
+    }
+    return null;
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (submitting) return;
+    setSuccess(null);
+    const validationError = validate();
+    if (validationError) {
+      setFormError(validationError);
+      return;
+    }
+
+    setSubmitting(true);
+    setFormError(null);
+    try {
+      const schedule = scheduleKind === 'once'
+        ? { type: 'once', runAt: new Date(`${scheduleDate}T${scheduleTime}`).toISOString() }
+        : { type: 'cron', expression: buildDailyCronExpression(scheduleTime), timezone: timezone.trim() };
+      const response = await api.cronCreate({
+        message: message.trim(),
+        projectKey,
+        schedule,
+        timezone: timezone.trim() || undefined,
+      });
+      if (!response.ok) {
+        const body = await response.json().catch(() => ({})) as { error?: string };
+        throw new Error(body?.error || `HTTP ${response.status}`);
+      }
+      resetForm();
+      setSuccess(t('cron.create.success', { defaultValue: 'Cron task created.' }));
+      await onCreated();
+    } catch (caught) {
+      setFormError(caught instanceof Error ? caught.message : String(caught));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="w-full space-y-5 px-8 py-5">
+      <div>
+        <h2 className="text-[20px] font-semibold tracking-tight text-neutral-900 dark:text-neutral-100">
+          {t('cron.create.title', { defaultValue: 'Create Cron Task' })}
+        </h2>
+        <p className="mt-0.5 text-[13px] text-neutral-500 dark:text-neutral-400">
+          {t('cron.create.subtitle', { defaultValue: 'Schedule a one-time or recurring background prompt.' })}
+        </p>
+      </div>
+
+      <form
+        onSubmit={(event) => void handleSubmit(event)}
+        className="w-full space-y-5 rounded-xl border border-neutral-200 bg-white p-5 dark:border-neutral-800 dark:bg-neutral-950"
+      >
+        {formError ? (
+          <div className="flex items-center gap-2 rounded-md bg-red-50 px-3 py-2 text-xxs text-red-600 dark:bg-red-950/40 dark:text-red-300">
+            <AlertCircle className="h-3.5 w-3.5" strokeWidth={1.75} />
+            <span>{formError}</span>
+          </div>
+        ) : success ? (
+          <div className="rounded-md bg-emerald-50 px-3 py-2 text-xxs text-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-300">
+            {success}
+          </div>
+        ) : null}
+
+        <label className="block">
+          <span className="text-[13px] font-medium text-neutral-800 dark:text-neutral-200">
+            {t('cron.create.fields.prompt', { defaultValue: 'Prompt' })}
+          </span>
+          <textarea
+            value={message}
+            onChange={(event) => setMessage(event.target.value)}
+            rows={5}
+            className="mt-1.5 w-full resize-y rounded-md border border-neutral-200 bg-white px-3 py-2 text-[13px] text-neutral-900 outline-none transition focus:border-blue-400 focus:ring-2 focus:ring-blue-100 dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-100 dark:focus:border-blue-500 dark:focus:ring-blue-950"
+            placeholder={t('cron.create.placeholders.prompt', { defaultValue: 'Describe what PilotDeck should do when this task runs.' })}
+          />
+        </label>
+
+        <label className="block">
+          <span className="text-[13px] font-medium text-neutral-800 dark:text-neutral-200">
+            {t('cron.create.fields.workspace', { defaultValue: 'Workspace' })}
+          </span>
+          <select
+            value={projectKey}
+            onChange={(event) => setProjectKey(event.target.value)}
+            className="mt-1.5 h-9 w-full rounded-md border border-neutral-200 bg-white px-3 text-[13px] text-neutral-900 outline-none transition focus:border-blue-400 focus:ring-2 focus:ring-blue-100 dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-100 dark:focus:border-blue-500 dark:focus:ring-blue-950"
+          >
+            <option value="">{t('cron.create.placeholders.workspace', { defaultValue: 'Select a workspace' })}</option>
+            {projects.map((project) => (
+              <option key={project.fullPath || project.name} value={project.fullPath || project.name}>
+                {project.displayName || project.name}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <div className="space-y-2.5">
+          <span className="text-[13px] font-medium text-neutral-800 dark:text-neutral-200">
+            {t('cron.create.fields.scheduleType', { defaultValue: 'Schedule Type' })}
+          </span>
+          <div className="flex w-fit rounded-md border border-neutral-200 bg-neutral-50 p-0.5 dark:border-neutral-800 dark:bg-neutral-900">
+            {(['once', 'cron'] as const).map((kind) => (
+              <button
+                key={kind}
+                type="button"
+                onClick={() => setScheduleKind(kind)}
+                className={cn(
+                  'inline-flex h-8 items-center gap-1.5 rounded px-3 text-[12px] font-medium transition-colors',
+                  scheduleKind === kind
+                    ? 'bg-white text-blue-600 shadow-sm dark:bg-neutral-800 dark:text-blue-300'
+                    : 'text-neutral-500 hover:text-neutral-800 dark:text-neutral-400 dark:hover:text-neutral-100',
+                )}
+              >
+                {kind === 'once' ? <CalendarClock className="h-3.5 w-3.5" strokeWidth={1.75} /> : <Clock className="h-3.5 w-3.5" strokeWidth={1.75} />}
+                {kind === 'once'
+                  ? t('cron.create.schedule.once', { defaultValue: 'One-time' })
+                  : t('cron.create.schedule.cron', { defaultValue: 'Recurring' })}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-[1fr_1fr_260px]">
+          <label className="block">
+            <span className="text-[13px] font-medium text-neutral-800 dark:text-neutral-200">
+              {t('cron.create.fields.date', { defaultValue: 'Date' })}
+            </span>
+            <input
+              type="date"
+              value={scheduleDate}
+              min={formatDateLocal(new Date())}
+              disabled={scheduleKind === 'cron'}
+              onChange={(event) => setScheduleDate(event.target.value)}
+              className="mt-1.5 h-9 w-full rounded-md border border-neutral-200 bg-white px-3 text-[13px] text-neutral-900 outline-none transition focus:border-blue-400 focus:ring-2 focus:ring-blue-100 disabled:cursor-not-allowed disabled:bg-neutral-100 disabled:text-neutral-400 dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-100 dark:focus:border-blue-500 dark:focus:ring-blue-950 dark:disabled:bg-neutral-900 dark:disabled:text-neutral-500"
+            />
+          </label>
+          <label className="block">
+            <span className="text-[13px] font-medium text-neutral-800 dark:text-neutral-200">
+              {t('cron.create.fields.time', { defaultValue: 'Time' })}
+            </span>
+            <input
+              type="time"
+              value={scheduleTime}
+              onChange={(event) => setScheduleTime(event.target.value)}
+              className="mt-1.5 h-9 w-full rounded-md border border-neutral-200 bg-white px-3 text-[13px] text-neutral-900 outline-none transition focus:border-blue-400 focus:ring-2 focus:ring-blue-100 dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-100 dark:focus:border-blue-500 dark:focus:ring-blue-950"
+            />
+          </label>
+          <label className="block">
+            <span className="text-[13px] font-medium text-neutral-800 dark:text-neutral-200">
+              {t('cron.create.fields.timezone', { defaultValue: 'Timezone' })}
+            </span>
+            <input
+              value={timezone}
+              onChange={(event) => setTimezone(event.target.value)}
+              className="mt-1.5 h-9 w-full rounded-md border border-neutral-200 bg-white px-3 text-[13px] text-neutral-900 outline-none transition focus:border-blue-400 focus:ring-2 focus:ring-blue-100 dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-100 dark:focus:border-blue-500 dark:focus:ring-blue-950"
+            />
+          </label>
+        </div>
+
+        <div className="flex items-center justify-end gap-2 pt-1">
+          <button
+            type="submit"
+            disabled={submitting}
+            className="inline-flex h-8 items-center gap-1.5 rounded-md bg-blue-600 px-3 text-[12px] font-medium text-white transition hover:bg-blue-700 disabled:opacity-50 dark:bg-blue-700 dark:hover:bg-blue-600"
+          >
+            {submitting ? <Loader2 className="h-3.5 w-3.5 animate-spin" strokeWidth={1.75} /> : <PlusCircle className="h-3.5 w-3.5" strokeWidth={1.75} />}
+            {t('cron.create.actions.submit', { defaultValue: 'Create Task' })}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}
+
+function ColumnHeaders({ t }: { t: (key: string, opts?: Record<string, string>) => string }) {
+  return (
+    <div className="flex items-center gap-4 border-b border-neutral-200 bg-neutral-50 px-5 py-2 dark:border-neutral-800 dark:bg-neutral-900/50">
+      <div className={COL.title}>
+        <span className="text-xxs font-medium uppercase tracking-wider text-neutral-500 dark:text-neutral-400">
+          {t('cron.columns.title', { defaultValue: 'Title' })}
+        </span>
+      </div>
+      <div className={COL.createdAt}>
+        <span className="text-xxs font-medium uppercase tracking-wider text-neutral-500 dark:text-neutral-400">
+          {t('cron.columns.createdAt', { defaultValue: 'Created' })}
+        </span>
+      </div>
+      <div className={COL.nextRunAt}>
+        <span className="text-xxs font-medium uppercase tracking-wider text-neutral-500 dark:text-neutral-400">
+          {t('cron.columns.nextRunAt', { defaultValue: 'Next Run' })}
+        </span>
+      </div>
+      <div className={COL.status}>
+        <span className="text-xxs font-medium uppercase tracking-wider text-neutral-500 dark:text-neutral-400">
+          {t('cron.columns.status', { defaultValue: 'Status' })}
+        </span>
+      </div>
+      <div className={COL.actions}>
+        <span className="text-xxs font-medium uppercase tracking-wider text-neutral-500 dark:text-neutral-400">
+          {t('cron.columns.actions', { defaultValue: 'Actions' })}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function CronJobRow({
+  job,
+  t,
+  onRefresh,
+}: {
+  job: CronJobOverview;
+  t: (key: string, opts?: Record<string, string>) => string;
+  onRefresh: () => Promise<void>;
+}) {
+  const [busy, setBusy] = useState(false);
+  const status = job.status === 'running' ? 'running' : 'scheduled';
+  const meta = CRON_STATUS_LABEL[status];
+
+  const runAction = async (action: 'runNow' | 'stop' | 'delete') => {
+    if (busy) return;
+    setBusy(true);
+    try {
+      const response = action === 'runNow'
+        ? await api.cronRunNow(job.id)
+        : action === 'stop'
+          ? await api.cronStop(job.id)
+          : await api.cronDelete(job.id);
+      if (!response.ok) {
+        const body = await response.json().catch(() => ({})) as { error?: string };
+        throw new Error(body?.error || `HTTP ${response.status}`);
+      }
+      await onRefresh();
+    } catch {
+      // The next refresh or global toast surface carries the visible error.
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="flex items-center gap-4 px-5 py-2.5 transition-colors hover:bg-neutral-50 dark:hover:bg-neutral-900/40">
+      <div className={cn(COL.title, 'truncate text-[13px] text-neutral-900 dark:text-neutral-100')} title={job.prompt || ''}>
+        {job.prompt || '—'}
+      </div>
+      <div className={cn(COL.createdAt, 'font-mono text-xxs tabular-nums text-neutral-500 dark:text-neutral-400')}>
+        {formatAbsoluteTime(job.createdAt)}
+      </div>
+      <div className={cn(COL.nextRunAt, 'font-mono text-xxs tabular-nums text-neutral-500 dark:text-neutral-400')}>
+        {job.nextRunAt ? formatAbsoluteTime(job.nextRunAt) || '—' : '—'}
+      </div>
+      <div className={COL.status}>
+        <span className={cn('inline-block rounded-full px-2 py-0.5 text-[11px] font-medium', CRON_STATUS_STYLE[status])}>
+          {t(meta.key, { defaultValue: meta.defaultValue })}
+        </span>
+      </div>
+      <div className={cn(COL.actions, 'flex items-center gap-1.5')}>
+        {status === 'running' ? (
+          <button
+            type="button"
+            disabled={busy}
+            onClick={() => void runAction('stop')}
+            className="inline-flex h-7 items-center gap-1 rounded-md bg-red-600 px-2.5 text-[11px] font-medium text-white transition hover:bg-red-700 disabled:opacity-50 dark:bg-red-700 dark:hover:bg-red-600"
+          >
+            {busy ? (
+              <Loader2 className="h-3 w-3 animate-spin" strokeWidth={2} />
+            ) : (
+              <>
+                <Square className="h-3 w-3" strokeWidth={2} />
+                {t('cron.actions.stop', { defaultValue: 'Stop' })}
+              </>
+            )}
+          </button>
+        ) : (
+          <button
+            type="button"
+            disabled={busy}
+            onClick={() => void runAction('runNow')}
+            className="inline-flex h-7 items-center gap-1 rounded-md bg-blue-600 px-2.5 text-[11px] font-medium text-white transition hover:bg-blue-700 disabled:opacity-50 dark:bg-blue-700 dark:hover:bg-blue-600"
+          >
+            {busy ? (
+              <Loader2 className="h-3 w-3 animate-spin" strokeWidth={2} />
+            ) : (
+              <>
+                <Play className="h-3 w-3" strokeWidth={2} />
+                {t('cron.actions.runNow', { defaultValue: 'Run Now' })}
+              </>
+            )}
+          </button>
+        )}
+        <button
+          type="button"
+          disabled={busy}
+          onClick={() => void runAction('delete')}
+          className="inline-flex h-7 items-center rounded-md border border-neutral-200 px-2 text-neutral-500 transition hover:border-red-300 hover:text-red-600 disabled:opacity-50 dark:border-neutral-700 dark:text-neutral-400 dark:hover:border-red-700 dark:hover:text-red-400"
+          title={t('cron.actions.delete', { defaultValue: 'Delete' })}
+        >
+          <Trash2 className="h-3.5 w-3.5" strokeWidth={1.75} />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/components/main-content-v2/PlansAndCronJobs.tsx
+++ b/ui/src/components/main-content-v2/PlansAndCronJobs.tsx
@@ -7,14 +7,9 @@ import {
   ChevronRight,
   FileText,
   Loader2,
-  Play,
   RefreshCw,
-  Square,
-  Trash2,
 } from 'lucide-react';
 import type {
-  CronJobOverview,
-  CronJobsOverviewResponse,
   DiscoveryPlanOverview,
   DiscoveryPlanStatus,
   Project,
@@ -80,23 +75,16 @@ const PLAN_STATUS_LABEL: Record<PlanDisplayStatus, { key: string; defaultValue: 
   archived: { key: 'plansCron.status.archived', defaultValue: 'Archived' },
 };
 
-const CRON_STATUS_STYLE: Record<'scheduled' | 'running', string> = {
-  scheduled: 'bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300',
-  running: 'bg-indigo-100 text-indigo-700 dark:bg-indigo-900/40 dark:text-indigo-300',
-};
-
-const CRON_STATUS_LABEL: Record<'scheduled' | 'running', { key: string; defaultValue: string }> = {
-  scheduled: { key: 'plansCron.status.scheduled', defaultValue: 'Scheduled' },
-  running: { key: 'plansCron.status.running', defaultValue: 'Running' },
-};
-
 // ---------------------------------------------------------------------------
-// Unified row type
+// Plan row type
 // ---------------------------------------------------------------------------
 
-type UnifiedItem =
-  | { kind: 'plan'; data: DiscoveryPlanOverview; projectName: string; projectDisplayName: string; projectKey: string }
-  | { kind: 'cron'; data: CronJobOverview; projectName: string; projectDisplayName: string; projectKey: string };
+type PlanItem = {
+  data: DiscoveryPlanOverview;
+  projectName: string;
+  projectDisplayName: string;
+  projectKey: string;
+};
 
 // ---------------------------------------------------------------------------
 // Time formatting
@@ -142,7 +130,6 @@ export default function PlansAndCronJobs({ onApplyWorkCycle, onOpenPlanDetail }:
   const [projects, setProjects] = useState<Project[]>([]);
   const [plansByProject, setPlansByProject] = useState<Map<string, DiscoveryPlanOverview[]>>(new Map());
   const [cyclesByProject, setCyclesByProject] = useState<Map<string, WorkCycleOverview[]>>(new Map());
-  const [cronJobs, setCronJobs] = useState<CronJobOverview[]>([]);
   const [collapsedProjects, setCollapsedProjects] = useState<Set<string>>(new Set());
   const [cycleBusy, setCycleBusy] = useState<string | null>(null);
   const [confirmingArchiveCycle, setConfirmingArchiveCycle] = useState<string | null>(null);
@@ -166,20 +153,12 @@ export default function PlansAndCronJobs({ onApplyWorkCycle, onOpenPlanDetail }:
       const projectsList: Project[] = await projectsRes.json();
       setProjects(projectsList);
 
-      const [cronRes, ...mixedResults] = await Promise.all([
-        api.allCronJobs(),
-        ...projectsList.flatMap((p) => [
+      const mixedResults = await Promise.all(
+        projectsList.flatMap((p) => [
           api.projectDiscoveryPlans(p.name),
           api.projectWorkCycles(p.name),
         ]),
-      ]);
-
-      if (cronRes.ok) {
-        const cronPayload = (await cronRes.json()) as CronJobsOverviewResponse;
-        setCronJobs(Array.isArray(cronPayload.jobs) ? cronPayload.jobs : []);
-      } else {
-        setCronJobs([]);
-      }
+      );
 
       const newPlansByProject = new Map<string, DiscoveryPlanOverview[]>();
       const newCyclesByProject = new Map<string, WorkCycleOverview[]>();
@@ -218,7 +197,7 @@ export default function PlansAndCronJobs({ onApplyWorkCycle, onOpenPlanDetail }:
     const projectMap = new Map<string, Project>();
     for (const p of projects) projectMap.set(p.name, p);
 
-    const result = new Map<string, { displayName: string; items: UnifiedItem[] }>();
+    const result = new Map<string, { displayName: string; items: PlanItem[] }>();
 
     for (const [projectName, plans] of plansByProject) {
       const project = projectMap.get(projectName);
@@ -228,42 +207,12 @@ export default function PlansAndCronJobs({ onApplyWorkCycle, onOpenPlanDetail }:
       }
       for (const plan of plans) {
         result.get(projectName)!.items.push({
-          kind: 'plan',
           data: plan,
           projectName,
           projectDisplayName: displayName,
           projectKey: project?.fullPath || '',
         });
       }
-    }
-
-    const activeCronJobs = cronJobs.filter(
-      (j) => j.status === 'scheduled' || j.status === 'running',
-    );
-
-    const projectKeyToName = new Map<string, string>();
-    for (const p of projects) {
-      projectKeyToName.set(p.name, p.name);
-      if (p.fullPath) projectKeyToName.set(p.fullPath, p.name);
-    }
-
-    for (const job of activeCronJobs) {
-      const projectName = job.projectKey
-        ? (projectKeyToName.get(job.projectKey) || job.projectKey)
-        : '__unassigned__';
-      const project = projectMap.get(projectName);
-      const displayName = project?.displayName || (projectName === '__unassigned__' ? '' : projectName);
-
-      if (!result.has(projectName)) {
-        result.set(projectName, { displayName, items: [] });
-      }
-      result.get(projectName)!.items.push({
-        kind: 'cron',
-        data: job,
-        projectName,
-        projectDisplayName: displayName,
-        projectKey: project?.fullPath || '',
-      });
     }
 
     for (const group of result.values()) {
@@ -275,7 +224,7 @@ export default function PlansAndCronJobs({ onApplyWorkCycle, onOpenPlanDetail }:
     }
 
     return result;
-  }, [projects, plansByProject, cronJobs]);
+  }, [projects, plansByProject]);
 
   const totalItems = useMemo(() => {
     let count = 0;
@@ -298,10 +247,10 @@ export default function PlansAndCronJobs({ onApplyWorkCycle, onOpenPlanDetail }:
       <div className="flex items-start justify-between">
         <div>
           <h2 className="text-[20px] font-semibold tracking-tight text-neutral-900 dark:text-neutral-100">
-            {t('plansCron.title', { defaultValue: 'Plans & Cron Jobs' })}
+            {t('plansCron.title', { defaultValue: 'Plans' })}
           </h2>
           <p className="mt-0.5 text-[13px] text-neutral-500 dark:text-neutral-400">
-            {t('plansCron.subtitle', { defaultValue: 'All plans and cron jobs across projects.' })}
+            {t('plansCron.subtitle', { defaultValue: 'Always-On plans across projects.' })}
           </p>
         </div>
         <button
@@ -325,21 +274,18 @@ export default function PlansAndCronJobs({ onApplyWorkCycle, onOpenPlanDetail }:
       {loading && totalItems === 0 ? (
         <div className="flex items-center gap-2 py-8 text-[13px] text-neutral-500 dark:text-neutral-400">
           <Loader2 className="h-3.5 w-3.5 animate-spin" strokeWidth={1.75} />
-          <span>{t('plansCron.loading', { defaultValue: 'Loading plans and cron jobs…' })}</span>
+          <span>{t('plansCron.loading', { defaultValue: 'Loading plans…' })}</span>
         </div>
       ) : totalItems === 0 && !loading ? (
         <div className="py-8 text-center text-[13px] text-neutral-500 dark:text-neutral-400">
           <FileText className="mx-auto mb-2 h-8 w-8 text-neutral-300 dark:text-neutral-600" strokeWidth={1.25} />
-          {t('plansCron.empty', { defaultValue: 'No plans or cron jobs found.' })}
+          {t('plansCron.empty', { defaultValue: 'No plans found.' })}
         </div>
       ) : (
         <div className="space-y-4">
           {[...grouped.entries()].map(([projectKey, { displayName, items }]) => {
             const isCollapsed = collapsedProjects.has(projectKey);
-            const label =
-              projectKey === '__unassigned__'
-                ? t('plansCron.unassigned', { defaultValue: 'Unassigned' })
-                : displayName;
+            const label = displayName;
 
             return (
               <div
@@ -366,11 +312,9 @@ export default function PlansAndCronJobs({ onApplyWorkCycle, onOpenPlanDetail }:
                 </button>
 
                 {!isCollapsed && (() => {
-                  const planItems = items.filter((i) => i.kind === 'plan');
-                  const cronItems = items.filter((i) => i.kind === 'cron');
                   const cycles = cyclesByProject.get(projectKey) ?? [];
                   const activeCycle = cycles.find((c) => c.status === 'active' || c.status === 'applying');
-                  const hasCompletedPlan = planItems.some((p) => {
+                  const hasCompletedPlan = items.some((p) => {
                     const s = (p.data as DiscoveryPlanOverview).status;
                     return s === 'completed' || s === 'completed_no_report';
                   });
@@ -422,11 +366,10 @@ export default function PlansAndCronJobs({ onApplyWorkCycle, onOpenPlanDetail }:
 
                   return (
                     <>
-                      {/* Plans sub-section */}
-                      {planItems.length > 0 && (
+                      {items.length > 0 && (
                         <SubSection
                           sectionKey={`${projectKey}::plans`}
-                          label={`${t('plansCron.type.plan', { defaultValue: 'Plan' })} (${planItems.length})`}
+                          label={`${t('plansCron.type.plan', { defaultValue: 'Plan' })} (${items.length})`}
                           collapsedSections={collapsedSections}
                           toggleSection={toggleSection}
                           actions={
@@ -490,32 +433,9 @@ export default function PlansAndCronJobs({ onApplyWorkCycle, onOpenPlanDetail }:
                         >
                           <ColumnHeaders t={t} />
                           <div className="divide-y divide-neutral-100 dark:divide-neutral-900">
-                            {planItems.map((item) => (
+                            {items.map((item) => (
                               <ItemRow
                                 key={`plan-${item.data.id}`}
-                                item={item}
-                                t={t}
-                                onRefresh={refresh}
-                                onOpenPlanDetail={onOpenPlanDetail}
-                              />
-                            ))}
-                          </div>
-                        </SubSection>
-                      )}
-
-                      {/* Cron Jobs sub-section */}
-                      {cronItems.length > 0 && (
-                        <SubSection
-                          sectionKey={`${projectKey}::crons`}
-                          label={`${t('plansCron.type.cronJob', { defaultValue: 'Cron Jobs' })} (${cronItems.length})`}
-                          collapsedSections={collapsedSections}
-                          toggleSection={toggleSection}
-                        >
-                          <ColumnHeaders t={t} />
-                          <div className="divide-y divide-neutral-100 dark:divide-neutral-900">
-                            {cronItems.map((item) => (
-                              <ItemRow
-                                key={`cron-${item.data.id}`}
                                 item={item}
                                 t={t}
                                 onRefresh={refresh}
@@ -538,7 +458,7 @@ export default function PlansAndCronJobs({ onApplyWorkCycle, onOpenPlanDetail }:
 }
 
 // ---------------------------------------------------------------------------
-// Collapsible sub-section (Plans / Cron Jobs within a project card)
+// Collapsible sub-section within a project card
 // ---------------------------------------------------------------------------
 
 function SubSection({
@@ -580,7 +500,7 @@ function SubSection({
 }
 
 // ---------------------------------------------------------------------------
-// Column headers (shared between Plans and Cron Jobs sub-sections)
+// Column headers
 // ---------------------------------------------------------------------------
 
 function ColumnHeaders({ t }: { t: (key: string, opts?: Record<string, string>) => string }) {
@@ -611,7 +531,7 @@ function ColumnHeaders({ t }: { t: (key: string, opts?: Record<string, string>) 
 }
 
 // ---------------------------------------------------------------------------
-// Table row (plan or cron)
+// Table row
 // ---------------------------------------------------------------------------
 
 function ItemRow({
@@ -620,40 +540,26 @@ function ItemRow({
   onRefresh,
   onOpenPlanDetail,
 }: {
-  item: UnifiedItem;
+  item: PlanItem;
   t: (key: string, opts?: Record<string, string>) => string;
   onRefresh: () => Promise<void>;
   onOpenPlanDetail?: (planId: string, projectName: string, projectDisplayName: string, sourceRunId: string, projectKey: string) => void;
 }) {
   const [busy, setBusy] = useState(false);
 
-  const isPlan = item.kind === 'plan';
-  const plan = isPlan ? item.data : null;
-  const job = isPlan ? null : item.data;
+  const plan = item.data;
+  const title = plan.title || '—';
+  const fullTitle = plan.title || '';
+  const createdAt = plan.createdAt;
+  const displayStatus = mapPlanStatus(plan.status);
+  const meta = PLAN_STATUS_LABEL[displayStatus];
+  const statusLabel = t(meta.key, { defaultValue: meta.defaultValue });
+  const statusStyle = PLAN_STATUS_STYLE[displayStatus];
 
-  const title = isPlan ? (plan!.title || '—') : (job!.prompt || '—');
-  const fullTitle = isPlan ? (plan!.title || '') : (job!.prompt || '');
-  const createdAt = isPlan ? plan!.createdAt : job!.createdAt;
-
-  let statusLabel: string;
-  let statusStyle: string;
-  let displayStatus: PlanDisplayStatus | null = null;
-  if (isPlan) {
-    displayStatus = mapPlanStatus(plan!.status);
-    const meta = PLAN_STATUS_LABEL[displayStatus];
-    statusLabel = t(meta.key, { defaultValue: meta.defaultValue });
-    statusStyle = PLAN_STATUS_STYLE[displayStatus];
-  } else {
-    const cs: 'scheduled' | 'running' = job!.status === 'running' ? 'running' : 'scheduled';
-    const meta = CRON_STATUS_LABEL[cs];
-    statusLabel = t(meta.key, { defaultValue: meta.defaultValue });
-    statusStyle = CRON_STATUS_STYLE[cs];
-  }
-
-  const showRetry = isPlan && displayStatus === 'failed';
+  const showRetry = displayStatus === 'failed';
 
   const handleRetry = async () => {
-    if (!plan || busy) return;
+    if (busy) return;
     setBusy(true);
     try {
       const res = await api.executeProjectDiscoveryPlan(item.projectName, plan.id, { source: 'manual' });
@@ -669,67 +575,14 @@ function ItemRow({
     }
   };
 
-  const handleCronDelete = async () => {
-    if (!job || busy) return;
-    setBusy(true);
-    try {
-      const res = await api.cronDelete(job.id);
-      if (!res.ok) {
-        const body = await res.json().catch(() => ({})) as { error?: string };
-        throw new Error(body?.error || `HTTP ${res.status}`);
-      }
-      await onRefresh();
-    } catch {
-      // Visible via refresh.
-    } finally {
-      setBusy(false);
-    }
-  };
-
-  const handleCronRunNow = async () => {
-    if (!job || busy) return;
-    setBusy(true);
-    try {
-      const res = await api.cronRunNow(job.id);
-      if (!res.ok) {
-        const body = await res.json().catch(() => ({})) as { error?: string };
-        throw new Error(body?.error || `HTTP ${res.status}`);
-      }
-      await onRefresh();
-    } catch {
-      // Visible via refresh.
-    } finally {
-      setBusy(false);
-    }
-  };
-
-  const handleCronStop = async () => {
-    if (!job || busy) return;
-    setBusy(true);
-    try {
-      const res = await api.cronStop(job.id);
-      if (!res.ok) {
-        const body = await res.json().catch(() => ({})) as { error?: string };
-        throw new Error(body?.error || `HTTP ${res.status}`);
-      }
-      await onRefresh();
-    } catch {
-      // Visible via refresh.
-    } finally {
-      setBusy(false);
-    }
-  };
-
-  const cronIsRunning = !isPlan && job?.status === 'running';
-
   return (
     <div className="flex items-center gap-4 px-5 py-2.5 transition-colors hover:bg-neutral-50 dark:hover:bg-neutral-900/40">
       {/* Title */}
       <div className={cn(COL.title, 'truncate text-[13px] text-neutral-900 dark:text-neutral-100')} title={fullTitle}>
-        {isPlan && onOpenPlanDetail ? (
+        {onOpenPlanDetail ? (
           <button
             type="button"
-            onClick={() => onOpenPlanDetail(plan!.id, item.projectName, item.projectDisplayName, (plan as DiscoveryPlanOverview).sourceRunId || (plan as DiscoveryPlanOverview).sourceDiscoverySessionId || '', item.projectKey)}
+            onClick={() => onOpenPlanDetail(plan.id, item.projectName, item.projectDisplayName, plan.sourceRunId || plan.sourceDiscoverySessionId || '', item.projectKey)}
             className="truncate text-left hover:underline"
           >
             {title}
@@ -753,68 +606,19 @@ function ItemRow({
 
       {/* Actions */}
       <div className={cn(COL.actions, 'flex items-center gap-1.5')}>
-        {isPlan ? (
-          <>
-            {showRetry && (
-              <button
-                type="button"
-                disabled={busy}
-                onClick={() => void handleRetry()}
-                className="inline-flex h-7 items-center rounded-md bg-blue-600 px-2.5 text-[11px] font-medium text-white transition hover:bg-blue-700 disabled:opacity-50 dark:bg-blue-700 dark:hover:bg-blue-600"
-              >
-                {busy ? (
-                  <Loader2 className="h-3 w-3 animate-spin" strokeWidth={2} />
-                ) : (
-                  t('plansCron.actions.retry', { defaultValue: 'Retry' })
-                )}
-              </button>
-            )}
-          </>
-        ) : (
-          <>
-            {cronIsRunning ? (
-              <button
-                type="button"
-                disabled={busy}
-                onClick={() => void handleCronStop()}
-                className="inline-flex h-7 items-center gap-1 rounded-md bg-red-600 px-2.5 text-[11px] font-medium text-white transition hover:bg-red-700 disabled:opacity-50 dark:bg-red-700 dark:hover:bg-red-600"
-              >
-                {busy ? (
-                  <Loader2 className="h-3 w-3 animate-spin" strokeWidth={2} />
-                ) : (
-                  <>
-                    <Square className="h-3 w-3" strokeWidth={2} />
-                    {t('plansCron.actions.stop', { defaultValue: 'Stop' })}
-                  </>
-                )}
-              </button>
-            ) : (
-              <button
-                type="button"
-                disabled={busy}
-                onClick={() => void handleCronRunNow()}
-                className="inline-flex h-7 items-center gap-1 rounded-md bg-blue-600 px-2.5 text-[11px] font-medium text-white transition hover:bg-blue-700 disabled:opacity-50 dark:bg-blue-700 dark:hover:bg-blue-600"
-              >
-                {busy ? (
-                  <Loader2 className="h-3 w-3 animate-spin" strokeWidth={2} />
-                ) : (
-                  <>
-                    <Play className="h-3 w-3" strokeWidth={2} />
-                    {t('plansCron.actions.runNow', { defaultValue: 'Run Now' })}
-                  </>
-                )}
-              </button>
-            )}
+        {showRetry && (
             <button
               type="button"
               disabled={busy}
-              onClick={() => void handleCronDelete()}
-              className="inline-flex h-7 items-center rounded-md border border-neutral-200 px-2 text-neutral-500 transition hover:border-red-300 hover:text-red-600 disabled:opacity-50 dark:border-neutral-700 dark:text-neutral-400 dark:hover:border-red-700 dark:hover:text-red-400"
-              title={t('plansCron.actions.delete', { defaultValue: 'Delete' })}
+              onClick={() => void handleRetry()}
+              className="inline-flex h-7 items-center rounded-md bg-blue-600 px-2.5 text-[11px] font-medium text-white transition hover:bg-blue-700 disabled:opacity-50 dark:bg-blue-700 dark:hover:bg-blue-600"
             >
-              <Trash2 className="h-3.5 w-3.5" strokeWidth={1.75} />
+              {busy ? (
+                <Loader2 className="h-3 w-3 animate-spin" strokeWidth={2} />
+              ) : (
+                t('plansCron.actions.retry', { defaultValue: 'Retry' })
+              )}
             </button>
-          </>
         )}
       </div>
     </div>

--- a/ui/src/components/main-content/view/MainContent.tsx
+++ b/ui/src/components/main-content/view/MainContent.tsx
@@ -20,6 +20,7 @@ import MainContentStateView from './subcomponents/MainContentStateView';
 import ErrorBoundary from './ErrorBoundary';
 
 const AlwaysOnV2 = React.lazy(() => import('../../main-content-v2/AlwaysOnV2'));
+const CronV2 = React.lazy(() => import('../../main-content-v2/CronV2'));
 const FilesV2 = React.lazy(() => import('../../main-content-v2/FilesV2'));
 const ShellV2 = React.lazy(() => import('../../main-content-v2/ShellV2'));
 const GitV2 = React.lazy(() => import('../../main-content-v2/GitV2'));
@@ -310,7 +311,7 @@ function MainContent({
     );
   }
 
-  if (!selectedProject && activeTab !== 'dashboard') {
+  if (!selectedProject && activeTab !== 'dashboard' && activeTab !== 'cron') {
     return (
       <MainContentStateView
         mode="empty"
@@ -497,6 +498,7 @@ function SplitBody(props: SplitBodyProps) {
     'shell',
     'git',
     'always-on',
+    'cron',
     'dashboard',
     'memory',
     'skills',
@@ -593,6 +595,7 @@ function SplitBody(props: SplitBodyProps) {
         />
       );
     }
+    if (activeTab === 'cron') return <CronV2 />;
     if (activeTab === 'dashboard') return <DashboardV2 projectFilter={selectedProject?.name} projectFullPath={selectedProject?.fullPath} onSelectProject={onSelectProjectByName} />;
     if (activeTab === 'memory') return <MemoryPanel selectedProject={selectedProject} />;
     if (activeTab === 'skills') return <SkillsV2 selectedProject={selectedProject} projects={projects} />;

--- a/ui/src/i18n/locales/en/alwaysOn.json
+++ b/ui/src/i18n/locales/en/alwaysOn.json
@@ -5,7 +5,7 @@
   },
   "tabs": {
     "dashboard": "Dashboard",
-    "plansCron": "Plans & Cron Jobs"
+    "plans": "Plans"
   },
   "dashboard": {
     "title": "Always-On Dashboard",
@@ -26,7 +26,7 @@
     },
     "runDetail": {
       "back": "Back to events",
-      "backToPlans": "Back to Plans & Cron Jobs",
+      "backToPlans": "Back to Plans",
       "loading": "Loading…",
       "untitled": "Untitled Plan",
       "workspaceStrategy": "Workspace",
@@ -60,10 +60,10 @@
     }
   },
   "plansCron": {
-    "title": "Plans & Cron Jobs",
-    "subtitle": "All plans and cron jobs across projects.",
-    "loading": "Loading plans and cron jobs…",
-    "empty": "No plans or cron jobs found.",
+    "title": "Plans",
+    "subtitle": "Always-On plans across projects.",
+    "loading": "Loading plans…",
+    "empty": "No plans found.",
     "unassigned": "Unassigned",
     "columns": {
       "title": "Title",
@@ -101,6 +101,65 @@
       "applying": "Applying…",
       "applied": "Applied",
       "archived": "Archived"
+    }
+  },
+  "cron": {
+    "title": "Cron",
+    "subtitle": "Scheduled cron jobs across projects.",
+    "loading": "Loading cron jobs...",
+    "empty": "No active cron jobs found.",
+    "unassigned": "Unassigned",
+    "tabs": {
+      "list": "Task List",
+      "create": "Create Task"
+    },
+    "columns": {
+      "title": "Title",
+      "createdAt": "Created",
+      "nextRunAt": "Next Run",
+      "status": "Status",
+      "actions": "Actions"
+    },
+    "actions": {
+      "delete": "Delete",
+      "runNow": "Run Now",
+      "stop": "Stop"
+    },
+    "status": {
+      "scheduled": "Scheduled",
+      "running": "Running"
+    },
+    "create": {
+      "title": "Create Cron Task",
+      "subtitle": "Schedule a one-time or recurring background prompt.",
+      "success": "Cron task created.",
+      "fields": {
+        "prompt": "Prompt",
+        "workspace": "Workspace",
+        "scheduleType": "Schedule Type",
+        "date": "Date",
+        "time": "Time",
+        "timezone": "Timezone"
+      },
+      "placeholders": {
+        "prompt": "Describe what PilotDeck should do when this task runs.",
+        "workspace": "Select a workspace"
+      },
+      "schedule": {
+        "once": "One-time",
+        "cron": "Recurring"
+      },
+      "validation": {
+        "messageRequired": "Prompt is required.",
+        "workspaceRequired": "Workspace is required.",
+        "dateRequired": "Date is required.",
+        "timeRequired": "Time is required.",
+        "timezoneRequired": "Timezone is required.",
+        "runAtFuture": "Run time must be in the future."
+      },
+      "actions": {
+        "submit": "Create Task"
+      }
     }
   }
 }

--- a/ui/src/i18n/locales/en/common.json
+++ b/ui/src/i18n/locales/en/common.json
@@ -27,7 +27,8 @@
     "tasks": "Tasks",
     "dashboard": "Routing",
     "memory": "Memory",
-    "skills": "Skills"
+    "skills": "Skills",
+    "cron": "Cron"
   },
   "skillsTab": {
     "pickProject": "Open a project to manage its skills.",

--- a/ui/src/i18n/locales/en/settings.json
+++ b/ui/src/i18n/locales/en/settings.json
@@ -856,7 +856,7 @@
       },
       "cron": {
         "title": "Cron",
-        "description": "Configure the background scheduler used by Cron jobs. Create and manage jobs from Always-On > Plans & Cron Jobs.",
+        "description": "Configure the background scheduler used by Cron jobs. Create and manage jobs from the Cron module.",
         "enabled": {
           "label": "Enabled",
           "description": "Master switch for scheduled Cron background tasks."

--- a/ui/src/i18n/locales/zh-CN/alwaysOn.json
+++ b/ui/src/i18n/locales/zh-CN/alwaysOn.json
@@ -5,7 +5,7 @@
   },
   "tabs": {
     "dashboard": "仪表盘",
-    "plansCron": "计划与定时任务"
+    "plans": "计划"
   },
   "dashboard": {
     "title": "Always-On 仪表盘",
@@ -60,10 +60,10 @@
     }
   },
   "plansCron": {
-    "title": "计划与定时任务",
-    "subtitle": "所有项目的计划与定时任务。",
-    "loading": "正在加载计划与定时任务…",
-    "empty": "暂无计划或定时任务。",
+    "title": "计划",
+    "subtitle": "所有项目的 Always-On 计划。",
+    "loading": "正在加载计划…",
+    "empty": "暂无计划。",
     "unassigned": "未关联项目",
     "columns": {
       "title": "标题",
@@ -101,6 +101,65 @@
       "applying": "正在应用…",
       "applied": "已应用",
       "archived": "已归档"
+    }
+  },
+  "cron": {
+    "title": "Cron",
+    "subtitle": "所有项目的定时 cron 任务。",
+    "loading": "正在加载 cron 任务...",
+    "empty": "暂无活跃 cron 任务。",
+    "unassigned": "未关联项目",
+    "tabs": {
+      "list": "任务列表",
+      "create": "创建任务"
+    },
+    "columns": {
+      "title": "标题",
+      "createdAt": "创建时间",
+      "nextRunAt": "下次运行",
+      "status": "状态",
+      "actions": "操作"
+    },
+    "actions": {
+      "delete": "删除",
+      "runNow": "立即运行",
+      "stop": "停止"
+    },
+    "status": {
+      "scheduled": "已安排",
+      "running": "运行中"
+    },
+    "create": {
+      "title": "创建 Cron 任务",
+      "subtitle": "安排一次性或周期性的后台提示词任务。",
+      "success": "Cron 任务已创建。",
+      "fields": {
+        "prompt": "提示词",
+        "workspace": "工作区",
+        "scheduleType": "任务类型",
+        "date": "日期",
+        "time": "时间",
+        "timezone": "时区"
+      },
+      "placeholders": {
+        "prompt": "描述 PilotDeck 在任务运行时应该做什么。",
+        "workspace": "选择工作区"
+      },
+      "schedule": {
+        "once": "一次性",
+        "cron": "周期"
+      },
+      "validation": {
+        "messageRequired": "请填写提示词。",
+        "workspaceRequired": "请选择工作区。",
+        "dateRequired": "请选择日期。",
+        "timeRequired": "请选择时间。",
+        "timezoneRequired": "请填写时区。",
+        "runAtFuture": "运行时间必须晚于当前时间。"
+      },
+      "actions": {
+        "submit": "创建任务"
+      }
     }
   }
 }

--- a/ui/src/i18n/locales/zh-CN/common.json
+++ b/ui/src/i18n/locales/zh-CN/common.json
@@ -27,7 +27,8 @@
     "tasks": "任务",
     "dashboard": "路由",
     "memory": "记忆",
-    "skills": "技能"
+    "skills": "技能",
+    "cron": "Cron"
   },
   "skillsTab": {
     "pickProject": "选一个项目来管理它的技能。",

--- a/ui/src/i18n/locales/zh-CN/settings.json
+++ b/ui/src/i18n/locales/zh-CN/settings.json
@@ -856,7 +856,7 @@
       },
       "cron": {
         "title": "Cron",
-        "description": "配置 Cron 任务使用的后台调度器。任务创建和管理仍在 Always-On > Plans & Cron Jobs 中完成。",
+        "description": "配置 Cron 任务使用的后台调度器。任务创建和管理在 Cron 模块中完成。",
         "enabled": {
           "label": "启用",
           "description": "定时 Cron 后台任务的总开关。"

--- a/ui/src/types/app.ts
+++ b/ui/src/types/app.ts
@@ -1,7 +1,7 @@
 export type SessionProvider = 'claude' | 'cursor' | 'codex' | 'gemini' | 'pilotdeck';
 export type ProjectSessionKind = 'background_task';
 
-export type AppTab = 'home' | 'chat' | 'always-on' | 'files' | 'shell' | 'git' | 'tasks' | 'memory' | 'skills' | 'preview' | 'dashboard' | `plugin:${string}`;
+export type AppTab = 'home' | 'chat' | 'always-on' | 'cron' | 'files' | 'shell' | 'git' | 'tasks' | 'memory' | 'skills' | 'preview' | 'dashboard' | `plugin:${string}`;
 
 export type AlwaysOnSessionTarget =
   | {
@@ -122,6 +122,7 @@ export interface CronJobOverview {
   cron: string;
   prompt: string;
   createdAt: string;
+  nextRunAt?: string;
   recurring: boolean;
   manualOnly: boolean;
   status: CronJobOverviewStatus;
@@ -132,7 +133,7 @@ export interface CronJobsOverviewResponse {
   jobs: CronJobOverview[];
 }
 
-export type AlwaysOnSubTab = 'dashboard' | 'plans-cron';
+export type AlwaysOnSubTab = 'dashboard' | 'plans';
 
 export interface DiscoveryContextCronItem {
   id: string;

--- a/ui/src/utils/api.js
+++ b/ui/src/utils/api.js
@@ -178,6 +178,11 @@ export const api = {
     authenticatedFetch(`/api/always-on/events?limit=${encodeURIComponent(limit)}${since ? `&since=${encodeURIComponent(since)}` : ''}`),
   allCronJobs: () =>
     authenticatedFetch('/api/always-on/cron-jobs'),
+  cronCreate: (payload) =>
+    authenticatedFetch('/api/always-on/cron-jobs', {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    }),
   cronRunNow: (taskId) =>
     authenticatedFetch(`/api/always-on/cron-jobs/${encodeURIComponent(taskId)}/run-now`, { method: 'POST' }),
   cronStop: (taskId) =>


### PR DESCRIPTION
## Summary

- split Cron jobs out of the Always-On plans panel into a dedicated Cron top-level page
- add a Cron task creation form backed by the existing gateway cronCreate API
- show next scheduled run time in the Cron list while keeping Always-On focused on plans only

## Impact

Users can manage scheduled Cron tasks from a focused Cron module instead of the Always-On plans view. The branch intentionally avoids the broader Always-On architecture refactor and background replay changes.

## Validation

- pnpm -C ui exec vitest run src/components/main-content-v2/CronV2.test.tsx
- pnpm -C ui exec vitest run src/components/main-content-v2
- npm run build

Note: pnpm -C ui run typecheck still fails on existing main-branch React type mismatches such as I18nextProvider, Routes, and lucide icons.