### PR TITLE
fix(ui): keep live thinking in process order

### DIFF
--- a/ui/src/components/chat-v2/MessagesPaneV2.tsx
+++ b/ui/src/components/chat-v2/MessagesPaneV2.tsx
@@ -29,6 +29,7 @@ import {
   getWebFetchWaitingStep,
   shouldRenderLiveProcessGroup,
   shouldShowWebFetchWaitingHint,
+  splitLiveProcessGroupDetailMessages,
   type LiveProcessGroup,
   type RenderableMessageItem,
 } from './processGrouping';
@@ -768,16 +769,23 @@ export default function MessagesPaneV2({
     const isLatestGroup = liveProcessGroups[liveProcessGroups.length - 1]?.id === group.id;
     const step = getLiveProcessGroupStep(group, t, group.isRunning && isLatestGroup ? liveStatusStep : null);
     const showWebFetchWaiting = shouldShowWebFetchWaitingHint(group, resolvedPlanModeActive);
+    const expanded = isProcessExpanded(group.id);
+    const { beforeStatusMessages, statusDetailMessages } = splitLiveProcessGroupDetailMessages(group);
     return (
       <Fragment key={group.id || `${group.afterOriginalIndex}-${index}`}>
+        {expanded && beforeStatusMessages.length > 0 ? (
+          <div className="pl-5">
+            {renderLiveProcessDetailMessages(beforeStatusMessages, `${group.id}-before-status`)}
+          </div>
+        ) : null}
         <ProcessLiveStatus
           step={step}
           compact
-          expanded={isProcessExpanded(group.id)}
+          expanded={expanded}
           onExpandedChange={(expanded) => handleProcessExpandedChange(group.id, expanded)}
         >
-          {group.detailMessages.length > 0
-            ? renderLiveProcessDetailMessages(group.detailMessages, group.id)
+          {statusDetailMessages.length > 0
+            ? renderLiveProcessDetailMessages(statusDetailMessages, group.id)
             : null}
         </ProcessLiveStatus>
         {showWebFetchWaiting ? (

--- a/ui/src/components/chat-v2/SubagentDetailMessageFlow.render.test.tsx
+++ b/ui/src/components/chat-v2/SubagentDetailMessageFlow.render.test.tsx
@@ -1,0 +1,121 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import type { ChatMessage } from '../chat/types/types';
+import SubagentDetailMessageFlow from './SubagentDetailMessageFlow';
+
+const baseTime = Date.parse('2026-05-18T08:00:00.000Z');
+
+function timestamp(offsetMs: number): string {
+  return new Date(baseTime + offsetMs).toISOString();
+}
+
+function assistant(id: string, content: string, offsetMs = 100): ChatMessage {
+  return {
+    id,
+    type: 'assistant',
+    content,
+    timestamp: timestamp(offsetMs),
+  };
+}
+
+function thinking(id: string, content: string, offsetMs = 200): ChatMessage {
+  return {
+    id,
+    type: 'assistant',
+    content,
+    timestamp: timestamp(offsetMs),
+    isThinking: true,
+  };
+}
+
+function streamingThinking(content: string, offsetMs = 200): ChatMessage {
+  return {
+    id: '__subagent_thinking_session-1_subagent-1',
+    type: 'assistant',
+    content,
+    timestamp: timestamp(offsetMs),
+    isThinking: true,
+    isStreaming: true,
+  };
+}
+
+function tool(id: string, toolName: string, offsetMs = 300): ChatMessage {
+  return {
+    id,
+    type: 'assistant',
+    content: '',
+    timestamp: timestamp(offsetMs),
+    isToolUse: true,
+    toolId: id,
+    toolName,
+    toolInput: JSON.stringify({ file_path: '/repo/src/App.tsx' }),
+    toolResult: null,
+  };
+}
+
+function renderFlow(messages: ChatMessage[], isRunning = true) {
+  return render(
+    <SubagentDetailMessageFlow
+      messages={messages}
+      provider="pilotdeck"
+      selectedProject={null}
+      createDiff={() => []}
+      showThinking
+      isRunning={isRunning}
+    />,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('SubagentDetailMessageFlow', () => {
+  it('renders streaming subagent thinking through the live preview channel', () => {
+    renderFlow([
+      assistant('a-1', 'I will edit the file.', 100),
+      streamingThinking('Choose the smallest patch.', 200),
+      tool('edit-1', 'Edit', 300),
+    ]);
+
+    const thinkingText = screen.getByText('Choose the smallest patch.');
+    const status = screen.getByRole('status');
+
+    expect(screen.getAllByText('Choose the smallest patch.')).toHaveLength(1);
+    expect(Boolean(thinkingText.compareDocumentPosition(status) & Node.DOCUMENT_POSITION_FOLLOWING)).toBe(true);
+  });
+
+  it('renders completed standalone subagent thinking once', () => {
+    renderFlow([
+      assistant('a-1', 'I will inspect the issue.', 100),
+      thinking('think-1', 'Standalone thought one.', 200),
+      thinking('think-2', 'Standalone thought two.', 300),
+    ], false);
+
+    expect(screen.getAllByText('Standalone thought one.')).toHaveLength(1);
+    expect(screen.getAllByText('Standalone thought two.')).toHaveLength(1);
+  });
+
+  it('keeps completed subagent thinking inside related tool status details', () => {
+    renderFlow([
+      assistant('a-1', 'I will inspect the issue.', 100),
+      thinking('think-1', 'Completed thought one.', 200),
+      thinking('think-2', 'Completed thought two.', 300),
+      tool('read-1', 'Read', 400),
+    ], false);
+
+    expect(screen.queryByText('Completed thought one.')).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: /Explored 1 file|已探索 1 个文件/i }));
+
+    const status = screen.getByRole('status');
+
+    expect(screen.getAllByText('Completed thought one.')).toHaveLength(1);
+    expect(screen.getAllByText('Completed thought two.')).toHaveLength(1);
+    expect(status.textContent).toContain('Completed thought one.');
+    expect(status.textContent).toContain('Completed thought two.');
+    expect(screen.queryByText('Thought through next step')).toBeNull();
+    expect(screen.getByText(/Explored 1 file|已探索 1 个文件/i)).toBeTruthy();
+  });
+});

--- a/ui/src/components/chat-v2/SubagentDetailMessageFlow.tsx
+++ b/ui/src/components/chat-v2/SubagentDetailMessageFlow.tsx
@@ -3,14 +3,16 @@ import { useTranslation } from 'react-i18next';
 import type { ChatMessage, ChatRunMode } from '../chat/types/types';
 import type { Project, SessionProvider } from '../../types/app';
 import MessageRowV2 from './MessageRowV2';
-import { ProcessLiveStatus, type ProcessTraceStep } from './ProcessTrace';
+import { ProcessLiveStatus, StreamingThinkingPreview, type ProcessTraceStep } from './ProcessTrace';
 import {
   buildRenderableMessageItems,
   getLiveProcessGroups,
   getLiveProcessGroupStep,
   getProcessToolKind,
   shouldRenderLiveProcessGroup,
+  splitLiveProcessGroupDetailMessages,
   type LiveProcessGroup,
+  type ProcessAttachment,
   type RenderableMessageItem,
 } from './processGrouping';
 
@@ -46,6 +48,32 @@ function isStreamingSubagentThinkingMessage(message: ChatMessage): boolean {
   return Boolean(message.isThinking && String(message.id || '').startsWith('__subagent_thinking_'));
 }
 
+function processAttachmentOverlapsLiveGroup(
+  attachment: ProcessAttachment,
+  liveGroups: LiveProcessGroup[],
+): boolean {
+  return liveGroups.some((group) => (
+    attachment.startIndex <= group.endIndex && attachment.endIndex >= group.startIndex
+  ));
+}
+
+function removeLiveOverlappingProcessAttachments(
+  item: RenderableMessageItem,
+  liveGroups: LiveProcessGroup[],
+): RenderableMessageItem {
+  if (liveGroups.length === 0) return item;
+
+  return {
+    ...item,
+    beforeProcessAttachments: item.beforeProcessAttachments.filter(
+      (attachment) => !processAttachmentOverlapsLiveGroup(attachment, liveGroups),
+    ),
+    afterProcessAttachments: item.afterProcessAttachments.filter(
+      (attachment) => !processAttachmentOverlapsLiveGroup(attachment, liveGroups),
+    ),
+  };
+}
+
 export default function SubagentDetailMessageFlow({
   messages,
   provider,
@@ -58,6 +86,21 @@ export default function SubagentDetailMessageFlow({
 }: SubagentDetailMessageFlowProps) {
   const { t } = useTranslation('chat');
   const [expandedProcessRows, setExpandedProcessRows] = useState<Map<string, boolean>>(() => new Map());
+
+  const streamingThinkingContent = useMemo(() => {
+    if (!showThinking || !isRunning) return null;
+    for (let index = messages.length - 1; index >= 0; index -= 1) {
+      const message = messages[index];
+      if (
+        isStreamingSubagentThinkingMessage(message) &&
+        typeof message.content === 'string' &&
+        message.content.trim()
+      ) {
+        return message.content;
+      }
+    }
+    return null;
+  }, [isRunning, messages, showThinking]);
 
   const thinkingStatusStep = useMemo<ProcessTraceStep>(() => {
     const lastToolMsg = [...messages].reverse().find(
@@ -104,9 +147,20 @@ export default function SubagentDetailMessageFlow({
     },
     [messages, showThinking],
   );
-  const renderableItems = useMemo(
-    () => buildRenderableMessageItems(renderableMessages, { isAssistantWorking: true }),
+  const baseRenderableItems = useMemo(
+    () => buildRenderableMessageItems(renderableMessages, { isAssistantWorking: true })
+      .filter((item) => !item.message.isAgentActivitySummary),
     [renderableMessages],
+  );
+  const liveProcessGroups = useMemo(
+    () => getLiveProcessGroups(renderableMessages, { isAssistantWorking: true })
+        .filter((group) => shouldRenderLiveProcessGroup(group, runMode))
+        .map((group) => isRunning ? group : { ...group, isRunning: false }),
+    [isRunning, renderableMessages, runMode],
+  );
+  const renderableItems = useMemo(
+    () => baseRenderableItems.map((item) => removeLiveOverlappingProcessAttachments(item, liveProcessGroups)),
+    [baseRenderableItems, liveProcessGroups],
   );
   const keyedItems = useMemo<KeyedRenderableMessageItem[]>(
     () => renderableItems.map((item, index) => ({
@@ -119,12 +173,6 @@ export default function SubagentDetailMessageFlow({
   const visibleOriginalIndices = useMemo(
     () => new Set(keyedItems.map((item) => item.originalIndex)),
     [keyedItems],
-  );
-  const liveProcessGroups = useMemo(
-    () => getLiveProcessGroups(renderableMessages, { isAssistantWorking: true })
-        .filter((group) => shouldRenderLiveProcessGroup(group, runMode))
-        .map((group) => isRunning ? group : { ...group, isRunning: false }),
-    [isRunning, renderableMessages, runMode],
   );
   const liveProcessGroupsByAnchor = useMemo(() => {
     const groupsByAnchor = new Map<number, LiveProcessGroup[]>();
@@ -139,8 +187,28 @@ export default function SubagentDetailMessageFlow({
     () => liveProcessGroups.filter((group) => !visibleOriginalIndices.has(group.afterOriginalIndex)),
     [liveProcessGroups, visibleOriginalIndices],
   );
+  const unanchoredLiveProcessGroupsByBeforeIndex = useMemo(() => {
+    const groupsByBeforeIndex = new Map<number, LiveProcessGroup[]>();
+    for (const group of unanchoredLiveProcessGroups) {
+      if (group.beforeOriginalIndex == null) continue;
+      const insertionItem = keyedItems.find((item) => item.originalIndex >= group.beforeOriginalIndex!);
+      if (!insertionItem) continue;
+      const groups = groupsByBeforeIndex.get(insertionItem.originalIndex) || [];
+      groups.push(group);
+      groupsByBeforeIndex.set(insertionItem.originalIndex, groups);
+    }
+    return groupsByBeforeIndex;
+  }, [keyedItems, unanchoredLiveProcessGroups]);
+  const bottomUnanchoredLiveProcessGroups = useMemo(
+    () => unanchoredLiveProcessGroups.filter((group) => {
+      if (group.beforeOriginalIndex == null) return true;
+      return !keyedItems.some((item) => item.originalIndex >= group.beforeOriginalIndex!);
+    }),
+    [keyedItems, unanchoredLiveProcessGroups],
+  );
   const hasOpenEndedLiveProcessGroup = liveProcessGroups.some((group) => group.isRunning);
   const shouldRenderBottomLiveStatus = isRunning && !hasOpenEndedLiveProcessGroup;
+  const shouldRenderBottomStreamingThinking = Boolean(streamingThinkingContent && !hasOpenEndedLiveProcessGroup);
 
   const isProcessExpanded = useCallback((processKey: string, defaultExpanded = false) => (
     expandedProcessRows.get(processKey) ?? defaultExpanded
@@ -183,52 +251,70 @@ export default function SubagentDetailMessageFlow({
   const renderLiveProcessGroup = useCallback((group: LiveProcessGroup, index: number) => {
     const isLatestGroup = liveProcessGroups[liveProcessGroups.length - 1]?.id === group.id;
     const step = getLiveProcessGroupStep(group, t, group.isRunning && isLatestGroup ? thinkingStatusStep : null);
+    const expanded = isProcessExpanded(group.id);
+    const { beforeStatusMessages, statusDetailMessages } = splitLiveProcessGroupDetailMessages(group);
+    const showStreamingThinkingBeforeStatus = Boolean(streamingThinkingContent && group.isRunning && isLatestGroup);
     return (
-      <ProcessLiveStatus
-        key={group.id || `${group.afterOriginalIndex}-${index}`}
-        step={step}
-        compact
-        expanded={isProcessExpanded(group.id)}
-        onExpandedChange={(expanded) => handleProcessExpandedChange(group.id, expanded)}
-      >
-        {group.detailMessages.length > 0
-          ? renderLiveProcessDetailMessages(group.detailMessages, group.id)
-          : null}
-      </ProcessLiveStatus>
+      <Fragment key={group.id || `${group.afterOriginalIndex}-${index}`}>
+        {expanded && beforeStatusMessages.length > 0 ? (
+          <div className="pl-5">
+            {renderLiveProcessDetailMessages(beforeStatusMessages, `${group.id}-before-status`)}
+          </div>
+        ) : null}
+        {showStreamingThinkingBeforeStatus ? (
+          <div className="pl-5">
+            <StreamingThinkingPreview content={streamingThinkingContent!} />
+          </div>
+        ) : null}
+        <ProcessLiveStatus
+          step={step}
+          compact
+          expanded={expanded}
+          onExpandedChange={(expanded) => handleProcessExpandedChange(group.id, expanded)}
+        >
+          {statusDetailMessages.length > 0
+            ? renderLiveProcessDetailMessages(statusDetailMessages, group.id)
+            : null}
+        </ProcessLiveStatus>
+      </Fragment>
     );
   }, [
     handleProcessExpandedChange,
     isProcessExpanded,
     liveProcessGroups,
     renderLiveProcessDetailMessages,
+    streamingThinkingContent,
     t,
     thinkingStatusStep,
   ]);
 
   if (
     keyedItems.length === 0 &&
-    unanchoredLiveProcessGroups.length === 0 &&
-    !shouldRenderBottomLiveStatus
+    bottomUnanchoredLiveProcessGroups.length === 0 &&
+    unanchoredLiveProcessGroupsByBeforeIndex.size === 0 &&
+    !shouldRenderBottomLiveStatus &&
+    !shouldRenderBottomStreamingThinking
   ) {
     return null;
   }
 
   return (
     <div className="flex min-w-0 flex-col gap-3 px-6 py-4">
-      {unanchoredLiveProcessGroups.length > 0 ? (
-        <div className="flex min-w-0 flex-col gap-2">
-          {unanchoredLiveProcessGroups.map(renderLiveProcessGroup)}
-        </div>
-      ) : null}
       {keyedItems.map((item) => {
         const previousMessage = item.renderIndex > 0 ? keyedItems[item.renderIndex - 1].message : null;
         const nextMessage = item.renderIndex < keyedItems.length - 1
           ? keyedItems[item.renderIndex + 1].message
           : null;
         const anchoredLiveGroups = liveProcessGroupsByAnchor.get(item.originalIndex) || [];
+        const beforeLiveGroups = unanchoredLiveProcessGroupsByBeforeIndex.get(item.originalIndex) || [];
 
         return (
           <Fragment key={item.itemKey}>
+            {beforeLiveGroups.length > 0 ? (
+              <div className="flex min-w-0 flex-col gap-2">
+                {beforeLiveGroups.map(renderLiveProcessGroup)}
+              </div>
+            ) : null}
             <MessageRowV2
               message={item.message}
               prevMessage={previousMessage}
@@ -251,8 +337,18 @@ export default function SubagentDetailMessageFlow({
           </Fragment>
         );
       })}
-      {shouldRenderBottomLiveStatus ? (
-        <ProcessLiveStatus step={thinkingStatusStep} />
+      {bottomUnanchoredLiveProcessGroups.length > 0 ? (
+        <div className="flex min-w-0 flex-col gap-2">
+          {bottomUnanchoredLiveProcessGroups.map(renderLiveProcessGroup)}
+        </div>
+      ) : null}
+      {shouldRenderBottomLiveStatus || shouldRenderBottomStreamingThinking ? (
+        <div className="flex min-w-0 flex-col">
+          <ProcessLiveStatus step={thinkingStatusStep} />
+          {shouldRenderBottomStreamingThinking ? (
+            <StreamingThinkingPreview content={streamingThinkingContent!} />
+          ) : null}
+        </div>
       ) : null}
     </div>
   );

--- a/ui/src/components/chat-v2/processGrouping.test.ts
+++ b/ui/src/components/chat-v2/processGrouping.test.ts
@@ -7,6 +7,8 @@ import {
   getLiveProcessGroups,
   hasPendingWebFetchInRunningGroup,
   shouldShowWebFetchWaitingHint,
+  splitLiveProcessGroupDetailMessages,
+  type LiveProcessGroup,
   type RenderableMessageItem,
 } from './processGrouping';
 
@@ -31,6 +33,16 @@ function assistant(id: string, content: string, offsetMs = 1000): ChatMessage {
     type: 'assistant',
     content,
     timestamp: timestamp(offsetMs),
+  };
+}
+
+function thinking(id: string, content = 'Thinking through the next step.', offsetMs = 500): ChatMessage {
+  return {
+    id,
+    type: 'assistant',
+    content,
+    timestamp: timestamp(offsetMs),
+    isThinking: true,
   };
 }
 
@@ -434,8 +446,51 @@ describe('processGrouping', () => {
     const groups = getLiveProcessGroups(messages, { isAssistantWorking: true });
 
     expect(items.map((item) => item.message.id)).toEqual(['u1', 'a1', 'a-final']);
-    expect(groups).toHaveLength(2);
-    expect(groups.every((group) => group.afterOriginalIndex === 1)).toBe(true);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].afterOriginalIndex).toBe(1);
+    expect(groups[0].messages.map((message) => message.id)).toEqual(['read-1', 'grep-1']);
+  });
+
+  it('does not render thinking as standalone after empty live assistant shells', () => {
+    const messages = [
+      user('u1'),
+      assistant('a1', 'Starting work.', 100),
+      tool('bash-1', 'Bash', { command: 'head -30 package.json' }, 200, null),
+      assistant('a-empty', '', 250),
+      thinking('think-1', 'Inspect the command output next.', 300),
+    ];
+
+    const items = buildRenderableMessageItems(messages, { isAssistantWorking: true });
+    const groups = getLiveProcessGroups(messages, { isAssistantWorking: true });
+
+    expect(items.map((item) => item.message.id)).toEqual(['u1', 'a1']);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].messages.map((message) => message.id)).toEqual(['bash-1', 'think-1']);
+    expect(groups[0].detailMessages.map((message) => message.id)).toEqual(['bash-1', 'think-1']);
+  });
+
+  it('keeps leading live thinking inside the current running status details', () => {
+    const group: LiveProcessGroup = {
+      id: 'group-1',
+      afterOriginalIndex: 1,
+      beforeOriginalIndex: null,
+      startIndex: 2,
+      endIndex: 4,
+      messages: [
+        thinking('think-1', 'Decide which file to edit.', 200),
+        tool('edit-1', 'Edit', { file_path: '/repo/src/App.tsx' }, 300, null),
+      ],
+      detailMessages: [
+        thinking('think-1', 'Decide which file to edit.', 200),
+        tool('edit-1', 'Edit', { file_path: '/repo/src/App.tsx' }, 300, null),
+      ],
+      isRunning: true,
+    };
+
+    const split = splitLiveProcessGroupDetailMessages(group);
+
+    expect(split.beforeStatusMessages).toEqual([]);
+    expect(split.statusDetailMessages.map((message) => message.id)).toEqual(['think-1', 'edit-1']);
   });
 
   it('keeps normalized empty assistant shells available as process separators', () => {
@@ -463,10 +518,9 @@ describe('processGrouping', () => {
       'a-final',
     ]);
     expect(items.map((item) => item.message.id)).toEqual(['u1', 'a1', 'a-final']);
-    expect(groups).toHaveLength(2);
+    expect(groups).toHaveLength(1);
     expect(groups.map((group) => group.messages.map((message) => message.id))).toEqual([
-      ['read-1'],
-      ['grep-1'],
+      ['read-1', 'grep-1'],
     ]);
   });
 

--- a/ui/src/components/chat-v2/processGrouping.ts
+++ b/ui/src/components/chat-v2/processGrouping.ts
@@ -730,6 +730,8 @@ export function buildRenderableMessageItems(
         if (groupStart < 0) groupStart = i;
         if (!msg.isThinking) hasNonThinking = true;
         else pendingThinkingIndices.push(i);
+      } else if (isEmptyAssistantShell(msg)) {
+        continue;
       } else {
         if (groupStart >= 0 && !hasNonThinking) {
           for (const idx of pendingThinkingIndices) {
@@ -879,6 +881,16 @@ export function getLiveProcessDetailMessages(messages: ChatMessage[]): ChatMessa
     .flatMap((group) => group.detailMessages);
 }
 
+export function splitLiveProcessGroupDetailMessages(group: LiveProcessGroup): {
+  beforeStatusMessages: ChatMessage[];
+  statusDetailMessages: ChatMessage[];
+} {
+  return {
+    beforeStatusMessages: [],
+    statusDetailMessages: group.detailMessages,
+  };
+}
+
 export function getLiveProcessGroups(
   messages: ChatMessage[],
   options: BuildRenderableMessageItemsOptions = {},
@@ -938,7 +950,6 @@ export function getLiveProcessGroups(
     }
 
     if (isEmptyAssistantShell(message)) {
-      finishGroup(index);
       continue;
     }
 

--- a/ui/src/components/chat-v2/useSubagentMessages.test.ts
+++ b/ui/src/components/chat-v2/useSubagentMessages.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+import type { NormalizedMessage } from '../../stores/useSessionStore';
+import type { SessionProvider } from '../../types/app';
+import { mergeSubagentDetailMessages } from './useSubagentMessages';
+
+const PROVIDER = 'pilotdeck' as SessionProvider;
+
+function textMessage(
+  id: string,
+  content: string,
+  timestamp: string,
+  overrides: Partial<NormalizedMessage> = {},
+): NormalizedMessage {
+  return {
+    id,
+    sessionId: 'session-1::sub::subagent-1',
+    timestamp,
+    provider: PROVIDER,
+    kind: 'text',
+    role: 'assistant',
+    content,
+    ...overrides,
+  };
+}
+
+function streamMessage(id: string, content: string, timestamp: string): NormalizedMessage {
+  return {
+    id,
+    sessionId: 'session-1::sub::subagent-1',
+    timestamp,
+    provider: PROVIDER,
+    kind: 'stream_delta',
+    role: 'assistant',
+    content,
+  };
+}
+
+function thinkingMessage(
+  id: string,
+  content: string,
+  timestamp: string,
+  overrides: Partial<NormalizedMessage> = {},
+): NormalizedMessage {
+  return {
+    id,
+    sessionId: 'session-1::sub::subagent-1',
+    timestamp,
+    provider: PROVIDER,
+    kind: 'thinking',
+    role: 'assistant',
+    content,
+    ...overrides,
+  };
+}
+
+describe('mergeSubagentDetailMessages', () => {
+  it('drops finalized realtime assistant text already covered by snapshot text', () => {
+    const snapshot = [
+      textMessage('snapshot-text', 'Persisted answer', '2026-05-28T00:00:02.000Z'),
+    ];
+    const realtime = [
+      textMessage('subagent_text_local_final', 'Realtime answer', '2026-05-28T00:00:01.000Z'),
+    ];
+
+    expect(mergeSubagentDetailMessages(snapshot, realtime, false).map((message) => message.id)).toEqual([
+      'snapshot-text',
+    ]);
+  });
+
+  it('keeps active subagent stream deltas after snapshot text', () => {
+    const snapshot = [
+      textMessage('snapshot-text', 'Persisted answer', '2026-05-28T00:00:02.000Z'),
+    ];
+    const realtime = [
+      streamMessage('__subagent_streaming_session-1_subagent-1', 'Still streaming', '2026-05-28T00:00:03.000Z'),
+    ];
+
+    expect(mergeSubagentDetailMessages(snapshot, realtime, false).map((message) => message.id)).toEqual([
+      'snapshot-text',
+      '__subagent_streaming_session-1_subagent-1',
+    ]);
+  });
+
+  it('keeps newer finalized realtime thinking when snapshot only has older thinking', () => {
+    const snapshot = [
+      thinkingMessage('snapshot-thinking-old', 'Older persisted thought', '2026-05-28T00:00:01.000Z'),
+    ];
+    const realtime = [
+      thinkingMessage('subagent_thinking_session-1_subagent-1_2', 'New local thought', '2026-05-28T00:00:03.000Z'),
+    ];
+
+    expect(mergeSubagentDetailMessages(snapshot, realtime, false).map((message) => message.id)).toEqual([
+      'snapshot-thinking-old',
+      'subagent_thinking_session-1_subagent-1_2',
+    ]);
+  });
+
+  it('drops finalized realtime thinking already covered by newer snapshot thinking', () => {
+    const snapshot = [
+      thinkingMessage('snapshot-thinking-new', 'Persisted thought', '2026-05-28T00:00:03.000Z'),
+    ];
+    const realtime = [
+      thinkingMessage('subagent_thinking_session-1_subagent-1_1', 'Local thought', '2026-05-28T00:00:02.000Z'),
+    ];
+
+    expect(mergeSubagentDetailMessages(snapshot, realtime, false).map((message) => message.id)).toEqual([
+      'snapshot-thinking-new',
+    ]);
+  });
+});

--- a/ui/src/components/chat-v2/useSubagentMessages.ts
+++ b/ui/src/components/chat-v2/useSubagentMessages.ts
@@ -43,7 +43,7 @@ function normalizeSubagentDetailContainers(messages: ChatMessage[]): ChatMessage
   });
 }
 
-function mergeSubagentDetailMessages(
+export function mergeSubagentDetailMessages(
   snapshotMessages: NormalizedMessage[],
   realtimeMessages: NormalizedMessage[],
   useSnapshotOnly: boolean,
@@ -61,10 +61,27 @@ function mergeSubagentDetailMessages(
   const snapshotToolIds = new Set(
     snapshotMessages.filter(m => m.kind === 'tool_use' && m.toolId).map(m => m.toolId!),
   );
+  const latestSnapshotFinalTimestamp = snapshotMessages.reduce<number | null>((latest, message) => {
+    if (
+      (message.kind !== 'text' || message.role === 'user') &&
+      message.kind !== 'thinking'
+    ) return latest;
+    const parsed = Date.parse(String(message.timestamp || ''));
+    if (!Number.isFinite(parsed)) return latest;
+    return latest == null ? parsed : Math.max(latest, parsed);
+  }, null);
   for (const message of realtimeMessages) {
     if (seenIds.has(message.id)) continue;
     if (message.kind === 'tool_use' && message.toolId && snapshotToolIds.has(message.toolId)) continue;
     if (message.kind === 'tool_result' && message.toolId && snapshotToolIds.has(message.toolId)) continue;
+    if (
+      ((message.kind === 'text' && message.role !== 'user') || message.kind === 'thinking') &&
+      latestSnapshotFinalTimestamp != null &&
+      !String(message.id || '').startsWith('__subagent_thinking_')
+    ) {
+      const parsed = Date.parse(String(message.timestamp || ''));
+      if (!Number.isFinite(parsed) || parsed <= latestSnapshotFinalTimestamp) continue;
+    }
     seenIds.add(message.id);
     merged.push(message);
   }

--- a/ui/src/stores/useSessionStore.streaming.test.ts
+++ b/ui/src/stores/useSessionStore.streaming.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { SessionProvider } from '../types/app';
 import {
+  computeMerged,
   createRafNotifyScheduler,
+  getFinalizedSubagentThinkingId,
   patchMergedStreamingMessage,
   type NormalizedMessage,
   type SessionSlot,
@@ -14,6 +16,8 @@ function makeSlot(overrides: Partial<SessionSlot> = {}): SessionSlot {
     serverMessages: [],
     realtimeMessages: [],
     activityMessages: [],
+    subagentDetailMessages: new Map(),
+    subagentLinks: new Map(),
     merged: [],
     _lastServerRef: [],
     _lastRealtimeRef: [],
@@ -24,6 +28,24 @@ function makeSlot(overrides: Partial<SessionSlot> = {}): SessionSlot {
     hasMore: false,
     offset: 0,
     tokenUsage: null,
+    ...overrides,
+  };
+}
+
+function textMessage(
+  id: string,
+  content: string,
+  timestamp: string,
+  overrides: Partial<NormalizedMessage> = {},
+): NormalizedMessage {
+  return {
+    id,
+    sessionId: 'web:s_test',
+    timestamp,
+    provider: PROVIDER,
+    kind: 'text',
+    role: 'assistant',
+    content,
     ...overrides,
   };
 }
@@ -40,7 +62,7 @@ function streamingMessage(sessionId: string, content: string): NormalizedMessage
 }
 
 describe('patchMergedStreamingMessage', () => {
-  it('updates merged content in place without replacing the merged array', () => {
+  it('updates merged content without recomputing from store inputs', () => {
     const sessionId = 'web:s_test';
     const streamId = `__streaming_${sessionId}`;
     const merged = [streamingMessage(sessionId, 'hello')];
@@ -50,11 +72,11 @@ describe('patchMergedStreamingMessage', () => {
       _lastRealtimeRef: [streamingMessage(sessionId, 'hello')],
     });
 
-    const mergedBefore = slot.merged;
+    const realtimeBefore = slot.realtimeMessages;
     const patched = patchMergedStreamingMessage(slot, streamId, 'hello world', PROVIDER);
 
     expect(patched).toBe(true);
-    expect(slot.merged).toBe(mergedBefore);
+    expect(slot.realtimeMessages).toBe(realtimeBefore);
     expect(slot.merged[0]?.content).toBe('hello world');
   });
 
@@ -73,6 +95,45 @@ describe('patchMergedStreamingMessage', () => {
     patchMergedStreamingMessage(slot, streamId, 'same', PROVIDER);
 
     expect(slot.merged[0]).toBe(rowBefore);
+  });
+});
+
+describe('computeMerged', () => {
+  it('drops finalized realtime assistant text once the same turn is persisted', () => {
+    const server = [
+      textMessage('tail-before-turn', 'Previous answer', '2026-05-28T00:00:00.000Z'),
+      textMessage('persisted-answer', 'Persisted answer', '2026-05-28T00:00:02.000Z'),
+    ];
+    const realtime = [
+      textMessage('text-local-final', 'Realtime answer', '2026-05-28T00:00:01.000Z', {
+        isFinal: true,
+        serverTailIdAtStart: 'tail-before-turn',
+      }),
+    ];
+
+    expect(computeMerged(server, realtime).map((message) => message.id)).toEqual([
+      'tail-before-turn',
+      'persisted-answer',
+    ]);
+  });
+
+  it('keeps later finalized realtime assistant text when only an earlier same-turn text is persisted', () => {
+    const server = [
+      textMessage('tail-before-turn', 'Previous answer', '2026-05-28T00:00:00.000Z'),
+      textMessage('persisted-earlier-answer', 'First same-turn answer', '2026-05-28T00:00:02.000Z'),
+    ];
+    const realtime = [
+      textMessage('text-local-second-final', 'Second same-turn answer', '2026-05-28T00:00:03.000Z', {
+        isFinal: true,
+        serverTailIdAtStart: 'tail-before-turn',
+      }),
+    ];
+
+    expect(computeMerged(server, realtime).map((message) => message.id)).toEqual([
+      'tail-before-turn',
+      'persisted-earlier-answer',
+      'text-local-second-final',
+    ]);
   });
 });
 
@@ -149,5 +210,18 @@ describe('createRafNotifyScheduler', () => {
     expect(cancelled).toEqual([1]);
     frames[0]?.();
     expect(onNotify).not.toHaveBeenCalled();
+  });
+});
+
+describe('subagent detail thinking ids', () => {
+  it('finalizes subagent thinking with timestamp-based id instead of local sequence', () => {
+    const id = getFinalizedSubagentThinkingId(
+      'session-1',
+      'subagent-1',
+      '2026-05-28T00:00:03.000Z',
+    );
+
+    expect(id).toBe(`subagent_thinking_session-1_subagent-1_${Date.parse('2026-05-28T00:00:03.000Z')}`);
+    expect(id).not.toBe('subagent_thinking_session-1_subagent-1_0');
   });
 });

--- a/ui/src/stores/useSessionStore.ts
+++ b/ui/src/stores/useSessionStore.ts
@@ -320,6 +320,37 @@ function hasEquivalentServerMessage(
   });
 }
 
+function hasSameTurnServerFinalMessage(
+  realtimeMessage: NormalizedMessage,
+  serverMessages: NormalizedMessage[],
+): boolean {
+  if (
+    realtimeMessage.isFinal !== true ||
+    (realtimeMessage.kind !== 'text' && realtimeMessage.kind !== 'thinking') ||
+    !realtimeMessage.serverTailIdAtStart
+  ) {
+    return false;
+  }
+
+  const tailIndex = serverMessages.findIndex((message) => (
+    message.id === realtimeMessage.serverTailIdAtStart
+  ));
+  if (tailIndex < 0) return false;
+  const realtimeTimestamp = parseTimestampMs(realtimeMessage.timestamp);
+  if (realtimeTimestamp == null) return false;
+
+  return serverMessages.slice(tailIndex + 1).some((serverMessage) => {
+    if (serverMessage.kind !== realtimeMessage.kind) return false;
+    if (serverMessage.role !== realtimeMessage.role) return false;
+    if (realtimeMessage.runId != null && serverMessage.runId != null && serverMessage.runId !== realtimeMessage.runId) {
+      return false;
+    }
+    const serverTimestamp = parseTimestampMs(serverMessage.timestamp);
+    if (serverTimestamp == null) return false;
+    return serverTimestamp >= realtimeTimestamp;
+  });
+}
+
 export function shouldKeepRealtimeAfterServerRefresh(
   realtimeMessage: NormalizedMessage,
   serverMessages: NormalizedMessage[],
@@ -332,6 +363,9 @@ export function shouldKeepRealtimeAfterServerRefresh(
     realtimeMessage.isFinal === true
     && (realtimeMessage.kind === 'text' || realtimeMessage.kind === 'thinking')
   ) {
+    if (hasSameTurnServerFinalMessage(realtimeMessage, serverMessages)) {
+      return false;
+    }
     return !hasEquivalentServerMessage(realtimeMessage, serverMessages);
   }
 
@@ -343,7 +377,7 @@ export function shouldKeepRealtimeAfterServerRefresh(
  * Server messages take priority (they're the persisted source of truth).
  * Realtime messages that aren't yet in server stay (in-flight streaming).
  */
-function computeMerged(server: NormalizedMessage[], realtime: NormalizedMessage[]): NormalizedMessage[] {
+export function computeMerged(server: NormalizedMessage[], realtime: NormalizedMessage[]): NormalizedMessage[] {
   if (realtime.length === 0) {
     return server;
   }
@@ -356,6 +390,7 @@ function computeMerged(server: NormalizedMessage[], realtime: NormalizedMessage[
     if (serverIds.has(message.id)) return false;
     if (isConfirmedUserMessageDuplicate(message, server)) return false;
     if (isLocalInterruptDuplicate(message, server)) return false;
+    if (hasSameTurnServerFinalMessage(message, server)) return false;
     // Dedup tool_use by toolId (invocation ID) — the message envelope ID
     // may differ between WebSocket replay and server-persisted copy, but
     // the underlying tool invocation is the same.
@@ -463,6 +498,15 @@ function forceRecomputeMerged(slot: SessionSlot): void {
 
 function streamingKey(sessionId: string, runId?: string): string {
   return runId ? `${sessionId}_${runId}` : sessionId;
+}
+
+export function getFinalizedSubagentThinkingId(
+  sessionId: string,
+  subagentId: string,
+  timestamp?: string,
+): string {
+  const timestampSuffix = Date.parse(String(timestamp || '')) || Date.now();
+  return `subagent_thinking_${sessionId}_${subagentId}_${timestampSuffix}`;
 }
 
 /**
@@ -780,9 +824,14 @@ export function useSessionStore() {
 
   const recordSubagentLink = useCallback((sessionId: string, msg: NormalizedMessage) => {
     const slot = getSlot(sessionId);
-    const toolCallId = (msg as Record<string, unknown>).toolCallId as string | undefined;
-    const subagentId = (msg as Record<string, unknown>).subagentId as string | undefined;
-    const subagentType = (msg as Record<string, unknown>).subagentType as string | undefined;
+    const linkMessage = msg as unknown as {
+      toolCallId?: string;
+      subagentId?: string;
+      subagentType?: string;
+    };
+    const toolCallId = linkMessage.toolCallId;
+    const subagentId = linkMessage.subagentId;
+    const subagentType = linkMessage.subagentType;
     if (toolCallId && subagentId) {
       const nextLinks = new Map(slot.subagentLinks);
       nextLinks.set(toolCallId, { subagentId, subagentType: subagentType || 'agent' });
@@ -932,7 +981,7 @@ export function useSessionStore() {
     const updated = [...current];
     updated[existingIndex] = {
       ...stream,
-      id: `subagent_thinking_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
+      id: getFinalizedSubagentThinkingId(sessionId, subagentId, stream.timestamp),
     };
     const nextMap = new Map(slot.subagentDetailMessages);
     nextMap.set(subagentId, updated);


### PR DESCRIPTION
## Summary
- keep live thinking attached to process groups instead of rendering as standalone rows
- render leading thinking above the current running tool status in main and subagent process views
- add regression coverage for main process grouping and subagent detail modal ordering

## Tests
- npm --prefix ui test -- SubagentDetailMessageFlow.render.test.tsx processGrouping.test.ts MessagesPaneV2.render.test.tsx