### PR TITLE
Fix OpenAI-compatible reasoning content and Kimi schemas

### DIFF
--- a/src/agent/loop/AgentLoop.ts
+++ b/src/agent/loop/AgentLoop.ts
@@ -2450,7 +2450,10 @@ function isMissingReasoningContentError(error: CanonicalModelError): boolean {
 }
 
 function addEmptyReasoningContentMarkers(messages: CanonicalMessage[]): CanonicalMessage[] {
-  return messages.map((message) => {
+  return messages.map((message, index) => {
+    if (index === messages.length - 1 && message.role === "assistant" && messageContent(message).length === 0) {
+      return message;
+    }
     if (message.role !== "assistant" || hasReplayableReasoningContent(message)) {
       return message;
     }

--- a/src/agent/loop/AgentLoop.ts
+++ b/src/agent/loop/AgentLoop.ts
@@ -235,6 +235,7 @@ export class AgentLoop {
     const MAX_JSON_SELF_CORRECT_RETRIES = 3;
     let jsonSelfCorrectCount = 0;
     let hasAttemptedToolCallRetry = false;
+    let hasAttemptedReasoningContentRetry = false;
     const largeFileRepair = new LargeFileRepair();
 
     /**
@@ -864,6 +865,21 @@ export class AgentLoop {
       await input.onDurableMessage?.(assistantMessage);
 
       if (assembled.error) {
+        if (
+          !hasAttemptedReasoningContentRetry &&
+          isMissingReasoningContentError(assembled.error)
+        ) {
+          hasAttemptedReasoningContentRetry = true;
+          messages = addEmptyReasoningContentMarkers(messages);
+          yield {
+            type: "turn_continued",
+            sessionId: input.sessionId,
+            turnId: input.turnId,
+            reason: "model_error",
+          };
+          continue;
+        }
+
         if (toolCalls.length > 0) {
           const projected = projectToolResults(
             toolCalls.map((call) =>
@@ -2425,6 +2441,34 @@ function textFromMessage(message: CanonicalMessage): string {
     .filter((block) => block.type === "text")
     .map((block) => block.text)
     .join("\n");
+}
+
+function isMissingReasoningContentError(error: CanonicalModelError): boolean {
+  return /\breasoning_content\b/i.test(error.message) &&
+    /thinking\s+mode/i.test(error.message) &&
+    /pass(?:ed)?\s+back/i.test(error.message);
+}
+
+function addEmptyReasoningContentMarkers(messages: CanonicalMessage[]): CanonicalMessage[] {
+  return messages.map((message) => {
+    if (message.role !== "assistant" || hasReplayableReasoningContent(message)) {
+      return message;
+    }
+    return {
+      ...message,
+      content: [
+        { type: "thinking", text: "", reasoningContent: "" },
+        ...messageContent(message),
+      ],
+    };
+  });
+}
+
+function hasReplayableReasoningContent(message: CanonicalMessage): boolean {
+  return messageContent(message).some((block) =>
+    block.type === "thinking" &&
+    ((block.reasoningContent ?? block.text).length > 0 || block.reasoningContent === "")
+  );
 }
 
 function appendPlanModeReminder(messages: CanonicalMessage[]): CanonicalMessage[] {

--- a/src/cron/tool/CronSchemas.ts
+++ b/src/cron/tool/CronSchemas.ts
@@ -5,7 +5,7 @@ export const CRON_SCHEDULE_SCHEMA = {
       required: ["type", "runAt"],
       additionalProperties: false,
       properties: {
-        type: { const: "once" },
+        type: { type: "string", const: "once" },
         runAt: { type: "string" },
       },
     },
@@ -14,7 +14,7 @@ export const CRON_SCHEDULE_SCHEMA = {
       required: ["type", "expression"],
       additionalProperties: false,
       properties: {
-        type: { const: "cron" },
+        type: { type: "string", const: "cron" },
         expression: { type: "string" },
         timezone: { type: "string" },
       },
@@ -24,9 +24,9 @@ export const CRON_SCHEDULE_SCHEMA = {
       required: ["type", "amount", "unit"],
       additionalProperties: false,
       properties: {
-        type: { const: "delay" },
+        type: { type: "string", const: "delay" },
         amount: { type: "number", exclusiveMinimum: 0 },
-        unit: { enum: ["second", "minute", "hour", "day"] },
+        unit: { type: "string", enum: ["second", "minute", "hour", "day"] },
       },
     },
   ],

--- a/src/model/protocol/canonical.ts
+++ b/src/model/protocol/canonical.ts
@@ -20,6 +20,8 @@ export type CanonicalThinkingBlock = {
    * when the message is replayed; preserved verbatim.
    */
   signature?: string;
+  /** Provider-native reasoning_content that should be replayed when present. */
+  reasoningContent?: string;
 };
 
 export type CanonicalImageBlock = {
@@ -252,7 +254,7 @@ export type CanonicalModelEvent =
     }
   | { type: "message_start"; role: "assistant"; raw?: unknown }
   | { type: "text_delta"; text: string; raw?: unknown }
-  | { type: "thinking_delta"; text: string; signature?: string; raw?: unknown }
+  | { type: "thinking_delta"; text: string; signature?: string; reasoningContent?: string; raw?: unknown }
   | { type: "tool_call_start"; id: string; name: string; raw?: unknown }
   | { type: "tool_call_delta"; id: string; delta: string; raw?: unknown }
   | { type: "tool_call_end"; toolCall: CanonicalToolCall; wasRepaired?: boolean; raw?: unknown }

--- a/src/model/providers/openai-responses/request.ts
+++ b/src/model/providers/openai-responses/request.ts
@@ -101,7 +101,7 @@ export function buildOpenAIResponsesRequest(
         type: "json_schema",
         name: request.outputSchema.name,
         description: request.outputSchema.description,
-        schema: request.outputSchema.schema,
+        schema: normalizeOpenAISchema(request.outputSchema.schema),
         strict: request.outputSchema.strict ?? true,
       },
     };

--- a/src/model/providers/openai/request.ts
+++ b/src/model/providers/openai/request.ts
@@ -4,6 +4,7 @@ import type {
   CanonicalMessage,
   CanonicalModelRequest,
   CanonicalPdfBlock,
+  CanonicalThinkingBlock,
   CanonicalToolChoice,
   CanonicalToolSchema,
   ModelDefinition,
@@ -135,7 +136,10 @@ export function buildOpenAIRequest(
   return body;
 }
 
-function toOpenAIMessages(message: CanonicalMessage, messageIndex: number): OpenAIMessage[] {
+function toOpenAIMessages(
+  message: CanonicalMessage,
+  messageIndex: number,
+): OpenAIMessage[] {
   if (message.role === "user") {
     return toOpenAIUserMessages(message);
   }
@@ -164,7 +168,9 @@ function toOpenAIMessages(message: CanonicalMessage, messageIndex: number): Open
       },
     }));
 
-  const thinkingBlocks = content.filter((block) => block.type === "thinking");
+  const thinkingBlocks = content.filter(
+    (block): block is CanonicalThinkingBlock => block.type === "thinking",
+  );
   const normalContent = content.filter(
     (block) =>
       block.type !== "tool_result" &&
@@ -182,10 +188,9 @@ function toOpenAIMessages(message: CanonicalMessage, messageIndex: number): Open
         : (message.role === "assistant" && thinkingBlocks.length > 0 ? "" : undefined),
       tool_calls: assistantToolCalls.length > 0 ? assistantToolCalls : undefined,
     };
-    // DeepSeek V4 requires reasoning_content to be passed back on assistant
-    // messages in multi-turn conversations; omitting it causes a 400 error.
-    if (message.role === "assistant" && thinkingBlocks.length > 0) {
-      msg.reasoning_content = thinkingBlocks.map((b) => b.text).join("\n");
+    const reasoningContent = toOpenAIReasoningContent(thinkingBlocks);
+    if (reasoningContent !== undefined) {
+      msg.reasoning_content = reasoningContent;
     }
     messages.push(msg);
   }
@@ -335,6 +340,20 @@ function toOpenAIContent(blocks: CanonicalContentBlock[]): string | unknown[] {
         return { type: "text", text: block.preview };
     }
   }).filter(Boolean);
+}
+
+function toOpenAIReasoningContent(
+  thinkingBlocks: CanonicalThinkingBlock[],
+): string | undefined {
+  const contexts = thinkingBlocks
+    .map((block) => block.reasoningContent ?? block.text)
+    .filter((text) => text.length > 0);
+
+  if (contexts.length === 0 && thinkingBlocks.length > 0) {
+    return "";
+  }
+
+  return contexts.length > 0 ? contexts.join("\n") : undefined;
 }
 
 function toOpenAITool(tool: CanonicalToolSchema, googleOpenAICompatible: boolean): OpenAITool {

--- a/src/model/providers/openai/request.ts
+++ b/src/model/providers/openai/request.ts
@@ -100,7 +100,7 @@ export function buildOpenAIRequest(
         description: request.outputSchema.description,
         schema: googleOpenAICompatible
           ? normalizeGoogleOpenAIResponseSchema(request.outputSchema.schema)
-          : request.outputSchema.schema,
+          : normalizeOpenAISchema(request.outputSchema.schema),
         strict: request.outputSchema.strict ?? true,
       },
     };

