### PR TITLE
Improve tool recovery and browser runtime defaults

### DIFF
--- a/skills/browser-use/SKILL.md
+++ b/skills/browser-use/SKILL.md
@@ -66,7 +66,8 @@ PilotDeck starts browser-use through `playwright-mcp` and uses practical default
 - `PILOTDECK_BROWSER_TIMEOUT_NAVIGATION_MS`: navigation timeout, default `90000`.
 - `PILOTDECK_BROWSER_PROXY_SERVER`: proxy passed directly to Chromium, for example `http://127.0.0.1:7890`.
 - `PILOTDECK_BROWSER_PROXY_BYPASS`: comma-separated proxy bypass list. Defaults include `localhost`, `127.0.0.1`, and `host.docker.internal`.
-- `PILOTDECK_BROWSER_PROXY_FROM_ENV=0`: do not infer a browser proxy from `PILOTDECK_PROXY`, `HTTPS_PROXY`, or `HTTP_PROXY`.
+- `PILOTDECK_BROWSER_PROXY_FROM_ENV=1`: infer a browser proxy from `PILOTDECK_PROXY`, `HTTPS_PROXY`, or `HTTP_PROXY`. This is disabled by default; use `PILOTDECK_BROWSER_PROXY_SERVER` when the proxy should be passed explicitly to Chromium.
+- If `pilotdeck.yaml` sets `proxy.url`, browser-use passes it to Chromium when no explicit browser proxy is set. `proxy.noProxy` is included in the browser proxy bypass list.
 
 Use a direct browser proxy when command-line HTTP tools can reach the network but browser navigation hangs or times out. Chromium does not always behave like curl or Python requests with inherited proxy environment variables.
 

--- a/skills/browser-use/SKILL.md
+++ b/skills/browser-use/SKILL.md
@@ -62,6 +62,8 @@ If the download is slow or blocked, configure your network proxy first and rerun
 
 - Prefer browser-use for interactive browser tasks. Prefer HTTP, curl, requests, or structured parsing for non-interactive retrieval and batch scraping.
 - Try the existing browser setup before any installation step. If it works, continue; do not reinstall or upgrade browser binaries.
+- If browser-use times out or the page does not require interaction, switch to HTTP/file parsing or a narrower browser action instead of repeatedly retrying the same navigation.
+- Keep browser-use calls targeted: navigate to one URL, wait for a specific visible signal, extract the needed text/state, then stop. Avoid using browser automation as a general crawler.
 - For local PilotDeck checks, open the URL shown by `pilotdeck status`, usually `http://localhost:3001`.
 - If no model provider is configured, a clean PilotDeck instance should land on onboarding rather than settings or chat.
 - Keep browser tasks small and observable: navigate, wait for a visible heading, inspect relevant text, then report evidence.

--- a/skills/browser-use/SKILL.md
+++ b/skills/browser-use/SKILL.md
@@ -58,11 +58,25 @@ Repeated installs are safe only when the installer can confirm the cache first. 
 
 If the download is slow or blocked, configure your network proxy first and rerun the install command. Browser automation is optional; PilotDeck core chat, files, skills, and settings work without it.
 
+## Runtime Configuration
+
+PilotDeck starts browser-use through `playwright-mcp` and uses practical defaults for slower pages:
+
+- `PILOTDECK_BROWSER_TIMEOUT_ACTION_MS`: browser action timeout, default `30000`.
+- `PILOTDECK_BROWSER_TIMEOUT_NAVIGATION_MS`: navigation timeout, default `90000`.
+- `PILOTDECK_BROWSER_PROXY_SERVER`: proxy passed directly to Chromium, for example `http://127.0.0.1:7890`.
+- `PILOTDECK_BROWSER_PROXY_BYPASS`: comma-separated proxy bypass list. Defaults include `localhost`, `127.0.0.1`, and `host.docker.internal`.
+- `PILOTDECK_BROWSER_PROXY_FROM_ENV=0`: do not infer a browser proxy from `PILOTDECK_PROXY`, `HTTPS_PROXY`, or `HTTP_PROXY`.
+
+Use a direct browser proxy when command-line HTTP tools can reach the network but browser navigation hangs or times out. Chromium does not always behave like curl or Python requests with inherited proxy environment variables.
+
 ## Usage Notes
 
 - Prefer browser-use for interactive browser tasks. Prefer HTTP, curl, requests, or structured parsing for non-interactive retrieval and batch scraping.
 - Try the existing browser setup before any installation step. If it works, continue; do not reinstall or upgrade browser binaries.
 - If browser-use times out or the page does not require interaction, switch to HTTP/file parsing or a narrower browser action instead of repeatedly retrying the same navigation.
