### PR TITLE
Improve invalid tool input recovery messages

### DIFF
--- a/src/tool/execution/ToolRuntime.ts
+++ b/src/tool/execution/ToolRuntime.ts
@@ -157,7 +157,12 @@ export class ToolRuntime {
           call.id,
           tool.name,
           "invalid_tool_input",
-          `PreToolUse hook produced invalid input for ${tool.name}.`,
+          `PreToolUse hook produced invalid input for ${tool.name}.
+
+${formatValidationError(tool.name, updatedValidation.issues, {
+            maxOutputTokens: runtimeContext.maxOutputTokens,
+            outputTruncated: runtimeContext.outputTruncated,
+          })}`,
           startedAt,
           context,
           { issues: updatedValidation.issues },
@@ -171,7 +176,10 @@ export class ToolRuntime {
         call.id,
         tool.name,
         "invalid_tool_input",
-        `Tool ${tool.name} rejected the input.`,
+        formatValidationError(tool.name, toolValidation.issues, {
+          maxOutputTokens: runtimeContext.maxOutputTokens,
+          outputTruncated: runtimeContext.outputTruncated,
+        }),
         startedAt,
         context,
         { issues: toolValidation.issues },

--- a/src/tool/execution/errorRecovery.ts
+++ b/src/tool/execution/errorRecovery.ts
@@ -1,4 +1,5 @@
 import type { PilotDeckToolErrorCode } from "../protocol/errors.js";
+import type { PilotDeckToolValidationIssue } from "../protocol/schema.js";
 
 export type ToolErrorFailureClass =
   | "fix_input"
@@ -14,6 +15,7 @@ export type ToolErrorRecoveryAdvice = {
   nextActions: string[];
   avoidRetryReason?: string;
   salientEvidence?: string[];
+  originalError?: string;
 };
 
 export type ToolErrorRecoveryResult = {
@@ -31,17 +33,21 @@ export function buildToolErrorRecovery(options: {
 }): ToolErrorRecoveryResult {
   const evidence = extractSalientEvidence(options.message, options.details);
   const advice: ToolErrorRecoveryAdvice = {
-    summary: summarizeError(options.code, options.toolName, options.message, evidence),
+    summary: summarizeError(options.code, options.toolName, options.message, evidence, options.details),
     failureClass: classifyError(options.code, options.toolName, options.message, options.details),
     nextActions: baseNextActions(options.code, options.toolName, {
       cwd: options.cwd,
       permissionMode: options.permissionMode,
-    }, options.details),
+    }, options.message, options.details),
     salientEvidence: evidence,
   };
   const avoidRetryReason = defaultAvoidRetryReason(options.code);
   if (avoidRetryReason) {
     advice.avoidRetryReason = avoidRetryReason;
+  }
+  const originalError = formatOriginalError(options.message);
+  if (originalError) {
+    advice.originalError = originalError;
   }
 
   advice.nextActions = uniqueStrings(advice.nextActions).slice(0, 3);
@@ -74,6 +80,10 @@ function formatRecoveryMessage(
     lines.push(`Do not retry unchanged: ${advice.avoidRetryReason}`);
   }
 
+  if (advice.originalError) {
+    lines.push("Original error:", advice.originalError);
+  }
+
   if (advice.nextActions.length > 0) {
     lines.push("Next actions:");
     advice.nextActions.forEach((action, index) => {
@@ -89,9 +99,21 @@ function summarizeError(
   toolName: string,
   rawMessage: string,
   evidence: string[],
+  details?: Record<string, unknown>,
 ): string {
   if (code === "invalid_tool_input") {
-    return `The ${toolName} input did not match the tool schema.`;
+    const firstIssue = readValidationIssues(details)[0];
+    if (firstIssue?.message) {
+      return trimSentence(firstIssue.message);
+    }
+    const firstLine = firstMeaningfulLine(rawMessage);
+    if (firstLine) {
+      return trimSentence(firstLine);
+    }
+    if (evidence.length > 0) {
+      return trimSentence(evidence[0]);
+    }
+    return `The ${toolName} input is invalid.`;
   }
   if (code === "tool_not_found") {
     return `The model emitted a tool name that is not registered: ${toolName}.`;
@@ -204,6 +226,7 @@ function baseNextActions(
   code: PilotDeckToolErrorCode,
   toolName: string,
   context: { cwd: string; permissionMode: string },
+  rawMessage: string,
   details?: Record<string, unknown>,
 ): string[] {
   if (toolName === "web_fetch") {
@@ -215,13 +238,7 @@ function baseNextActions(
 
   switch (code) {
     case "invalid_tool_input":
-      if (toolName === "write_file" || toolName === "edit_file") {
-        return [
-          "Fix the tool arguments to match the schema before calling the tool again.",
-          "Create or edit a smaller valid chunk first, then continue with focused follow-up edits.",
-        ];
-      }
-      return ["Fix the tool arguments to match the schema before calling the tool again."];
+      return invalidToolInputNextActions(toolName, rawMessage, details);
     case "tool_not_found":
       return ["Use a registered canonical tool name from the current tool list."];
     case "plan_mode_violation":
@@ -257,6 +274,90 @@ function baseNextActions(
     default:
       return [`Inspect the evidence, change the approach, then retry only with corrected inputs. Current permission mode: ${context.permissionMode}.`];
   }
+}
+
+function invalidToolInputNextActions(
+  toolName: string,
+  rawMessage: string,
+  details?: Record<string, unknown>,
+): string[] {
+  const issues = readValidationIssues(details);
+  const haystack = [rawMessage, ...issues.map((issue) => `${issue.path}: ${issue.message}`)].join("\n");
+
+  if (/File has not been read yet/i.test(haystack)) {
+    return [
+      "Call read_file with the same file_path to establish the current file snapshot before writing.",
+      `Retry ${toolName} only after reading the file, or use edit_file for a focused change based on the current contents.`,
+    ];
+  }
+
+  if (/File has changed since the last read/i.test(haystack)) {
+    return [
+      "Call read_file with the same file_path again to refresh the file snapshot.",
+      `Retry ${toolName} using the refreshed contents so you do not overwrite concurrent changes.`,
+    ];
+  }
+
+  if (/String to replace not found|old_string.*not found|not appear in the target file/i.test(haystack)) {
+    return [
+      "Call read_file with the same file_path and copy the exact current text you need to replace.",
+      "Retry edit_file with a precise old_string that appears exactly once in the current file.",
+    ];
+  }
+
+  if (/Found \d+ matches of old_string|multiple matches|replace_all/i.test(haystack)) {
+    return [
+      "Use a more specific old_string that uniquely identifies the intended edit, including nearby context if needed.",
+      "If every occurrence should change, set replace_all to true and ensure that broad replacement is intended.",
+    ];
+  }
+
+  if (toolName === "bash" && /timeout \d+ms exceeds|timeout .*exceeds|exceeds the maximum|maximum of 600000/i.test(haystack)) {
+    return [
+      "Use timeout=600000 or less for foreground bash.",
+      "For a finite long-running command that should finish, use task_create and then task_wait to block for completion.",
+      "For long-lived services or watchers, use task_create with task_output for progress and task_stop for cleanup.",
+    ];
+  }
+
+  if (toolName === "bash" && /background|nohup|disown|setsid|task_create|task_wait/i.test(haystack)) {
+    return [
+      "Run short commands directly in foreground bash with a timeout of 600000ms or less.",
+      "For finite background work, use task_create and then task_wait so completion output returns to the model context.",
+      "For long-lived services or watchers, use task_create with task_output for progress checks and task_stop for cleanup.",
+    ];
+  }
+
+  const missing = issues.find((issue) => issue.code === "required");
+  if (missing) {
+    const param = cleanIssuePath(missing.path);
+    const actions = [`Include the required parameter ${formatParam(param)} in the next ${toolName} call.`];
+    if (/content|output truncated|token limit|output token/i.test(haystack)) {
+      actions.push("Create a smaller but complete draft first, then continue with focused follow-up edits or patches.");
+    }
+    return actions;
+  }
+
+  const invalidType = issues.find((issue) => issue.code === "invalid_type");
+  if (invalidType) {
+    return [`Change ${formatParam(cleanIssuePath(invalidType.path))} to the expected type before retrying: ${trimSentence(invalidType.message)}.`];
+  }
+
+  const unknown = issues.find((issue) => issue.code === "unknown_property");
+  if (unknown) {
+    return [`Remove or rename the unexpected parameter ${formatParam(cleanIssuePath(unknown.path))}; use only parameters from the tool schema.`];
+  }
+
+  const enumIssue = issues.find((issue) => issue.code === "invalid_enum");
+  if (enumIssue) {
+    return [`Use one of the allowed values for ${formatParam(cleanIssuePath(enumIssue.path))}: ${trimSentence(enumIssue.message)}.`];
+  }
+
+  if (issues.length > 0) {
+    return [`Fix ${formatParam(cleanIssuePath(issues[0].path))}: ${trimSentence(issues[0].message)}`];
+  }
+
+  return ["Fix the specific invalid argument described in the error message before calling the tool again."];
 }
 
 function webFetchNextActions(
@@ -326,12 +427,13 @@ function defaultAvoidRetryReason(code: PilotDeckToolErrorCode): string | undefin
 }
 
 function extractSalientEvidence(rawMessage: string, details?: Record<string, unknown>): string[] {
+  const issueEvidence = readValidationIssues(details).map(formatIssueEvidence);
   const lines = rawMessage
     .split(/\r?\n/)
     .map((line) => line.trim())
     .filter(Boolean)
     .filter((line) => !/^TOOL_ERROR\[/i.test(line));
-  const evidence = lines.slice(0, 2);
+  const evidence = [...issueEvidence, ...lines.slice(0, 2)];
   const status = readNumber(details, "status");
   if (typeof status === "number") {
     const statusText = readString(details, "statusText");
@@ -354,6 +456,46 @@ function extractSalientEvidence(rawMessage: string, details?: Record<string, unk
     evidence.push(firstMeaningfulLine(stderr));
   }
   return uniqueStrings(evidence.filter(Boolean).map(trimSentence));
+}
+
+function readValidationIssues(details?: Record<string, unknown>): PilotDeckToolValidationIssue[] {
+  const issues = details?.issues;
+  if (!Array.isArray(issues)) {
+    return [];
+  }
+  return issues.flatMap((issue): PilotDeckToolValidationIssue[] => {
+    if (!issue || typeof issue !== "object") {
+      return [];
+    }
+    const record = issue as Record<string, unknown>;
+    const path = typeof record.path === "string" ? record.path : "input";
+    const message = typeof record.message === "string" ? record.message : "Invalid tool input.";
+    const code = typeof record.code === "string" ? record.code : "invalid_schema";
+    if (!isValidationIssueCode(code)) {
+      return [{ path, code: "invalid_schema", message }];
+    }
+    return [{ path, code, message }];
+  });
+}
+
+function isValidationIssueCode(value: string): value is PilotDeckToolValidationIssue["code"] {
+  return value === "required"
+    || value === "unknown_property"
+    || value === "invalid_type"
+    || value === "invalid_enum"
+    || value === "invalid_schema";
+}
+
+function formatIssueEvidence(issue: PilotDeckToolValidationIssue): string {
+  return `${cleanIssuePath(issue.path)}: ${issue.message}`;
+}
+
+function cleanIssuePath(path: string): string {
+  return path.replace(/^\$\.?/, "") || "input";
+}
+
+function formatParam(path: string): string {
+  return `\`${path}\``;
 }
 
 function errorHaystack(rawMessage: string, details?: Record<string, unknown>): string {
@@ -385,6 +527,24 @@ function trimSentence(value: string): string {
     return compact;
   }
   return compact.slice(0, 217).trimEnd() + "...";
+}
+
+const ORIGINAL_ERROR_MAX_CHARS = 2_000;
+
+function formatOriginalError(rawMessage: string): string | undefined {
+  const cleaned = rawMessage
+    .split(/\r?\n/)
+    .map((line) => line.trimEnd())
+    .filter((line) => !/^TOOL_ERROR\[/i.test(line.trim()))
+    .join("\n")
+    .trim();
+  if (!cleaned) {
+    return undefined;
+  }
+  if (cleaned.length <= ORIGINAL_ERROR_MAX_CHARS) {
+    return cleaned;
+  }
+  return `${cleaned.slice(0, ORIGINAL_ERROR_MAX_CHARS).trimEnd()}\n... [original error truncated; ${cleaned.length} chars total]`;
 }
 
 function uniqueStrings(values: string[]): string[] {

--- a/tests/tool/error-recovery.spec.ts
+++ b/tests/tool/error-recovery.spec.ts
@@ -1,0 +1,124 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { buildToolErrorRecovery } from "../../src/tool/execution/errorRecovery.js";
+import type { PilotDeckToolValidationIssue } from "../../src/tool/protocol/schema.js";
+
+function recovery(options: {
+  toolName: string;
+  message: string;
+  issues?: PilotDeckToolValidationIssue[];
+}) {
+  return buildToolErrorRecovery({
+    code: "invalid_tool_input",
+    toolName: options.toolName,
+    message: options.message,
+    cwd: "/workspace",
+    permissionMode: "bypassPermissions",
+    details: options.issues ? { issues: options.issues } : undefined,
+  }).message;
+}
+
+test("write_file freshness error tells the model to read the file first", () => {
+  const text = recovery({
+    toolName: "write_file",
+    message: "write_file failed due to the following issue:\nFile has not been read yet. Read it first before writing to it.",
+    issues: [{
+      path: "file_path",
+      code: "invalid_schema",
+      message: "File has not been read yet. Read it first before writing to it.",
+    }],
+  });
+
+  assert.match(text, /Summary: File has not been read yet\. Read it first before writing to it\./);
+  assert.match(text, /Evidence:\n- file_path: File has not been read yet/);
+  assert.match(text, /Original error:\nwrite_file failed due to the following issue:/);
+  assert.match(text, /Call read_file with the same file_path/);
+  assert.doesNotMatch(text, /did not match the tool schema/i);
+  assert.doesNotMatch(text, /smaller valid chunk/i);
+});
+
+test("write_file missing content points at the missing field and chunked recovery", () => {
+  const text = recovery({
+    toolName: "write_file",
+    message: "write_file failed due to the following issue:\nThe required parameter `content` is missing",
+    issues: [{ path: "$.content", code: "required", message: "The required parameter `content` is missing" }],
+  });
+
+  assert.match(text, /Summary: The required parameter `content` is missing/);
+  assert.match(text, /Include the required parameter `content`/);
+  assert.match(text, /smaller but complete draft/i);
+  assert.doesNotMatch(text, /did not match the tool schema/i);
+});
+
+test("invalid tool input keeps a bounded original error block", () => {
+  const longDetail = "x".repeat(2_400);
+  const text = recovery({
+    toolName: "bash",
+    message: `Foreground bash timeout 900000ms exceeds the maximum of 600000ms.\n${longDetail}`,
+  });
+
+  assert.match(text, /Original error:\nForeground bash timeout 900000ms exceeds the maximum of 600000ms\./);
+  assert.match(text, /original error truncated; \d+ chars total/);
+  assert.match(text, /Next actions:/);
+});
+
+test("edit_file old_string miss tells the model to reread and copy exact text", () => {
+  const text = recovery({
+    toolName: "edit_file",
+    message: "String to replace not found in file.\nString: old text",
+  });
+
+  assert.match(text, /Summary: String to replace not found in file\./);
+  assert.match(text, /Call read_file with the same file_path/);
+  assert.match(text, /exact current text/i);
+  assert.doesNotMatch(text, /did not match the tool schema/i);
+});
+
+test("read_file invalid range preserves the concrete issue", () => {
+  const text = recovery({
+    toolName: "read_file",
+    message: "read_file failed due to the following issue:\noffset must be a 1-based line number (>= 1).",
+    issues: [{ path: "offset", code: "invalid_schema", message: "offset must be a 1-based line number (>= 1)." }],
+  });
+
+  assert.match(text, /Summary: offset must be a 1-based line number/);
+  assert.match(text, /Fix `offset`: offset must be a 1-based line number/);
+  assert.doesNotMatch(text, /did not match the tool schema/i);
+});
+
+test("bash missing command reports the required command parameter", () => {
+  const text = recovery({
+    toolName: "bash",
+    message: "bash failed due to the following issue:\nThe required parameter `command` is missing",
+    issues: [{ path: "$.command", code: "required", message: "The required parameter `command` is missing" }],
+  });
+
+  assert.match(text, /Summary: The required parameter `command` is missing/);
+  assert.match(text, /Include the required parameter `command`/);
+  assert.doesNotMatch(text, /did not match the tool schema/i);
+});
+
+test("bash timeout over max keeps foreground and task_wait guidance", () => {
+  const text = recovery({
+    toolName: "bash",
+    message: "Foreground bash timeout 900000ms exceeds the maximum of 600000ms. Use timeout=600000 or less for foreground bash. If the command must run in the background, use task_create and then task_wait to block for completion; use task_output only for progress checks and task_stop to clean up long-lived processes.",
+  });
+
+  assert.match(text, /Summary: Foreground bash timeout 900000ms exceeds the maximum of 600000ms/);
+  assert.match(text, /Use timeout=600000 or less for foreground bash/);
+  assert.match(text, /task_create and then task_wait/);
+  assert.doesNotMatch(text, /did not match the tool schema/i);
+});
+
+test("bash background rejection keeps background-specific guidance", () => {
+  const text = recovery({
+    toolName: "bash",
+    message: "This command appears to start background work. Use timeout=600000 or less for foreground bash. If the command must run in the background, use task_create and then task_wait to block for completion; use task_output only for progress checks and task_stop to clean up long-lived processes.",
+  });
+
+  assert.match(text, /Summary: This command appears to start background work/);
+  assert.match(text, /Run short commands directly in foreground bash/);
+  assert.match(text, /task_create and then task_wait/);
+  assert.doesNotMatch(text, /did not match the tool schema/i);
+});


### PR DESCRIPTION
## Summary
- surface concrete validation issues in model-visible invalid tool input errors
- include a bounded Original error block, following Hermes-style raw error visibility
- add targeted recovery guidance for file freshness/edit issues and bash timeout/background guardrails

## Tests
- npm run build
- node --test --test-force-exit --test-timeout 60000 dist/tests/tool/error-recovery.spec.js dist/tests/tool/bash-result-display.spec.js dist/tests/tool/new-file-write.spec.js

Note: the clean PR worktree used a local node_modules symlink to the main checkout dependencies for validation.