### PR TITLE
fix(tool): keep truncated results within maxBytes for small caps

### DIFF
--- a/src/tool/protocol/result.ts
+++ b/src/tool/protocol/result.ts
@@ -161,9 +161,14 @@ export function applyResultSizeLimit(
 
   const suffix = "\n[Tool output truncated: head and tail shown.]";
   const suffixBytes = Buffer.byteLength(suffix, "utf8");
-  const budget = Math.max(0, maxBytes - suffixBytes);
   const text = content.map(contentToText).join("\n");
-  const truncatedText = headTailTruncateUtf8(text, budget) + suffix;
+  // If maxBytes cannot even fit the suffix, cap the notice itself instead of
+  // appending it in full and blowing past the limit; otherwise reserve room
+  // for the suffix so head + tail + suffix stays within maxBytes.
+  const truncatedText =
+    maxBytes <= suffixBytes
+      ? truncateUtf8(suffix, maxBytes)
+      : headTailTruncateUtf8(text, maxBytes - suffixBytes) + suffix;
   const returnedBytes = Buffer.byteLength(truncatedText, "utf8");
 
   return {

--- a/tests/tool/tool-result-size-limit.spec.ts
+++ b/tests/tool/tool-result-size-limit.spec.ts
@@ -21,3 +21,31 @@ test("applyResultSizeLimit keeps both head and tail when truncating text output"
   assert.match(text, /middle omitted/);
   assert.match(text, /head and tail shown/);
 });
+
+test("applyResultSizeLimit never returns more bytes than a small maxBytes cap", () => {
+  const suffixBytes = Buffer.byteLength("\n[Tool output truncated: head and tail shown.]", "utf8");
+  const original = "x".repeat(500);
+
+  for (const maxBytes of [0, 1, suffixBytes - 1, suffixBytes, suffixBytes + 1]) {
+    const { content, metadata } = applyResultSizeLimit([{ type: "text", text: original }], maxBytes);
+    const text = content[0]?.type === "text" ? content[0].text : "";
+    const returnedBytes = Buffer.byteLength(text, "utf8");
+
+    assert.ok(returnedBytes <= maxBytes, `maxBytes=${maxBytes}: returned ${returnedBytes} bytes`);
+    assert.equal(metadata?.truncated, true);
+    assert.equal(metadata?.originalBytes, 500);
+    assert.equal(metadata?.returnedBytes, returnedBytes);
+  }
+});
+
+test("applyResultSizeLimit stays UTF-8 safe and within the cap at a byte boundary", () => {
+  const original = "€".repeat(300); // 3 bytes per character
+  const maxBytes = 121;
+  const { content, metadata } = applyResultSizeLimit([{ type: "text", text: original }], maxBytes);
+  const text = content[0]?.type === "text" ? content[0].text : "";
+  const returnedBytes = Buffer.byteLength(text, "utf8");
+
+  assert.ok(returnedBytes <= maxBytes, `returned ${returnedBytes} bytes`);
+  assert.equal(metadata?.returnedBytes, returnedBytes);
+  assert.ok(!text.includes("�"), "output must not contain replacement characters");
+});


### PR DESCRIPTION
## Summary

`applyResultSizeLimit()` computed a head/tail budget with `Math.max(0, maxBytes - suffixBytes)` but still appended the **full** truncation suffix afterwards. When `maxBytes` was smaller than the suffix (`"\n[Tool output truncated: head and tail shown.]"`, 46 bytes), the returned text exceeded the requested cap.

Per the report, a one-byte result with `maxBytes = 0` returned the full 46-byte notice and `metadata.returnedBytes` recorded `46` — both larger than the requested maximum.

This fix caps the notice itself when `maxBytes` cannot fit the suffix, and otherwise reserves room for the suffix as before. The returned text and `metadata.returnedBytes` now stay within `maxBytes` for every non-negative limit. UTF-8 safety is preserved via the existing `truncateUtf8` helper.

Fixes #426

## Test plan

Extended `tests/tool/tool-result-size-limit.spec.ts`:

- returned bytes and `metadata.returnedBytes` never exceed `maxBytes` for `0`, `1`, `suffixBytes - 1`, `suffixBytes`, and `suffixBytes + 1`;
- a multibyte (`€`) result stays within the cap and contains no U+FFFD replacement characters at the byte boundary;
- the existing head/tail truncation test is unchanged.

```
$ node --test dist/tests/tool/tool-result-size-limit.spec.js
# tests 3
# pass 3
# fail 0
```

Full suite (`npm test`) stays green.