### PR TITLE
fix(cron): schedule.delay.unit 补上 type:"string"，修复 moonshot schema 校验失败

### DIFF
--- a/src/cron/tool/CronSchemas.ts
+++ b/src/cron/tool/CronSchemas.ts
@@ -26,7 +26,7 @@ export const CRON_SCHEDULE_SCHEMA = {
       properties: {
         type: { const: "delay" },
         amount: { type: "number", exclusiveMinimum: 0 },
-        unit: { enum: ["second", "minute", "hour", "day"] },
+        unit: { type: "string", enum: ["second", "minute", "hour", "day"] },
       },
     },
   ],


### PR DESCRIPTION
## 问题
`CRON_SCHEDULE_SCHEMA` 的 `delay` 分支中 `unit` 字段仅有 `enum` 缺少 `type`，导致 moonshot 在加载 `cron_create` 工具时校验失败：

```
tools.function.parameters is not a valid moonshot flavored json schema
→ At path 'properties.schedule.anyOf.properties.unit': type is not defined
```

结果所有依赖该工具的 agent 对话返回「服务暂时不可用」。

## 修复
给 `unit` 补上 `type: "string"`：

```ts
unit: { type: "string", enum: ["second", "minute", "hour", "day"] },
```

## 验证
修复后模型成功接受工具定义，cron 定时能力正常工作（"10分钟后提醒开会" 可执行）。

🤖 Generated with Claude Code