--- a/src/model/providers/openai/response.ts
+++ b/src/model/providers/openai/response.ts
@@ -23,9 +23,15 @@ export function parseOpenAIResponse(raw: unknown, provider = "openai"): Canonica
   const content: CanonicalContentBlock[] = [];
   const idState = createResponseToolCallIdState(response);
 
-  const reasoningText = readReasoningText(message.reasoning_content) ?? readReasoningText(message.reasoning);
+  const reasoningText =
+    readReasoningText(message.reasoning_content) ??
+    readReasoningText(message.reasoning);
   if (reasoningText) {
-    content.push({ type: "thinking", text: reasoningText });
+    content.push({
+      type: "thinking",
+      text: reasoningText,
+      reasoningContent: reasoningText,
+    });
   }
   if (Array.isArray(message.reasoning_details)) {
     const reasoning = message.reasoning_details
@@ -33,7 +39,11 @@ export function parseOpenAIResponse(raw: unknown, provider = "openai"): Canonica
       .filter((text): text is string => Boolean(text))
       .join("\n");
     if (reasoning.length > 0) {
-      content.push({ type: "thinking", text: reasoning });
+      content.push({
+        type: "thinking",
+        text: reasoning,
+        reasoningContent: reasoning,
+      });
     }
   }
 

--- a/src/model/providers/openai/schema.ts
+++ b/src/model/providers/openai/schema.ts
@@ -1,6 +1,7 @@
 /**
  * Azure/OpenAI-compatible endpoints can require `items` whenever a schema node
  * allows `array` (including union types like `type: ["string", "array"]`).
+ * Moonshot/Kimi also requires explicit `type` on literal `enum`/`const` nodes.
  * Normalize tool input schemas defensively to avoid provider-side 400s.
  */
 export function normalizeOpenAISchema(schema: Record<string, unknown>): Record<string, unknown> {
@@ -20,6 +21,13 @@ function normalizeOpenAISchemaNode(node: unknown): unknown {
     normalized[key] = normalizeOpenAISchemaNode(value);
   }
 
+  if (!("type" in normalized)) {
+    const inferredType = inferLiteralSchemaType(normalized);
+    if (inferredType) {
+      normalized.type = inferredType;
+    }
+  }
+
   const typeField = normalized.type;
   const allowsArray = typeField === "array"
     || (Array.isArray(typeField) && typeField.includes("array"));
@@ -28,6 +36,55 @@ function normalizeOpenAISchemaNode(node: unknown): unknown {
   }
 
   return normalized;
+}
+
+function inferLiteralSchemaType(node: Record<string, unknown>): string | undefined {
+  if ("const" in node) {
+    return schemaTypeForLiteral(node.const);
+  }
+
+  const enumValues = node.enum;
+  if (!Array.isArray(enumValues) || enumValues.length === 0) {
+    return undefined;
+  }
+
+  const types = enumValues.map(schemaTypeForLiteral);
+  if (types.some((type) => !type)) {
+    return undefined;
+  }
+
+  const uniqueTypes = new Set(types);
+  if (uniqueTypes.size === 1) {
+    return types[0];
+  }
+
+  if (uniqueTypes.size === 2 && uniqueTypes.has("integer") && uniqueTypes.has("number")) {
+    return "number";
+  }
+
+  return undefined;
+}
+
+function schemaTypeForLiteral(value: unknown): string | undefined {
+  if (typeof value === "string") {
+    return "string";
+  }
+  if (typeof value === "boolean") {
+    return "boolean";
+  }
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return Number.isInteger(value) ? "integer" : "number";
+  }
+  if (value === null) {
+    return "null";
+  }
+  if (Array.isArray(value)) {
+    return "array";
+  }
+  if (isRecord(value)) {
+    return "object";
+  }
+  return undefined;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/model/providers/openai/stream.ts
+++ b/src/model/providers/openai/stream.ts
@@ -171,7 +171,7 @@ export function normalizeOpenAIStreamEvent(
       events.push(...splitThinkContent(delta.content, state, raw));
     }
 
