### PR TITLE
fix(skill-creator): don't crash report generator on empty history

### DIFF
--- a/skills/skill-creator/scripts/generate_report.py
+++ b/skills/skill-creator/scripts/generate_report.py
@@ -202,8 +202,12 @@ def generate_html(data: dict, auto_refresh: bool = False, skill_name: str = "") 
         <tbody>
 """)
 
-    # Find best iteration for highlighting
-    if test_queries:
+    # Find best iteration for highlighting. history may be empty (e.g. a live
+    # report rendered before the first iteration completes); max() would raise
+    # ValueError, so skip highlighting when there is nothing to highlight.
+    if not history:
+        best_iter = None
+    elif test_queries:
         best_iter = max(history, key=lambda h: h.get("test_passed") or 0).get("iteration")
     else:
         best_iter = max(history, key=lambda h: h.get("train_passed", h.get("passed", 0))).get("iteration")


### PR DESCRIPTION
## Summary

`generate_html()` in `skills/skill-creator/scripts/generate_report.py` calls `max(history, ...)` unconditionally to pick the best iteration to highlight. When `history` is empty, `max()` raises `ValueError: max() iterable argument is empty`, so the report generator crashes instead of producing a valid report.

Closes #417.

## Why this matters

The report is meant to be rendered incrementally (the script even supports `auto_refresh`), so it can legitimately be asked to render before the first iteration result exists — a live "run just started" state, a partial result, or any caller that wants a valid page before evaluation begins. Every other part of `generate_html` already tolerates an empty `history` (the query-discovery block is guarded by `if history:`); the best-iteration highlight was the one spot that still assumed at least one iteration, turning an expected early state into a crash.

## Fix

Guard the empty case before the `max()` calls:

```python
if not history:
    best_iter = None
elif test_queries:
    best_iter = max(history, key=lambda h: h.get("test_passed") or 0).get("iteration")
else:
    best_iter = max(history, key=lambda h: h.get("train_passed", h.get("passed", 0))).get("iteration")
```

`best_iter` is only read inside the `for h in history:` row loop, which does not run when `history` is empty, so `None` is safe. The non-empty path is unchanged.

## Testing

Reproduced against the current file: `generate_html({"history": []})` raised `ValueError: max() iterable argument is empty` before the change and returns a valid ~5.8KB HTML document after it. A non-empty history still emits the `best-row` highlight (verified), and `python3 -m py_compile generate_report.py` passes.
