### PR TITLE
fix(ui): keep live thinking and text in process order

### DIFF
--- a/ui/src/components/chat/hooks/useChatRealtimeHandlers.ts
+++ b/ui/src/components/chat/hooks/useChatRealtimeHandlers.ts
@@ -51,6 +51,58 @@ type LatestChatMessage = {
   [key: string]: any;
 };
 
+function normalizeAssistantStreamText(value?: string): string {
+  return typeof value === 'string' ? value.replace(/\s+/g, ' ').trim() : '';
+}
+
+function parseAssistantStreamTimestamp(value?: string): number | null {
+  if (!value) return null;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function isCompatibleAssistantStreamRun(incoming: NormalizedMessage, existing: NormalizedMessage): boolean {
+  if (incoming.runId != null && existing.runId != null) return incoming.runId === existing.runId;
+  const isActiveStream = existing.kind === 'stream_delta' && String(existing.id || '').startsWith('__streaming_');
+  if (!isActiveStream) return false;
+  const incomingTimestamp = parseAssistantStreamTimestamp(incoming.timestamp);
+  const existingTimestamp = parseAssistantStreamTimestamp(existing.timestamp);
+  if (incomingTimestamp == null || existingTimestamp == null) return false;
+  return Math.abs(incomingTimestamp - existingTimestamp) <= 10_000;
+}
+
+export function getDuplicateAssistantStreamTextState(
+  incoming: NormalizedMessage,
+  realtimeMessages: NormalizedMessage[],
+): { isDuplicate: boolean; hasActiveStream: boolean; activeStreamRunId?: string | null } {
+  if (incoming.kind !== 'text' || incoming.role !== 'assistant') {
+    return { isDuplicate: false, hasActiveStream: false };
+  }
+
+  const incomingText = normalizeAssistantStreamText(incoming.content);
+  if (!incomingText) {
+    return { isDuplicate: false, hasActiveStream: false };
+  }
+
+  let hasActiveStream = false;
+  let activeStreamRunId: string | null | undefined;
+  const isDuplicate = realtimeMessages.some((message) => {
+    const isAssistantText = message.kind === 'text' && message.role === 'assistant';
+    const isActiveStream = message.kind === 'stream_delta' && String(message.id || '').startsWith('__streaming_');
+    if (!isAssistantText && !isActiveStream) return false;
+    if (isAssistantText && (incoming.runId == null || message.runId == null)) return false;
+    if (!isCompatibleAssistantStreamRun(incoming, message)) return false;
+    if (normalizeAssistantStreamText(message.content) !== incomingText) return false;
+    if (isActiveStream) {
+      hasActiveStream = true;
+      activeStreamRunId = message.runId ?? null;
+    }
+    return true;
+  });
+
+  return { isDuplicate, hasActiveStream, activeStreamRunId };
+}
+
 
 function getExplicitSessionId(msg: LatestChatMessage): string | null {
   const value = msg.sessionId ?? msg.session_id ?? msg.actualSessionId ?? msg.newSessionId;
@@ -440,12 +492,14 @@ export function useChatRealtimeHandlers({
     // The streaming pipeline (stream_delta → stream_end → finalizeStreaming)
     // already creates a text message in realtimeMessages. If the backend also
     // sends a standalone 'text' message with the same content, skip it.
-    const isDuplicateStreamText =
-      msg.kind === 'text' && msg.role === 'assistant' &&
-      sessionStore.getSessionSlot?.(sid)?.realtimeMessages.some(
-        (m) => m.kind === 'text' && m.role === 'assistant' && m.content === (msg as NormalizedMessage).content,
-      );
-    if (!isDuplicateStreamText) {
+    const duplicateStreamTextState = getDuplicateAssistantStreamTextState(
+      msg as NormalizedMessage,
+      sessionStore.getSessionSlot?.(sid)?.realtimeMessages ?? [],
+    );
+    if (duplicateStreamTextState.hasActiveStream) {
+      sessionStore.finalizeStreaming(sid, duplicateStreamTextState.activeStreamRunId ?? undefined);
+    }
+    if (!duplicateStreamTextState.isDuplicate) {
       sessionStore.appendRealtime(sid, msg as NormalizedMessage);
     }
 

--- a/ui/src/stores/useSessionStore.streaming.test.ts
+++ b/ui/src/stores/useSessionStore.streaming.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { SessionProvider } from '../types/app';
+import { getDuplicateAssistantStreamTextState } from '../components/chat/hooks/useChatRealtimeHandlers';
 import {
   computeMerged,
   createRafNotifyScheduler,
   getFinalizedSubagentThinkingId,
   patchMergedStreamingMessage,
+  upsertRealtimeMessages,
   type NormalizedMessage,
   type SessionSlot,
 } from './useSessionStore';
@@ -99,10 +101,29 @@ describe('patchMergedStreamingMessage', () => {
 });
 
 describe('computeMerged', () => {
-  it('drops finalized realtime assistant text once the same turn is persisted', () => {
+  it('keeps finalized realtime assistant text until an equivalent same-turn server text is persisted', () => {
     const server = [
       textMessage('tail-before-turn', 'Previous answer', '2026-05-28T00:00:00.000Z'),
       textMessage('persisted-answer', 'Persisted answer', '2026-05-28T00:00:02.000Z'),
+    ];
+    const realtime = [
+      textMessage('text-local-final', 'Realtime answer', '2026-05-28T00:00:01.000Z', {
+        isFinal: true,
+        serverTailIdAtStart: 'tail-before-turn',
+      }),
+    ];
+
+    expect(computeMerged(server, realtime).map((message) => message.id)).toEqual([
+      'tail-before-turn',
+      'persisted-answer',
+      'text-local-final',
+    ]);
+  });
+
+  it('drops finalized realtime assistant text once equivalent same-turn text is persisted', () => {
+    const server = [
+      textMessage('tail-before-turn', 'Previous answer', '2026-05-28T00:00:00.000Z'),
+      textMessage('persisted-answer', 'Realtime answer', '2026-05-28T00:00:02.000Z'),
     ];
     const realtime = [
       textMessage('text-local-final', 'Realtime answer', '2026-05-28T00:00:01.000Z', {
@@ -134,6 +155,189 @@ describe('computeMerged', () => {
       'persisted-earlier-answer',
       'text-local-second-final',
     ]);
+  });
+});
+
+describe('getDuplicateAssistantStreamTextState', () => {
+  it('detects standalone assistant text duplicated by an active stream row', () => {
+    const incoming = textMessage('server-text', 'Hello from stream', '2026-05-28T00:00:02.000Z', {
+      runId: 'run-1',
+    });
+    const realtime = [
+      {
+        id: '__streaming_web:s_test_run-1',
+        sessionId: 'web:s_test',
+        timestamp: '2026-05-28T00:00:01.000Z',
+        provider: PROVIDER,
+        kind: 'stream_delta' as const,
+        content: 'Hello\nfrom stream',
+        runId: 'run-1',
+      },
+    ];
+
+    expect(getDuplicateAssistantStreamTextState(incoming, realtime)).toEqual({
+      isDuplicate: true,
+      hasActiveStream: true,
+      activeStreamRunId: 'run-1',
+    });
+  });
+
+  it('returns null activeStreamRunId for duplicate active stream without runId', () => {
+    const incoming = textMessage('server-text', 'Hello from stream', '2026-05-28T00:00:02.000Z', {
+      runId: 'run-1',
+    });
+    const realtime = [
+      {
+        id: '__streaming_web:s_test',
+        sessionId: 'web:s_test',
+        timestamp: '2026-05-28T00:00:01.000Z',
+        provider: PROVIDER,
+        kind: 'stream_delta' as const,
+        content: 'Hello from stream',
+      },
+    ];
+
+    expect(getDuplicateAssistantStreamTextState(incoming, realtime)).toEqual({
+      isDuplicate: true,
+      hasActiveStream: true,
+      activeStreamRunId: null,
+    });
+  });
+
+  it('does not dedupe assistant text against a different run stream', () => {
+    const incoming = textMessage('server-text', 'Hello from stream', '2026-05-28T00:00:02.000Z', {
+      runId: 'run-2',
+    });
+    const realtime = [
+      {
+        id: '__streaming_web:s_test_run-1',
+        sessionId: 'web:s_test',
+        timestamp: '2026-05-28T00:00:01.000Z',
+        provider: PROVIDER,
+        kind: 'stream_delta' as const,
+        content: 'Hello from stream',
+        runId: 'run-1',
+      },
+    ];
+
+    expect(getDuplicateAssistantStreamTextState(incoming, realtime)).toEqual({
+      isDuplicate: false,
+      hasActiveStream: false,
+    });
+  });
+
+  it('does not dedupe finalized assistant text without runId in the handler helper', () => {
+    const incoming = textMessage('incoming-text', 'Same answer', '2026-05-28T00:00:10.000Z');
+    const realtime = [
+      textMessage('existing-text', 'Same answer', '2026-05-28T00:00:01.000Z'),
+    ];
+
+    expect(getDuplicateAssistantStreamTextState(incoming, realtime)).toEqual({
+      isDuplicate: false,
+      hasActiveStream: false,
+    });
+  });
+
+  it('does not dedupe active stream text without runId outside the short time window', () => {
+    const incoming = textMessage('incoming-text', 'Same answer', '2026-05-28T00:01:00.000Z');
+    const realtime = [
+      {
+        id: '__streaming_web:s_test',
+        sessionId: 'web:s_test',
+        timestamp: '2026-05-28T00:00:01.000Z',
+        provider: PROVIDER,
+        kind: 'stream_delta' as const,
+        content: 'Same answer',
+      },
+    ];
+
+    expect(getDuplicateAssistantStreamTextState(incoming, realtime)).toEqual({
+      isDuplicate: false,
+      hasActiveStream: false,
+    });
+  });
+});
+
+describe('upsertRealtimeMessages', () => {
+  it('replaces an active stream row with duplicate standalone assistant text', () => {
+    const existing: NormalizedMessage[] = [
+      {
+        id: '__streaming_web:s_test_run-1',
+        sessionId: 'web:s_test',
+        timestamp: '2026-05-28T00:00:01.000Z',
+        provider: PROVIDER,
+        kind: 'stream_delta',
+        content: 'Final answer',
+        runId: 'run-1',
+        serverTailIdAtStart: 'tail-before-turn',
+      },
+    ];
+    const incoming = textMessage('server-text', 'Final answer', '2026-05-28T00:00:02.000Z', {
+      runId: 'run-1',
+    });
+
+    const updated = upsertRealtimeMessages(existing, [incoming]);
+
+    expect(updated).toHaveLength(1);
+    expect(updated[0]?.id).toBe('server-text');
+    expect(updated[0]?.kind).toBe('text');
+    expect(updated[0]?.serverTailIdAtStart).toBe('tail-before-turn');
+  });
+
+  it('dedupes duplicate standalone assistant text in the same run', () => {
+    const existing = [
+      textMessage('local-text', 'Final answer', '2026-05-28T00:00:01.000Z', { runId: 'run-1' }),
+    ];
+    const incoming = textMessage('server-text', 'Final answer', '2026-05-28T00:00:02.000Z', {
+      runId: 'run-1',
+    });
+
+    const updated = upsertRealtimeMessages(existing, [incoming]);
+
+    expect(updated).toHaveLength(1);
+    expect(updated[0]?.id).toBe('server-text');
+  });
+
+  it('keeps identical assistant text from different runs', () => {
+    const existing = [
+      textMessage('run-1-text', 'Same answer', '2026-05-28T00:00:01.000Z', { runId: 'run-1' }),
+    ];
+    const incoming = textMessage('run-2-text', 'Same answer', '2026-05-28T00:01:01.000Z', {
+      runId: 'run-2',
+    });
+
+    const updated = upsertRealtimeMessages(existing, [incoming]);
+
+    expect(updated.map((message) => message.id)).toEqual(['run-1-text', 'run-2-text']);
+  });
+
+  it('keeps duplicate finalized assistant text when runId is missing', () => {
+    const existing = [
+      textMessage('first-text', 'Same answer', '2026-05-28T00:00:01.000Z'),
+    ];
+    const incoming = textMessage('second-text', 'Same answer', '2026-05-28T00:00:02.000Z');
+
+    const updated = upsertRealtimeMessages(existing, [incoming]);
+
+    expect(updated.map((message) => message.id)).toEqual(['first-text', 'second-text']);
+  });
+
+  it('keeps duplicate active stream text without runId outside the short time window', () => {
+    const existing: NormalizedMessage[] = [
+      {
+        id: '__streaming_web:s_test',
+        sessionId: 'web:s_test',
+        timestamp: '2026-05-28T00:00:01.000Z',
+        provider: PROVIDER,
+        kind: 'stream_delta',
+        content: 'Same answer',
+      },
+    ];
+    const incoming = textMessage('incoming-text', 'Same answer', '2026-05-28T00:01:00.000Z');
+
+    const updated = upsertRealtimeMessages(existing, [incoming]);
+
+    expect(updated.map((message) => message.id)).toEqual(['__streaming_web:s_test', 'incoming-text']);
   });
 });
 

--- a/ui/src/stores/useSessionStore.ts
+++ b/ui/src/stores/useSessionStore.ts
@@ -338,6 +338,8 @@ function hasSameTurnServerFinalMessage(
   if (tailIndex < 0) return false;
   const realtimeTimestamp = parseTimestampMs(realtimeMessage.timestamp);
   if (realtimeTimestamp == null) return false;
+  const realtimeText = normalizeRealtimeText(realtimeMessage.content);
+  if (!realtimeText) return false;
 
   return serverMessages.slice(tailIndex + 1).some((serverMessage) => {
     if (serverMessage.kind !== realtimeMessage.kind) return false;
@@ -347,7 +349,8 @@ function hasSameTurnServerFinalMessage(
     }
     const serverTimestamp = parseTimestampMs(serverMessage.timestamp);
     if (serverTimestamp == null) return false;
-    return serverTimestamp >= realtimeTimestamp;
+    if (serverTimestamp < realtimeTimestamp) return false;
+    return normalizeRealtimeText(serverMessage.content) === realtimeText;
   });
 }
 
@@ -436,7 +439,38 @@ function getUpsertKey(message: NormalizedMessage): string {
   return message.id;
 }
 
-function upsertRealtimeMessages(
+function isCompatibleRealtimeTextRun(a: NormalizedMessage, b: NormalizedMessage): boolean {
+  if (a.runId != null && b.runId != null) return a.runId === b.runId;
+  const hasActiveStream = a.kind === 'stream_delta' || b.kind === 'stream_delta';
+  if (!hasActiveStream) return false;
+  const aTime = parseTimestampMs(a.timestamp);
+  const bTime = parseTimestampMs(b.timestamp);
+  if (aTime == null || bTime == null) return false;
+  return Math.abs(aTime - bTime) <= 10_000;
+}
+
+function findDuplicateAssistantRealtimeTextIndex(
+  messages: NormalizedMessage[],
+  incoming: NormalizedMessage,
+): number {
+  if (incoming.kind !== 'text' || incoming.role !== 'assistant') return -1;
+  const incomingText = normalizeRealtimeText(incoming.content);
+  if (!incomingText) return -1;
+
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const existing = messages[index];
+    const isAssistantText = existing.kind === 'text' && existing.role === 'assistant';
+    const isActiveAssistantStream = existing.kind === 'stream_delta' && String(existing.id || '').startsWith('__streaming_');
+    if (!isAssistantText && !isActiveAssistantStream) continue;
+    if (!isCompatibleRealtimeTextRun(existing, incoming)) continue;
+    if (normalizeRealtimeText(existing.content) !== incomingText) continue;
+    return index;
+  }
+
+  return -1;
+}
+
+export function upsertRealtimeMessages(
   existing: NormalizedMessage[],
   incoming: NormalizedMessage[],
 ): NormalizedMessage[] {
@@ -453,6 +487,17 @@ function upsertRealtimeMessages(
         };
         continue;
       }
+    }
+    const duplicateAssistantTextIndex = findDuplicateAssistantRealtimeTextIndex(updated, message);
+    if (duplicateAssistantTextIndex >= 0) {
+      const previousKey = getUpsertKey(updated[duplicateAssistantTextIndex]);
+      updated[duplicateAssistantTextIndex] = {
+        ...message,
+        serverTailIdAtStart: message.serverTailIdAtStart ?? updated[duplicateAssistantTextIndex].serverTailIdAtStart,
+      };
+      indexByKey.delete(previousKey);
+      indexByKey.set(getUpsertKey(message), duplicateAssistantTextIndex);
+      continue;
     }
     const key = getUpsertKey(message);
     const existingIndex = indexByKey.get(key);


### PR DESCRIPTION
## Summary
- keep empty assistant shell messages from splitting live process groups
- keep live/completed thinking attached to the related process status instead of rendering as standalone rows
- fix main-flow and subagent snapshot/realtime duplicate assistant text/thinking during streaming
- keep subagent live thinking preview visible while preserving completed thinking and collapsible process details
- anchor subagent live process groups by original message order instead of forcing unanchored groups to the top

## Tests
- `npm --prefix ui test -- useSessionStore.streaming.test.ts useSubagentMessages.test.ts SubagentDetailMessageFlow.render.test.tsx processGrouping.test.ts MessagesPaneV2.render.test.tsx`

## Notes
- `npm --prefix ui run typecheck` still hits existing React/lucide JSX type conflicts unrelated to this PR.