+- If a full-page screenshot times out while waiting for fonts or page stability, avoid retrying the identical screenshot. Try a viewport screenshot, a narrower element/clip, a short targeted wait, or a direct Playwright script with an explicit timeout.
+- If navigation to a public site times out but curl or Python succeeds, check whether `PILOTDECK_BROWSER_PROXY_SERVER` is set for Chromium.
 - Keep browser-use calls targeted: navigate to one URL, wait for a specific visible signal, extract the needed text/state, then stop. Avoid using browser automation as a general crawler.
 - For local PilotDeck checks, open the URL shown by `pilotdeck status`, usually `http://localhost:3001`.
 - If no model provider is configured, a clean PilotDeck instance should land on onboarding rather than settings or chat.

--- a/src/cli/createLocalGateway.ts
+++ b/src/cli/createLocalGateway.ts
@@ -61,7 +61,7 @@ import {
 } from "../mcp/index.js";
 import { createModelRuntime, type ModelRuntime } from "../model/index.js";
 import { createDefaultPermissionContext, type PermissionRule } from "../permission/index.js";
-import { loadPilotConfig, resolvePilotHome } from "../pilot/index.js";
+import { loadPilotConfig, resolvePilotHome, type PilotProxyConfig } from "../pilot/index.js";
 import { createPilotConfigStoreSync, type PilotConfigStore } from "../pilot/config/PilotConfigStore.js";
 import type { PilotAgentModelSelection, PilotConfigSnapshot } from "../pilot/config/types.js";
 import { DEFAULT_JUDGE_TIMEOUT_MS, DEFAULT_ALLOWED_TOOLS, DEFAULT_TRIGGER_TIERS, type RouterConfig } from "../router/config/schema.js";
@@ -922,7 +922,7 @@ class ProjectRuntimeRegistry {
           return {
             ...spec,
             cwd: outDir,
-            args: buildBrowserUseArgs(spec.args ?? [], outDir, this.options.env),
+            args: buildBrowserUseArgs(spec.args ?? [], outDir, this.options.env, runtime.snapshot.config.proxy),
           };
         }
         return spec;
@@ -1433,10 +1433,11 @@ function readPositiveIntegerEnv(value: string | undefined): number | undefined {
   return Math.floor(parsed);
 }
 