-    const reasoning = delta.reasoning ?? delta.reasoning_content;
+    const reasoning = delta.reasoning_content ?? delta.reasoning;
     if (typeof reasoning === "string" && reasoning.length > 0) {
       const prev = state.reasoningSnapshot;
       let emit: string;
@@ -183,7 +183,7 @@ export function normalizeOpenAIStreamEvent(
         state.reasoningSnapshot = prev + reasoning;
       }
       if (emit.length > 0) {
-        events.push({ type: "thinking_delta", text: emit, raw });
+        events.push({ type: "thinking_delta", text: emit, reasoningContent: emit, raw });
       }
     }
 

--- a/src/model/streaming/assembleModelMessage.ts
+++ b/src/model/streaming/assembleModelMessage.ts
@@ -19,6 +19,7 @@ export type ModelMessageAssemblerState = {
   content: CanonicalContentBlock[];
   textBuffer: string;
   thinkingBuffer: string;
+  thinkingReasoningContentBuffer: string;
   thinkingSignature?: string;
   usage: CanonicalUsage;
   finishReason?: CanonicalFinishReason;
@@ -51,6 +52,7 @@ export function createModelMessageAssemblerState(): ModelMessageAssemblerState {
     content: [],
     textBuffer: "",
     thinkingBuffer: "",
+    thinkingReasoningContentBuffer: "",
     usage: {},
     toolCalls: [],
   };
@@ -71,6 +73,9 @@ export function applyModelEventToAssembler(
       return;
     case "thinking_delta":
       state.thinkingBuffer += event.text;
+      if (event.reasoningContent !== undefined) {
+        state.thinkingReasoningContentBuffer += event.reasoningContent;
+      }
       if (event.signature !== undefined && event.signature.length > 0) {
         state.thinkingSignature = event.signature;
       }
@@ -186,16 +191,24 @@ function nextToolCallId(rawId: string | undefined, index: number, used: Set<stri
 }
 
 function flushTextBuffers(state: ModelMessageAssemblerState): void {
-  if (state.thinkingBuffer.length > 0 || state.thinkingSignature !== undefined) {
+  if (
+    state.thinkingBuffer.length > 0 ||
+    state.thinkingReasoningContentBuffer.length > 0 ||
+    state.thinkingSignature !== undefined
+  ) {
     const block: CanonicalThinkingBlock = {
       type: "thinking",
       text: state.thinkingBuffer,
     };
+    if (state.thinkingReasoningContentBuffer.length > 0) {
+      block.reasoningContent = state.thinkingReasoningContentBuffer;
+    }
     if (state.thinkingSignature !== undefined) {
       block.signature = state.thinkingSignature;
     }
     state.content.push(block);
     state.thinkingBuffer = "";
+    state.thinkingReasoningContentBuffer = "";
     state.thinkingSignature = undefined;
   }
 

--- a/tests/model/request/openaiReasoningContent.spec.ts
+++ b/tests/model/request/openaiReasoningContent.spec.ts
@@ -1,0 +1,120 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { buildModelRequest } from "../../../src/model/index.js";
+import type {
+  CanonicalMessage,
+  CanonicalModelRequest,
+  ModelCapabilities,
+  ModelConfig,
+  ModelDefinition,
+  ProviderConfig,
+} from "../../../src/model/index.js";
+
+test("openai-compatible requests replay all stored reasoning content", () => {
+  for (const provider of ["deepseek", "local"] as const) {
+    const body = buildModelRequest({
+      provider,
+      model: provider === "deepseek" ? "deepseek-chat" : "local-chat",
+      stream: true,
+      messages: [assistantWithMixedThinking()],
+    }, modelConfig()) as { messages: Array<{ reasoning_content?: string }> };
+
+    assert.equal(
+      body.messages[0]?.reasoning_content,
+      "anthropic native content\ndeepseek native content",
+    );
+  }
+});
+
+test("openai-compatible requests fall back to thinking text when native content is missing", () => {
+  const body = buildModelRequest({
+    provider: "local",
+    model: "local-chat",
+    stream: true,
+    messages: [{
+      role: "assistant",
+      content: [
+        { type: "thinking", text: "legacy reasoning text" },
+        { type: "thinking", text: "signed reasoning text", signature: "sig-123" },
+      ],
+    }],
+  }, modelConfig()) as { messages: Array<{ reasoning_content?: string }> };
+
+  assert.equal(body.messages[0]?.reasoning_content, "legacy reasoning text\nsigned reasoning text");
+});
+
+test("openai-compatible requests can replay an intentionally empty reasoning marker", () => {
+  const body = buildModelRequest({
+    provider: "local",
+    model: "local-chat",
+    stream: true,
+    messages: [{
+      role: "assistant",
+      content: [
+        { type: "thinking", text: "", reasoningContent: "" },
+        { type: "text", text: "visible answer" },
+      ],
+    }],
+  }, modelConfig()) as { messages: Array<{ reasoning_content?: string }> };
+
+  assert.equal(body.messages[0]?.reasoning_content, "");
+});
+
+function assistantWithMixedThinking(): CanonicalMessage {
+  return {
+    role: "assistant",
+    content: [
+      {
+        type: "thinking",
+        text: "anthropic thought",
+        reasoningContent: "anthropic native content",
+      },
+      {
+        type: "thinking",
+        text: "deepseek thought",
+        reasoningContent: "deepseek native content",
+      },
+    ],
+  };
+}
+
+function modelConfig(): ModelConfig {
+  const capabilities: ModelCapabilities = {
+    supportsToolUse: true,
+    supportsStreaming: true,
+    supportsParallelToolCalls: true,
+    supportsThinking: true,
+    supportsJsonSchema: true,
+    supportsSystemPrompt: true,
+    supportsPromptCache: false,
+    maxContextTokens: 128_000,
+    maxOutputTokens: 4_096,
+  };
+  const deepseek = provider("deepseek", "https://api.deepseek.com/v1", "deepseek-chat", capabilities);
+  const local = provider("local", "https://example.invalid/v1", "local-chat", capabilities);
+  return { providers: { deepseek, local } };
+}
+
+function provider(
+  id: string,
+  url: string,
+  modelId: string,
+  capabilities: ModelCapabilities,
+): ProviderConfig {
+  const models: Record<string, ModelDefinition> = {
+    [modelId]: {
+      id: modelId,
+      capabilities,
+      multimodal: { input: ["text"] },
+    },
+  };
+  return {
+    id,
+    protocol: "openai",
+    url,
+    apiKey: "test",
+    headers: {},
+    models,
+  };
+}

--- a/tests/model/request/openaiSchema.spec.ts
+++ b/tests/model/request/openaiSchema.spec.ts
@@ -2,6 +2,15 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import { CRON_SCHEDULE_SCHEMA } from "../../../src/cron/tool/CronSchemas.js";
+import { buildModelRequest } from "../../../src/model/index.js";
+import type {
+  CanonicalModelRequest,
+  ModelCapabilities,
+  ModelConfig,
+  ModelDefinition,
+  ModelProtocol,
+  ProviderConfig,
+} from "../../../src/model/index.js";
 import { normalizeOpenAISchema } from "../../../src/model/providers/openai/schema.js";
 
 test("openai schema normalization adds explicit types to cron literal variants", () => {
@@ -47,3 +56,82 @@ test("openai schema normalization preserves array item fallback", () => {
   const properties = normalized.properties as Record<string, Record<string, unknown>>;
   assert.deepEqual(properties.value.items, {});
 });
+
+test("openai response_format schemas get literal types normalized", () => {
+  const body = buildModelRequest(outputSchemaRequest("openai"), modelConfig("openai")) as {
+    response_format?: { json_schema: { schema: Record<string, unknown> } };
+  };
+
+  const schema = body.response_format?.json_schema.schema;
+  assert.ok(schema);
+  assertLiteralTypes(schema);
+});
+
+test("openai responses output schemas get literal types normalized", () => {
+  const body = buildModelRequest(outputSchemaRequest("openai-responses"), modelConfig("openai-responses")) as {
+    text?: { format: { schema: Record<string, unknown> } };
+  };
+
+  const schema = body.text?.format.schema;
+  assert.ok(schema);
+  assertLiteralTypes(schema);
+});
+
+function outputSchemaRequest(provider: string): CanonicalModelRequest {
+  return {
+    provider,
+    model: "test-model",
+    stream: true,
+    messages: [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+    outputSchema: {
+      name: "result",
+      schema: {
+        type: "object",
+        additionalProperties: false,
+        required: ["status", "kind"],
+        properties: {
+          status: { enum: ["ok", "failed"] },
+          kind: { const: "report" },
+        },
+      },
+    },
+  };
+}
+
+function assertLiteralTypes(schema: Record<string, unknown>): void {
+  const properties = schema.properties as Record<string, Record<string, unknown>>;
+  assert.equal(properties.status.type, "string");
+  assert.deepEqual(properties.status.enum, ["ok", "failed"]);
+  assert.equal(properties.kind.type, "string");
+  assert.equal(properties.kind.const, "report");
+}
+
+function modelConfig(protocol: ModelProtocol): ModelConfig {
+  const capabilities: ModelCapabilities = {
+    supportsToolUse: true,
+    supportsStreaming: true,
+    supportsParallelToolCalls: true,
+    supportsThinking: false,
+    supportsJsonSchema: true,
+    supportsSystemPrompt: true,
+    supportsPromptCache: false,
+    maxContextTokens: 128_000,
+    maxOutputTokens: 4_096,
+  };
+  const models: Record<string, ModelDefinition> = {
+    "test-model": {
+      id: "test-model",
+      capabilities,
+      multimodal: { input: ["text"] },
+    },
+  };
+  const provider: ProviderConfig = {
+    id: protocol,
+    protocol,
+    url: "https://example.invalid/v1",
+    apiKey: "test",
+    headers: {},
+    models,
+  };
+  return { providers: { [protocol]: provider } };
+}

--- a/tests/model/request/openaiSchema.spec.ts
+++ b/tests/model/request/openaiSchema.spec.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { CRON_SCHEDULE_SCHEMA } from "../../../src/cron/tool/CronSchemas.js";
+import { normalizeOpenAISchema } from "../../../src/model/providers/openai/schema.js";
+
+test("openai schema normalization adds explicit types to cron literal variants", () => {
+  const normalized = normalizeOpenAISchema({
+    type: "object",
+    required: ["schedule"],
+    additionalProperties: false,
+    properties: {
+      schedule: CRON_SCHEDULE_SCHEMA,
+    },
+  });
+
+  const properties = normalized.properties as Record<string, Record<string, unknown>>;
+  const schedule = properties.schedule;
+  const variants = schedule.anyOf as Array<Record<string, unknown>>;
+
+  const onceProperties = variants[0]?.properties as Record<string, Record<string, unknown>>;
+  assert.equal(onceProperties.type.type, "string");
+  assert.equal(onceProperties.type.const, "once");
+
+  const cronProperties = variants[1]?.properties as Record<string, Record<string, unknown>>;
+  assert.equal(cronProperties.type.type, "string");
+  assert.equal(cronProperties.type.const, "cron");
+
+  const delayProperties = variants[2]?.properties as Record<string, Record<string, unknown>>;
+  assert.equal(delayProperties.type.type, "string");
+  assert.equal(delayProperties.type.const, "delay");
+  assert.equal(delayProperties.unit.type, "string");
+  assert.deepEqual(delayProperties.unit.enum, ["second", "minute", "hour", "day"]);
+});
+
+test("openai schema normalization preserves array item fallback", () => {
+  const normalized = normalizeOpenAISchema({
+    type: "object",
+    additionalProperties: false,
+    properties: {
+      value: {
+        type: ["string", "array"],
+      },
+    },
+  });
+
+  const properties = normalized.properties as Record<string, Record<string, unknown>>;
+  assert.deepEqual(properties.value.items, {});
+});

--- a/tests/model/streaming/openaiReasoningContent.spec.ts
+++ b/tests/model/streaming/openaiReasoningContent.spec.ts
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  applyModelEventToAssembler,
+  assembleAssistantMessage,
+  createModelMessageAssemblerState,
+} from "../../../src/model/index.js";
+import {
+  createOpenAIStreamState,
+  normalizeOpenAIStreamEvent,
+} from "../../../src/model/providers/openai/stream.js";
+
+test("openai stream parser preserves native reasoning content for replay", () => {
+  const streamState = createOpenAIStreamState();
+  const events = normalizeOpenAIStreamEvent({
+    choices: [{
+      delta: { reasoning_content: "native content" },
+    }],
+  }, streamState);
+
+  const assembler = createModelMessageAssemblerState();
+  for (const event of events) {
+    applyModelEventToAssembler(assembler, event);
+  }
+  applyModelEventToAssembler(assembler, { type: "message_end", finishReason: "stop" });
+
+  const assembled = assembleAssistantMessage(assembler);
+  assert.deepEqual(assembled.message.content[0], {
+    type: "thinking",
+    text: "native content",
+    reasoningContent: "native content",
+  });
+});


### PR DESCRIPTION
## Summary
- preserve and replay OpenAI-compatible reasoning_content across streaming and non-streaming responses
- add one-shot recovery that inserts empty reasoning_content markers when the API reports missing thinking-mode reasoning_content
- make cron tool schemas and OpenAI-compatible schema normalization explicit enough for Moonshot/Kimi

## Tests
- pnpm exec tsc -p tsconfig.json --noEmit
- pnpm exec tsx --test tests/model/request/openaiReasoningContent.spec.ts tests/model/streaming/openaiReasoningContent.spec.ts tests/model/anthropicThinkingSignature.test.ts tests/model/request/openaiSchema.spec.ts