### PR TITLE
Fix streaming replay, subagent launch, and light scrollbars

### DIFF
--- a/src/agent/sub/SubAgentSession.ts
+++ b/src/agent/sub/SubAgentSession.ts
@@ -207,10 +207,12 @@ export class SubAgentSession {
       if (tool.name === "ask_user_question") {
         continue; // Subagents have no elicitation channel.
       }
+      if (!wildcard && !allowedSet.has(tool.name)) {
+        continue;
+      }
       if (forceReadOnly && !tool.isReadOnly({} as never)) {
         continue; // S9 — read-only subagents reject side-effecting tools outright.
       }
-      if (!wildcard && !allowedSet.has(tool.name)) continue;
       scoped.register(tool as PilotDeckToolDefinition);
     }
     return scoped;

--- a/src/gateway/client/InProcessGateway.ts
+++ b/src/gateway/client/InProcessGateway.ts
@@ -1313,7 +1313,7 @@ export function mapAgentEvent(event: AgentEvent, runId: string): GatewayEvent[] 
     case "model_request_started":
       return [{ type: "model_request_started", model: event.model, provider: event.provider }];
     case "model_event":
-      return mapModelEvent(event.event);
+      return mapModelEvent(event.event, runId);
     case "tool_calls_detected":
       return event.calls.map((call) => ({
         type: "tool_call_started",
@@ -1714,12 +1714,12 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function mapModelEvent(event: CanonicalModelEvent): GatewayEvent[] {
+function mapModelEvent(event: CanonicalModelEvent, runId: string): GatewayEvent[] {
   switch (event.type) {
     case "text_delta":
-      return [{ type: "assistant_text_delta", text: event.text }];
+      return [{ type: "assistant_text_delta", text: event.text, runId }];
     case "thinking_delta":
-      return [{ type: "assistant_thinking_delta", text: event.text }];
+      return [{ type: "assistant_thinking_delta", text: event.text, runId }];
     case "error":
       // Model-level errors are internal control flow until AgentLoop decides
       // whether they are recoverable. Surfacing them here duplicates the final

--- a/src/gateway/client/InProcessGateway.ts
+++ b/src/gateway/client/InProcessGateway.ts
@@ -243,8 +243,9 @@ export class InProcessGateway implements Gateway {
   emitForSession(sessionKey: string, event: GatewayEvent): boolean {
     const sink = this.emitSinks.get(sessionKey);
     if (!sink) return false;
-    this.recordActiveTurnEvent(sessionKey, event);
-    sink(event);
+    const eventWithRunId = this.withActiveTurnRunId(sessionKey, event);
+    this.recordActiveTurnEvent(sessionKey, eventWithRunId);
+    sink(eventWithRunId);
     return true;
   }
 
@@ -386,6 +387,7 @@ export class InProcessGateway implements Gateway {
             }));
             const gatewayEvent: GatewayEvent = {
               type: "error",
+              runId,
               code: "turn_timeout",
               message,
               recoverable: false,
@@ -513,6 +515,7 @@ export class InProcessGateway implements Gateway {
           }));
           const gatewayEvent: GatewayEvent = {
             type: "error",
+            runId,
             code: "gateway_submit_failed",
             message,
             recoverable: false,
@@ -886,10 +889,28 @@ export class InProcessGateway implements Gateway {
       replay.truncated = true;
     }
   }
+
+  private withActiveTurnRunId(sessionKey: string, event: GatewayEvent): GatewayEvent {
+    if (getGatewayEventRunId(event)) return event;
+    const replay = this.activeTurnReplays.get(sessionKey);
+    if (!replay) return event;
+    return { ...event, runId: replay.runId };
+  }
 }
 
 function cloneGatewayEvent(event: GatewayEvent): GatewayEvent {
   return JSON.parse(JSON.stringify(event)) as GatewayEvent;
+}
+
+function getGatewayEventRunId(event: GatewayEvent): string | undefined {
+  return typeof event.runId === "string" && event.runId.trim()
+    ? event.runId.trim()
+    : undefined;
+}
+
+function withGatewayRunId(event: GatewayEvent, runId: string): GatewayEvent {
+  if (getGatewayEventRunId(event)) return event;
+  return { ...event, runId };
 }
 
 function resolveSubmitTurnTelemetry(input: GatewaySubmitTurnInput): {
@@ -1307,6 +1328,12 @@ function inferToolErrorCategory(code: string | undefined):
 }
 
 export function mapAgentEvent(event: AgentEvent, runId: string): GatewayEvent[] {
+  return mapAgentEventForTurn(event, runId).map((gatewayEvent) =>
+    withGatewayRunId(gatewayEvent, runId)
+  );
+}
+
+function mapAgentEventForTurn(event: AgentEvent, runId: string): GatewayEvent[] {
   switch (event.type) {
     case "turn_started":
       return [{ type: "turn_started", runId }];

--- a/src/gateway/protocol/types.ts
+++ b/src/gateway/protocol/types.ts
@@ -130,9 +130,9 @@ export type GatewayRecordAgentStatusMessageInput = {
 export type GatewayEvent =
   | { type: "turn_started"; runId: string }
   | { type: "model_request_started"; model?: string; provider?: string }
-  | { type: "assistant_text_delta"; text: string }
+  | { type: "assistant_text_delta"; text: string; runId?: string }
   | { type: "assistant_attachment"; attachment: GatewayOutboundAttachment }
-  | { type: "assistant_thinking_delta"; text: string }
+  | { type: "assistant_thinking_delta"; text: string; runId?: string }
   | { type: "tool_call_started"; toolCallId: string; name: string; argsPreview?: string }
   | {
       type: "tool_call_finished";

--- a/src/gateway/protocol/types.ts
+++ b/src/gateway/protocol/types.ts
@@ -127,12 +127,20 @@ export type GatewayRecordAgentStatusMessageInput = {
   status: AgentStatusMessageInput;
 };
 
-export type GatewayEvent =
+type GatewayTurnScopedEventMetadata = {
+  /**
+   * Stable id of the active turn that produced this event. Turn-scoped events
+   * carry it so streaming clients can match deltas with lifecycle boundaries.
+   */
+  runId?: string;
+};
+
+export type GatewayEvent = GatewayTurnScopedEventMetadata & (
   | { type: "turn_started"; runId: string }
   | { type: "model_request_started"; model?: string; provider?: string }
-  | { type: "assistant_text_delta"; text: string; runId?: string }
+  | { type: "assistant_text_delta"; text: string }
   | { type: "assistant_attachment"; attachment: GatewayOutboundAttachment }
-  | { type: "assistant_thinking_delta"; text: string; runId?: string }
+  | { type: "assistant_thinking_delta"; text: string }
   | { type: "tool_call_started"; toolCallId: string; name: string; argsPreview?: string }
   | {
       type: "tool_call_finished";
@@ -223,7 +231,8 @@ export type GatewayEvent =
         message?: string;
         raw?: string;
       };
-    };
+    }
+);
 
 export type GatewayActiveTurnSnapshotInput = {
   sessionKey: string;

--- a/src/tool/builtin/agent.ts
+++ b/src/tool/builtin/agent.ts
@@ -294,10 +294,25 @@ export function buildAskModeAgentToolSchema(): {
 }
 
 function normalizeRequestedSubagentType(value: string | undefined): string | undefined {
-  if (value === "general_purpose") {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  const normalized = trimmed.toLowerCase();
+  if (
+    normalized === "general-purpose" ||
+    normalized === "general_purpose" ||
+    normalized === "general purpose"
+  ) {
     return "general-purpose";
   }
-  return value;
+  if (normalized === "explore" || normalized === "explorer") {
+    return "explore";
+  }
+  if (normalized === "plan" || normalized === "verify") {
+    return normalized;
+  }
+  return trimmed;
 }
 
 async function runFullFork(args: {

--- a/src/web/client/protocol.ts
+++ b/src/web/client/protocol.ts
@@ -40,7 +40,11 @@ export type WebElicitationAnswer =
   | { type: "answered"; answers: Record<string, string | string[]>; annotations?: Record<string, { preview?: string; notes?: string }> }
   | { type: "cancelled"; reason?: string };
 
-export type WebGatewayEvent =
+type WebGatewayEventMetadata = {
+  runId?: string;
+};
+
+export type WebGatewayEvent = WebGatewayEventMetadata & (
   | { type: "turn_started"; runId: string }
   | { type: "assistant_text_delta"; text: string }
   | { type: "assistant_thinking_delta"; text: string }
@@ -109,7 +113,8 @@ export type WebGatewayEvent =
         message?: string;
         raw?: string;
       };
-    };
+    }
+);
 
 export type WebGatewayMethod =
   | "submit_turn"

--- a/tests/agent/sub/SubAgentSession.spec.ts
+++ b/tests/agent/sub/SubAgentSession.spec.ts
@@ -1,0 +1,112 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { SubAgentSession } from "../../../src/agent/sub/SubAgentSession.js";
+import { SUBAGENT_DEFINITIONS } from "../../../src/agent/sub/builtinSubagentTypes.js";
+import { createDefaultPermissionContext } from "../../../src/permission/index.js";
+import {
+  ToolRegistry,
+  type PilotDeckToolDefinition,
+} from "../../../src/tool/index.js";
+import type { AgentRouterRuntime } from "../../../src/agent/runtime/AgentRuntimeDependencies.js";
+
+const FINAL_REPORT = [
+  "Scope: inspected inputs",
+  "Result: ok",
+  "Key files: none",
+  "Files changed: none",
+  "Issues: none",
+].join("\n");
+
+function createNoopTool(
+  name: string,
+  isReadOnly: PilotDeckToolDefinition["isReadOnly"],
+): PilotDeckToolDefinition {
+  return {
+    name,
+    description: `${name} test tool`,
+    kind: "custom",
+    inputSchema: {
+      type: "object",
+      additionalProperties: true,
+      properties: {},
+    },
+    isReadOnly,
+    isConcurrencySafe: () => true,
+    execute: async () => ({
+      content: [{ type: "text", text: "ok" }],
+      data: {},
+    }),
+  };
+}
+
+function createRouter(): AgentRouterRuntime {
+  return {
+    decide: async ({ request }) => ({
+      provider: request.provider,
+      model: request.model,
+      scenarioType: "default",
+      isSubagent: true,
+      orchestrating: false,
+      resolvedFrom: "fallback",
+      mutations: {},
+    }),
+    execute: async function* () {
+      yield { type: "text_delta", text: FINAL_REPORT };
+      yield {
+        type: "usage",
+        usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+      };
+    },
+    stream: async function* () {
+      yield { type: "text_delta", text: FINAL_REPORT };
+    },
+  } as AgentRouterRuntime;
+}
+
+test("explore subagent ignores unrelated input-sensitive read-only tools", async () => {
+  const readOnlyChecks: string[] = [];
+  const registry = new ToolRegistry();
+  registry.register(createNoopTool("execute_code", (input) => {
+    readOnlyChecks.push("execute_code");
+    return (input as { code: string }).code.length === 0;
+  }));
+  registry.register(createNoopTool("read_file", () => {
+    readOnlyChecks.push("read_file");
+    return true;
+  }));
+
+  const session = new SubAgentSession({
+    definition: SUBAGENT_DEFINITIONS.explore,
+    directive: "Inspect the provided files.",
+    parentConfig: {
+      provider: "test",
+      model: "test-model",
+      cwd: process.cwd(),
+      permissionMode: "bypassPermissions",
+      permissionContext: createDefaultPermissionContext({
+        cwd: process.cwd(),
+        mode: "bypassPermissions",
+        canPrompt: true,
+        bypassAvailable: true,
+      }),
+    },
+    parentDependencies: {
+      router: createRouter(),
+      tools: {
+        registry,
+        scheduler: {} as never,
+      },
+    },
+    parentSessionId: "parent-session",
+    parentTurnId: "parent-turn",
+    subagentSessionId: "subagent-session",
+    subagentId: "subagent-1",
+  });
+
+  const report = await session.run();
+
+  assert.equal(report.definitionId, "explore");
+  assert.equal(report.markdown, FINAL_REPORT);
+  assert.deepEqual(readOnlyChecks, ["read_file"]);
+});

--- a/tests/gateway/map-agent-event-runid.spec.ts
+++ b/tests/gateway/map-agent-event-runid.spec.ts
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { AgentEvent } from "../../src/agent/protocol/events.js";
+import { mapAgentEvent } from "../../src/gateway/client/InProcessGateway.js";
+
+test("mapAgentEvent propagates runId to streaming lifecycle boundaries", () => {
+  const runId = "run-1";
+
+  const toolStarted = mapAgentEvent({
+    type: "tool_calls_detected",
+    sessionId: "session-1",
+    turnId: "turn-1",
+    calls: [{ id: "call-1", name: "bash", input: { command: "pwd" } }],
+  } as unknown as AgentEvent, runId);
+  assert.equal(toolStarted[0]?.type, "tool_call_started");
+  assert.equal(toolStarted[0]?.runId, runId);
+
+  const completed = mapAgentEvent({
+    type: "turn_completed",
+    sessionId: "session-1",
+    turnId: "turn-1",
+    result: {
+      stopReason: "completed",
+      usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+    },
+  } as unknown as AgentEvent, runId);
+  assert.equal(completed[0]?.type, "turn_completed");
+  assert.equal(completed[0]?.runId, runId);
+
+  const failed = mapAgentEvent({
+    type: "turn_failed",
+    sessionId: "session-1",
+    turnId: "turn-1",
+    error: { code: "model_error", message: "boom" },
+  } as unknown as AgentEvent, runId);
+  assert.equal(failed[0]?.type, "error");
+  assert.equal(failed[0]?.runId, runId);
+});

--- a/tests/tool/builtin/agent-subagent-type.spec.ts
+++ b/tests/tool/builtin/agent-subagent-type.spec.ts
@@ -1,0 +1,120 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createAgentTool } from "../../../src/tool/builtin/agent.js";
+import type {
+  PilotDeckSubagentForkApi,
+  PilotDeckToolModelClient,
+  PilotDeckToolRuntimeContext,
+} from "../../../src/tool/index.js";
+
+function baseContext(
+  fork: PilotDeckSubagentForkApi,
+  overrides: Partial<PilotDeckToolRuntimeContext> = {},
+): PilotDeckToolRuntimeContext {
+  return {
+    sessionId: "s1",
+    turnId: "t1",
+    cwd: process.cwd(),
+    permissionMode: "bypassPermissions",
+    permissionContext: {
+      mode: "bypassPermissions",
+      cwd: process.cwd(),
+      additionalWorkingDirectories: [],
+      canPrompt: true,
+      bypassAvailable: true,
+      rules: { allow: [], deny: [], ask: [] },
+    },
+    subagent: fork,
+    ...overrides,
+  };
+}
+
+function createFork(calls: string[]): PilotDeckSubagentForkApi {
+  return {
+    depth: 0,
+    maxSubagentDepth: 1,
+    listDefinitions: () => [
+      { id: "general-purpose", description: "general" },
+      { id: "explore", description: "explore" },
+      { id: "plan", description: "plan" },
+      { id: "verify", description: "verify" },
+    ],
+    isAllowedDefinition: (id) => ["general-purpose", "explore", "plan", "verify"].includes(id),
+    fork: async ({ definitionId }) => {
+      calls.push(definitionId);
+      return {
+        markdown: "Scope: test\nResult: ok\nKey files: none\nFiles changed: none\nIssues: none",
+        usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+        turns: 1,
+        durationMs: 1,
+        parsed: undefined,
+      };
+    },
+  };
+}
+
+test("agent tool accepts explorer as an alias for explore", async () => {
+  const calls: string[] = [];
+  const tool = createAgentTool();
+  const result = await tool.execute(
+    { description: "inspect code", prompt: "inspect", subagent_type: "explorer" },
+    baseContext(createFork(calls)),
+  );
+
+  assert.equal(result.data?.subagentType, "explore");
+  assert.deepEqual(calls, ["explore"]);
+});
+
+test("agent tool defaults general-purpose to explore in ask mode", async () => {
+  const calls: string[] = [];
+  const tool = createAgentTool();
+  const result = await tool.execute(
+    { description: "inspect code", prompt: "inspect" },
+    baseContext(createFork(calls), { runMode: "ask" }),
+  );
+
+  assert.equal(result.data?.subagentType, "explore");
+  assert.deepEqual(calls, ["explore"]);
+});
+
+test("agent tool preserves unknown custom fallback subagent names", async () => {
+  const requests: string[] = [];
+  const model: PilotDeckToolModelClient = {
+    async *stream(request) {
+      requests.push(String(request.metadata?.subagent));
+      yield { type: "text_delta", text: "custom ok" };
+    },
+  };
+  const tool = createAgentTool({
+    model,
+    subagents: {
+      CustomAgent: {
+        type: "general-purpose",
+        description: "custom",
+        systemPrompt: "custom",
+      },
+    },
+  });
+
+  const result = await tool.execute(
+    { description: "custom run", prompt: "run", subagent_type: " CustomAgent " },
+    {
+      sessionId: "s1",
+      turnId: "t1",
+      cwd: process.cwd(),
+      permissionMode: "bypassPermissions",
+      permissionContext: {
+        mode: "bypassPermissions",
+        cwd: process.cwd(),
+        additionalWorkingDirectories: [],
+        canPrompt: true,
+        bypassAvailable: true,
+        rules: { allow: [], deny: [], ask: [] },
+      },
+    },
+  );
+
+  assert.equal(result.data?.subagentType, "CustomAgent");
+  assert.deepEqual(requests, ["general-purpose"]);
+});

--- a/ui/src/components/app-shell/SidebarV2.tsx
+++ b/ui/src/components/app-shell/SidebarV2.tsx
@@ -1252,7 +1252,6 @@ export default function SidebarV2({
         role="separator"
         aria-orientation="vertical"
         aria-label={t('sidebar:tooltips.resize', { defaultValue: 'Resize sidebar' }) as string}
-        title={t('sidebar:tooltips.resize', { defaultValue: 'Drag to resize' }) as string}
         onMouseDown={handleResizeStart}
         onDoubleClick={() => {
           setSidebarWidth(SIDEBAR_DEFAULT_WIDTH);

--- a/ui/src/components/chat-v2/MessagesPaneV2.tsx
+++ b/ui/src/components/chat-v2/MessagesPaneV2.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { Fragment, memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import type { Dispatch, ReactNode, RefObject, SetStateAction } from 'react';
 import { useTranslation } from 'react-i18next';
 import { XCircle, GitBranch } from 'lucide-react';
@@ -295,7 +295,7 @@ function isForkedChatSession(session: ProjectSession | null): boolean {
   );
 }
 
-export default function MessagesPaneV2({
+function MessagesPaneV2({
   scrollContainerRef,
   onWheel,
   onTouchMove,
@@ -1188,6 +1188,8 @@ export default function MessagesPaneV2({
     </div>
   );
 }
+
+export default memo(MessagesPaneV2);
 
 function isSubagentActivity(activity: ChatMessage): boolean {
   const activityId = String(activity.activityId || activity.runId || '');

--- a/ui/src/components/chat-v2/SubagentDetailModal.tsx
+++ b/ui/src/components/chat-v2/SubagentDetailModal.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, type ReactNode } from 'react';
+import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import { X, Loader2 } from 'lucide-react';
 import type { ChatMessage } from '../chat/types/types';
@@ -82,11 +83,11 @@ export default function SubagentDetailModal({
     );
   }
 
-  return (
+  const modal = (
     <div
       ref={overlayRef}
       data-modal-overlay
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm"
+      className="fixed inset-0 z-[10000] flex items-center justify-center bg-black/40 p-4 backdrop-blur-sm"
       onClick={handleOverlayClick}
     >
       <div className="relative flex max-h-[80vh] w-full max-w-3xl flex-col overflow-hidden rounded-xl border border-neutral-200 bg-white shadow-2xl dark:border-neutral-700 dark:bg-neutral-900">
@@ -115,4 +116,10 @@ export default function SubagentDetailModal({
       </div>
     </div>
   );
+
+  if (typeof document === 'undefined') {
+    return modal;
+  }
+
+  return createPortal(modal, document.body);
 }

--- a/ui/src/components/chat/hooks/useChatRealtimeHandlers.ts
+++ b/ui/src/components/chat/hooks/useChatRealtimeHandlers.ts
@@ -55,6 +55,12 @@ function normalizeAssistantStreamText(value?: string): string {
   return typeof value === 'string' ? value.replace(/\s+/g, ' ').trim() : '';
 }
 
+function getMessageRunId(message: { runId?: unknown }): string | undefined {
+  return typeof message.runId === 'string' && message.runId.trim()
+    ? message.runId.trim()
+    : undefined;
+}
+
 function parseAssistantStreamTimestamp(value?: string): number | null {
   if (!value) return null;
   const parsed = Date.parse(value);
@@ -101,6 +107,109 @@ export function getDuplicateAssistantStreamTextState(
   });
 
   return { isDuplicate, hasActiveStream, activeStreamRunId };
+}
+
+type ActiveTurnReplayState = {
+  realtimeMessages?: NormalizedMessage[];
+  serverMessages?: NormalizedMessage[];
+};
+
+type VolatileReplayBlock = {
+  kind: 'stream_delta' | 'thinking';
+  messages: LatestChatMessage[];
+  text: string;
+  runId?: string;
+};
+
+function isRenderedVolatileBlockCandidate(
+  block: VolatileReplayBlock,
+  message: NormalizedMessage,
+): boolean {
+  const blockText = normalizeAssistantStreamText(block.text);
+  if (!blockText) return false;
+
+  const messageRunId = getMessageRunId(message);
+  if (block.runId && messageRunId && block.runId !== messageRunId) {
+    return false;
+  }
+
+  if (block.kind === 'stream_delta') {
+    const isAssistantText = message.kind === 'text' && message.role === 'assistant';
+    const isActiveStream = message.kind === 'stream_delta' && String(message.id || '').startsWith('__streaming_');
+    if (!isAssistantText && !isActiveStream) return false;
+  } else if (message.kind !== 'thinking') {
+    return false;
+  }
+
+  return normalizeAssistantStreamText(message.content) === blockText;
+}
+
+function hasRenderedVolatileReplayBlock(
+  block: VolatileReplayBlock,
+  state: ActiveTurnReplayState,
+): boolean {
+  const messages = [
+    ...(state.realtimeMessages || []),
+    ...(state.serverMessages || []),
+  ];
+  return messages.some((message) => isRenderedVolatileBlockCandidate(block, message));
+}
+
+export function getActiveTurnReplayMessagesToApply(
+  activeTurnMessages: LatestChatMessage[],
+  state: ActiveTurnReplayState = {},
+  options: { skipVolatile?: boolean } = {},
+): LatestChatMessage[] {
+  if (!Array.isArray(activeTurnMessages) || activeTurnMessages.length === 0) {
+    return [];
+  }
+
+  const output: LatestChatMessage[] = [];
+  let block: VolatileReplayBlock | null = null;
+
+  const flushBlock = () => {
+    if (!block) return;
+    if (!options.skipVolatile && !hasRenderedVolatileReplayBlock(block, state)) {
+      output.push(...block.messages);
+    }
+    block = null;
+  };
+
+  for (const message of activeTurnMessages) {
+    const kind = String(message?.kind || '');
+    if (kind === 'thinking' || kind === 'stream_delta') {
+      if (block && block.kind !== kind) {
+        flushBlock();
+      }
+      if (!block) {
+        block = {
+          kind: kind as 'thinking' | 'stream_delta',
+          messages: [],
+          text: '',
+          runId: getMessageRunId(message),
+        };
+      }
+      block.messages.push(message);
+      block.text += typeof message.content === 'string' ? message.content : '';
+      block.runId ??= getMessageRunId(message);
+      continue;
+    }
+
+    if (kind === 'stream_end') {
+      if (block?.kind === 'stream_delta') {
+        block.messages.push(message);
+        block.runId ??= getMessageRunId(message);
+        flushBlock();
+      }
+      continue;
+    }
+
+    flushBlock();
+    output.push(message);
+  }
+
+  flushBlock();
+  return output;
 }
 
 
@@ -263,17 +372,21 @@ export function useChatRealtimeHandlers({
             const hasSeenSameVolatileReplay = Boolean(
               volatileSignature && previousVolatileSignature === volatileSignature,
             );
-            // Only replay messages that have stable IDs and can be deduped
-            // against server data (tool_use by toolId, tool_result/status by id).
-            // Skip thinking, stream_delta, stream_end — these create messages
-            // with generated IDs that can't be matched to server copies.
-            // But if this tab has no active streaming state (e.g. another tab
-            // started the turn), we need to replay them so content renders.
-            const skipKinds = new Set(['thinking', 'stream_delta', 'stream_end']);
+            // Replay active-turn snapshots only for content this tab has not
+            // already rendered. Volatile stream/thinking chunks are grouped
+            // into blocks so a status poll cannot re-feed an already-finalized
+            // assistant text back into the streaming accumulator.
             const skipVolatileReplay =
               hasLiveStreaming || hasReplayedCurrentTurnToolUse || hasSeenSameVolatileReplay;
-            for (const activeTurnMessage of msg.activeTurnMessages) {
-              if (skipVolatileReplay && skipKinds.has(activeTurnMessage.kind)) continue;
+            const activeTurnMessagesToApply = getActiveTurnReplayMessagesToApply(
+              msg.activeTurnMessages,
+              {
+                realtimeMessages: slot?.realtimeMessages || [],
+                serverMessages: slot?.serverMessages || [],
+              },
+              { skipVolatile: skipVolatileReplay },
+            );
+            for (const activeTurnMessage of activeTurnMessagesToApply) {
               handleMessage(activeTurnMessage, statusSessionId);
             }
             if (volatileSignature) {

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -73,6 +73,7 @@
     --header-safe-area-top: env(safe-area-inset-top, 0px);
     --header-base-padding: 8px;
     --header-total-padding: calc(var(--header-safe-area-top) + var(--header-base-padding));
+    color-scheme: light;
   }
   
   /* Fallback for older iOS versions */
@@ -118,6 +119,7 @@
     --nav-divider-color: 0 0% 15% / 0.7;
     --nav-input-bg: 0 0% 15% / 0.5;
     --nav-input-focus-ring: 0 0% 96% / 0.12;
+    color-scheme: dark;
   }
 }
 
@@ -139,6 +141,31 @@
     height: 100%;
     margin: 0;
     padding: 0;
+    background: hsl(var(--background));
+    scrollbar-width: thin;
+    scrollbar-color: hsl(var(--muted-foreground) / 0.35) hsl(var(--background));
+  }
+
+  html::-webkit-scrollbar,
+  body::-webkit-scrollbar {
+    width: 8px;
+    height: 8px;
+  }
+
+  html::-webkit-scrollbar-track,
+  body::-webkit-scrollbar-track {
+    background: hsl(var(--background));
+  }
+
+  html::-webkit-scrollbar-thumb,
+  body::-webkit-scrollbar-thumb {
+    background-color: hsl(var(--muted-foreground) / 0.35);
+    border-radius: 4px;
+  }
+
+  html::-webkit-scrollbar-thumb:hover,
+  body::-webkit-scrollbar-thumb:hover {
+    background-color: hsl(var(--muted-foreground) / 0.55);
   }
   
   /* Root element with safe area padding for PWA */
@@ -426,12 +453,13 @@
     --tw-ring-offset-color: rgb(31 41 55); /* gray-800 */
   }
   
-  /* Ensure textarea text is always visible in dark mode */
+  /* Ensure textarea text is always visible in the active theme */
   textarea {
-    color-scheme: light dark;
+    color-scheme: light;
   }
   
   .dark textarea {
+    color-scheme: dark;
     color: rgb(243 244 246) !important; /* gray-100 */
     -webkit-text-fill-color: rgb(243 244 246) !important;
     caret-color: rgb(243 244 246) !important;

--- a/ui/src/stores/useSessionStore.streaming.test.ts
+++ b/ui/src/stores/useSessionStore.streaming.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { SessionProvider } from '../types/app';
-import { getDuplicateAssistantStreamTextState } from '../components/chat/hooks/useChatRealtimeHandlers';
+import {
+  getActiveTurnReplayMessagesToApply,
+  getDuplicateAssistantStreamTextState,
+} from '../components/chat/hooks/useChatRealtimeHandlers';
 import {
   computeMerged,
   createRafNotifyScheduler,
@@ -255,6 +258,159 @@ describe('getDuplicateAssistantStreamTextState', () => {
       isDuplicate: false,
       hasActiveStream: false,
     });
+  });
+});
+
+describe('getActiveTurnReplayMessagesToApply', () => {
+  it('skips active-turn stream replay already represented by finalized realtime text', () => {
+    const activeTurnMessages = [
+      {
+        id: 'delta-1',
+        sessionId: 'web:s_test',
+        timestamp: '2026-05-28T00:00:02.000Z',
+        provider: PROVIDER,
+        kind: 'stream_delta' as const,
+        content: 'Hello ',
+        runId: 'run-1',
+      },
+      {
+        id: 'delta-2',
+        sessionId: 'web:s_test',
+        timestamp: '2026-05-28T00:00:03.000Z',
+        provider: PROVIDER,
+        kind: 'stream_delta' as const,
+        content: 'world',
+        runId: 'run-1',
+      },
+      {
+        id: 'end-1',
+        sessionId: 'web:s_test',
+        timestamp: '2026-05-28T00:00:04.000Z',
+        provider: PROVIDER,
+        kind: 'stream_end' as const,
+        runId: 'run-1',
+      },
+    ];
+
+    const messagesToApply = getActiveTurnReplayMessagesToApply(activeTurnMessages, {
+      realtimeMessages: [
+        textMessage('local-final', 'Hello world', '2026-05-28T00:00:01.000Z', {
+          isFinal: true,
+          runId: 'run-1',
+        }),
+      ],
+    });
+
+    expect(messagesToApply).toEqual([]);
+  });
+
+  it('keeps non-volatile replay frames while dropping duplicate stream blocks', () => {
+    const activeTurnMessages = [
+      {
+        id: 'delta-1',
+        sessionId: 'web:s_test',
+        timestamp: '2026-05-28T00:00:02.000Z',
+        provider: PROVIDER,
+        kind: 'stream_delta' as const,
+        content: 'Already rendered',
+        runId: 'run-1',
+      },
+      {
+        id: 'end-1',
+        sessionId: 'web:s_test',
+        timestamp: '2026-05-28T00:00:03.000Z',
+        provider: PROVIDER,
+        kind: 'stream_end' as const,
+        runId: 'run-1',
+      },
+      {
+        id: 'tool-1',
+        sessionId: 'web:s_test',
+        timestamp: '2026-05-28T00:00:04.000Z',
+        provider: PROVIDER,
+        kind: 'tool_use' as const,
+        toolId: 'tool-call-1',
+        toolName: 'Read',
+      },
+    ];
+
+    const messagesToApply = getActiveTurnReplayMessagesToApply(activeTurnMessages, {
+      realtimeMessages: [
+        textMessage('local-final', 'Already rendered', '2026-05-28T00:00:01.000Z', {
+          isFinal: true,
+          runId: 'run-1',
+        }),
+      ],
+    });
+
+    expect(messagesToApply.map((message) => message.id)).toEqual(['tool-1']);
+  });
+
+  it('drops only the rendered stream block when a later block is new', () => {
+    const activeTurnMessages = [
+      {
+        id: 'delta-1',
+        sessionId: 'web:s_test',
+        timestamp: '2026-05-28T00:00:02.000Z',
+        provider: PROVIDER,
+        kind: 'stream_delta' as const,
+        content: 'First block',
+        runId: 'run-1',
+      },
+      {
+        id: 'end-1',
+        sessionId: 'web:s_test',
+        timestamp: '2026-05-28T00:00:03.000Z',
+        provider: PROVIDER,
+        kind: 'stream_end' as const,
+        runId: 'run-1',
+      },
+      {
+        id: 'delta-2',
+        sessionId: 'web:s_test',
+        timestamp: '2026-05-28T00:00:04.000Z',
+        provider: PROVIDER,
+        kind: 'stream_delta' as const,
+        content: 'Second block',
+        runId: 'run-1',
+      },
+    ];
+
+    const messagesToApply = getActiveTurnReplayMessagesToApply(activeTurnMessages, {
+      realtimeMessages: [
+        textMessage('local-final', 'First block', '2026-05-28T00:00:01.000Z', {
+          isFinal: true,
+          runId: 'run-1',
+        }),
+      ],
+    });
+
+    expect(messagesToApply.map((message) => message.id)).toEqual(['delta-2']);
+  });
+
+  it('does not drop same-content stream blocks from a different known run', () => {
+    const activeTurnMessages = [
+      {
+        id: 'delta-1',
+        sessionId: 'web:s_test',
+        timestamp: '2026-05-28T00:00:02.000Z',
+        provider: PROVIDER,
+        kind: 'stream_delta' as const,
+        content: 'Same text',
+        runId: 'run-2',
+      },
+    ];
+
+    const messagesToApply = getActiveTurnReplayMessagesToApply(activeTurnMessages, {
+      realtimeMessages: [
+        textMessage('local-final', 'Same text', '2026-05-28T00:00:01.000Z', {
+          isFinal: true,
+          runId: 'run-1',
+        }),
+      ],
+    });
+
+    expect(messagesToApply.map((message) => message.id)).toEqual(['delta-1']);
   });
 });
 


### PR DESCRIPTION
## Summary
- Avoid duplicate active-turn streaming/thinking replay in the chat UI by grouping volatile replay blocks and matching rendered content by runId.
- Fix explore/read-only subagent startup by filtering allowed tools before probing input-sensitive isReadOnly handlers, and normalize common agent subagent_type aliases.
- Force light-mode native scrollbars to follow the app theme on macOS/Electron.

## Tests
- npm run build
- node --test --test-timeout 60000 dist/tests/agent/sub/SubAgentSession.spec.js dist/tests/tool/builtin/agent-subagent-type.spec.js
- npm --prefix ui test -- src/stores/useSessionStore.streaming.test.ts
- npm --prefix ui run build

Note: ui build still reports the existing Tailwind textarea selector warnings.