-function buildBrowserUseArgs(
+export function buildBrowserUseArgs(
   baseArgs: string[],
   outputDir: string,
   env: Record<string, string | undefined>,
+  configProxy?: PilotProxyConfig,
 ): string[] {
   let args = [...baseArgs];
   args = appendCliArg(args, "--output-dir", outputDir);
@@ -1459,10 +1460,10 @@ function buildBrowserUseArgs(
     ),
   );
 
-  const proxyServer = resolveBrowserProxyServer(env);
-  if (proxyServer) {
-    args = appendCliArg(args, "--proxy-server", proxyServer);
-    const proxyBypass = resolveBrowserProxyBypass(env);
+  const proxy = resolveBrowserProxyServer(env, configProxy);
+  if (proxy) {
+    args = appendCliArg(args, "--proxy-server", proxy.server);
+    const proxyBypass = resolveBrowserProxyBypass(env, configProxy, proxy.source);
     if (proxyBypass) {
       args = appendCliArg(args, "--proxy-bypass", proxyBypass);
     }
@@ -1477,29 +1478,41 @@ function appendCliArg(args: string[], flag: string, value: string): string[] {
   return [...args, flag, value];
 }
 
-function resolveBrowserProxyServer(env: Record<string, string | undefined>): string | undefined {
+type BrowserProxySource = "browser-env" | "env" | "config";
+
+function resolveBrowserProxyServer(
+  env: Record<string, string | undefined>,
+  configProxy?: PilotProxyConfig,
+): { server: string; source: BrowserProxySource } | undefined {
   const explicit = cleanEnvValue(env.PILOTDECK_BROWSER_PROXY_SERVER);
   if (explicit) {
     if (/^(0|false|off|none|direct)$/i.test(explicit)) return undefined;
-    return explicit;
+    return { server: explicit, source: "browser-env" };
   }
-  if (/^(0|false|off|none|direct)$/i.test(cleanEnvValue(env.PILOTDECK_BROWSER_PROXY_FROM_ENV) ?? "")) {
-    return undefined;
+  if (/^(1|true|on|yes)$/i.test(cleanEnvValue(env.PILOTDECK_BROWSER_PROXY_FROM_ENV) ?? "")) {
+    const envProxy = (
+      cleanEnvValue(env.PILOTDECK_PROXY)
+      ?? cleanEnvValue(env.https_proxy)
+      ?? cleanEnvValue(env.HTTPS_PROXY)
+      ?? cleanEnvValue(env.http_proxy)
+      ?? cleanEnvValue(env.HTTP_PROXY)
+    );
+    if (envProxy) return { server: envProxy, source: "env" };
   }
-  return (
-    cleanEnvValue(env.PILOTDECK_PROXY)
-    ?? cleanEnvValue(env.https_proxy)
-    ?? cleanEnvValue(env.HTTPS_PROXY)
-    ?? cleanEnvValue(env.http_proxy)
-    ?? cleanEnvValue(env.HTTP_PROXY)
-  );
+  const configUrl = cleanEnvValue(configProxy?.url);
+  return configUrl ? { server: configUrl, source: "config" } : undefined;
 }
 
-function resolveBrowserProxyBypass(env: Record<string, string | undefined>): string {
+function resolveBrowserProxyBypass(
+  env: Record<string, string | undefined>,
+  configProxy: PilotProxyConfig | undefined,
+  proxySource: BrowserProxySource,
+): string {
   const explicit = cleanEnvValue(env.PILOTDECK_BROWSER_PROXY_BYPASS);
   if (explicit) return explicit;
   const noProxy = cleanEnvValue(env.no_proxy) ?? cleanEnvValue(env.NO_PROXY);
-  return [noProxy, "localhost", "127.0.0.1", "host.docker.internal"].filter(Boolean).join(",");
+  const configNoProxy = proxySource === "config" ? cleanEnvValue(configProxy?.noProxy) : undefined;
+  return [noProxy, configNoProxy, "localhost", "127.0.0.1", "host.docker.internal"].filter(Boolean).join(",");
 }
 
 function cleanEnvValue(value: string | undefined): string | undefined {

--- a/src/cli/createLocalGateway.ts
+++ b/src/cli/createLocalGateway.ts
@@ -483,6 +483,9 @@ type ProjectRuntime = {
   perSessionServerSpecs?: import("../mcp/protocol/types.js").PilotDeckMcpServerSpec[];
 };
 
+const DEFAULT_BROWSER_ACTION_TIMEOUT_MS = 30_000;
+const DEFAULT_BROWSER_NAVIGATION_TIMEOUT_MS = 90_000;
+
 class ProjectRuntimeRegistry {
   private readonly runtimes = new Map<string, ProjectRuntime>();
   private gateway?: InProcessGateway;
@@ -916,7 +919,11 @@ class ProjectRuntimeRegistry {
             sanitizeSessionIdForPath(context.sessionKey),
           );
           mkdirSyncFs(outDir, { recursive: true });
-          return { ...spec, cwd: outDir, args: [...(spec.args ?? []), `--output-dir=${outDir}`] };
+          return {
+            ...spec,
+            cwd: outDir,
+            args: buildBrowserUseArgs(spec.args ?? [], outDir, this.options.env),
+          };
         }
         return spec;
       });
@@ -1424,4 +1431,78 @@ function readPositiveIntegerEnv(value: string | undefined): number | undefined {
   const parsed = Number.parseInt(value.trim(), 10);
   if (!Number.isFinite(parsed) || parsed <= 0) return undefined;
   return Math.floor(parsed);
+}
+
+function buildBrowserUseArgs(
+  baseArgs: string[],
+  outputDir: string,
+  env: Record<string, string | undefined>,
+): string[] {
+  let args = [...baseArgs];
+  args = appendCliArg(args, "--output-dir", outputDir);
+  args = appendCliArg(
+    args,
+    "--timeout-action",
+    String(
+      readPositiveIntegerEnv(env.PILOTDECK_BROWSER_TIMEOUT_ACTION_MS)
+        ?? readPositiveIntegerEnv(env.PILOTDECK_BROWSER_ACTION_TIMEOUT_MS)
+        ?? DEFAULT_BROWSER_ACTION_TIMEOUT_MS,
+    ),
+  );
+  args = appendCliArg(
+    args,
+    "--timeout-navigation",
+    String(
+      readPositiveIntegerEnv(env.PILOTDECK_BROWSER_TIMEOUT_NAVIGATION_MS)
+        ?? readPositiveIntegerEnv(env.PILOTDECK_BROWSER_NAVIGATION_TIMEOUT_MS)
+        ?? DEFAULT_BROWSER_NAVIGATION_TIMEOUT_MS,
+    ),
+  );
+
+  const proxyServer = resolveBrowserProxyServer(env);
+  if (proxyServer) {
+    args = appendCliArg(args, "--proxy-server", proxyServer);
+    const proxyBypass = resolveBrowserProxyBypass(env);
+    if (proxyBypass) {
+      args = appendCliArg(args, "--proxy-bypass", proxyBypass);
+    }
+  }
+  return args;
+}
+
+function appendCliArg(args: string[], flag: string, value: string): string[] {
+  if (args.includes(flag) || args.some((arg) => arg.startsWith(`${flag}=`))) {
+    return args;
+  }
+  return [...args, flag, value];
+}
+
+function resolveBrowserProxyServer(env: Record<string, string | undefined>): string | undefined {
+  const explicit = cleanEnvValue(env.PILOTDECK_BROWSER_PROXY_SERVER);
+  if (explicit) {
+    if (/^(0|false|off|none|direct)$/i.test(explicit)) return undefined;
+    return explicit;
+  }
+  if (/^(0|false|off|none|direct)$/i.test(cleanEnvValue(env.PILOTDECK_BROWSER_PROXY_FROM_ENV) ?? "")) {
+    return undefined;
+  }
+  return (
+    cleanEnvValue(env.PILOTDECK_PROXY)
+    ?? cleanEnvValue(env.https_proxy)
+    ?? cleanEnvValue(env.HTTPS_PROXY)
+    ?? cleanEnvValue(env.http_proxy)
+    ?? cleanEnvValue(env.HTTP_PROXY)
+  );
+}
+
+function resolveBrowserProxyBypass(env: Record<string, string | undefined>): string {
+  const explicit = cleanEnvValue(env.PILOTDECK_BROWSER_PROXY_BYPASS);
+  if (explicit) return explicit;
+  const noProxy = cleanEnvValue(env.no_proxy) ?? cleanEnvValue(env.NO_PROXY);
+  return [noProxy, "localhost", "127.0.0.1", "host.docker.internal"].filter(Boolean).join(",");
+}
+
+function cleanEnvValue(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
 }

--- a/src/tool/builtin/bash.ts
+++ b/src/tool/builtin/bash.ts
@@ -57,6 +57,8 @@ Usage:
 const LONG_TASK_HINT =
   "Use timeout=600000 or less for foreground bash. If the command must run in the background, use task_create and then task_wait to block for completion; use task_output only for progress checks and task_stop to clean up long-lived processes.";
 
+const STREAM_DIAGNOSTIC_MAX_CHARS = 600;
+
 const SHELL_BACKGROUND_WRAPPER_RE = /(?:^|[;&|]\s*|&&\s*|\|\|\s*|\$\(\s*)(?:nohup|disown|setsid)\b/iu;
 const TRAILING_BACKGROUND_RE = /(?:^|[^&])&\s*(?:[)#}\]]\s*)?$/u;
 const INLINE_BACKGROUND_RE = /(?:^|[;|]\s*)[^\n;&|]+&\s*(?:[;|]|&&|\|\|)/u;
@@ -150,9 +152,11 @@ export function createBashTool(options?: CreateBashToolOptions): PilotDeckToolDe
 
       if (result.exitCode !== 0) {
         const summary = formatShellFailure(command, result);
+        const diagnostic = formatShellFailureDiagnostic(result);
         throw new PilotDeckToolRuntimeError("tool_execution_failed", summary, {
           command,
           exitCode: result.exitCode,
+          diagnostic,
           stdout: result.stdout,
           stderr: result.stderr,
           timedOut: result.timedOut,
@@ -265,6 +269,82 @@ function formatShellFailure(
     lines.push("", "stdout:", result.stdout.trimEnd());
   }
   return lines.join("\n");
+}
+
+function formatShellFailureDiagnostic(
+  result: { exitCode: number | null; stdout: string; stderr: string },
+): string {
+  const stream = result.stderr.trim().length > 0 ? result.stderr : result.stdout;
+  const traceback = parsePythonTraceback(stream);
+  const moduleMissing = parseMissingModule(stream);
+  const commandNotFound = parseCommandNotFound(stream);
+  const syntaxError = parseSyntaxError(stream);
+
+  const lines = [
+    "BASH_FAILURE_DIAGNOSTIC",
+    `- exit_code: ${result.exitCode ?? "null"}`,
+  ];
+
+  if (traceback) {
+    lines.push(`- likely_cause: ${traceback.exception}`);
+    if (traceback.location) lines.push(`- failing_location: ${traceback.location}`);
+    lines.push("- next_step: inspect the failing file/line, fix that specific cause, then rerun the smallest command that exercises it.");
+  } else if (moduleMissing) {
+    lines.push(`- likely_cause: missing Python module ${moduleMissing}`);
+    lines.push("- next_step: install the missing module if allowed, or rewrite the script to use available dependencies.");
+  } else if (commandNotFound) {
+    lines.push(`- likely_cause: command not found: ${commandNotFound}`);
+    lines.push("- next_step: check whether the command is installed or use an available equivalent.");
+  } else if (syntaxError) {
+    lines.push(`- likely_cause: ${syntaxError}`);
+    lines.push("- next_step: fix the syntax in the saved script or command, then rerun a minimal check.");
+  } else {
+    lines.push("- likely_cause: command exited non-zero; inspect stderr/stdout below for the root cause.");
+    lines.push("- next_step: change the command or script before retrying; do not rerun unchanged.");
+  }
+
+  const stderrTail = tailSnippet(result.stderr, STREAM_DIAGNOSTIC_MAX_CHARS);
+  if (stderrTail) lines.push("- stderr_tail:", indentBlock(stderrTail));
+  const stdoutTail = tailSnippet(result.stdout, STREAM_DIAGNOSTIC_MAX_CHARS);
+  if (stdoutTail && !stderrTail.includes(stdoutTail)) lines.push("- stdout_tail:", indentBlock(stdoutTail));
+  return lines.join("\n");
+}
+
+function parsePythonTraceback(text: string): { exception: string; location?: string } | undefined {
+  if (!/Traceback \(most recent call last\):/u.test(text)) return undefined;
+  const lines = text.split(/\r?\n/);
+  let location: string | undefined;
+  for (const line of lines) {
+    const match = /^\s*File "([^"]+)", line (\d+)(?:, in (.*))?/u.exec(line);
+    if (match) {
+      location = `${match[1]}:${match[2]}${match[3] ? ` in ${match[3].trim()}` : ""}`;
+    }
+  }
+  const exception = [...lines].reverse().map((line) => line.trim()).find((line) => /^[A-Za-z_][\w.]*(?:Error|Exception|Warning)\b/u.test(line));
+  return { exception: exception ?? "Python traceback", location };
+}
+
+function parseMissingModule(text: string): string | undefined {
+  return /(?:ModuleNotFoundError|ImportError): No module named ['"]([^'"]+)['"]/u.exec(text)?.[1];
+}
+
+function parseCommandNotFound(text: string): string | undefined {
+  return /(?:^|\n)(?:.*?:\s*)?([^\s:]+): command not found\b/u.exec(text)?.[1];
+}
+
+function parseSyntaxError(text: string): string | undefined {
+  return /(?:^|\n)\s*(SyntaxError:[^\n]+)/u.exec(text)?.[1]?.trim();
+}
+
+function tailSnippet(value: string, maxChars: number): string {
+  const trimmed = value.trimEnd();
+  if (!trimmed) return "";
+  if (trimmed.length <= maxChars) return trimmed;
+  return `... [${trimmed.length - maxChars} chars omitted] ...\n${trimmed.slice(-maxChars)}`;
+}
+
+function indentBlock(value: string): string {
+  return value.split(/\r?\n/).map((line) => `  ${line}`).join("\n");
 }
 
 function foregroundBackgroundGuidance(command: string): string | undefined {

--- a/src/tool/builtin/executeCode.ts
+++ b/src/tool/builtin/executeCode.ts
@@ -210,7 +210,9 @@ async function validateExecuteCodeInput(input: ExecuteCodeInput) {
 }
 
 function isExecuteCodeReadOnly(input: ExecuteCodeInput): boolean {
-  return !containsWriteCapableHelper(input.code) && readOnlyBashCallsOnly(input.code);
+  const code = input && typeof input.code === "string" ? input.code : "";
+  if (!code) return false;
+  return !containsWriteCapableHelper(code) && readOnlyBashCallsOnly(code);
 }
 
 function containsWriteCapableHelper(code: string): boolean {

--- a/src/tool/builtin/taskTools.ts
+++ b/src/tool/builtin/taskTools.ts
@@ -163,7 +163,7 @@ export function createTaskCreateTool(
     name: "task_create",
     aliases: ["TaskCreate"],
     description:
-      "Spawn a shell command as a detached background task. Returns immediately with a taskId; it does not automatically push completion output back into the model context. For long-running tasks that should finish, call task_wait next. Use task_output for progress checks and task_stop for long-lived processes.",
+      "Spawn a shell command as a detached background task. Returns immediately with a taskId; it does not automatically push completion output back into the model context. For long-running tasks that should finish, call task_wait immediately after task_create so the final output returns to the current context. Use task_output only for progress checks, not manual sleep polling. Use task_stop for long-lived services/watchers.",
     kind: "shell",
     inputSchema: {
       type: "object",
@@ -352,7 +352,7 @@ export function createTaskWaitTool(
     name: "task_wait",
     aliases: ["TaskWait"],
     description:
-      "Block until a background task finishes or timeoutMs elapses, then return the task status and output. Use this immediately after task_create for long-running commands that should eventually complete. It does not stop the task when timeoutMs elapses.",
+      "Block until a background task finishes or timeoutMs elapses, then return the task status and output. Use this immediately after task_create for finite long-running commands such as builds, tests, conversions, downloads, or batch scripts. It does not stop the task when timeoutMs elapses; call task_wait again or task_output for progress.",
     kind: "shell",
     inputSchema: {
       type: "object",

--- a/src/tool/execution/ToolRuntime.ts
+++ b/src/tool/execution/ToolRuntime.ts
@@ -456,6 +456,11 @@ function formatRawToolErrorDetails(details?: Record<string, unknown>): string | 
     if (durationMs !== undefined) lines.push(`- duration_ms: ${String(durationMs)}`);
   }
 
+  const diagnostic = readStringDetail(details, "diagnostic");
+  if (diagnostic) {
+    lines.push("", "Diagnostic:", diagnostic.trimEnd());
+  }
+
   appendRawStream(lines, "stdout", readStringDetail(details, "stdout"));
   appendRawStream(lines, "stderr", readStringDetail(details, "stderr"));
 

--- a/tests/gateway/browser-use-args.spec.ts
+++ b/tests/gateway/browser-use-args.spec.ts
@@ -1,0 +1,77 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { buildBrowserUseArgs } from "../../src/cli/createLocalGateway.js";
+
+test("browser-use args do not inherit generic proxy env by default", () => {
+  const args = buildBrowserUseArgs(["--browser", "chromium"], "/tmp/pd-browser", {
+    HTTPS_PROXY: "http://user:pass@example.test:8080",
+  });
+
+  assert.deepEqual(args.slice(0, 2), ["--browser", "chromium"]);
+  assert.equal(args.includes("--proxy-server"), false);
+  assert.equal(args.includes("http://user:pass@example.test:8080"), false);
+  assert.deepEqual(args.slice(args.indexOf("--output-dir"), args.indexOf("--output-dir") + 2), [
+    "--output-dir",
+    "/tmp/pd-browser",
+  ]);
+});
+
+test("browser-use args use explicit browser proxy server", () => {
+  const args = buildBrowserUseArgs([], "/tmp/pd-browser", {
+    PILOTDECK_BROWSER_PROXY_SERVER: "http://127.0.0.1:7890",
+    NO_PROXY: "example.test",
+  });
+
+  assert.deepEqual(args.slice(args.indexOf("--proxy-server"), args.indexOf("--proxy-server") + 2), [
+    "--proxy-server",
+    "http://127.0.0.1:7890",
+  ]);
+  assert.deepEqual(args.slice(args.indexOf("--proxy-bypass"), args.indexOf("--proxy-bypass") + 2), [
+    "--proxy-bypass",
+    "example.test,localhost,127.0.0.1,host.docker.internal",
+  ]);
+});
+
+test("browser-use args only inherit generic proxy env when opted in", () => {
+  const args = buildBrowserUseArgs([], "/tmp/pd-browser", {
+    PILOTDECK_BROWSER_PROXY_FROM_ENV: "1",
+    HTTPS_PROXY: "http://proxy.example.test:8080",
+  }, {
+    url: "http://config-proxy.example.test:7890",
+  });
+
+  assert.deepEqual(args.slice(args.indexOf("--proxy-server"), args.indexOf("--proxy-server") + 2), [
+    "--proxy-server",
+    "http://proxy.example.test:8080",
+  ]);
+});
+
+test("browser-use args use config proxy when browser env proxy is absent", () => {
+  const args = buildBrowserUseArgs([], "/tmp/pd-browser", {
+    NO_PROXY: "env-bypass.example.test",
+  }, {
+    url: "http://config-proxy.example.test:7890",
+    noProxy: "config-bypass.example.test",
+  });
+
+  assert.deepEqual(args.slice(args.indexOf("--proxy-server"), args.indexOf("--proxy-server") + 2), [
+    "--proxy-server",
+    "http://config-proxy.example.test:7890",
+  ]);
+  assert.deepEqual(args.slice(args.indexOf("--proxy-bypass"), args.indexOf("--proxy-bypass") + 2), [
+    "--proxy-bypass",
+    "env-bypass.example.test,config-bypass.example.test,localhost,127.0.0.1,host.docker.internal",
+  ]);
+});
+
+test("browser-use args allow explicit direct mode to disable config proxy", () => {
+  const args = buildBrowserUseArgs([], "/tmp/pd-browser", {
+    PILOTDECK_BROWSER_PROXY_SERVER: "direct",
+  }, {
+    url: "http://config-proxy.example.test:7890",
+  });
+
+  assert.equal(args.includes("--proxy-server"), false);
+  assert.equal(args.includes("http://config-proxy.example.test:7890"), false);
+});

--- a/tests/gateway/weixin-nonblocking-login.spec.ts
+++ b/tests/gateway/weixin-nonblocking-login.spec.ts
@@ -13,6 +13,9 @@ import {
 import type { Gateway, GatewayChannelKey } from "../../src/gateway/index.js";
 
 test("WeixinChannel.start returns while QR login is waiting", async (t) => {
+  t.mock.method(console, "log", () => undefined);
+  t.mock.method(console, "error", () => undefined);
+
   const tempDir = await mkdtemp(join(tmpdir(), "pilotdeck-weixin-start-"));
   t.after(async () => {
     await rm(tempDir, { recursive: true, force: true });

--- a/tests/tool/bash-result-display.spec.ts
+++ b/tests/tool/bash-result-display.spec.ts
@@ -88,6 +88,8 @@ test("bash failure tool result includes raw stdout and stderr tail for UI and mo
     const text = result.content[0]?.type === "text" ? result.content[0].text : "";
     assert.match(text, /TOOL_ERROR\[tool_execution_failed\]\[bash\]/);
     assert.match(text, /Raw tool details:/);
+    assert.match(text, /Diagnostic:/);
+    assert.match(text, /BASH_FAILURE_DIAGNOSTIC/);
     assert.match(text, /- command: npm test/);
     assert.match(text, /- exit_code: 1/);
     assert.match(text, /stdout:/);
@@ -114,6 +116,31 @@ test("bash failure tool result includes raw stdout and stderr tail for UI and mo
   } finally {
     await rm(dir, { recursive: true, force: true });
   }
+});
+
+test("bash failure diagnostic extracts Python traceback location and exception", async () => {
+  const runtime = createRuntime({
+    async run() {
+      return {
+        exitCode: 1,
+        stdout: "",
+        stderr: `Traceback (most recent call last):\n  File "/tmp_workspace/script.py", line 7, in <module>\n    main()\n  File "/tmp_workspace/script.py", line 3, in main\n    raise TypeError("bad frame")\nTypeError: bad frame\n`,
+        timedOut: false,
+        durationMs: 9,
+      };
+    },
+  });
+
+  const result = await runtime.execute(
+    { id: "call-bash", name: "bash", input: { command: "python3 script.py" } },
+    context(),
+  );
+
+  assert.equal(result.type, "error");
+  const text = result.content[0]?.type === "text" ? result.content[0].text : "";
+  assert.match(text, /BASH_FAILURE_DIAGNOSTIC/);
+  assert.match(text, /likely_cause: TypeError: bad frame/);
+  assert.match(text, /failing_location: \/tmp_workspace\/script\.py:3 in main/);
 });
 
 test("bash success keeps full output for ToolResultBudget persistence", async () => {

--- a/tests/tool/builtin/executeCode.spec.ts
+++ b/tests/tool/builtin/executeCode.spec.ts
@@ -1,0 +1,10 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createExecuteCodeTool } from "../../../src/tool/builtin/executeCode.js";
+
+test("execute_code read-only probe handles missing input", () => {
+  const tool = createExecuteCodeTool();
+
+  assert.equal(tool.isReadOnly({} as never), false);
+});


### PR DESCRIPTION
## Summary
- Improve bash/tool failure guidance for foreground timeouts and background work by pointing agents toward bounded foreground runs or task_create + task_wait.
- Add browser-use runtime defaults for action/navigation timeout and optional Chromium proxy env configuration.
- Harden execute_code read-only probing against missing input and stabilize the Weixin nonblocking login test under node --test.

## Validation
- npm run build
- node --test --test-force-exit --test-timeout 60000 dist/tests/gateway/weixin-nonblocking-login.spec.js
- node --test --test-force-exit --test-timeout 60000 dist/tests/tool/bash-result-display.spec.js dist/tests/tool/error-recovery.spec.js dist/tests/agent/sub/SubAgentSession.spec.js dist/tests/tool/builtin/executeCode.spec.js
- npm test