### PR TITLE
fix(streaming): stabilize thinking block identity

### DIFF
--- a/src/gateway/client/InProcessGateway.ts
+++ b/src/gateway/client/InProcessGateway.ts
@@ -1748,7 +1748,14 @@ function mapModelEvent(event: CanonicalModelEvent, runId: string): GatewayEvent[
     case "text_delta":
       return [{ type: "assistant_text_delta", text: event.text, runId }];
     case "thinking_delta":
-      return [{ type: "assistant_thinking_delta", text: event.text, runId }];
+      return [{
+        type: "assistant_thinking_delta",
+        text: event.text,
+        ...(event.reasoningContent !== undefined ? { reasoningContent: event.reasoningContent } : {}),
+        ...(event.thinkingBlockId !== undefined ? { thinkingBlockId: event.thinkingBlockId } : {}),
+        ...(event.thinkingBlockSeq !== undefined ? { thinkingBlockSeq: event.thinkingBlockSeq } : {}),
+        runId,
+      }];
     case "error":
       // Model-level errors are internal control flow until AgentLoop decides
       // whether they are recoverable. Surfacing them here duplicates the final
@@ -1777,7 +1784,19 @@ function mapSubagentModelEvent(
       return [{
         type: "agent_status",
         event: "subagent_thinking_delta",
-        detail: { ...base, text: event.event.text },
+        detail: {
+          ...base,
+          text: event.event.text,
+          ...(event.event.reasoningContent !== undefined
+            ? { reasoningContent: event.event.reasoningContent }
+            : {}),
+          ...(event.event.thinkingBlockId !== undefined
+            ? { thinkingBlockId: event.event.thinkingBlockId }
+            : {}),
+          ...(event.event.thinkingBlockSeq !== undefined
+            ? { thinkingBlockSeq: event.event.thinkingBlockSeq }
+            : {}),
+        },
       }];
     case "error":
       return [{

--- a/src/gateway/protocol/types.ts
+++ b/src/gateway/protocol/types.ts
@@ -141,7 +141,13 @@ export type GatewayEvent = GatewayTurnScopedEventMetadata & (
   | { type: "assistant_text_delta"; text: string }
   | { type: "assistant_attachment"; attachment: GatewayOutboundAttachment }
   | { type: "file_artifacts"; artifacts: import("../../session/artifacts/FileArtifact.js").FileArtifact[] }
-  | { type: "assistant_thinking_delta"; text: string }
+  | {
+      type: "assistant_thinking_delta";
+      text: string;
+      reasoningContent?: string;
+      thinkingBlockId?: string;
+      thinkingBlockSeq?: number;
+    }
   | { type: "tool_call_started"; toolCallId: string; name: string; argsPreview?: string }
   | {
       type: "tool_call_finished";

--- a/src/model/protocol/canonical.ts
+++ b/src/model/protocol/canonical.ts
@@ -254,7 +254,15 @@ export type CanonicalModelEvent =
     }
   | { type: "message_start"; role: "assistant"; raw?: unknown }
   | { type: "text_delta"; text: string; raw?: unknown }
-  | { type: "thinking_delta"; text: string; signature?: string; reasoningContent?: string; raw?: unknown }
+  | {
+      type: "thinking_delta";
+      text: string;
+      signature?: string;
+      reasoningContent?: string;
+      thinkingBlockId?: string;
+      thinkingBlockSeq?: number;
+      raw?: unknown;
+    }
   | { type: "tool_call_start"; id: string; name: string; raw?: unknown }
   | { type: "tool_call_delta"; id: string; delta: string; raw?: unknown }
   | { type: "tool_call_end"; toolCall: CanonicalToolCall; wasRepaired?: boolean; raw?: unknown }

--- a/src/model/providers/anthropic/stream.ts
+++ b/src/model/providers/anthropic/stream.ts
@@ -3,6 +3,13 @@ import type { CanonicalModelEvent, CanonicalToolCall } from "../../protocol/cano
 import { ModelProviderError, parseRetryAfterFromMessage } from "../../protocol/errors.js";
 import { normalizeAnthropicFinishReason } from "../../response/normalizeFinishReason.js";
 import { normalizeAnthropicUsage } from "../../response/normalizeUsage.js";
+import {
+  appendThinkingBlockText,
+  clearThinkingBlock,
+  createThinkingBlockTracker,
+  getThinkingBlockIdentity,
+  type ThinkingBlockTracker,
+} from "../../streaming/thinkingBlock.js";
 
 type FailedToolCall = {
   index: number;
@@ -15,12 +22,14 @@ type FailedToolCall = {
 export type AnthropicStreamState = {
   toolCalls: Map<number, Partial<CanonicalToolCall> & { inputBuffer?: string }>;
   failedToolCalls: FailedToolCall[];
+  thinkingBlocks: ThinkingBlockTracker;
 };
 
 export function createAnthropicStreamState(): AnthropicStreamState {
   return {
     toolCalls: new Map(),
     failedToolCalls: [],
+    thinkingBlocks: createThinkingBlockTracker(),
   };
 }
 
@@ -111,6 +120,14 @@ function contentBlockStartEvents(
     ];
   }
 
+  if (block.type === "thinking" && index !== undefined) {
+    getThinkingBlockIdentity(state.thinkingBlocks, thinkingBlockKey(index), {
+      blockId: readString(block.id),
+      blockSeq: index,
+      idPrefix: "anthropic-thinking",
+    });
+  }
+
   return [];
 }
 
@@ -122,14 +139,23 @@ function contentBlockDeltaEvents(
 ): CanonicalModelEvent[] {
   switch (delta.type) {
     case "text_delta":
+      if (index !== undefined) {
+        clearThinkingBlock(state.thinkingBlocks, thinkingBlockKey(index));
+      }
       return [{ type: "text_delta", text: readString(delta.text) ?? "", raw }];
     case "thinking_delta":
-      return [{ type: "thinking_delta", text: readString(delta.thinking) ?? "", raw }];
+      return thinkingDeltaEvent(state, index, readString(delta.thinking) ?? "", raw);
     case "signature_delta":
       // Anthropic extended-thinking signature; emitted as a thinking_delta with
       // an empty text and the signature payload so the assembler can attach it
       // to the active thinking block. Required for prompt-cache validity.
-      return [{ type: "thinking_delta", text: "", signature: readString(delta.signature) ?? "", raw }];
+      return thinkingDeltaEvent(
+        state,
+        index,
+        "",
+        raw,
+        readString(delta.signature) ?? undefined,
+      );
     case "input_json_delta":
       if (index !== undefined) {
         const current = state.toolCalls.get(index) ?? { id: String(index), name: "", inputBuffer: "" };
@@ -158,6 +184,8 @@ function contentBlockStopEvents(
   if (index === undefined) {
     return [];
   }
+
+  clearThinkingBlock(state.thinkingBlocks, thinkingBlockKey(index));
 
   const toolCall = state.toolCalls.get(index);
   if (!toolCall) {
@@ -261,6 +289,47 @@ function toolCallIdForIndex(index: number | undefined, state: AnthropicStreamSta
     return "";
   }
   return state.toolCalls.get(index)?.id ?? String(index);
+}
+
+function thinkingDeltaEvent(
+  state: AnthropicStreamState,
+  index: number | undefined,
+  text: string,
+  raw: unknown,
+  signature?: string,
+): CanonicalModelEvent[] {
+  if (index === undefined) {
+    return [{
+      type: "thinking_delta",
+      text,
+      ...(signature !== undefined ? { signature } : {}),
+      raw,
+    }];
+  }
+
+  const identity = appendThinkingBlockText(
+    state.thinkingBlocks,
+    thinkingBlockKey(index),
+    text,
+    {
+      blockId: undefined,
+      blockSeq: index,
+      idPrefix: "anthropic-thinking",
+    },
+  ).identity;
+
+  return [{
+    type: "thinking_delta",
+    text,
+    ...(signature !== undefined ? { signature } : {}),
+    thinkingBlockId: identity.thinkingBlockId,
+    thinkingBlockSeq: identity.thinkingBlockSeq,
+    raw,
+  }];
+}
+
+function thinkingBlockKey(index: number): string {
+  return `index:${index}`;
 }
 
 function asRecord(value: unknown): Record<string, unknown> {

--- a/src/model/providers/google/stream.ts
+++ b/src/model/providers/google/stream.ts
@@ -3,6 +3,12 @@ import {
   normalizeGoogleFinishReason,
   normalizeGoogleUsage,
 } from "./response.js";
+import {
+  appendThinkingBlockText,
+  clearThinkingBlocks,
+  createThinkingBlockTracker,
+  type ThinkingBlockTracker,
+} from "../../streaming/thinkingBlock.js";
 
 type GoogleStreamToolCallState = {
   baseId: string;
@@ -13,6 +19,7 @@ export type GoogleStreamState = {
   started: boolean;
   ended: boolean;
   toolCalls: GoogleStreamToolCallState;
+  thinkingBlocks: ThinkingBlockTracker;
 };
 
 export function createGoogleStreamState(): GoogleStreamState {
@@ -23,6 +30,7 @@ export function createGoogleStreamState(): GoogleStreamState {
       baseId: "google_stream",
       usedIds: new Set(),
     },
+    thinkingBlocks: createThinkingBlockTracker(),
   };
 }
 
@@ -47,13 +55,17 @@ export function normalizeGoogleStreamEvent(
     events.push({ type: "usage", usage, raw });
   }
 
-  for (const candidate of readCandidates(chunk)) {
-    for (const part of readParts(candidate)) {
-      events.push(...partEvents(part, state, raw));
+  const candidates = readCandidates(chunk);
+  for (let candidateIndex = 0; candidateIndex < candidates.length; candidateIndex += 1) {
+    const candidate = candidates[candidateIndex]!;
+    const parts = readParts(candidate);
+    for (let partIndex = 0; partIndex < parts.length; partIndex += 1) {
+      events.push(...partEvents(parts[partIndex], state, raw, candidateIndex, partIndex));
     }
 
     if (candidate.finishReason) {
       state.ended = true;
+      clearThinkingBlocks(state.thinkingBlocks);
       events.push({
         type: "message_end",
         finishReason: normalizeGoogleFinishReason(candidate.finishReason),
@@ -65,18 +77,44 @@ export function normalizeGoogleStreamEvent(
   return events;
 }
 
-function partEvents(part: unknown, state: GoogleStreamState, raw: unknown): CanonicalModelEvent[] {
+function partEvents(
+  part: unknown,
+  state: GoogleStreamState,
+  raw: unknown,
+  candidateIndex: number,
+  partIndex: number,
+): CanonicalModelEvent[] {
   const record = asRecord(part);
   const text = readString(record.text);
   if (text !== undefined) {
     if (record.thought === true) {
-      return [{ type: "thinking_delta", text, signature: readString(record.thoughtSignature), raw }];
+      const identity = appendThinkingBlockText(
+        state.thinkingBlocks,
+        thinkingBlockKey(candidateIndex, partIndex),
+        text,
+        {
+          blockSeq: state.thinkingBlocks.nextThinkingBlockSeq + 1,
+          idPrefix: "google-thinking",
+        },
+      ).identity;
+      return [{
+        type: "thinking_delta",
+        text,
+        ...(readString(record.thoughtSignature)
+          ? { signature: readString(record.thoughtSignature) }
+          : {}),
+        thinkingBlockId: identity.thinkingBlockId,
+        thinkingBlockSeq: identity.thinkingBlockSeq,
+        raw,
+      }];
     }
+    clearThinkingBlocks(state.thinkingBlocks);
     return text.length > 0 ? [{ type: "text_delta", text, raw }] : [];
   }
 
   const functionCall = asRecord(record.functionCall);
   if (Object.keys(functionCall).length > 0) {
+    clearThinkingBlocks(state.thinkingBlocks);
     const toolCall = toToolCall(functionCall, state.toolCalls, raw);
     const args = JSON.stringify(toolCall.input ?? {});
     return [
@@ -87,6 +125,10 @@ function partEvents(part: unknown, state: GoogleStreamState, raw: unknown): Cano
   }
 
   return [];
+}
+
+function thinkingBlockKey(candidateIndex: number, partIndex: number): string {
+  return `candidate:${candidateIndex}:part:${partIndex}`;
 }
 
 function toToolCall(

--- a/src/model/providers/openai-responses/stream.ts
+++ b/src/model/providers/openai-responses/stream.ts
@@ -3,6 +3,13 @@ import { randomUUID } from "node:crypto";
 import type { CanonicalModelEvent, CanonicalToolCall } from "../../protocol/canonical.js";
 import { ModelProviderError } from "../../protocol/errors.js";
 import { normalizeOpenAIUsage } from "../../response/normalizeUsage.js";
+import {
+  appendThinkingBlockText,
+  clearThinkingBlock,
+  clearThinkingBlocks,
+  createThinkingBlockTracker,
+  type ThinkingBlockTracker,
+} from "../../streaming/thinkingBlock.js";
 
 type ToolCallState = Partial<CanonicalToolCall> & {
   argumentsBuffer?: string;
@@ -18,6 +25,7 @@ export type OpenAIResponsesStreamState = {
   completedToolCallKeys: Set<string>;
   usedToolCallIds: Set<string>;
   sawToolCall: boolean;
+  thinkingBlocks: ThinkingBlockTracker;
 };
 
 export function createOpenAIResponsesStreamState(): OpenAIResponsesStreamState {
@@ -28,6 +36,7 @@ export function createOpenAIResponsesStreamState(): OpenAIResponsesStreamState {
     completedToolCallKeys: new Set(),
     usedToolCallIds: new Set(),
     sawToolCall: false,
+    thinkingBlocks: createThinkingBlockTracker(),
   };
 }
 
@@ -51,20 +60,23 @@ export function normalizeOpenAIResponsesStreamEvent(
 
   if (type === "response.output_text.delta" && typeof event.delta === "string" && event.delta.length > 0) {
     ensureStarted(events, state, raw);
+    clearThinkingBlocks(state.thinkingBlocks);
     events.push({ type: "text_delta", text: event.delta, raw });
   }
 
   if (isReasoningDelta(type) && typeof event.delta === "string" && event.delta.length > 0) {
     ensureStarted(events, state, raw);
-    events.push({ type: "thinking_delta", text: event.delta, raw });
+    events.push(...emitThinkingDelta(event, state, event.delta, raw));
   }
 
   if (type === "response.output_item.added") {
+    clearThinkingBlocks(state.thinkingBlocks);
     events.push(...handleOutputItemAdded(event, state, raw));
   }
 
   if (type === "response.function_call_arguments.delta" && typeof event.delta === "string") {
     ensureStarted(events, state, raw);
+    clearThinkingBlocks(state.thinkingBlocks);
     const toolCall = ensureToolCall(event, state);
     toolCall.argumentsBuffer = `${toolCall.argumentsBuffer ?? ""}${event.delta}`;
     events.push({ type: "tool_call_delta", id: toolCall.id ?? "", delta: event.delta, raw });
@@ -72,6 +84,7 @@ export function normalizeOpenAIResponsesStreamEvent(
 
   if (type === "response.function_call_arguments.done") {
     ensureStarted(events, state, raw);
+    clearThinkingBlocks(state.thinkingBlocks);
     if (isCompletedToolCall(event, state)) {
       return events;
     }
@@ -87,6 +100,7 @@ export function normalizeOpenAIResponsesStreamEvent(
     const item = asRecord(event.item);
     if (item.type === "function_call") {
       ensureStarted(events, state, raw);
+      clearThinkingBlocks(state.thinkingBlocks);
       if (isCompletedToolCall({ ...event, item }, state)) {
         return events;
       }
@@ -101,6 +115,7 @@ export function normalizeOpenAIResponsesStreamEvent(
 
   if (type === "response.completed") {
     ensureStarted(events, state, raw);
+    clearThinkingBlocks(state.thinkingBlocks);
     const usage = normalizeOpenAIUsage(response.usage);
     if (usage) {
       events.push({ type: "usage", usage, raw });
@@ -114,6 +129,7 @@ export function normalizeOpenAIResponsesStreamEvent(
 
   if (type === "response.incomplete") {
     ensureStarted(events, state, raw);
+    clearThinkingBlocks(state.thinkingBlocks);
     events.push({ type: "message_end", finishReason: "length", raw });
   }
 
@@ -121,6 +137,7 @@ export function normalizeOpenAIResponsesStreamEvent(
     if (type === "response.failed") {
       ensureStarted(events, state, raw);
     }
+    clearThinkingBlocks(state.thinkingBlocks);
     const responseError = asRecord(response.error);
     const eventError = asRecord(event.error);
     const error = Object.keys(responseError).length > 0 ? responseError : eventError;
@@ -271,6 +288,44 @@ function isReasoningDelta(type: string): boolean {
   return type === "response.reasoning_summary_text.delta"
     || type === "response.reasoning_text.delta"
     || type === "response.reasoning.delta";
+}
+
+function emitThinkingDelta(
+  event: Record<string, unknown>,
+  state: OpenAIResponsesStreamState,
+  text: string,
+  raw: unknown,
+): CanonicalModelEvent[] {
+  const key = thinkingBlockKey(event, state);
+  const identity = appendThinkingBlockText(
+    state.thinkingBlocks,
+    key,
+    text,
+    {
+      blockId: readNonEmptyString(event.item_id) ?? readNonEmptyString(asRecord(event.item).id),
+      blockSeq: readNumber(event.output_index) ?? readNumber(event.content_index) ?? readNumber(event.sequence_number),
+      idPrefix: "openai-responses-thinking",
+    },
+  ).identity;
+
+  return [{
+    type: "thinking_delta",
+    text,
+    thinkingBlockId: identity.thinkingBlockId,
+    thinkingBlockSeq: identity.thinkingBlockSeq,
+    raw,
+  }];
+}
+
+function thinkingBlockKey(event: Record<string, unknown>, state: OpenAIResponsesStreamState): string {
+  const item = asRecord(event.item);
+  const index = readNumber(event.output_index) ?? readNumber(event.content_index) ?? readNumber(event.sequence_number);
+  return readNonEmptyString(event.item_id)
+    ?? readNonEmptyString(item.id)
+    ?? readNonEmptyString(event.call_id)
+    ?? readNonEmptyString(item.call_id)
+    ?? (index !== undefined ? `index:${index}` : undefined)
+    ?? `response:${state.responseId ?? state.streamSyntheticId}`;
 }
 
 function chooseToolCallId(state: OpenAIResponsesStreamState, incomingId: string | undefined): string {

--- a/src/model/providers/openai/stream.ts
+++ b/src/model/providers/openai/stream.ts
@@ -8,6 +8,7 @@ import {
   appendThinkingBlockText,
   clearThinkingBlock,
   createThinkingBlockTracker,
+  getThinkingBlockIdentity,
   type ThinkingBlockTracker,
 } from "../../streaming/thinkingBlock.js";
 
@@ -97,7 +98,7 @@ export function splitThinkContent(
       if (idx !== -1) {
         const before = current.substring(0, idx);
         if (before.length > 0) {
-          events.push(...emitThinkingDelta(state, thinkingKey, before, raw));
+          events.push(...emitRawThinkingDelta(state, thinkingKey, before, raw));
         }
         current = current.substring(idx + THINK_CLOSE.length);
         state.thinkFsm = "NORMAL";
@@ -109,10 +110,10 @@ export function splitThinkContent(
           state.tagBuffer = current.substring(current.length - buffered);
           const safe = current.substring(0, current.length - buffered);
           if (safe.length > 0) {
-            events.push(...emitThinkingDelta(state, thinkingKey, safe, raw));
+            events.push(...emitRawThinkingDelta(state, thinkingKey, safe, raw));
           }
         } else {
-          events.push(...emitThinkingDelta(state, thinkingKey, current, raw));
+          events.push(...emitRawThinkingDelta(state, thinkingKey, current, raw));
         }
         current = "";
       }
@@ -136,6 +137,31 @@ function bufferPartialTag(text: string, tag: string): number {
   return 0;
 }
 
+function emitRawThinkingDelta(
+  state: OpenAIStreamState,
+  key: string,
+  text: string,
+  raw: unknown,
+): CanonicalModelEvent[] {
+  if (text.length === 0) {
+    return [];
+  }
+
+  const identity = getThinkingBlockIdentity(state.thinkingBlocks, key, {
+    idPrefix: "openai-thinking",
+  });
+
+  return [{
+    type: "thinking_delta",
+    text,
+    thinkingBlockId: identity.thinkingBlockId,
+    thinkingBlockSeq: identity.thinkingBlockSeq,
+    raw,
+  }];
+}
+
+// OpenAI `reasoning_content` behaves like a growing snapshot; raw `<think>`
+// content is emitted as-is through emitRawThinkingDelta().
 function emitThinkingDelta(
   state: OpenAIStreamState,
   key: string,

--- a/src/model/providers/openai/stream.ts
+++ b/src/model/providers/openai/stream.ts
@@ -4,6 +4,12 @@ import type { CanonicalModelEvent, CanonicalToolCall } from "../../protocol/cano
 import { ModelProviderError } from "../../protocol/errors.js";
 import { normalizeOpenAIFinishReason } from "../../response/normalizeFinishReason.js";
 import { normalizeOpenAIUsage } from "../../response/normalizeUsage.js";
+import {
+  appendThinkingBlockText,
+  clearThinkingBlock,
+  createThinkingBlockTracker,
+  type ThinkingBlockTracker,
+} from "../../streaming/thinkingBlock.js";
 
 export type ThinkFsmMode = "NORMAL" | "THINKING";
 
@@ -22,7 +28,7 @@ export type OpenAIStreamState = {
   toolCallBaseId?: string;
   thinkFsm: ThinkFsmMode;
   tagBuffer: string;
-  reasoningSnapshot: string;
+  thinkingBlocks: ThinkingBlockTracker;
 };
 
 export function createOpenAIStreamState(): OpenAIStreamState {
@@ -33,7 +39,7 @@ export function createOpenAIStreamState(): OpenAIStreamState {
     streamSyntheticId: `stream_${randomUUID().slice(0, 12)}`,
     thinkFsm: "NORMAL",
     tagBuffer: "",
-    reasoningSnapshot: "",
+    thinkingBlocks: createThinkingBlockTracker(),
   };
 }
 
@@ -50,11 +56,13 @@ const THINK_CLOSE = "</think>";
 export function splitThinkContent(
   content: string,
   state: OpenAIStreamState,
+  choiceIndex: number,
   raw: unknown,
 ): CanonicalModelEvent[] {
   const events: CanonicalModelEvent[] = [];
   let current = state.tagBuffer + content;
   state.tagBuffer = "";
+  const thinkingKey = choiceThinkingKey(choiceIndex);
 
   while (current.length > 0) {
     if (state.thinkFsm === "NORMAL") {
@@ -62,6 +70,7 @@ export function splitThinkContent(
       if (idx !== -1) {
         const before = current.substring(0, idx);
         if (before.length > 0) {
+          clearThinkingBlock(state.thinkingBlocks, thinkingKey);
           events.push({ type: "text_delta", text: before, raw });
         }
         current = current.substring(idx + THINK_OPEN.length);
@@ -73,9 +82,11 @@ export function splitThinkContent(
           state.tagBuffer = current.substring(current.length - buffered);
           const safe = current.substring(0, current.length - buffered);
           if (safe.length > 0) {
+            clearThinkingBlock(state.thinkingBlocks, thinkingKey);
             events.push({ type: "text_delta", text: safe, raw });
           }
         } else {
+          clearThinkingBlock(state.thinkingBlocks, thinkingKey);
           events.push({ type: "text_delta", text: current, raw });
         }
         current = "";
@@ -86,10 +97,11 @@ export function splitThinkContent(
       if (idx !== -1) {
         const before = current.substring(0, idx);
         if (before.length > 0) {
-          events.push({ type: "thinking_delta", text: before, raw });
+          events.push(...emitThinkingDelta(state, thinkingKey, before, raw));
         }
         current = current.substring(idx + THINK_CLOSE.length);
         state.thinkFsm = "NORMAL";
+        clearThinkingBlock(state.thinkingBlocks, thinkingKey);
       } else {
         // Check if the tail could be a partial `</think>` close tag
         const buffered = bufferPartialTag(current, THINK_CLOSE);
@@ -97,10 +109,10 @@ export function splitThinkContent(
           state.tagBuffer = current.substring(current.length - buffered);
           const safe = current.substring(0, current.length - buffered);
           if (safe.length > 0) {
-            events.push({ type: "thinking_delta", text: safe, raw });
+            events.push(...emitThinkingDelta(state, thinkingKey, safe, raw));
           }
         } else {
-          events.push({ type: "thinking_delta", text: current, raw });
+          events.push(...emitThinkingDelta(state, thinkingKey, current, raw));
         }
         current = "";
       }
@@ -122,6 +134,42 @@ function bufferPartialTag(text: string, tag: string): number {
     }
   }
   return 0;
+}
+
+function emitThinkingDelta(
+  state: OpenAIStreamState,
+  key: string,
+  text: string,
+  raw: unknown,
+  extra: {
+    reasoningContent?: string;
+  } = {},
+): CanonicalModelEvent[] {
+  if (text.length === 0 && extra.reasoningContent === undefined) {
+    return [];
+  }
+
+  const result = appendThinkingBlockText(
+    state.thinkingBlocks,
+    key,
+    text,
+    {
+      blockId: undefined,
+      idPrefix: "openai-thinking",
+    },
+  );
+  if (result.delta.length === 0) {
+    return [];
+  }
+
+  return [{
+    type: "thinking_delta",
+    text: result.delta,
+    ...(extra.reasoningContent !== undefined ? { reasoningContent: result.delta } : {}),
+    thinkingBlockId: result.identity.thinkingBlockId,
+    thinkingBlockSeq: result.identity.thinkingBlockSeq,
+    raw,
+  }];
 }
 
 export function normalizeOpenAIStreamEvent(
@@ -168,31 +216,27 @@ export function normalizeOpenAIStreamEvent(
     const delta = asRecord(choiceRecord.delta);
 
     if (typeof delta.content === "string" && delta.content.length > 0) {
-      events.push(...splitThinkContent(delta.content, state, raw));
+      events.push(...splitThinkContent(delta.content, state, choiceIndex, raw));
     }
 
     const reasoning = delta.reasoning_content ?? delta.reasoning;
     if (typeof reasoning === "string" && reasoning.length > 0) {
-      const prev = state.reasoningSnapshot;
-      let emit: string;
-      if (reasoning.startsWith(prev)) {
-        emit = reasoning.slice(prev.length);
-        state.reasoningSnapshot = reasoning;
-      } else {
-        emit = reasoning;
-        state.reasoningSnapshot = prev + reasoning;
-      }
-      if (emit.length > 0) {
-        events.push({ type: "thinking_delta", text: emit, reasoningContent: emit, raw });
+      const emitted = emitThinkingDelta(state, choiceThinkingKey(choiceIndex), reasoning, raw, {
+        reasoningContent: reasoning,
+      });
+      if (emitted.length > 0) {
+        events.push(...emitted);
       }
     }
 
     if (Array.isArray(delta.tool_calls)) {
+      clearThinkingBlock(state.thinkingBlocks, choiceThinkingKey(choiceIndex));
       events.push(...toolCallEvents(delta.tool_calls, state, raw, choiceIndex));
     }
 
     if (choiceRecord.finish_reason) {
       const fr = normalizeOpenAIFinishReason(choiceRecord.finish_reason);
+      clearThinkingBlock(state.thinkingBlocks, choiceThinkingKey(choiceIndex));
       events.push(...finishToolCalls(state, raw, fr, choiceIndex));
       events.push({ type: "message_end", finishReason: fr, raw });
     }
@@ -350,6 +394,10 @@ function readNonEmptyString(value: unknown): string | undefined {
 
 function streamToolCallKey(choiceIndex: number, toolIndex: number): string {
   return `${choiceIndex}:${toolIndex}`;
+}
+
+function choiceThinkingKey(choiceIndex: number): string {
+  return `choice:${choiceIndex}`;
 }
 
 function chooseStreamToolCallId(

--- a/src/model/streaming/thinkingBlock.ts
+++ b/src/model/streaming/thinkingBlock.ts
@@ -1,0 +1,100 @@
+export type ThinkingBlockIdentity = {
+  thinkingBlockId: string;
+  thinkingBlockSeq: number;
+};
+
+type ThinkingBlockEntry = ThinkingBlockIdentity & {
+  reasoningSnapshot: string;
+};
+
+export type ThinkingBlockTracker = {
+  nextThinkingBlockSeq: number;
+  blocksByKey: Map<string, ThinkingBlockEntry>;
+};
+
+export function createThinkingBlockTracker(): ThinkingBlockTracker {
+  return {
+    nextThinkingBlockSeq: 0,
+    blocksByKey: new Map(),
+  };
+}
+
+export function getThinkingBlockIdentity(
+  tracker: ThinkingBlockTracker,
+  key: string,
+  options: {
+    blockId?: string;
+    blockSeq?: number;
+    idPrefix?: string;
+  } = {},
+): ThinkingBlockIdentity {
+  const existing = tracker.blocksByKey.get(key);
+  if (existing) {
+    return existing;
+  }
+
+  const seq = options.blockSeq ?? tracker.nextThinkingBlockSeq + 1;
+  tracker.nextThinkingBlockSeq = Math.max(tracker.nextThinkingBlockSeq + 1, seq);
+  const id = normalizeThinkingBlockId(options.blockId, options.idPrefix, seq);
+  const entry: ThinkingBlockEntry = {
+    thinkingBlockId: id,
+    thinkingBlockSeq: seq,
+    reasoningSnapshot: "",
+  };
+  tracker.blocksByKey.set(key, entry);
+  return entry;
+}
+
+export function appendThinkingBlockText(
+  tracker: ThinkingBlockTracker,
+  key: string,
+  text: string,
+  options: {
+    blockId?: string;
+    blockSeq?: number;
+    idPrefix?: string;
+  } = {},
+): { identity: ThinkingBlockIdentity; delta: string } {
+  const identity = getThinkingBlockIdentity(tracker, key, options);
+  const entry = tracker.blocksByKey.get(key)!;
+  if (text.length === 0) {
+    return { identity, delta: "" };
+  }
+
+  const previous = entry.reasoningSnapshot;
+  let delta: string;
+  if (previous.length > 0 && text.startsWith(previous)) {
+    delta = text.slice(previous.length);
+    entry.reasoningSnapshot = text;
+  } else {
+    delta = text;
+    entry.reasoningSnapshot = `${previous}${text}`;
+  }
+  tracker.blocksByKey.set(key, entry);
+  return { identity, delta };
+}
+
+export function clearThinkingBlock(tracker: ThinkingBlockTracker, key: string): void {
+  tracker.blocksByKey.delete(key);
+}
+
+export function clearThinkingBlocks(tracker: ThinkingBlockTracker): void {
+  tracker.blocksByKey.clear();
+}
+
+function normalizeThinkingBlockId(
+  blockId: string | undefined,
+  idPrefix: string | undefined,
+  seq: number,
+): string {
+  const nativeId = typeof blockId === "string" ? blockId.trim() : "";
+  if (nativeId.length > 0) {
+    return nativeId;
+  }
+  const prefix = safeIdPart(idPrefix ?? "thinking");
+  return `${prefix}_${seq}`;
+}
+
+function safeIdPart(value: string): string {
+  return value.trim().replace(/[^A-Za-z0-9_-]+/g, "_").replace(/^_+|_+$/g, "") || "thinking";
+}

--- a/src/web/client/protocol.ts
+++ b/src/web/client/protocol.ts
@@ -47,7 +47,13 @@ type WebGatewayEventMetadata = {
 export type WebGatewayEvent = WebGatewayEventMetadata & (
   | { type: "turn_started"; runId: string }
   | { type: "assistant_text_delta"; text: string }
-  | { type: "assistant_thinking_delta"; text: string }
+  | {
+      type: "assistant_thinking_delta";
+      text: string;
+      reasoningContent?: string;
+      thinkingBlockId?: string;
+      thinkingBlockSeq?: number;
+    }
   | { type: "file_artifacts"; artifacts: import("../../session/artifacts/FileArtifact.js").FileArtifact[] }
   | {
       type: "tool_call_started";

--- a/src/web/client/webMessage.ts
+++ b/src/web/client/webMessage.ts
@@ -108,6 +108,9 @@ export type WebMessage = {
   requestId?: string;
   ok?: boolean;
   text?: string;
+  reasoningContent?: string;
+  thinkingBlockId?: string;
+  thinkingBlockSeq?: number;
   contentI18n?: { key: string; params?: Record<string, unknown> };
   userHintI18n?: { key: string; params?: Record<string, unknown> };
   images?: Array<{
@@ -149,6 +152,7 @@ export type WebMessageReducerState = {
   currentAssistantId?: string;
   /** Active assistant thinking id where thinking deltas are appended. */
   currentThinkingId?: string;
+  currentThinkingBlockKey?: string;
   /** Map toolCallId -> message id so we can flip to tool_result on finish. */
   toolMessageByCallId: Record<string, string>;
   /** True after this turn has already shown a visible failure status. */
@@ -189,6 +193,7 @@ export function applyWebGatewayEvent(
         ...state,
         currentAssistantId: undefined,
         currentThinkingId: undefined,
+        currentThinkingBlockKey: undefined,
         hasVisibleFailureStatus: false,
       };
 
@@ -204,6 +209,8 @@ export function applyWebGatewayEvent(
               ? { ...m, text: `${m.text ?? ""}${event.text}` }
               : m,
           ),
+          currentThinkingId: undefined,
+          currentThinkingBlockKey: undefined,
         };
       }
       const id = newId();
@@ -222,21 +229,38 @@ export function applyWebGatewayEvent(
         ...state,
         messages: [...state.messages, message],
         currentAssistantId: id,
+        currentThinkingId: undefined,
+        currentThinkingBlockKey: undefined,
       };
     }
 
     case "assistant_thinking_delta": {
-      if (!event.text) {
+      const deltaText = event.text || event.reasoningContent || "";
+      if (!deltaText) {
         return state;
       }
-      if (state.currentThinkingId) {
+      const nextBlockKey = getThinkingBlockKey(event);
+      const currentBlockKey = state.currentThinkingBlockKey;
+      const isSameThinkingBlock = state.currentThinkingId
+        && (currentBlockKey === undefined || nextBlockKey === undefined || currentBlockKey === nextBlockKey);
+      if (isSameThinkingBlock) {
         return {
           ...state,
           messages: state.messages.map((m) =>
             m.id === state.currentThinkingId
-              ? { ...m, text: `${m.text ?? ""}${event.text}` }
+              ? {
+                  ...m,
+                  text: `${m.text ?? ""}${deltaText}`,
+                  ...(event.reasoningContent !== undefined
+                    ? { reasoningContent: `${m.reasoningContent ?? ""}${event.reasoningContent}` }
+                    : {}),
+                  ...(event.thinkingBlockId !== undefined ? { thinkingBlockId: event.thinkingBlockId } : {}),
+                  ...(event.thinkingBlockSeq !== undefined ? { thinkingBlockSeq: event.thinkingBlockSeq } : {}),
+                }
               : m,
           ),
+          currentAssistantId: undefined,
+          currentThinkingBlockKey: currentBlockKey ?? nextBlockKey,
         };
       }
       const id = newId();
@@ -248,13 +272,18 @@ export function applyWebGatewayEvent(
         provider: "pilotdeck",
         role: "assistant",
         kind: "thinking",
-        text: event.text,
+        text: deltaText,
+        ...(event.reasoningContent !== undefined ? { reasoningContent: event.reasoningContent } : {}),
+        ...(event.thinkingBlockId !== undefined ? { thinkingBlockId: event.thinkingBlockId } : {}),
+        ...(event.thinkingBlockSeq !== undefined ? { thinkingBlockSeq: event.thinkingBlockSeq } : {}),
         source: "live",
       };
       return {
         ...state,
         messages: [...state.messages, message],
+        currentAssistantId: undefined,
         currentThinkingId: id,
+        currentThinkingBlockKey: nextBlockKey,
       };
     }
 
@@ -297,6 +326,8 @@ export function applyWebGatewayEvent(
           [event.toolCallId]: id,
         },
         currentAssistantId: undefined,
+        currentThinkingId: undefined,
+        currentThinkingBlockKey: undefined,
       };
     }
 
@@ -386,6 +417,8 @@ export function applyWebGatewayEvent(
         ...state,
         messages: [...state.messages, message],
         currentAssistantId: undefined,
+        currentThinkingId: undefined,
+        currentThinkingBlockKey: undefined,
       };
     }
 
@@ -413,6 +446,8 @@ export function applyWebGatewayEvent(
         ...state,
         messages: [...state.messages, message],
         currentAssistantId: undefined,
+        currentThinkingId: undefined,
+        currentThinkingBlockKey: undefined,
       };
     }
 
@@ -477,6 +512,7 @@ export function applyWebGatewayEvent(
         messages: [...state.messages, message],
         currentAssistantId: undefined,
         currentThinkingId: undefined,
+        currentThinkingBlockKey: undefined,
       };
     }
 
@@ -518,6 +554,7 @@ export function applyWebGatewayEvent(
         messages: [...state.messages, message],
         currentAssistantId: undefined,
         currentThinkingId: undefined,
+        currentThinkingBlockKey: undefined,
         hasVisibleFailureStatus: state.hasVisibleFailureStatus
           || (kind === "error" && detail.visible !== false),
       };
@@ -529,6 +566,7 @@ export function applyWebGatewayEvent(
           ...state,
           currentAssistantId: undefined,
           currentThinkingId: undefined,
+          currentThinkingBlockKey: undefined,
         };
       }
       const id = newId();
@@ -553,6 +591,7 @@ export function applyWebGatewayEvent(
         messages: [...state.messages, message],
         currentAssistantId: undefined,
         currentThinkingId: undefined,
+        currentThinkingBlockKey: undefined,
       };
     }
   }
@@ -574,6 +613,23 @@ function isI18nDescriptor(value: unknown): value is { key: string; params?: Reco
   return typeof value === "object"
     && value !== null
     && typeof (value as { key?: unknown }).key === "string";
+}
+
+function getThinkingBlockKey(event: {
+  runId?: string;
+  thinkingBlockId?: string;
+  thinkingBlockSeq?: number;
+}): string | undefined {
+  const runId = typeof event.runId === "string" && event.runId.trim().length > 0
+    ? event.runId.trim()
+    : "";
+  if (typeof event.thinkingBlockId === "string" && event.thinkingBlockId.trim().length > 0) {
+    return `${runId}|id:${event.thinkingBlockId.trim()}`;
+  }
+  if (typeof event.thinkingBlockSeq === "number" && Number.isFinite(event.thinkingBlockSeq)) {
+    return `${runId}|seq:${event.thinkingBlockSeq}`;
+  }
+  return runId || undefined;
 }
 
 function isErrorAgentStatusEvent(event: WebGatewayEvent & { type: "agent_status" }): boolean {

--- a/tests/gateway/map-agent-event-runid.spec.ts
+++ b/tests/gateway/map-agent-event-runid.spec.ts
@@ -37,3 +37,27 @@ test("mapAgentEvent propagates runId to streaming lifecycle boundaries", () => {
   assert.equal(failed[0]?.type, "error");
   assert.equal(failed[0]?.runId, runId);
 });
+
+test("mapAgentEvent forwards thinking block identity fields", () => {
+  const events = mapAgentEvent({
+    type: "model_event",
+    sessionId: "session-1",
+    turnId: "turn-1",
+    event: {
+      type: "thinking_delta",
+      text: "inspect",
+      reasoningContent: "native inspect",
+      thinkingBlockId: "block-1",
+      thinkingBlockSeq: 7,
+    },
+  } as unknown as AgentEvent, "run-1");
+
+  assert.deepEqual(events[0], {
+    type: "assistant_thinking_delta",
+    text: "inspect",
+    reasoningContent: "native inspect",
+    thinkingBlockId: "block-1",
+    thinkingBlockSeq: 7,
+    runId: "run-1",
+  });
+});

--- a/tests/model/streaming/thinkingBlockIdentity.spec.ts
+++ b/tests/model/streaming/thinkingBlockIdentity.spec.ts
@@ -1,0 +1,157 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { CanonicalModelEvent } from "../../../src/model/protocol/canonical.js";
+import {
+  createAnthropicStreamState,
+  normalizeAnthropicStreamEvent,
+} from "../../../src/model/providers/anthropic/stream.js";
+import {
+  createGoogleStreamState,
+  normalizeGoogleStreamEvent,
+} from "../../../src/model/providers/google/stream.js";
+import {
+  createOpenAIResponsesStreamState,
+  normalizeOpenAIResponsesStreamEvent,
+} from "../../../src/model/providers/openai-responses/stream.js";
+import {
+  createOpenAIStreamState,
+  normalizeOpenAIStreamEvent,
+} from "../../../src/model/providers/openai/stream.js";
+
+type ThinkingDelta = Extract<CanonicalModelEvent, { type: "thinking_delta" }>;
+
+function thinkingDeltas(events: CanonicalModelEvent[]): ThinkingDelta[] {
+  return events.filter((event): event is ThinkingDelta => event.type === "thinking_delta");
+}
+
+test("anthropic stream keeps one thinking identity per native content block", () => {
+  const state = createAnthropicStreamState();
+  normalizeAnthropicStreamEvent({
+    type: "content_block_start",
+    index: 0,
+    content_block: { type: "thinking", id: "anthropic-native-block" },
+  }, state);
+
+  const deltas = thinkingDeltas([
+    ...normalizeAnthropicStreamEvent({
+      type: "content_block_delta",
+      index: 0,
+      delta: { type: "thinking_delta", thinking: "Inspect " },
+    }, state),
+    ...normalizeAnthropicStreamEvent({
+      type: "content_block_delta",
+      index: 0,
+      delta: { type: "thinking_delta", thinking: "the state" },
+    }, state),
+  ]);
+
+  assert.equal(deltas.length, 2);
+  assert.equal(deltas[0]?.thinkingBlockId, "anthropic-native-block");
+  assert.equal(deltas[1]?.thinkingBlockId, "anthropic-native-block");
+  assert.equal(deltas[0]?.thinkingBlockSeq, 0);
+  assert.equal(deltas[1]?.thinkingBlockSeq, 0);
+});
+
+test("openai think-tag stream reuses identity within a block and advances after close", () => {
+  const state = createOpenAIStreamState();
+  const deltas = thinkingDeltas([
+    ...normalizeOpenAIStreamEvent({
+      choices: [{ index: 0, delta: { content: "<think>Plan " } }],
+    }, state),
+    ...normalizeOpenAIStreamEvent({
+      choices: [{ index: 0, delta: { content: "A</think><think>Plan B</think>" } }],
+    }, state),
+  ]);
+
+  assert.deepEqual(deltas.map((event) => event.text), ["Plan ", "A", "Plan B"]);
+  assert.equal(deltas[0]?.thinkingBlockId, deltas[1]?.thinkingBlockId);
+  assert.equal(deltas[0]?.thinkingBlockSeq, deltas[1]?.thinkingBlockSeq);
+  assert.notEqual(deltas[1]?.thinkingBlockId, deltas[2]?.thinkingBlockId);
+  assert.notEqual(deltas[1]?.thinkingBlockSeq, deltas[2]?.thinkingBlockSeq);
+});
+
+test("openai reasoning_content snapshots emit only the new delta for one block", () => {
+  const state = createOpenAIStreamState();
+  const deltas = thinkingDeltas([
+    ...normalizeOpenAIStreamEvent({
+      choices: [{ index: 0, delta: { reasoning_content: "Plan" } }],
+    }, state),
+    ...normalizeOpenAIStreamEvent({
+      choices: [{ index: 0, delta: { reasoning_content: "Plan now" } }],
+    }, state),
+    ...normalizeOpenAIStreamEvent({
+      choices: [{ index: 0, delta: { reasoning_content: " done" } }],
+    }, state),
+  ]);
+
+  assert.deepEqual(deltas.map((event) => event.text), ["Plan", " now", " done"]);
+  assert.deepEqual(deltas.map((event) => event.reasoningContent), ["Plan", " now", " done"]);
+  assert.equal(new Set(deltas.map((event) => event.thinkingBlockId)).size, 1);
+});
+
+test("openai responses stream maps item ids to stable thinking block ids", () => {
+  const state = createOpenAIResponsesStreamState();
+  const deltas = thinkingDeltas([
+    ...normalizeOpenAIResponsesStreamEvent({
+      type: "response.reasoning_text.delta",
+      item_id: "rs_123",
+      output_index: 0,
+      delta: "Check ",
+    }, state),
+    ...normalizeOpenAIResponsesStreamEvent({
+      type: "response.reasoning_text.delta",
+      item_id: "rs_123",
+      output_index: 0,
+      delta: "again",
+    }, state),
+  ]);
+
+  assert.equal(deltas.length, 2);
+  assert.equal(deltas[0]?.thinkingBlockId, "rs_123");
+  assert.equal(deltas[1]?.thinkingBlockId, "rs_123");
+  assert.equal(deltas[0]?.thinkingBlockSeq, deltas[1]?.thinkingBlockSeq);
+});
+
+test("openai responses stream falls back to output index when item id is absent", () => {
+  const state = createOpenAIResponsesStreamState();
+  const first = thinkingDeltas(normalizeOpenAIResponsesStreamEvent({
+    type: "response.reasoning_text.delta",
+    output_index: 0,
+    delta: "First block",
+  }, state))[0];
+  const second = thinkingDeltas(normalizeOpenAIResponsesStreamEvent({
+    type: "response.reasoning_text.delta",
+    output_index: 1,
+    delta: "Second block",
+  }, state))[0];
+
+  assert.equal(first?.thinkingBlockSeq, 0);
+  assert.equal(second?.thinkingBlockSeq, 1);
+  assert.notEqual(first?.thinkingBlockId, second?.thinkingBlockId);
+});
+
+test("google thought parts keep a stable synthetic thinking identity", () => {
+  const state = createGoogleStreamState();
+  const deltas = thinkingDeltas([
+    ...normalizeGoogleStreamEvent({
+      candidates: [{
+        content: {
+          parts: [{ text: "Inspect ", thought: true, thoughtSignature: "sig-google" }],
+        },
+      }],
+    }, state),
+    ...normalizeGoogleStreamEvent({
+      candidates: [{
+        content: {
+          parts: [{ text: "state", thought: true }],
+        },
+      }],
+    }, state),
+  ]);
+
+  assert.equal(deltas.length, 2);
+  assert.equal(deltas[0]?.thinkingBlockId, deltas[1]?.thinkingBlockId);
+  assert.equal(deltas[0]?.thinkingBlockSeq, deltas[1]?.thinkingBlockSeq);
+  assert.equal(deltas[0]?.signature, "sig-google");
+});

--- a/tests/model/streaming/thinkingBlockIdentity.spec.ts
+++ b/tests/model/streaming/thinkingBlockIdentity.spec.ts
@@ -71,6 +71,22 @@ test("openai think-tag stream reuses identity within a block and advances after 
   assert.notEqual(deltas[1]?.thinkingBlockSeq, deltas[2]?.thinkingBlockSeq);
 });
 
+test("openai think-tag stream keeps repeated-prefix raw deltas", () => {
+  const state = createOpenAIStreamState();
+  const deltas = thinkingDeltas([
+    ...normalizeOpenAIStreamEvent({
+      choices: [{ index: 0, delta: { content: "<think>ha" } }],
+    }, state),
+    ...normalizeOpenAIStreamEvent({
+      choices: [{ index: 0, delta: { content: "ha</think>" } }],
+    }, state),
+  ]);
+
+  assert.deepEqual(deltas.map((event) => event.text), ["ha", "ha"]);
+  assert.equal(new Set(deltas.map((event) => event.thinkingBlockId)).size, 1);
+  assert.equal(new Set(deltas.map((event) => event.thinkingBlockSeq)).size, 1);
+});
+
 test("openai reasoning_content snapshots emit only the new delta for one block", () => {
   const state = createOpenAIStreamState();
   const deltas = thinkingDeltas([

--- a/tests/web/thinking-block.spec.ts
+++ b/tests/web/thinking-block.spec.ts
@@ -1,0 +1,112 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { applyWebGatewayEvent, createWebMessageReducerState } from "../../src/web/client/webMessage.js";
+
+function reducerOptions() {
+  let id = 0;
+  return {
+    sessionKey: "s1",
+    projectKey: "p1",
+    now: () => new Date("2026-07-09T00:00:00.000Z"),
+    newId: () => `msg-${++id}`,
+  };
+}
+
+test("web reducer appends deltas for the same thinking block into one message", () => {
+  const options = reducerOptions();
+  let state = createWebMessageReducerState();
+
+  state = applyWebGatewayEvent(state, {
+    type: "assistant_thinking_delta",
+    text: "Inspect ",
+    runId: "run-1",
+    thinkingBlockId: "block-a",
+    thinkingBlockSeq: 3,
+  }, options);
+  state = applyWebGatewayEvent(state, {
+    type: "assistant_thinking_delta",
+    text: "state",
+    runId: "run-1",
+    thinkingBlockId: "block-a",
+    thinkingBlockSeq: 3,
+  }, options);
+
+  assert.equal(state.messages.length, 1);
+  assert.equal(state.messages[0]?.kind, "thinking");
+  assert.equal(state.messages[0]?.text, "Inspect state");
+  assert.equal(state.messages[0]?.thinkingBlockId, "block-a");
+  assert.equal(state.messages[0]?.thinkingBlockSeq, 3);
+});
+
+test("web reducer creates a new thinking message when block id changes", () => {
+  const options = reducerOptions();
+  let state = createWebMessageReducerState();
+
+  state = applyWebGatewayEvent(state, {
+    type: "assistant_thinking_delta",
+    text: "First",
+    runId: "run-1",
+    thinkingBlockId: "block-a",
+  }, options);
+  state = applyWebGatewayEvent(state, {
+    type: "assistant_thinking_delta",
+    text: "Second",
+    runId: "run-1",
+    thinkingBlockId: "block-b",
+  }, options);
+
+  assert.deepEqual(state.messages.map((message) => message.text), ["First", "Second"]);
+});
+
+test("web reducer uses thinkingBlockSeq as the fallback block key", () => {
+  const options = reducerOptions();
+  let state = createWebMessageReducerState();
+
+  state = applyWebGatewayEvent(state, {
+    type: "assistant_thinking_delta",
+    text: "A",
+    runId: "run-1",
+    thinkingBlockSeq: 1,
+  }, options);
+  state = applyWebGatewayEvent(state, {
+    type: "assistant_thinking_delta",
+    text: "B",
+    runId: "run-1",
+    thinkingBlockSeq: 2,
+  }, options);
+
+  assert.deepEqual(state.messages.map((message) => message.text), ["A", "B"]);
+});
+
+test("web reducer preserves legacy merging when thinking block fields are absent", () => {
+  const options = reducerOptions();
+  let state = createWebMessageReducerState();
+
+  state = applyWebGatewayEvent(state, {
+    type: "assistant_thinking_delta",
+    text: "Legacy ",
+    runId: "run-1",
+  }, options);
+  state = applyWebGatewayEvent(state, {
+    type: "assistant_thinking_delta",
+    text: "block",
+    runId: "run-1",
+  }, options);
+  state = applyWebGatewayEvent(state, {
+    type: "tool_call_started",
+    toolCallId: "call-1",
+    name: "bash",
+    runId: "run-1",
+  }, options);
+  state = applyWebGatewayEvent(state, {
+    type: "assistant_thinking_delta",
+    text: "Next",
+    runId: "run-1",
+  }, options);
+
+  assert.deepEqual(
+    state.messages.filter((message) => message.kind === "thinking").map((message) => message.text),
+    ["Legacy block", "Next"],
+  );
+});

--- a/ui/server/pilotdeck-bridge.js
+++ b/ui/server/pilotdeck-bridge.js
@@ -450,6 +450,15 @@ export function gatewayEventToFrames(event, sessionId, provider) {
                     ...base,
                     kind: 'thinking',
                     content: event.text,
+                    ...(event.reasoningContent !== undefined
+                        ? { reasoningContent: event.reasoningContent }
+                        : {}),
+                    ...(event.thinkingBlockId !== undefined
+                        ? { thinkingBlockId: event.thinkingBlockId }
+                        : {}),
+                    ...(event.thinkingBlockSeq !== undefined
+                        ? { thinkingBlockSeq: event.thinkingBlockSeq }
+                        : {}),
                 }),
             ];
         case 'file_artifacts':
@@ -890,6 +899,15 @@ function createSubagentDetailFrames(event, base, detail) {
                 id: `subagent_detail_thinking_${sanitizeMessageId(detailSessionId)}_${Date.now()}`,
                 kind: 'thinking',
                 content: detail.text || '',
+                ...(detail.reasoningContent !== undefined
+                    ? { reasoningContent: detail.reasoningContent }
+                    : {}),
+                ...(detail.thinkingBlockId !== undefined
+                    ? { thinkingBlockId: detail.thinkingBlockId }
+                    : {}),
+                ...(detail.thinkingBlockSeq !== undefined
+                    ? { thinkingBlockSeq: detail.thinkingBlockSeq }
+                    : {}),
             })];
         case 'subagent_tool_call_started': {
             const toolCallId = String(detail.toolCallId || randomUUID());

--- a/ui/server/pilotdeck-bridge.test.js
+++ b/ui/server/pilotdeck-bridge.test.js
@@ -6,6 +6,27 @@ import {
 } from './pilotdeck-bridge.js';
 
 describe('gatewayEventToFrames agent status errors', () => {
+    it('preserves thinking block identity on live thinking frames', () => {
+        const frames = gatewayEventToFrames({
+            type: 'assistant_thinking_delta',
+            text: 'Inspect',
+            reasoningContent: 'native Inspect',
+            thinkingBlockId: 'block-1',
+            thinkingBlockSeq: 7,
+            runId: 'run-1',
+        }, 'web:s_test', 'pilotdeck');
+
+        expect(frames).toHaveLength(1);
+        expect(frames[0]).toMatchObject({
+            kind: 'thinking',
+            content: 'Inspect',
+            reasoningContent: 'native Inspect',
+            thinkingBlockId: 'block-1',
+            thinkingBlockSeq: 7,
+            runId: 'run-1',
+        });
+    });
+
     it('maps tool result detail availability to a mergeable tool_result frame', () => {
         const frames = gatewayEventToFrames({
             type: 'tool_result_detail_available',

--- a/ui/server/projects.js
+++ b/ui/server/projects.js
@@ -24,8 +24,11 @@ import os from 'node:os';
 
 import {
     getPilotDeckGateway,
+    isGatewayUnavailableError,
 } from './pilotdeck-bridge.js';
 import { mapLegacySessionPresentation } from '../../src/web/server/legacySessionPresentation.js';
+import { describeWebProject, listWebProjects } from '../../src/web/server/listProjects.js';
+import { listProjectSessions } from '../../src/session/index.js';
 import {
     resolvePilotHome,
     createProjectId,
@@ -58,6 +61,12 @@ async function detectTaskMaster(projectPath) {
 }
 
 const directoryCache = new Map();
+const parsedProjectGatewayTimeoutMs =
+    Number.parseInt(process.env.PILOTDECK_PROJECTS_GATEWAY_TIMEOUT_MS ?? '', 10);
+const PROJECT_GATEWAY_TIMEOUT_MS = Number.isFinite(parsedProjectGatewayTimeoutMs)
+    ? parsedProjectGatewayTimeoutMs
+    : 2_500;
+let loggedGatewayFallback = false;
 
 function rememberProjectDirectory(name, fullPath) {
     if (!name || !fullPath) return;
@@ -135,9 +144,122 @@ async function readMarkedProjectPaths() {
     return result;
 }
 
+function createProjectGatewayTimeoutError() {
+    const error = new Error(
+        `[projects] gateway did not become ready within ${PROJECT_GATEWAY_TIMEOUT_MS}ms`,
+    );
+    error.code = 'project_gateway_timeout';
+    return error;
+}
+
+function isProjectGatewayFallbackError(error) {
+    return error?.code === 'project_gateway_timeout' || isGatewayUnavailableError(error);
+}
+
+function logProjectGatewayFallback(error, context) {
+    if (loggedGatewayFallback) return;
+    loggedGatewayFallback = true;
+    console.warn(
+        `[projects] gateway unavailable during ${context}; using local project/session index:`,
+        error?.message || error,
+    );
+}
+
+async function getGatewayForProjectReads(context) {
+    const gatewayPromise = getPilotDeckGateway();
+    const timeoutMs = PROJECT_GATEWAY_TIMEOUT_MS;
+    const boundedGatewayPromise = timeoutMs > 0
+        ? new Promise((resolve, reject) => {
+            const timer = setTimeout(() => reject(createProjectGatewayTimeoutError()), timeoutMs);
+            gatewayPromise.then(
+                (gateway) => {
+                    clearTimeout(timer);
+                    resolve(gateway);
+                },
+                (error) => {
+                    clearTimeout(timer);
+                    reject(error);
+                },
+            );
+        })
+        : gatewayPromise;
+
+    try {
+        return await boundedGatewayPromise;
+    } catch (error) {
+        if (!isProjectGatewayFallbackError(error)) {
+            throw error;
+        }
+        logProjectGatewayFallback(error, context);
+        return null;
+    }
+}
+
+async function listProjectsFromGatewayOrDisk(gateway) {
+    if (gateway) {
+        try {
+            const { projects = [] } = await gateway.listProjects();
+            return { gateway, projects };
+        } catch (error) {
+            if (!isProjectGatewayFallbackError(error)) {
+                throw error;
+            }
+            logProjectGatewayFallback(error, 'project list');
+        }
+    }
+
+    const pilotHome = resolvePilotHome(process.env);
+    const { projects = [] } = await listWebProjects({ pilotHome });
+    return { gateway: null, projects };
+}
+
+async function listSessionsFromGatewayOrDisk(gateway, projectKey, { limit = 5, cursor } = {}) {
+    if (gateway) {
+        try {
+            return await gateway.listSessions({ projectKey, limit, cursor });
+        } catch (error) {
+            if (!isProjectGatewayFallbackError(error)) {
+                throw error;
+            }
+            logProjectGatewayFallback(error, 'session list');
+        }
+    }
+
+    const offset = cursor ? Number.parseInt(cursor, 10) : 0;
+    const safeOffset = Number.isFinite(offset) ? offset : 0;
+    const sessions = await listProjectSessions({
+        projectRoot: projectKey,
+        pilotHome: resolvePilotHome(process.env),
+        limit,
+        offset: safeOffset,
+    });
+    const nextOffset = safeOffset + sessions.length;
+    return {
+        sessions,
+        nextCursor: limit && sessions.length === limit ? String(nextOffset) : undefined,
+    };
+}
+
+async function describeProjectFromGatewayOrDisk(gateway, projectKey) {
+    if (gateway) {
+        try {
+            return await gateway.describeProject({ projectKey });
+        } catch (error) {
+            if (!isProjectGatewayFallbackError(error)) {
+                throw error;
+            }
+            logProjectGatewayFallback(error, 'project summary');
+        }
+    }
+
+    return describeWebProject(projectKey, { pilotHome: resolvePilotHome(process.env) });
+}
+
 async function getProjects(progressCallback = null) {
-    const gateway = await getPilotDeckGateway();
-    const { projects: webProjects } = await gateway.listProjects();
+    let gateway = await getGatewayForProjectReads('project list');
+    const listedProjects = await listProjectsFromGatewayOrDisk(gateway);
+    gateway = listedProjects.gateway;
+    const webProjects = listedProjects.projects;
     const markedProjects = await readMarkedProjectPaths();
     const markedProjectIdsByPath = new Map(
         [...markedProjects.entries()].map(([id, cwd]) => [path.resolve(cwd), id]),
@@ -199,8 +321,7 @@ async function getProjects(progressCallback = null) {
             });
         }
 
-        const sessionsResult = await gateway
-            .listSessions({ projectKey: fullPath, limit: 5 })
+        const sessionsResult = await listSessionsFromGatewayOrDisk(gateway, fullPath, { limit: 5 })
             .catch(() => ({ sessions: [] }));
         const sessions = (sessionsResult.sessions || []).map((session) =>
             toLegacySession(session, name),
@@ -242,18 +363,15 @@ async function getProjects(progressCallback = null) {
     let generalTotal = 0;
     let generalLastActivity;
     try {
-        const generalGateway = await getPilotDeckGateway();
         // Pair the first page query with describeProject so the General
         // workspace gets the real session count instead of the page size.
         // Without this, sessionMeta.hasMore was hardcoded `false` and the
         // sidebar would silently truncate to the first 5 sessions even
         // when dozens existed under ~/.pilotdeck/projects/<encoded>/chats/.
         const [generalSessionsResult, generalSummary] = await Promise.all([
-            generalGateway
-                .listSessions({ projectKey: generalHome, limit: 5 })
+            listSessionsFromGatewayOrDisk(gateway, generalHome, { limit: 5 })
                 .catch(() => ({ sessions: [] })),
-            generalGateway
-                .describeProject({ projectKey: generalHome })
+            describeProjectFromGatewayOrDisk(gateway, generalHome)
                 .catch(() => null),
         ]);
         generalSessions = (generalSessionsResult.sessions || []).map((session) =>
@@ -288,7 +406,7 @@ async function getProjects(progressCallback = null) {
 }
 
 async function getSessions(projectName, limit = 5, offset = 0) {
-    const gateway = await getPilotDeckGateway();
+    const gateway = await getGatewayForProjectReads('session list');
     const projectPath = await extractProjectDirectory(projectName);
     const cursor = offset > 0 ? String(offset) : undefined;
     // Fan-out the page query and the project summary (for the authoritative
@@ -300,11 +418,9 @@ async function getSessions(projectName, limit = 5, offset = 0) {
     // to the user as a button that "doesn't react" once they've already
     // pulled in everything that exists.
     const [listResult, summary] = await Promise.all([
-        gateway
-            .listSessions({ projectKey: projectPath, limit, cursor })
+        listSessionsFromGatewayOrDisk(gateway, projectPath, { limit, cursor })
             .catch(() => ({ sessions: [] })),
-        gateway
-            .describeProject({ projectKey: projectPath })
+        describeProjectFromGatewayOrDisk(gateway, projectPath)
             .catch(() => null),
     ]);
     const sessions = (listResult.sessions || []).map((session) =>

--- a/ui/server/projects.test.js
+++ b/ui/server/projects.test.js
@@ -1,0 +1,116 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { createProjectId, getPilotProjectChatDir } from '../../src/pilot/index.js';
+
+const tempDirs = [];
+const originalPilotHome = process.env.PILOT_HOME;
+const originalGatewayTimeout = process.env.PILOTDECK_PROJECTS_GATEWAY_TIMEOUT_MS;
+
+afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+    for (const dir of tempDirs.splice(0)) {
+        rmSync(dir, { recursive: true, force: true });
+    }
+    restoreEnv('PILOT_HOME', originalPilotHome);
+    restoreEnv('PILOTDECK_PROJECTS_GATEWAY_TIMEOUT_MS', originalGatewayTimeout);
+});
+
+describe('projects gateway fallback', () => {
+    it('loads Board project data from disk when the gateway is unavailable', async () => {
+        vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const pilotHome = makeTempDir('pilotdeck-projects-home-');
+        const projectRoot = makeTempDir('pilotdeck-project-root-');
+        const projectName = createProjectId(projectRoot);
+        writeProjectMarker(pilotHome, projectRoot);
+        writeSession(pilotHome, projectRoot, 'web:s_local', 'hello from local history');
+
+        const { getProjects, getSessions } = await importProjectsWithUnavailableGateway(pilotHome);
+
+        const projects = await getProjects();
+        const project = projects.find((item) => item.fullPath === projectRoot);
+
+        expect(projects[0]).toMatchObject({ name: 'general', fullPath: pilotHome });
+        expect(project).toMatchObject({
+            name: projectName,
+            displayName: projectRoot.split('/').pop(),
+            sessionMeta: { total: 1, hasMore: false },
+        });
+        expect(project.sessions).toHaveLength(1);
+        expect(project.sessions[0]).toMatchObject({
+            id: 'web:s_local',
+            firstPrompt: 'hello from local history',
+            __projectName: projectName,
+        });
+
+        const sessionsPage = await getSessions(projectName, 5, 0);
+
+        expect(sessionsPage).toMatchObject({
+            total: 1,
+            hasMore: false,
+            offset: 0,
+            limit: 5,
+        });
+        expect(sessionsPage.sessions).toHaveLength(1);
+        expect(sessionsPage.sessions[0]).toMatchObject({
+            id: 'web:s_local',
+            firstPrompt: 'hello from local history',
+        });
+    });
+});
+
+async function importProjectsWithUnavailableGateway(pilotHome) {
+    process.env.PILOT_HOME = pilotHome;
+    process.env.PILOTDECK_PROJECTS_GATEWAY_TIMEOUT_MS = '1';
+    vi.doMock('./pilotdeck-bridge.js', () => ({
+        getPilotDeckGateway: vi.fn(async () => {
+            throw new Error('[pilotdeck-bridge] gateway connect failed after 1ms: Failed to connect to gateway WebSocket.');
+        }),
+        isGatewayUnavailableError: vi.fn((error) =>
+            /gateway connect failed|failed to connect to gateway websocket/i.test(error?.message || String(error))),
+    }));
+    vi.doMock('./database/db.js', () => ({
+        applyCustomSessionNames: vi.fn(),
+    }));
+
+    return import('./projects.js');
+}
+
+function makeTempDir(prefix) {
+    const dir = mkdtempSync(join(tmpdir(), prefix));
+    tempDirs.push(dir);
+    return dir;
+}
+
+function writeProjectMarker(pilotHome, projectRoot) {
+    const projectDir = join(pilotHome, 'projects', createProjectId(projectRoot));
+    mkdirSync(projectDir, { recursive: true });
+    writeFileSync(join(projectDir, '.cwd'), `${projectRoot}\n`, 'utf-8');
+}
+
+function writeSession(pilotHome, projectRoot, sessionId, text) {
+    const chatDir = getPilotProjectChatDir(projectRoot, pilotHome);
+    mkdirSync(chatDir, { recursive: true });
+    const entry = {
+        type: 'accepted_input',
+        createdAt: '2026-07-30T00:00:00.000Z',
+        messages: [
+            {
+                role: 'user',
+                content: [{ type: 'text', text }],
+            },
+        ],
+    };
+    writeFileSync(join(chatDir, `${sessionId}.jsonl`), `${JSON.stringify(entry)}\n`, 'utf-8');
+}
+
+function restoreEnv(name, value) {
+    if (value === undefined) {
+        delete process.env[name];
+    } else {
+        process.env[name] = value;
+    }
+}

--- a/ui/src/components/chat-v2/processGrouping.test.ts
+++ b/ui/src/components/chat-v2/processGrouping.test.ts
@@ -268,6 +268,26 @@ describe('processGrouping', () => {
     expect(processAttachments(thirdAssistant)).toHaveLength(0);
   });
 
+  it('merges consecutive thinking details inside a completed process row', () => {
+    const messages = [
+      user('u1'),
+      thinking('think-1', 'Inspect the first path.', 100),
+      thinking('think-2', 'Inspect the second path.', 200),
+      thinking('think-3', 'Summarize the reads.', 300),
+      assistant('a1', 'Ready.', 400),
+    ];
+
+    const items = buildRenderableMessageItems(messages);
+    const attachment = processAttachments(items.find((item) => item.message.id === 'a1'))[0];
+
+    expect(attachment?.processDetailMessages).toHaveLength(1);
+    expect(attachment?.processDetailMessages[0]?.id).toBe('think-1+think-2+think-3');
+    expect(attachment?.processDetailMessages[0]?.content).toBe(
+      'Inspect the first path.\n\nInspect the second path.\n\nSummarize the reads.',
+    );
+    expect(attachment?.processSummary.thinkingCount).toBe(3);
+  });
+
   it('attaches completed run duration after the user turn finishes', () => {
     const messages: ChatMessage[] = [
       user('u1'),
@@ -491,6 +511,27 @@ describe('processGrouping', () => {
 
     expect(split.beforeStatusMessages).toEqual([]);
     expect(split.statusDetailMessages.map((message) => message.id)).toEqual(['think-1', 'edit-1']);
+  });
+
+  it('merges consecutive thinking details inside a live process group', () => {
+    const messages = [
+      user('u1'),
+      assistant('a1', 'Starting work.', 100),
+      thinking('think-1', 'Inspect the first path.', 200),
+      thinking('think-2', 'Inspect the second path.', 300),
+      tool('read-1', 'Read', { file_path: '/repo/src/App.tsx' }, 400, null),
+    ];
+
+    const groups = getLiveProcessGroups(messages, { isAssistantWorking: true });
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].detailMessages.map((message) => message.id)).toEqual([
+      'think-1+think-2',
+      'read-1',
+    ]);
+    expect(groups[0].detailMessages[0]?.content).toBe(
+      'Inspect the first path.\n\nInspect the second path.',
+    );
   });
 
   it('keeps normalized empty assistant shells available as process separators', () => {

--- a/ui/src/components/chat-v2/processGrouping.ts
+++ b/ui/src/components/chat-v2/processGrouping.ts
@@ -364,6 +364,28 @@ function isExpandableProcessMessage(message: ChatMessage): boolean {
   return true;
 }
 
+function mergeThinkingDetailMessages(messages: ChatMessage[]): ChatMessage[] {
+  const merged: ChatMessage[] = [];
+
+  for (const message of messages) {
+    const previous = merged[merged.length - 1];
+    if (message.isThinking && previous?.isThinking) {
+      const previousContent = String(previous.content || '').trim();
+      const nextContent = String(message.content || '').trim();
+      merged[merged.length - 1] = {
+        ...previous,
+        id: `${previous.id || 'thinking'}+${message.id || 'thinking'}`,
+        content: [previousContent, nextContent].filter(Boolean).join('\n\n'),
+        timestamp: message.timestamp || previous.timestamp,
+      };
+      continue;
+    }
+    merged.push(message);
+  }
+
+  return merged;
+}
+
 function canHostProcessSummary(message: ChatMessage): boolean {
   return (
     message.type === 'assistant' &&
@@ -655,7 +677,7 @@ function collectCompletedProcessSegments(messages: ChatMessage[], turn: MessageT
       startIndex: segmentStartIndex,
       endIndex,
       messages: segmentMessages,
-      detailMessages: segmentMessages.filter(isExpandableProcessMessage),
+      detailMessages: mergeThinkingDetailMessages(segmentMessages.filter(isExpandableProcessMessage)),
       previousHostIndex,
       nextHostIndex,
     });
@@ -920,7 +942,7 @@ export function getLiveProcessGroups(
     }
 
     const first = groupMessages[0];
-    const detail = groupMessages.filter(isExpandableProcessMessage);
+    const detail = mergeThinkingDetailMessages(groupMessages.filter(isExpandableProcessMessage));
     const gid = getStableProcessSegmentId(messages, liveTurn, first, groupStartIndex);
     groups.push({
       id: gid,

--- a/ui/src/components/chat/hooks/useChatRealtimeHandlers.ts
+++ b/ui/src/components/chat/hooks/useChatRealtimeHandlers.ts
@@ -57,7 +57,7 @@ function normalizeAssistantStreamText(value?: string): string {
   return typeof value === 'string' ? value.replace(/\s+/g, ' ').trim() : '';
 }
 
-function getReplayMessageRawText(message: { content?: unknown; reasoningContent?: unknown }): string {
+function getReplayMessageRawText(message: { content?: unknown; text?: unknown; reasoningContent?: unknown }): string {
   if (typeof message.content === 'string') {
     if (normalizeAssistantStreamText(message.content).length > 0) {
       return message.content;
@@ -66,10 +66,13 @@ function getReplayMessageRawText(message: { content?: unknown; reasoningContent?
       return message.content;
     }
   }
+  if (typeof message.text === 'string' && normalizeAssistantStreamText(message.text).length > 0) {
+    return message.text;
+  }
   return typeof message.reasoningContent === 'string' ? message.reasoningContent : '';
 }
 
-function getReplayMessageText(message: { content?: unknown; reasoningContent?: unknown }): string {
+function getReplayMessageText(message: { content?: unknown; text?: unknown; reasoningContent?: unknown }): string {
   return normalizeAssistantStreamText(getReplayMessageRawText(message));
 }
 
@@ -255,6 +258,28 @@ function hasRenderedVolatileReplayBlock(
     ...(state.serverMessages || []),
   ];
   return messages.some((message) => isRenderedVolatileBlockCandidate(block, message));
+}
+
+export function isThinkingReplayAlreadyRendered(
+  message: LatestChatMessage,
+  state: ActiveTurnReplayState = {},
+): boolean {
+  if (String(message?.kind || '') !== 'thinking') {
+    return false;
+  }
+  const text = getReplayMessageRawText(message);
+  if (!normalizeAssistantStreamText(text)) {
+    return false;
+  }
+  return hasRenderedVolatileReplayBlock({
+    kind: 'thinking',
+    messages: [message],
+    text,
+    runId: getMessageRunId(message),
+    blockKey: getThinkingBlockKey(message),
+  }, {
+    realtimeMessages: state.realtimeMessages,
+  });
 }
 
 export function getActiveTurnReplayMessagesToApply(
@@ -689,12 +714,17 @@ export function useChatRealtimeHandlers({
       if (!text) return;
       const nextThinking = getThinkingStreamState(msg);
       const activeThinking = thinkingBySessionRef.current.get(sid);
+      const slot = sessionStore.getSessionSlot?.(sid);
+      if (isThinkingReplayAlreadyRendered(msg, {
+        realtimeMessages: slot?.realtimeMessages || [],
+      })) {
+        return;
+      }
       if (activeThinking && !isSameThinkingStream(activeThinking, nextThinking)) {
         finalizeThinkingForSession(sid, activeThinking);
       }
       thinkingBySessionRef.current.set(sid, nextThinking);
       // Read current thinking content and append delta
-      const slot = sessionStore.getSessionSlot?.(sid);
       const streamId = getThinkingStreamMessageId(sid, nextThinking);
       const existing = slot?.realtimeMessages.find((m: any) => m.id === streamId);
       const currentText = existing?.content || '';

--- a/ui/src/components/chat/hooks/useChatRealtimeHandlers.ts
+++ b/ui/src/components/chat/hooks/useChatRealtimeHandlers.ts
@@ -44,6 +44,8 @@ type LatestChatMessage = {
   content?: string;
   text?: string;
   tokens?: number;
+  thinkingBlockId?: string;
+  thinkingBlockSeq?: number;
   canInterrupt?: boolean;
   tokenBudget?: unknown;
   newSessionId?: string;
@@ -55,10 +57,88 @@ function normalizeAssistantStreamText(value?: string): string {
   return typeof value === 'string' ? value.replace(/\s+/g, ' ').trim() : '';
 }
 
+function getReplayMessageRawText(message: { content?: unknown; reasoningContent?: unknown }): string {
+  if (typeof message.content === 'string') {
+    if (normalizeAssistantStreamText(message.content).length > 0) {
+      return message.content;
+    }
+    if (typeof message.reasoningContent !== 'string' || message.reasoningContent.length === 0) {
+      return message.content;
+    }
+  }
+  return typeof message.reasoningContent === 'string' ? message.reasoningContent : '';
+}
+
+function getReplayMessageText(message: { content?: unknown; reasoningContent?: unknown }): string {
+  return normalizeAssistantStreamText(getReplayMessageRawText(message));
+}
+
+function renderedTextCoversReplayBlock(renderedText: string, replayText: string): boolean {
+  return renderedText === replayText || renderedText.startsWith(replayText);
+}
+
 function getMessageRunId(message: { runId?: unknown }): string | undefined {
   return typeof message.runId === 'string' && message.runId.trim()
     ? message.runId.trim()
     : undefined;
+}
+
+function getThinkingBlockKey(message: { thinkingBlockId?: unknown; thinkingBlockSeq?: unknown }): string | undefined {
+  if (typeof message.thinkingBlockId === 'string' && message.thinkingBlockId.trim().length > 0) {
+    return `id:${message.thinkingBlockId.trim()}`;
+  }
+  if (typeof message.thinkingBlockSeq === 'number' && Number.isFinite(message.thinkingBlockSeq)) {
+    return `seq:${message.thinkingBlockSeq}`;
+  }
+  return undefined;
+}
+
+function getThinkingStreamState(message: {
+  runId?: unknown;
+  thinkingBlockId?: unknown;
+  thinkingBlockSeq?: unknown;
+}): {
+  runId?: string;
+  blockKey?: string;
+  thinkingBlockId?: string;
+  thinkingBlockSeq?: number;
+} {
+  return {
+    runId: getMessageRunId(message),
+    blockKey: getThinkingBlockKey(message),
+    thinkingBlockId: typeof message.thinkingBlockId === 'string' && message.thinkingBlockId.trim().length > 0
+      ? message.thinkingBlockId.trim()
+      : undefined,
+    thinkingBlockSeq: typeof message.thinkingBlockSeq === 'number' && Number.isFinite(message.thinkingBlockSeq)
+      ? message.thinkingBlockSeq
+      : undefined,
+  };
+}
+
+function getThinkingStreamMessageId(
+  sessionId: string,
+  identity: {
+    runId?: string;
+    blockKey?: string;
+  },
+): string {
+  const streamBase = identity.runId ? `${sessionId}_${identity.runId}` : sessionId;
+  return identity.blockKey
+    ? `__streaming_thinking_${streamBase}_${identity.blockKey.replace(/[^A-Za-z0-9_-]+/g, '_')}`
+    : `__streaming_thinking_${streamBase}`;
+}
+
+function isSameThinkingStream(
+  a: { runId?: string; blockKey?: string },
+  b: { runId?: string; blockKey?: string },
+): boolean {
+  if (a.runId != null && b.runId != null && a.runId !== b.runId) {
+    return false;
+  }
+  if (a.blockKey != null && b.blockKey != null) {
+    return a.blockKey === b.blockKey;
+  }
+  return true;
 }
 
 function parseAssistantStreamTimestamp(value?: string): number | null {
@@ -119,7 +199,24 @@ type VolatileReplayBlock = {
   messages: LatestChatMessage[];
   text: string;
   runId?: string;
+  blockKey?: string;
 };
+
+export function getActiveTurnReplaySignature(activeTurnMessages: LatestChatMessage[]): string {
+  if (!Array.isArray(activeTurnMessages) || activeTurnMessages.length === 0) {
+    return '';
+  }
+
+  return activeTurnMessages
+    .filter((message) => ['thinking', 'stream_delta', 'stream_end'].includes(String(message?.kind)))
+    .map((message) => {
+      const kind = String(message?.kind || '');
+      const runId = getMessageRunId(message) ?? '';
+      const blockKey = kind === 'thinking' ? (getThinkingBlockKey(message) ?? '') : '';
+      return `${kind}:${runId}:${blockKey}:${getReplayMessageText(message)}`;
+    })
+    .join('||');
+}
 
 function isRenderedVolatileBlockCandidate(
   block: VolatileReplayBlock,
@@ -141,7 +238,12 @@ function isRenderedVolatileBlockCandidate(
     return false;
   }
 
-  return normalizeAssistantStreamText(message.content) === blockText;
+  const messageBlockKey = message.kind === 'thinking' ? getThinkingBlockKey(message) : undefined;
+  if (block.kind === 'thinking' && block.blockKey && messageBlockKey && block.blockKey !== messageBlockKey) {
+    return false;
+  }
+
+  return renderedTextCoversReplayBlock(getReplayMessageText(message), blockText);
 }
 
 function hasRenderedVolatileReplayBlock(
@@ -181,17 +283,25 @@ export function getActiveTurnReplayMessagesToApply(
       if (block && block.kind !== kind) {
         flushBlock();
       }
+      const messageBlockKey = kind === 'thinking' ? getThinkingBlockKey(message) : undefined;
+      if (block && block.kind === 'thinking' && messageBlockKey && block.blockKey && block.blockKey !== messageBlockKey) {
+        flushBlock();
+      }
       if (!block) {
         block = {
           kind: kind as 'thinking' | 'stream_delta',
           messages: [],
           text: '',
           runId: getMessageRunId(message),
+          blockKey: messageBlockKey,
         };
       }
       block.messages.push(message);
-      block.text += typeof message.content === 'string' ? message.content : '';
+      block.text += getReplayMessageRawText(message);
       block.runId ??= getMessageRunId(message);
+      if (kind === 'thinking') {
+        block.blockKey ??= messageBlockKey;
+      }
       continue;
     }
 
@@ -296,10 +406,32 @@ export function useChatRealtimeHandlers({
 }: UseChatRealtimeHandlersArgs) {
   const { subscribe } = useWebSocket();
 
-  // Track which sessions have active thinking (just a boolean flag now)
-  const thinkingBySessionRef = useRef<Map<string, boolean>>(new Map());
+  // Track the active thinking block per session so live updates can follow block boundaries.
+  const thinkingBySessionRef = useRef<Map<string, {
+    runId?: string;
+    blockKey?: string;
+    thinkingBlockId?: string;
+    thinkingBlockSeq?: number;
+  }>>(new Map());
   // Dedup volatile active-turn replay chunks across reconnect/status polls.
   const activeTurnReplaySignatureRef = useRef<Map<string, string>>(new Map());
+
+  const finalizeThinkingForSession = useCallback((
+    sessionId: string,
+    thinking: {
+      runId?: string;
+      thinkingBlockId?: string;
+      thinkingBlockSeq?: number;
+    } | undefined,
+  ) => {
+    if (!thinking) return;
+    sessionStore.finalizeStreamingThinking(
+      sessionId,
+      thinking.runId,
+      thinking.thinkingBlockId,
+      thinking.thinkingBlockSeq,
+    );
+  }, [sessionStore]);
 
   const handleMessage = useCallback((latestMessage: LatestChatMessage, fallbackSessionId?: string | null) => {
     if (!latestMessage) return;
@@ -364,10 +496,7 @@ export function useChatRealtimeHandlers({
             );
             const hasReplayedCurrentTurnToolUse = activeTurnToolIds.size > 0
               && [...activeTurnToolIds].some((toolId) => replayedToolIds.has(toolId));
-            const volatileSignature = msg.activeTurnMessages
-              .filter((message) => ['thinking', 'stream_delta', 'stream_end'].includes(String(message?.kind)))
-              .map((message) => `${message.kind}:${message.id || ''}:${message.content || ''}`)
-              .join('||');
+            const volatileSignature = getActiveTurnReplaySignature(msg.activeTurnMessages);
             const previousVolatileSignature = activeTurnReplaySignatureRef.current.get(statusSessionId);
             const hasSeenSameVolatileReplay = Boolean(
               volatileSignature && previousVolatileSignature === volatileSignature,
@@ -476,7 +605,7 @@ export function useChatRealtimeHandlers({
     }
 
     if (msg.kind === 'text' && msg.role === 'user') {
-      if (thinkingBySessionRef.current.has(sid)) {
+      if (thinkingBySessionRef.current.get(sid)) {
         thinkingBySessionRef.current.delete(sid);
       }
     }
@@ -541,9 +670,10 @@ export function useChatRealtimeHandlers({
       const text = msg.content || '';
       if (!text) return;
       // Content starting means thinking is done
-      if (thinkingBySessionRef.current.has(sid)) {
+      const activeThinking = thinkingBySessionRef.current.get(sid);
+      if (activeThinking) {
         thinkingBySessionRef.current.delete(sid);
-        sessionStore.finalizeStreamingThinking(sid, msgRunId);
+        finalizeThinkingForSession(sid, activeThinking);
       }
       const slot = sessionStore.getSessionSlot?.(sid);
       const streamId = `__streaming_${streamKey}`;
@@ -555,25 +685,37 @@ export function useChatRealtimeHandlers({
 
     // --- Thinking: direct accumulation (same as content) ---
     if (msg.kind === 'thinking') {
-      const text = msg.content || '';
+      const text = getReplayMessageRawText(msg);
       if (!text) return;
-      // Mark that thinking is active
-      thinkingBySessionRef.current.set(sid, true as any);
+      const nextThinking = getThinkingStreamState(msg);
+      const activeThinking = thinkingBySessionRef.current.get(sid);
+      if (activeThinking && !isSameThinkingStream(activeThinking, nextThinking)) {
+        finalizeThinkingForSession(sid, activeThinking);
+      }
+      thinkingBySessionRef.current.set(sid, nextThinking);
       // Read current thinking content and append delta
       const slot = sessionStore.getSessionSlot?.(sid);
-      const streamId = `__streaming_thinking_${streamKey}`;
+      const streamId = getThinkingStreamMessageId(sid, nextThinking);
       const existing = slot?.realtimeMessages.find((m: any) => m.id === streamId);
       const currentText = existing?.content || '';
-      sessionStore.updateStreamingThinking(sid, currentText + text, provider, msgRunId);
+      sessionStore.updateStreamingThinking(
+        sid,
+        currentText + text,
+        provider,
+        msgRunId,
+        nextThinking.thinkingBlockId,
+        nextThinking.thinkingBlockSeq,
+      );
       return;
     }
 
     // --- Stream end: finalize content stream ---
     if (msg.kind === 'stream_end') {
       // Finalize thinking if still active
-      if (thinkingBySessionRef.current.has(sid)) {
+      const activeThinking = thinkingBySessionRef.current.get(sid);
+      if (activeThinking) {
         thinkingBySessionRef.current.delete(sid);
-        sessionStore.finalizeStreamingThinking(sid, msgRunId);
+        finalizeThinkingForSession(sid, activeThinking);
       }
       sessionStore.finalizeStreaming(sid, msgRunId);
       return;
@@ -585,18 +727,16 @@ export function useChatRealtimeHandlers({
     ]);
     if (flushKinds.has(msg.kind as string)) {
       // Finalize thinking if still active (model moved past thinking)
-      if (thinkingBySessionRef.current.has(sid)) {
+      const activeThinking = thinkingBySessionRef.current.get(sid);
+      if (activeThinking) {
         thinkingBySessionRef.current.delete(sid);
-        sessionStore.finalizeStreamingThinking(sid, msgRunId);
+        finalizeThinkingForSession(sid, activeThinking);
       }
       // Finalize content stream on tool_use / complete / error.
       // The gateway may not send stream_end, so tool_use is the
       // reliable signal that the text block has ended.
       if (msg.kind === 'tool_use' || msg.kind === 'complete' || msg.kind === 'error') {
         sessionStore.finalizeStreaming(sid, msgRunId);
-      }
-      if (msg.kind === 'complete' || msg.kind === 'error') {
-        sessionStore.finalizeStreamingThinking(sid, msgRunId);
       }
     }
 
@@ -646,11 +786,6 @@ export function useChatRealtimeHandlers({
       case 'complete': {
         if (sid) {
           activeTurnReplaySignatureRef.current.delete(sid);
-          // Finalize both thinking and content streams
-          if (thinkingBySessionRef.current.has(sid)) {
-            thinkingBySessionRef.current.delete(sid);
-          }
-          sessionStore.finalizeStreamingThinking(sid, msgRunId);
           sessionStore.finalizeStreaming(sid, msgRunId);
         }
 
@@ -831,6 +966,7 @@ export function useChatRealtimeHandlers({
     onWebSocketReconnect,
     selectedProject,
     sessionStore,
+    finalizeThinkingForSession,
   ]);
 
   useEffect(() => {

--- a/ui/src/stores/useSessionStore.streaming.test.ts
+++ b/ui/src/stores/useSessionStore.streaming.test.ts
@@ -1,15 +1,19 @@
+import { act, renderHook } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import type { SessionProvider } from '../types/app';
 import {
+  getActiveTurnReplaySignature,
   getActiveTurnReplayMessagesToApply,
   getDuplicateAssistantStreamTextState,
 } from '../components/chat/hooks/useChatRealtimeHandlers';
 import {
   computeMerged,
   createRafNotifyScheduler,
+  finalizeStreamingRealtimeMessages,
   getFinalizedSubagentThinkingId,
   patchMergedStreamingMessage,
   upsertRealtimeMessages,
+  useSessionStore,
   type NormalizedMessage,
   type SessionSlot,
 } from './useSessionStore';
@@ -49,6 +53,24 @@ function textMessage(
     timestamp,
     provider: PROVIDER,
     kind: 'text',
+    role: 'assistant',
+    content,
+    ...overrides,
+  };
+}
+
+function thinkingMessage(
+  id: string,
+  content: string,
+  timestamp: string,
+  overrides: Partial<NormalizedMessage> = {},
+): NormalizedMessage {
+  return {
+    id,
+    sessionId: 'web:s_test',
+    timestamp,
+    provider: PROVIDER,
+    kind: 'thinking',
     role: 'assistant',
     content,
     ...overrides,
@@ -123,24 +145,6 @@ describe('computeMerged', () => {
     ]);
   });
 
-  it('drops finalized realtime assistant text once equivalent same-turn text is persisted', () => {
-    const server = [
-      textMessage('tail-before-turn', 'Previous answer', '2026-05-28T00:00:00.000Z'),
-      textMessage('persisted-answer', 'Realtime answer', '2026-05-28T00:00:02.000Z'),
-    ];
-    const realtime = [
-      textMessage('text-local-final', 'Realtime answer', '2026-05-28T00:00:01.000Z', {
-        isFinal: true,
-        serverTailIdAtStart: 'tail-before-turn',
-      }),
-    ];
-
-    expect(computeMerged(server, realtime).map((message) => message.id)).toEqual([
-      'tail-before-turn',
-      'persisted-answer',
-    ]);
-  });
-
   it('keeps later finalized realtime assistant text when only an earlier same-turn text is persisted', () => {
     const server = [
       textMessage('tail-before-turn', 'Previous answer', '2026-05-28T00:00:00.000Z'),
@@ -158,6 +162,112 @@ describe('computeMerged', () => {
       'persisted-earlier-answer',
       'text-local-second-final',
     ]);
+  });
+});
+
+describe('finalizeStreamingRealtimeMessages', () => {
+  it('drops duplicate streaming thinking that is already finalized in the same run', () => {
+    const realtime: NormalizedMessage[] = [
+      thinkingMessage('local-thinking-final', 'Inspect the flow', '2026-05-28T00:00:01.000Z', {
+        isFinal: true,
+        runId: 'run-1',
+      }),
+      thinkingMessage('__streaming_thinking_web:s_test_run-1', 'Inspect the flow', '2026-05-28T00:00:02.000Z', {
+        runId: 'run-1',
+      }),
+    ];
+
+    const updated = finalizeStreamingRealtimeMessages(realtime, {
+      sessionId: 'web:s_test',
+      runId: 'run-1',
+      kind: 'thinking',
+      newId: 'new-thinking-final',
+    });
+
+    expect(updated.map((message) => message.id)).toEqual(['local-thinking-final']);
+  });
+
+  it('replaces a shorter finalized thinking row with the fuller streaming block', () => {
+    const realtime: NormalizedMessage[] = [
+      thinkingMessage('local-thinking-final', 'Inspect the flow', '2026-05-28T00:00:01.000Z', {
+        isFinal: true,
+        runId: 'run-1',
+      }),
+      thinkingMessage(
+        '__streaming_thinking_web:s_test_run-1',
+        'Inspect the flow, then use the tool.',
+        '2026-05-28T00:00:02.000Z',
+        { runId: 'run-1' },
+      ),
+    ];
+
+    const updated = finalizeStreamingRealtimeMessages(realtime, {
+      sessionId: 'web:s_test',
+      runId: 'run-1',
+      kind: 'thinking',
+      newId: 'new-thinking-final',
+    });
+
+    expect(updated).toHaveLength(1);
+    expect(updated[0]?.id).toBe('local-thinking-final');
+    expect(updated[0]?.content).toBe('Inspect the flow, then use the tool.');
+  });
+
+  it('finalizes only the matching thinking block id', () => {
+    const realtime: NormalizedMessage[] = [
+      thinkingMessage(
+        '__streaming_thinking_web:s_test_run-1_id_block-a',
+        'First block',
+        '2026-05-28T00:00:01.000Z',
+        { runId: 'run-1', thinkingBlockId: 'block-a', thinkingBlockSeq: 1 },
+      ),
+      thinkingMessage(
+        '__streaming_thinking_web:s_test_run-1_id_block-b',
+        'Second block',
+        '2026-05-28T00:00:02.000Z',
+        { runId: 'run-1', thinkingBlockId: 'block-b', thinkingBlockSeq: 2 },
+      ),
+    ];
+
+    const updated = finalizeStreamingRealtimeMessages(realtime, {
+      sessionId: 'web:s_test',
+      runId: 'run-1',
+      kind: 'thinking',
+      newId: 'final-block-a',
+      thinkingBlockId: 'block-a',
+      thinkingBlockSeq: 1,
+    });
+
+    expect(updated.map((message) => message.id)).toEqual([
+      'final-block-a',
+      '__streaming_thinking_web:s_test_run-1_id_block-b',
+    ]);
+    expect(updated[0]?.isFinal).toBe(true);
+    expect(updated[1]?.isFinal).toBeUndefined();
+  });
+
+  it('does not collapse different thinking block ids with the same text', () => {
+    const realtime: NormalizedMessage[] = [
+      thinkingMessage('final-block-a', 'Same text', '2026-05-28T00:00:01.000Z', {
+        isFinal: true,
+        runId: 'run-1',
+        thinkingBlockId: 'block-a',
+      }),
+      thinkingMessage('__streaming_thinking_web:s_test_run-1_id_block-b', 'Same text', '2026-05-28T00:00:02.000Z', {
+        runId: 'run-1',
+        thinkingBlockId: 'block-b',
+      }),
+    ];
+
+    const updated = finalizeStreamingRealtimeMessages(realtime, {
+      sessionId: 'web:s_test',
+      runId: 'run-1',
+      kind: 'thinking',
+      newId: 'final-block-b',
+      thinkingBlockId: 'block-b',
+    });
+
+    expect(updated.map((message) => message.id)).toEqual(['final-block-a', 'final-block-b']);
   });
 });
 
@@ -262,6 +372,75 @@ describe('getDuplicateAssistantStreamTextState', () => {
 });
 
 describe('getActiveTurnReplayMessagesToApply', () => {
+  it('uses content-stable signatures for repeated volatile snapshots with fresh ids', () => {
+    const firstSnapshot = [
+      {
+        id: 'thinking-id-from-first-status',
+        sessionId: 'web:s_test',
+        timestamp: '2026-05-28T00:00:02.000Z',
+        provider: PROVIDER,
+        kind: 'thinking' as const,
+        content: 'Checking the current flow.',
+        runId: 'run-1',
+      },
+      {
+        id: 'end-id-from-first-status',
+        sessionId: 'web:s_test',
+        timestamp: '2026-05-28T00:00:03.000Z',
+        provider: PROVIDER,
+        kind: 'stream_end' as const,
+        runId: 'run-1',
+      },
+    ];
+    const secondSnapshot = firstSnapshot.map((message) => ({
+      ...message,
+      id: `${message.id}-different`,
+    }));
+
+    expect(getActiveTurnReplaySignature(firstSnapshot)).toBe(
+      getActiveTurnReplaySignature(secondSnapshot),
+    );
+  });
+
+  it('skips stale thinking replay already covered by a longer finalized thinking block', () => {
+    const activeTurnMessages = [
+      {
+        id: 'thinking-replay',
+        sessionId: 'web:s_test',
+        timestamp: '2026-05-28T00:00:02.000Z',
+        provider: PROVIDER,
+        kind: 'thinking' as const,
+        content: 'Inspect the flow',
+        runId: 'run-1',
+      },
+      {
+        id: 'tool-1',
+        sessionId: 'web:s_test',
+        timestamp: '2026-05-28T00:00:04.000Z',
+        provider: PROVIDER,
+        kind: 'tool_use' as const,
+        toolId: 'tool-call-1',
+        toolName: 'Read',
+      },
+    ];
+
+    const messagesToApply = getActiveTurnReplayMessagesToApply(activeTurnMessages, {
+      realtimeMessages: [
+        thinkingMessage(
+          'local-thinking-final',
+          'Inspect the flow, then use the tool.',
+          '2026-05-28T00:00:01.000Z',
+          {
+            isFinal: true,
+            runId: 'run-1',
+          },
+        ),
+      ],
+    });
+
+    expect(messagesToApply.map((message) => message.id)).toEqual(['tool-1']);
+  });
+
   it('skips active-turn stream replay already represented by finalized realtime text', () => {
     const activeTurnMessages = [
       {
@@ -494,6 +673,136 @@ describe('upsertRealtimeMessages', () => {
     const updated = upsertRealtimeMessages(existing, [incoming]);
 
     expect(updated.map((message) => message.id)).toEqual(['__streaming_web:s_test', 'incoming-text']);
+  });
+
+  it('replaces an active thinking stream row with a fuller duplicate thinking frame', () => {
+    const existing = [
+      thinkingMessage('__streaming_thinking_web:s_test_run-1', 'Inspect the flow', '2026-05-28T00:00:01.000Z', {
+        runId: 'run-1',
+      }),
+    ];
+    const incoming = thinkingMessage(
+      'incoming-thinking',
+      'Inspect the flow, then use the tool.',
+      '2026-05-28T00:00:02.000Z',
+      { runId: 'run-1' },
+    );
+
+    const updated = upsertRealtimeMessages(existing, [incoming]);
+
+    expect(updated).toHaveLength(1);
+    expect(updated[0]?.id).toBe('incoming-thinking');
+    expect(updated[0]?.content).toBe('Inspect the flow, then use the tool.');
+  });
+
+  it('keeps an existing fuller thinking row when a stale shorter duplicate arrives', () => {
+    const existing = [
+      thinkingMessage(
+        'existing-thinking',
+        'Inspect the flow, then use the tool.',
+        '2026-05-28T00:00:01.000Z',
+        { runId: 'run-1' },
+      ),
+    ];
+    const incoming = thinkingMessage('incoming-thinking', 'Inspect the flow', '2026-05-28T00:00:02.000Z', {
+      runId: 'run-1',
+    });
+
+    const updated = upsertRealtimeMessages(existing, [incoming]);
+
+    expect(updated.map((message) => message.id)).toEqual(['existing-thinking']);
+    expect(updated[0]?.content).toBe('Inspect the flow, then use the tool.');
+  });
+
+  it('does not dedupe thinking frames from different known block ids', () => {
+    const existing = [
+      thinkingMessage('thinking-a', 'Same text', '2026-05-28T00:00:01.000Z', {
+        runId: 'run-1',
+        thinkingBlockId: 'block-a',
+      }),
+    ];
+    const incoming = thinkingMessage('thinking-b', 'Same text', '2026-05-28T00:00:02.000Z', {
+      runId: 'run-1',
+      thinkingBlockId: 'block-b',
+    });
+
+    const updated = upsertRealtimeMessages(existing, [incoming]);
+
+    expect(updated.map((message) => message.id)).toEqual(['thinking-a', 'thinking-b']);
+  });
+
+  it('dedupes thinking frames with the same block id by keeping the fuller text', () => {
+    const existing = [
+      thinkingMessage('thinking-a', 'Inspect', '2026-05-28T00:00:01.000Z', {
+        runId: 'run-1',
+        thinkingBlockId: 'block-a',
+      }),
+    ];
+    const incoming = thinkingMessage('thinking-a-replay', 'Inspect state', '2026-05-28T00:00:02.000Z', {
+      runId: 'run-1',
+      thinkingBlockId: 'block-a',
+    });
+
+    const updated = upsertRealtimeMessages(existing, [incoming]);
+
+    expect(updated).toHaveLength(1);
+    expect(updated[0]?.id).toBe('thinking-a-replay');
+    expect(updated[0]?.content).toBe('Inspect state');
+  });
+});
+
+describe('useSessionStore streaming thinking blocks', () => {
+  it('updates the same live row for one thinking block id and creates another row for a new block', () => {
+    const { result } = renderHook(() => useSessionStore());
+
+    act(() => {
+      result.current.updateStreamingThinking('web:s_test', 'Inspect', PROVIDER, 'run-1', 'block-a', 1);
+      result.current.updateStreamingThinking('web:s_test', 'Inspect state', PROVIDER, 'run-1', 'block-a', 1);
+      result.current.updateStreamingThinking('web:s_test', 'Use tool', PROVIDER, 'run-1', 'block-b', 2);
+    });
+
+    const realtime = result.current.getSessionSlot('web:s_test')?.realtimeMessages ?? [];
+
+    expect(realtime.map((message) => message.content)).toEqual(['Inspect state', 'Use tool']);
+    expect(realtime.map((message) => message.thinkingBlockId)).toEqual(['block-a', 'block-b']);
+  });
+
+  it('finalizes only one active thinking block and leaves the next block streaming', () => {
+    const { result } = renderHook(() => useSessionStore());
+
+    act(() => {
+      result.current.updateStreamingThinking('web:s_test', 'Inspect', PROVIDER, 'run-1', 'block-a', 1);
+      result.current.updateStreamingThinking('web:s_test', 'Use tool', PROVIDER, 'run-1', 'block-b', 2);
+      result.current.finalizeStreamingThinking('web:s_test', 'run-1', 'block-a', 1);
+      result.current.finalizeStreamingThinking('web:s_test', 'run-1', 'block-a', 1);
+    });
+
+    const realtime = result.current.getSessionSlot('web:s_test')?.realtimeMessages ?? [];
+
+    expect(realtime).toHaveLength(2);
+    expect(realtime[0]?.content).toBe('Inspect');
+    expect(realtime[0]?.isFinal).toBe(true);
+    expect(realtime[0]?.id.startsWith('__streaming_thinking_')).toBe(false);
+    expect(realtime[1]?.content).toBe('Use tool');
+    expect(realtime[1]?.isFinal).toBeUndefined();
+    expect(realtime[1]?.id).toBe('__streaming_thinking_web:s_test_run-1_id_block-b');
+  });
+
+  it('preserves legacy fallback when thinking block fields are absent', () => {
+    const { result } = renderHook(() => useSessionStore());
+
+    act(() => {
+      result.current.updateStreamingThinking('web:s_test', 'Legacy', PROVIDER, 'run-1');
+      result.current.updateStreamingThinking('web:s_test', 'Legacy block', PROVIDER, 'run-1');
+      result.current.finalizeStreamingThinking('web:s_test', 'run-1');
+      result.current.finalizeStreamingThinking('web:s_test', 'run-1');
+    });
+
+    const realtime = result.current.getSessionSlot('web:s_test')?.realtimeMessages ?? [];
+
+    expect(realtime).toHaveLength(1);
+    expect(realtime[0]?.content).toBe('Legacy block');
+    expect(realtime[0]?.isFinal).toBe(true);
   });
 });
 

--- a/ui/src/stores/useSessionStore.streaming.test.ts
+++ b/ui/src/stores/useSessionStore.streaming.test.ts
@@ -116,6 +116,23 @@ function toolUseMessage(id: string, timestamp = '2026-05-28T00:00:02.000Z'): Nor
   };
 }
 
+function toolResultMessage(
+  id: string,
+  toolId = 'tool-read-1',
+  timestamp = '2026-05-28T00:00:04.000Z',
+): NormalizedMessage {
+  return {
+    id,
+    sessionId: 'web:s_test',
+    timestamp,
+    provider: PROVIDER,
+    kind: 'tool_result',
+    toolName: 'Read',
+    toolId,
+    toolResult: { content: 'ok', isError: false },
+  };
+}
+
 describe('patchMergedStreamingMessage', () => {
   it('updates merged content without recomputing from store inputs', () => {
     const sessionId = 'web:s_test';
@@ -150,6 +167,30 @@ describe('patchMergedStreamingMessage', () => {
     patchMergedStreamingMessage(slot, streamId, 'same', PROVIDER);
 
     expect(slot.merged[0]).toBe(rowBefore);
+  });
+});
+
+describe('useSessionStore compact boundaries', () => {
+  it('recomputes merged messages immediately for realtime compact boundaries', () => {
+    const { result } = renderHook(() => useSessionStore());
+
+    act(() => {
+      result.current.appendRealtime('web:s_test', {
+        id: 'compact-1',
+        sessionId: 'web:s_test',
+        timestamp: '2026-05-28T00:00:01.000Z',
+        provider: PROVIDER,
+        kind: 'compact_boundary',
+        text: 'Context compacted',
+        preTokens: 120,
+      });
+    });
+
+    const messages = result.current.getMessages('web:s_test');
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0]?.kind).toBe('compact_boundary');
+    expect(result.current.getSessionSlot('web:s_test')?.realtimeMessages).toHaveLength(1);
   });
 });
 
@@ -926,7 +967,7 @@ describe('upsertRealtimeMessages', () => {
     ]);
   });
 
-  it('does not move later thinking across tool process boundaries', () => {
+  it('keeps late thinking before assistant content even after the matching tool use is shown', () => {
     const existing = [
       textMessage('text-final', 'I inspected the file.', '2026-05-28T00:00:01.000Z', {
         isFinal: true,
@@ -945,9 +986,36 @@ describe('upsertRealtimeMessages', () => {
     const updated = upsertRealtimeMessages(existing, [incoming]);
 
     expect(updated.map((message) => message.id)).toEqual([
+      '__streaming_thinking_web:s_test_run-1_id_block-a',
       'text-final',
       'tool-read-1',
-      '__streaming_thinking_web:s_test_run-1_id_block-a',
+    ]);
+  });
+
+  it('does not move later thinking across tool result boundaries', () => {
+    const existing = [
+      textMessage('text-final', 'I inspected the file.', '2026-05-28T00:00:01.000Z', {
+        isFinal: true,
+        runId: 'run-1',
+        serverTailIdAtStart: 'tail-before-turn',
+      }),
+      toolUseMessage('tool-read-1'),
+      toolResultMessage('tool-result-1'),
+    ];
+    const incoming = thinkingMessage('__streaming_thinking_web:s_test_run-1_id_block-b', 'Decide next step', '2026-05-28T00:00:05.000Z', {
+      runId: 'run-1',
+      thinkingBlockId: 'block-b',
+      thinkingBlockSeq: 2,
+      serverTailIdAtStart: 'tail-before-turn',
+    });
+
+    const updated = upsertRealtimeMessages(existing, [incoming]);
+
+    expect(updated.map((message) => message.id)).toEqual([
+      'text-final',
+      'tool-read-1',
+      'tool-result-1',
+      '__streaming_thinking_web:s_test_run-1_id_block-b',
     ]);
   });
 });
@@ -982,6 +1050,22 @@ describe('useSessionStore streaming thinking blocks', () => {
     expect(realtime.map((message) => message.content)).toEqual(['Plan first', 'Visible answer']);
     expect(realtime[0]?.id).toBe('__streaming_thinking_web:s_test_run-1_id_block-a');
     expect(realtime[1]?.id).toBe('__streaming_web:s_test_run-1');
+  });
+
+  it('keeps late-arriving live thinking before finalized content after tool use appears', () => {
+    const { result } = renderHook(() => useSessionStore());
+
+    act(() => {
+      result.current.updateStreaming('web:s_test', 'Visible answer', PROVIDER, 'run-1');
+      result.current.finalizeStreaming('web:s_test', 'run-1');
+      result.current.appendRealtime('web:s_test', toolUseMessage('tool-read-1'));
+      result.current.updateStreamingThinking('web:s_test', 'Plan first', PROVIDER, 'run-1', 'block-a', 1);
+    });
+
+    const realtime = result.current.getSessionSlot('web:s_test')?.realtimeMessages ?? [];
+
+    expect(realtime.map((message) => message.kind)).toEqual(['thinking', 'text', 'tool_use']);
+    expect(realtime.map((message) => message.content)).toEqual(['Plan first', 'Visible answer', undefined]);
   });
 
   it('finalizes only one active thinking block and leaves the next block streaming', () => {

--- a/ui/src/stores/useSessionStore.streaming.test.ts
+++ b/ui/src/stores/useSessionStore.streaming.test.ts
@@ -305,6 +305,32 @@ describe('pruneRealtimeMessagesAfterServerRefresh', () => {
       '__streaming_thinking_web:s_test_run-1_id_block-b',
     ]);
   });
+
+  it('drops finalized live thinking when the server history has text without role', () => {
+    const server = [
+      textMessage('tail-before-turn', 'Previous answer', '2026-05-28T00:00:00.000Z'),
+      {
+        id: 'server-thinking',
+        sessionId: 'web:s_test',
+        timestamp: '2026-05-28T00:00:04.000Z',
+        provider: PROVIDER,
+        kind: 'thinking' as const,
+        text: 'The user is just saying "hello".',
+      },
+      textMessage('server-text', 'Hello there', '2026-05-28T00:00:05.000Z'),
+    ];
+    const realtime = [
+      thinkingMessage('thinking-final', 'The user is just saying "hello".', '2026-05-28T00:00:01.000Z', {
+        isFinal: true,
+        runId: 'run-1',
+        serverTailIdAtStart: 'tail-before-turn',
+      }),
+    ];
+
+    const pruned = pruneRealtimeMessagesAfterServerRefresh(realtime, server);
+
+    expect(pruned).toEqual([]);
+  });
 });
 
 describe('getDuplicateAssistantStreamTextState', () => {

--- a/ui/src/stores/useSessionStore.streaming.test.ts
+++ b/ui/src/stores/useSessionStore.streaming.test.ts
@@ -90,6 +90,32 @@ function streamingMessage(sessionId: string, content: string): NormalizedMessage
   };
 }
 
+function streamingRunMessage(sessionId: string, runId: string, content: string): NormalizedMessage {
+  return {
+    id: `__streaming_${sessionId}_${runId}`,
+    sessionId,
+    timestamp: '2026-05-28T00:00:01.000Z',
+    provider: PROVIDER,
+    kind: 'stream_delta',
+    content,
+    runId,
+    serverTailIdAtStart: 'tail-before-turn',
+  };
+}
+
+function toolUseMessage(id: string, timestamp = '2026-05-28T00:00:02.000Z'): NormalizedMessage {
+  return {
+    id,
+    sessionId: 'web:s_test',
+    timestamp,
+    provider: PROVIDER,
+    kind: 'tool_use',
+    toolName: 'Read',
+    toolId: id,
+    toolInput: { file_path: '/repo/src/App.tsx' },
+  };
+}
+
 describe('patchMergedStreamingMessage', () => {
   it('updates merged content without recomputing from store inputs', () => {
     const sessionId = 'web:s_test';
@@ -858,6 +884,72 @@ describe('upsertRealtimeMessages', () => {
     expect(updated[0]?.id).toBe('thinking-a-replay');
     expect(updated[0]?.content).toBe('Inspect state');
   });
+
+  it('inserts late-arriving thinking before active assistant stream content in the same run', () => {
+    const existing = [
+      streamingRunMessage('web:s_test', 'run-1', 'Visible answer'),
+    ];
+    const incoming = thinkingMessage('__streaming_thinking_web:s_test_run-1_id_block-a', 'Plan first', '2026-05-28T00:00:02.000Z', {
+      runId: 'run-1',
+      thinkingBlockId: 'block-a',
+      thinkingBlockSeq: 1,
+      serverTailIdAtStart: 'tail-before-turn',
+    });
+
+    const updated = upsertRealtimeMessages(existing, [incoming]);
+
+    expect(updated.map((message) => message.id)).toEqual([
+      '__streaming_thinking_web:s_test_run-1_id_block-a',
+      '__streaming_web:s_test_run-1',
+    ]);
+  });
+
+  it('inserts late-arriving thinking before assistant text that replaced a stream row', () => {
+    const existing = [
+      textMessage('standalone-text', 'Visible answer', '2026-05-28T00:00:01.000Z', {
+        runId: 'run-1',
+        serverTailIdAtStart: 'tail-before-turn',
+      }),
+    ];
+    const incoming = thinkingMessage('__streaming_thinking_web:s_test_run-1_id_block-a', 'Plan first', '2026-05-28T00:00:02.000Z', {
+      runId: 'run-1',
+      thinkingBlockId: 'block-a',
+      thinkingBlockSeq: 1,
+      serverTailIdAtStart: 'tail-before-turn',
+    });
+
+    const updated = upsertRealtimeMessages(existing, [incoming]);
+
+    expect(updated.map((message) => message.id)).toEqual([
+      '__streaming_thinking_web:s_test_run-1_id_block-a',
+      'standalone-text',
+    ]);
+  });
+
+  it('does not move later thinking across tool process boundaries', () => {
+    const existing = [
+      textMessage('text-final', 'I inspected the file.', '2026-05-28T00:00:01.000Z', {
+        isFinal: true,
+        runId: 'run-1',
+        serverTailIdAtStart: 'tail-before-turn',
+      }),
+      toolUseMessage('tool-read-1'),
+    ];
+    const incoming = thinkingMessage('__streaming_thinking_web:s_test_run-1_id_block-a', 'Decide next tool', '2026-05-28T00:00:03.000Z', {
+      runId: 'run-1',
+      thinkingBlockId: 'block-a',
+      thinkingBlockSeq: 1,
+      serverTailIdAtStart: 'tail-before-turn',
+    });
+
+    const updated = upsertRealtimeMessages(existing, [incoming]);
+
+    expect(updated.map((message) => message.id)).toEqual([
+      'text-final',
+      'tool-read-1',
+      '__streaming_thinking_web:s_test_run-1_id_block-a',
+    ]);
+  });
 });
 
 describe('useSessionStore streaming thinking blocks', () => {
@@ -874,6 +966,22 @@ describe('useSessionStore streaming thinking blocks', () => {
 
     expect(realtime.map((message) => message.content)).toEqual(['Inspect state', 'Use tool']);
     expect(realtime.map((message) => message.thinkingBlockId)).toEqual(['block-a', 'block-b']);
+  });
+
+  it('keeps late-arriving live thinking before active streamed assistant content', () => {
+    const { result } = renderHook(() => useSessionStore());
+
+    act(() => {
+      result.current.updateStreaming('web:s_test', 'Visible answer', PROVIDER, 'run-1');
+      result.current.updateStreamingThinking('web:s_test', 'Plan first', PROVIDER, 'run-1', 'block-a', 1);
+    });
+
+    const realtime = result.current.getSessionSlot('web:s_test')?.realtimeMessages ?? [];
+
+    expect(realtime.map((message) => message.kind)).toEqual(['thinking', 'stream_delta']);
+    expect(realtime.map((message) => message.content)).toEqual(['Plan first', 'Visible answer']);
+    expect(realtime[0]?.id).toBe('__streaming_thinking_web:s_test_run-1_id_block-a');
+    expect(realtime[1]?.id).toBe('__streaming_web:s_test_run-1');
   });
 
   it('finalizes only one active thinking block and leaves the next block streaming', () => {

--- a/ui/src/stores/useSessionStore.streaming.test.ts
+++ b/ui/src/stores/useSessionStore.streaming.test.ts
@@ -5,6 +5,7 @@ import {
   getActiveTurnReplaySignature,
   getActiveTurnReplayMessagesToApply,
   getDuplicateAssistantStreamTextState,
+  isThinkingReplayAlreadyRendered,
 } from '../components/chat/hooks/useChatRealtimeHandlers';
 import {
   computeMerged,
@@ -652,6 +653,52 @@ describe('getActiveTurnReplayMessagesToApply', () => {
     });
 
     expect(messagesToApply.map((message) => message.id)).toEqual(['delta-1']);
+  });
+});
+
+describe('isThinkingReplayAlreadyRendered', () => {
+  it('detects a thinking replay already covered by finalized realtime thinking', () => {
+    const replay = {
+      id: 'thinking-replay',
+      sessionId: 'web:s_test',
+      timestamp: '2026-05-28T00:00:02.000Z',
+      provider: PROVIDER,
+      kind: 'thinking' as const,
+      text: 'The user is just saying "hello".',
+      runId: 'run-1',
+    };
+
+    expect(isThinkingReplayAlreadyRendered(replay, {
+      realtimeMessages: [
+        thinkingMessage(
+          'thinking-final',
+          'The user is just saying "hello".',
+          '2026-05-28T00:00:01.000Z',
+          { isFinal: true, runId: 'run-1' },
+        ),
+      ],
+    })).toBe(true);
+  });
+
+  it('does not treat a longer thinking replay as already rendered', () => {
+    const replay = {
+      id: 'thinking-replay',
+      sessionId: 'web:s_test',
+      timestamp: '2026-05-28T00:00:02.000Z',
+      provider: PROVIDER,
+      kind: 'thinking' as const,
+      content: 'Inspect the flow, then use a tool.',
+      runId: 'run-1',
+    };
+
+    expect(isThinkingReplayAlreadyRendered(replay, {
+      realtimeMessages: [
+        thinkingMessage('thinking-final', 'Inspect the flow', '2026-05-28T00:00:01.000Z', {
+          isFinal: true,
+          runId: 'run-1',
+        }),
+      ],
+    })).toBe(false);
   });
 });
 

--- a/ui/src/stores/useSessionStore.streaming.test.ts
+++ b/ui/src/stores/useSessionStore.streaming.test.ts
@@ -12,6 +12,7 @@ import {
   finalizeStreamingRealtimeMessages,
   getFinalizedSubagentThinkingId,
   patchMergedStreamingMessage,
+  pruneRealtimeMessagesAfterServerRefresh,
   upsertRealtimeMessages,
   useSessionStore,
   type NormalizedMessage,
@@ -268,6 +269,41 @@ describe('finalizeStreamingRealtimeMessages', () => {
     });
 
     expect(updated.map((message) => message.id)).toEqual(['final-block-a', 'final-block-b']);
+  });
+});
+
+describe('pruneRealtimeMessagesAfterServerRefresh', () => {
+  it('drops finalized live thinking/text once the server has the same turn content', () => {
+    const server = [
+      textMessage('tail-before-turn', 'Previous answer', '2026-05-28T00:00:00.000Z'),
+      thinkingMessage('server-thinking', 'Inspect the flow', '2026-05-28T00:00:04.000Z'),
+      textMessage('server-text', 'Final answer', '2026-05-28T00:00:05.000Z'),
+    ];
+    const realtime = [
+      thinkingMessage('thinking-final', 'Inspect the flow', '2026-05-28T00:00:01.000Z', {
+        isFinal: true,
+        runId: 'run-1',
+        serverTailIdAtStart: 'tail-before-turn',
+        thinkingBlockId: 'block-a',
+        thinkingBlockSeq: 1,
+      }),
+      textMessage('text-final', 'Final answer', '2026-05-28T00:00:02.000Z', {
+        isFinal: true,
+        runId: 'run-1',
+        serverTailIdAtStart: 'tail-before-turn',
+      }),
+      thinkingMessage('__streaming_thinking_web:s_test_run-1_id_block-b', 'Still streaming', '2026-05-28T00:00:03.000Z', {
+        runId: 'run-1',
+        thinkingBlockId: 'block-b',
+        thinkingBlockSeq: 2,
+      }),
+    ];
+
+    const pruned = pruneRealtimeMessagesAfterServerRefresh(realtime, server);
+
+    expect(pruned.map((message) => message.id)).toEqual([
+      '__streaming_thinking_web:s_test_run-1_id_block-b',
+    ]);
   });
 });
 

--- a/ui/src/stores/useSessionStore.streaming.test.ts
+++ b/ui/src/stores/useSessionStore.streaming.test.ts
@@ -232,6 +232,62 @@ describe('computeMerged', () => {
       'text-local-second-final',
     ]);
   });
+
+  it('places live thinking before server-side assistant snapshots in the same turn', () => {
+    const server = [
+      textMessage('tail-before-turn', 'Previous answer', '2026-05-28T00:00:00.000Z'),
+      textMessage('persisted-answer', 'I inspected the file.', '2026-05-28T00:00:02.000Z'),
+      toolUseMessage('tool-read-1', '2026-05-28T00:00:03.000Z'),
+    ];
+    const realtime = [
+      thinkingMessage('__streaming_thinking_web:s_test_run-1_id_block-a', 'Plan next step', '2026-05-28T00:00:04.000Z', {
+        runId: 'run-1',
+        thinkingBlockId: 'block-a',
+        thinkingBlockSeq: 1,
+        serverTailIdAtStart: 'tail-before-turn',
+      }),
+      thinkingMessage('__streaming_thinking_web:s_test_run-1_id_block-b', 'Then inspect the result', '2026-05-28T00:00:05.000Z', {
+        runId: 'run-1',
+        thinkingBlockId: 'block-b',
+        thinkingBlockSeq: 2,
+        serverTailIdAtStart: 'tail-before-turn',
+      }),
+    ];
+
+    expect(computeMerged(server, realtime).map((message) => message.id)).toEqual([
+      'tail-before-turn',
+      '__streaming_thinking_web:s_test_run-1_id_block-a',
+      '__streaming_thinking_web:s_test_run-1_id_block-b',
+      'persisted-answer',
+      'tool-read-1',
+    ]);
+  });
+
+  it('keeps a later live thinking block after its server-side tool result', () => {
+    const server = [
+      textMessage('tail-before-turn', 'Previous answer', '2026-05-28T00:00:00.000Z'),
+      textMessage('persisted-answer', 'I inspected the file.', '2026-05-28T00:00:02.000Z'),
+      toolUseMessage('tool-read-1', '2026-05-28T00:00:03.000Z'),
+      toolResultMessage('tool-result-1', 'tool-read-1', '2026-05-28T00:00:04.000Z'),
+    ];
+    const realtime = [
+      toolResultMessage('tool-result-1', 'tool-read-1', '2026-05-28T00:00:04.000Z'),
+      thinkingMessage('__streaming_thinking_web:s_test_run-1_id_block-b', 'Decide next step', '2026-05-28T00:00:05.000Z', {
+        runId: 'run-1',
+        thinkingBlockId: 'block-b',
+        thinkingBlockSeq: 2,
+        serverTailIdAtStart: 'tail-before-turn',
+      }),
+    ];
+
+    expect(computeMerged(server, realtime).map((message) => message.id)).toEqual([
+      'tail-before-turn',
+      'persisted-answer',
+      'tool-read-1',
+      'tool-result-1',
+      '__streaming_thinking_web:s_test_run-1_id_block-b',
+    ]);
+  });
 });
 
 describe('finalizeStreamingRealtimeMessages', () => {

--- a/ui/src/stores/useSessionStore.ts
+++ b/ui/src/stores/useSessionStore.ts
@@ -220,9 +220,19 @@ function normalizeRealtimeText(value?: string): string {
   return typeof value === 'string' ? value.replace(/\s+/g, ' ').trim() : '';
 }
 
-function getMessageComparisonText(message: Pick<NormalizedMessage, 'content' | 'reasoningContent'>): string {
+function getMessageComparisonText(message: Pick<NormalizedMessage, 'content' | 'text' | 'reasoningContent'>): string {
   const contentText = normalizeRealtimeText(message.content);
-  return contentText || normalizeRealtimeText(message.reasoningContent);
+  return contentText || normalizeRealtimeText(message.text) || normalizeRealtimeText(message.reasoningContent);
+}
+
+function areComparableMessageRoles(
+  first: Pick<NormalizedMessage, 'kind' | 'role'>,
+  second: Pick<NormalizedMessage, 'kind' | 'role'>,
+): boolean {
+  if (first.kind === 'thinking' && second.kind === 'thinking') {
+    return (first.role ?? 'assistant') === (second.role ?? 'assistant');
+  }
+  return first.role === second.role;
 }
 
 function getThinkingBlockKey(message: Pick<NormalizedMessage, 'thinkingBlockId' | 'thinkingBlockSeq'>): string | undefined {
@@ -263,7 +273,7 @@ function isConfirmedUserMessageDuplicate(
     return false;
   }
 
-  const realtimeText = normalizeRealtimeText(realtimeMessage.content);
+  const realtimeText = getMessageComparisonText(realtimeMessage);
   if (!realtimeText) return false;
 
   const realtimeTimestamp = parseTimestampMs(realtimeMessage.timestamp);
@@ -350,8 +360,8 @@ function hasEquivalentServerMessage(
 
   return candidates.some((serverMessage) => {
     if (serverMessage.kind !== realtimeMessage.kind) return false;
-    if (serverMessage.role !== realtimeMessage.role) return false;
-    return normalizeRealtimeText(serverMessage.content) === realtimeText;
+    if (!areComparableMessageRoles(serverMessage, realtimeMessage)) return false;
+    return getMessageComparisonText(serverMessage) === realtimeText;
   });
 }
 
@@ -373,19 +383,19 @@ function hasSameTurnServerFinalMessage(
   if (tailIndex < 0) return false;
   const realtimeTimestamp = parseTimestampMs(realtimeMessage.timestamp);
   if (realtimeTimestamp == null) return false;
-  const realtimeText = normalizeRealtimeText(realtimeMessage.content);
+  const realtimeText = getMessageComparisonText(realtimeMessage);
   if (!realtimeText) return false;
 
   return serverMessages.slice(tailIndex + 1).some((serverMessage) => {
     if (serverMessage.kind !== realtimeMessage.kind) return false;
-    if (serverMessage.role !== realtimeMessage.role) return false;
+    if (!areComparableMessageRoles(serverMessage, realtimeMessage)) return false;
     if (realtimeMessage.runId != null && serverMessage.runId != null && serverMessage.runId !== realtimeMessage.runId) {
       return false;
     }
     const serverTimestamp = parseTimestampMs(serverMessage.timestamp);
     if (serverTimestamp == null) return false;
     if (serverTimestamp < realtimeTimestamp) return false;
-    return normalizeRealtimeText(serverMessage.content) === realtimeText;
+    return getMessageComparisonText(serverMessage) === realtimeText;
   });
 }
 

--- a/ui/src/stores/useSessionStore.ts
+++ b/ui/src/stores/useSessionStore.ts
@@ -320,6 +320,133 @@ function isLocalInterruptDuplicate(
   });
 }
 
+function hasEquivalentServerMessage(
+  realtimeMessage: NormalizedMessage,
+  serverMessages: NormalizedMessage[],
+): boolean {
+  const realtimeText = normalizeRealtimeText(realtimeMessage.content);
+  if (!realtimeText) return false;
+
+  let candidates = serverMessages;
+  if (realtimeMessage.serverTailIdAtStart) {
+    const tailIndex = serverMessages.findIndex((message) =>
+      message.id === realtimeMessage.serverTailIdAtStart
+    );
+    if (tailIndex < 0) return false;
+    candidates = serverMessages.slice(tailIndex + 1);
+  } else {
+    let lastUserIndex = -1;
+    for (let index = serverMessages.length - 1; index >= 0; index -= 1) {
+      const message = serverMessages[index];
+      if (message.kind === 'text' && message.role === 'user') {
+        lastUserIndex = index;
+        break;
+      }
+    }
+    if (lastUserIndex >= 0) {
+      candidates = serverMessages.slice(lastUserIndex + 1);
+    }
+  }
+
+  return candidates.some((serverMessage) => {
+    if (serverMessage.kind !== realtimeMessage.kind) return false;
+    if (serverMessage.role !== realtimeMessage.role) return false;
+    return normalizeRealtimeText(serverMessage.content) === realtimeText;
+  });
+}
+
+function hasSameTurnServerFinalMessage(
+  realtimeMessage: NormalizedMessage,
+  serverMessages: NormalizedMessage[],
+): boolean {
+  if (
+    realtimeMessage.isFinal !== true ||
+    (realtimeMessage.kind !== 'text' && realtimeMessage.kind !== 'thinking') ||
+    !realtimeMessage.serverTailIdAtStart
+  ) {
+    return false;
+  }
+
+  const tailIndex = serverMessages.findIndex((message) => (
+    message.id === realtimeMessage.serverTailIdAtStart
+  ));
+  if (tailIndex < 0) return false;
+  const realtimeTimestamp = parseTimestampMs(realtimeMessage.timestamp);
+  if (realtimeTimestamp == null) return false;
+  const realtimeText = normalizeRealtimeText(realtimeMessage.content);
+  if (!realtimeText) return false;
+
+  return serverMessages.slice(tailIndex + 1).some((serverMessage) => {
+    if (serverMessage.kind !== realtimeMessage.kind) return false;
+    if (serverMessage.role !== realtimeMessage.role) return false;
+    if (realtimeMessage.runId != null && serverMessage.runId != null && serverMessage.runId !== realtimeMessage.runId) {
+      return false;
+    }
+    const serverTimestamp = parseTimestampMs(serverMessage.timestamp);
+    if (serverTimestamp == null) return false;
+    if (serverTimestamp < realtimeTimestamp) return false;
+    return normalizeRealtimeText(serverMessage.content) === realtimeText;
+  });
+}
+
+export function shouldKeepRealtimeAfterServerRefresh(
+  realtimeMessage: NormalizedMessage,
+  serverMessages: NormalizedMessage[],
+): boolean {
+  if (realtimeMessage.id.startsWith('__streaming_')) {
+    return true;
+  }
+
+  if (
+    realtimeMessage.isFinal === true
+    && (realtimeMessage.kind === 'text' || realtimeMessage.kind === 'thinking')
+  ) {
+    if (hasSameTurnServerFinalMessage(realtimeMessage, serverMessages)) {
+      return false;
+    }
+    return !hasEquivalentServerMessage(realtimeMessage, serverMessages);
+  }
+
+  return false;
+}
+
+export function pruneRealtimeMessagesAfterServerRefresh(
+  realtimeMessages: NormalizedMessage[],
+  serverMessages: NormalizedMessage[],
+  options: {
+    fetchStartedAt?: number;
+  } = {},
+): NormalizedMessage[] {
+  if (realtimeMessages.length === 0 || serverMessages.length === 0) {
+    return realtimeMessages;
+  }
+
+  if (options.fetchStartedAt === undefined) {
+    return realtimeMessages.filter((message) =>
+      shouldKeepRealtimeAfterServerRefresh(message, serverMessages)
+    );
+  }
+
+  const latestServerTimestamp = serverMessages.reduce(
+    (max, message) => Math.max(max, parseTimestampMs(message.timestamp) ?? 0),
+    0,
+  );
+  const watermark = Math.max(options.fetchStartedAt, latestServerTimestamp);
+  const serverIds = new Set(serverMessages.map((message) => message.id));
+  const serverToolIds = new Set(
+    serverMessages
+      .filter((message) => message.kind === 'tool_use' && message.toolId)
+      .map((message) => message.toolId!),
+  );
+
+  return realtimeMessages.filter((message) => {
+    if (shouldKeepRealtimeAfterServerRefresh(message, serverMessages)) return true;
+    if (serverIds.has(message.id)) return false;
+    if (message.kind === 'tool_use' && message.toolId && serverToolIds.has(message.toolId)) return false;
+    return (parseTimestampMs(message.timestamp) || 0) > watermark;
+  });
+}
+
 /**
  * Compute merged messages: server + realtime, deduped by id.
  * Server messages take priority (they're the persisted source of truth).
@@ -801,6 +928,7 @@ export function useSessionStore() {
     const slot = getSlot(sessionId);
     slot.status = 'loading';
     notify(sessionId);
+    const fetchStartedAt = Date.now();
 
     try {
       const params = new URLSearchParams();
@@ -841,6 +969,12 @@ export function useSessionStore() {
       slot.fetchedAt = Date.now();
       slot.status = 'idle';
       slot.lastError = null;
+
+      slot.realtimeMessages = pruneRealtimeMessagesAfterServerRefresh(
+        slot.realtimeMessages,
+        messages,
+        { fetchStartedAt },
+      );
 
       recomputeMergedIfNeeded(slot);
       if (data.tokenUsage) {
@@ -1210,6 +1344,14 @@ export function useSessionStore() {
       slot.total = data.total ?? slot.serverMessages.length;
       slot.hasMore = Boolean(data.hasMore);
       slot.fetchedAt = Date.now();
+
+      if (slot.realtimeMessages.length > 0 && incomingMessages.length > 0) {
+        slot.realtimeMessages = pruneRealtimeMessagesAfterServerRefresh(
+          slot.realtimeMessages,
+          incomingMessages,
+        );
+      }
+
       recomputeMergedIfNeeded(slot);
       notify(sessionId);
     } catch (error) {

--- a/ui/src/stores/useSessionStore.ts
+++ b/ui/src/stores/useSessionStore.ts
@@ -130,6 +130,8 @@ export interface NormalizedMessage {
   taskResult?: string;
   trigger?: string;
   preTokens?: number;
+  postTokens?: number;
+  messagesSummarized?: number;
   compactLevel?: number;
   compactStage?: string;
   compactStageLabel?: string;
@@ -543,21 +545,34 @@ function isStreamedAssistantContent(message: NormalizedMessage): boolean {
   return (
     message.kind === 'text' &&
     message.role === 'assistant' &&
-    typeof message.serverTailIdAtStart === 'string'
+    (
+      typeof message.serverTailIdAtStart === 'string' ||
+      (message.isFinal === true && typeof message.runId === 'string' && message.runId.trim().length > 0)
+    )
   );
 }
 
-function isRealtimeProcessBoundary(message: NormalizedMessage): boolean {
+function isRealtimeAssistantSegmentBoundary(message: NormalizedMessage): boolean {
+  if (message.kind === 'text' && message.role === 'user') {
+    return true;
+  }
   return (
-    message.kind === 'tool_use' ||
     message.kind === 'tool_result' ||
-    message.kind === 'task_notification' ||
     message.kind === 'compact_boundary' ||
-    message.kind === 'interactive_prompt' ||
-    message.kind === 'permission_request' ||
+    message.kind === 'interrupted' ||
     message.kind === 'error' ||
-    message.kind === 'interrupted'
+    message.kind === 'complete'
   );
+}
+
+function getRealtimeAssistantSegmentStartIndex(messages: NormalizedMessage[], beforeIndex: number): number {
+  for (let index = beforeIndex - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (message && isRealtimeAssistantSegmentBoundary(message)) {
+      return index + 1;
+    }
+  }
+  return 0;
 }
 
 function isSameRealtimeRunOrTurn(first: NormalizedMessage, second: NormalizedMessage): boolean {
@@ -578,19 +593,13 @@ function findLateThinkingInsertIndex(
     return -1;
   }
 
-  const turnStart = getRealtimeTurnStartIndex(messages, messages.length);
-  for (let index = turnStart; index < messages.length; index += 1) {
+  const segmentStart = getRealtimeAssistantSegmentStartIndex(messages, messages.length);
+  for (let index = segmentStart; index < messages.length; index += 1) {
     const candidate = messages[index];
     if (!isStreamedAssistantContent(candidate)) {
       continue;
     }
     if (!isSameRealtimeRunOrTurn(candidate, incoming)) {
-      continue;
-    }
-    const crossesProcessBoundary = messages
-      .slice(index + 1)
-      .some(isRealtimeProcessBoundary);
-    if (crossesProcessBoundary) {
       continue;
     }
     return index;
@@ -1059,11 +1068,11 @@ export function useSessionStore() {
         { fetchStartedAt },
       );
 
-      recomputeMergedIfNeeded(slot);
       if (data.tokenUsage) {
         slot.tokenUsage = data.tokenUsage;
       }
 
+      recomputeMergedIfNeeded(slot);
       notify(sessionId);
       return slot;
     } catch (error) {
@@ -1150,7 +1159,7 @@ export function useSessionStore() {
     // Skip expensive merged recomputation and React re-render for message
     // kinds that are invisible in the UI (they return null from conversion).
     // The next visible message will trigger the recompute anyway.
-    const INVISIBLE_KINDS = new Set(['status', 'session_created', 'permission_cancelled', 'compact_boundary']);
+    const INVISIBLE_KINDS = new Set(['status', 'session_created', 'permission_cancelled']);
     if (!INVISIBLE_KINDS.has(msg.kind)) {
       recomputeMergedIfNeeded(slot);
       notify(sessionId);
@@ -1427,6 +1436,9 @@ export function useSessionStore() {
       slot.total = data.total ?? slot.serverMessages.length;
       slot.hasMore = Boolean(data.hasMore);
       slot.fetchedAt = Date.now();
+      if (data.tokenUsage) {
+        slot.tokenUsage = data.tokenUsage;
+      }
 
       if (slot.realtimeMessages.length > 0 && incomingMessages.length > 0) {
         slot.realtimeMessages = pruneRealtimeMessagesAfterServerRefresh(

--- a/ui/src/stores/useSessionStore.ts
+++ b/ui/src/stores/useSessionStore.ts
@@ -536,6 +536,73 @@ function isActiveRealtimeContentStream(message: NormalizedMessage, kind: Message
   return false;
 }
 
+function isStreamedAssistantContent(message: NormalizedMessage): boolean {
+  if (message.kind === 'stream_delta' && String(message.id || '').startsWith('__streaming_')) {
+    return true;
+  }
+  return (
+    message.kind === 'text' &&
+    message.role === 'assistant' &&
+    typeof message.serverTailIdAtStart === 'string'
+  );
+}
+
+function isRealtimeProcessBoundary(message: NormalizedMessage): boolean {
+  return (
+    message.kind === 'tool_use' ||
+    message.kind === 'tool_result' ||
+    message.kind === 'task_notification' ||
+    message.kind === 'compact_boundary' ||
+    message.kind === 'interactive_prompt' ||
+    message.kind === 'permission_request' ||
+    message.kind === 'error' ||
+    message.kind === 'interrupted'
+  );
+}
+
+function isSameRealtimeRunOrTurn(first: NormalizedMessage, second: NormalizedMessage): boolean {
+  if (first.runId != null && second.runId != null) {
+    return first.runId === second.runId;
+  }
+  if (first.serverTailIdAtStart != null && second.serverTailIdAtStart != null) {
+    return first.serverTailIdAtStart === second.serverTailIdAtStart;
+  }
+  return false;
+}
+
+function findLateThinkingInsertIndex(
+  messages: NormalizedMessage[],
+  incoming: NormalizedMessage,
+): number {
+  if (incoming.kind !== 'thinking') {
+    return -1;
+  }
+
+  const turnStart = getRealtimeTurnStartIndex(messages, messages.length);
+  for (let index = turnStart; index < messages.length; index += 1) {
+    const candidate = messages[index];
+    if (!isStreamedAssistantContent(candidate)) {
+      continue;
+    }
+    if (!isSameRealtimeRunOrTurn(candidate, incoming)) {
+      continue;
+    }
+    const crossesProcessBoundary = messages
+      .slice(index + 1)
+      .some(isRealtimeProcessBoundary);
+    if (crossesProcessBoundary) {
+      continue;
+    }
+    return index;
+  }
+
+  return -1;
+}
+
+function buildUpsertIndex(messages: NormalizedMessage[]): Map<string, number> {
+  return new Map(messages.map((message, index) => [getUpsertKey(message), index]));
+}
+
 function isCompatibleRealtimeTextRun(a: NormalizedMessage, b: NormalizedMessage): boolean {
   if (a.runId != null && b.runId != null) return a.runId === b.runId;
   const hasActiveStream = (
@@ -714,7 +781,7 @@ export function upsertRealtimeMessages(
 ): NormalizedMessage[] {
   if (incoming.length === 0) return existing;
   const updated = [...existing];
-  const indexByKey = new Map(updated.map((message, index) => [getUpsertKey(message), index]));
+  let indexByKey = buildUpsertIndex(updated);
   for (const message of incoming) {
     if (message.kind === 'tool_result' && message.toolId && message.resultPath) {
       const existingToolResultIndex = findLatestToolResultIndex(updated, message.toolId);
@@ -743,8 +810,14 @@ export function upsertRealtimeMessages(
     const key = getUpsertKey(message);
     const existingIndex = indexByKey.get(key);
     if (existingIndex === undefined) {
-      indexByKey.set(key, updated.length);
-      updated.push(message);
+      const insertIndex = findLateThinkingInsertIndex(updated, message);
+      if (insertIndex >= 0) {
+        updated.splice(insertIndex, 0, message);
+        indexByKey = buildUpsertIndex(updated);
+      } else {
+        indexByKey.set(key, updated.length);
+        updated.push(message);
+      }
     } else {
       updated[existingIndex] = message;
     }
@@ -1523,7 +1596,7 @@ export function useSessionStore() {
         ...(thinkingBlockSeq !== undefined ? { thinkingBlockSeq } : {}),
         serverTailIdAtStart: serverTailId ?? undefined,
       };
-      slot.realtimeMessages = [...slot.realtimeMessages, msg];
+      slot.realtimeMessages = upsertRealtimeMessages(slot.realtimeMessages, [msg]);
     }
     recomputeMergedIfNeeded(slot);
     notify(sessionId);

--- a/ui/src/stores/useSessionStore.ts
+++ b/ui/src/stores/useSessionStore.ts
@@ -511,7 +511,23 @@ export function computeMerged(server: NormalizedMessage[], realtime: NormalizedM
     }
   }
 
-  const result = [...server, ...extra];
+  const result = [...server];
+  for (const message of extra) {
+    if (message.kind === 'thinking') {
+      const insertIndex = findLiveThinkingServerInsertIndex(server, realtime, message);
+      if (insertIndex >= 0) {
+        // Resolve the original server anchor after earlier live inserts so
+        // consecutive thinking blocks retain their realtime order.
+        const nextServerMessage = server[insertIndex];
+        const actualInsertIndex = nextServerMessage
+          ? result.findIndex((candidate) => candidate === nextServerMessage)
+          : result.findIndex((candidate) => candidate === server[server.length - 1]) + 1;
+        result.splice(actualInsertIndex >= 0 ? actualInsertIndex : result.length, 0, message);
+        continue;
+      }
+    }
+    result.push(message);
+  }
   return result;
 }
 
@@ -583,6 +599,53 @@ function isSameRealtimeRunOrTurn(first: NormalizedMessage, second: NormalizedMes
     return first.serverTailIdAtStart === second.serverTailIdAtStart;
   }
   return false;
+}
+
+function findServerAnchorIndex(
+  server: NormalizedMessage[],
+  message: NormalizedMessage,
+): number {
+  const directIndex = server.findIndex((candidate) => (
+    candidate.id === message.id && candidate.kind === message.kind
+  ));
+  if (directIndex >= 0) return directIndex;
+
+  if ((message.kind === 'tool_use' || message.kind === 'tool_result') && message.toolId) {
+    return server.findIndex((candidate) => (
+      candidate.kind === message.kind && candidate.toolId === message.toolId
+    ));
+  }
+
+  return -1;
+}
+
+function findLiveThinkingServerInsertIndex(
+  server: NormalizedMessage[],
+  realtime: NormalizedMessage[],
+  incoming: NormalizedMessage,
+): number {
+  if (incoming.kind !== 'thinking' || !incoming.serverTailIdAtStart) return -1;
+
+  const tailIndex = server.findIndex((message) => message.id === incoming.serverTailIdAtStart);
+  if (tailIndex < 0) return -1;
+
+  const incomingIndex = realtime.indexOf(incoming);
+  if (incomingIndex >= 0) {
+    // A later thinking block belongs after its preceding server-backed tool.
+    for (let index = incomingIndex - 1; index >= 0; index -= 1) {
+      const previous = realtime[index];
+      if (previous.kind !== 'tool_use' && previous.kind !== 'tool_result') continue;
+      const anchorIndex = findServerAnchorIndex(server, previous);
+      if (anchorIndex > tailIndex) return anchorIndex + 1;
+      break;
+    }
+  }
+
+  // The first live thinking block belongs before current-turn assistant text.
+  const firstCurrentTurnIndex = server.findIndex((message, index) => (
+    index > tailIndex && message.kind === 'text' && message.role === 'assistant'
+  ));
+  return firstCurrentTurnIndex >= 0 ? firstCurrentTurnIndex : tailIndex + 1;
 }
 
 function findLateThinkingInsertIndex(

--- a/ui/src/stores/useSessionStore.ts
+++ b/ui/src/stores/useSessionStore.ts
@@ -53,6 +53,9 @@ export interface NormalizedMessage {
   // kind-specific fields (flat for simplicity)
   role?: 'user' | 'assistant';
   content?: string;
+  reasoningContent?: string;
+  thinkingBlockId?: string;
+  thinkingBlockSeq?: number;
   contentI18n?: { key: string; params?: Record<string, unknown> };
   userHintI18n?: { key: string; params?: Record<string, unknown> };
   images?: string[];
@@ -217,6 +220,31 @@ function normalizeRealtimeText(value?: string): string {
   return typeof value === 'string' ? value.replace(/\s+/g, ' ').trim() : '';
 }
 
+function getMessageComparisonText(message: Pick<NormalizedMessage, 'content' | 'reasoningContent'>): string {
+  const contentText = normalizeRealtimeText(message.content);
+  return contentText || normalizeRealtimeText(message.reasoningContent);
+}
+
+function getThinkingBlockKey(message: Pick<NormalizedMessage, 'thinkingBlockId' | 'thinkingBlockSeq'>): string | undefined {
+  if (typeof message.thinkingBlockId === 'string' && message.thinkingBlockId.trim().length > 0) {
+    return `id:${message.thinkingBlockId.trim()}`;
+  }
+  if (typeof message.thinkingBlockSeq === 'number' && Number.isFinite(message.thinkingBlockSeq)) {
+    return `seq:${message.thinkingBlockSeq}`;
+  }
+  return undefined;
+}
+
+function getRealtimeTurnStartIndex(messages: NormalizedMessage[], beforeIndex: number): number {
+  for (let index = beforeIndex - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (message?.kind === 'text' && message.role === 'user') {
+      return index + 1;
+    }
+  }
+  return 0;
+}
+
 function parseTimestampMs(value?: string): number | null {
   if (!value) return null;
   const parsed = Date.parse(value);
@@ -264,7 +292,6 @@ function isConfirmedUserMessageDuplicate(
 
 /**
  * The backend pushes a synthetic `interrupted` notice the moment abort fires
-
  * "[Request interrupted by user]" entry into the JSONL during the next user
  * turn. Once that JSONL entry is replayed via the server, drop the locally
  * pushed one to avoid stacking two dividers in the conversation.
@@ -293,101 +320,6 @@ function isLocalInterruptDuplicate(
   });
 }
 
-// NOTE: isLocalFinalizedDuplicate was removed because it prematurely filtered
-// finalized thinking/text messages when ANY server data existed (even from
-// prior turns). The refreshFromServer cleanup already removes non-streaming
-// realtime messages once the server commits the current turn's data.
-
-function hasEquivalentServerMessage(
-  realtimeMessage: NormalizedMessage,
-  serverMessages: NormalizedMessage[],
-): boolean {
-  const realtimeText = normalizeRealtimeText(realtimeMessage.content);
-  if (!realtimeText) return false;
-
-  let candidates = serverMessages;
-  if (realtimeMessage.serverTailIdAtStart) {
-    const tailIndex = serverMessages.findIndex((message) =>
-      message.id === realtimeMessage.serverTailIdAtStart
-    );
-    if (tailIndex < 0) return false;
-    candidates = serverMessages.slice(tailIndex + 1);
-  } else {
-    let lastUserIndex = -1;
-    for (let index = serverMessages.length - 1; index >= 0; index -= 1) {
-      const message = serverMessages[index];
-      if (message.kind === 'text' && message.role === 'user') {
-        lastUserIndex = index;
-        break;
-      }
-    }
-    if (lastUserIndex >= 0) {
-      candidates = serverMessages.slice(lastUserIndex + 1);
-    }
-  }
-
-  return candidates.some((serverMessage) => {
-    if (serverMessage.kind !== realtimeMessage.kind) return false;
-    if (serverMessage.role !== realtimeMessage.role) return false;
-    return normalizeRealtimeText(serverMessage.content) === realtimeText;
-  });
-}
-
-function hasSameTurnServerFinalMessage(
-  realtimeMessage: NormalizedMessage,
-  serverMessages: NormalizedMessage[],
-): boolean {
-  if (
-    realtimeMessage.isFinal !== true ||
-    (realtimeMessage.kind !== 'text' && realtimeMessage.kind !== 'thinking') ||
-    !realtimeMessage.serverTailIdAtStart
-  ) {
-    return false;
-  }
-
-  const tailIndex = serverMessages.findIndex((message) => (
-    message.id === realtimeMessage.serverTailIdAtStart
-  ));
-  if (tailIndex < 0) return false;
-  const realtimeTimestamp = parseTimestampMs(realtimeMessage.timestamp);
-  if (realtimeTimestamp == null) return false;
-  const realtimeText = normalizeRealtimeText(realtimeMessage.content);
-  if (!realtimeText) return false;
-
-  return serverMessages.slice(tailIndex + 1).some((serverMessage) => {
-    if (serverMessage.kind !== realtimeMessage.kind) return false;
-    if (serverMessage.role !== realtimeMessage.role) return false;
-    if (realtimeMessage.runId != null && serverMessage.runId != null && serverMessage.runId !== realtimeMessage.runId) {
-      return false;
-    }
-    const serverTimestamp = parseTimestampMs(serverMessage.timestamp);
-    if (serverTimestamp == null) return false;
-    if (serverTimestamp < realtimeTimestamp) return false;
-    return normalizeRealtimeText(serverMessage.content) === realtimeText;
-  });
-}
-
-export function shouldKeepRealtimeAfterServerRefresh(
-  realtimeMessage: NormalizedMessage,
-  serverMessages: NormalizedMessage[],
-): boolean {
-  if (realtimeMessage.id.startsWith('__streaming_')) {
-    return true;
-  }
-
-  if (
-    realtimeMessage.isFinal === true
-    && (realtimeMessage.kind === 'text' || realtimeMessage.kind === 'thinking')
-  ) {
-    if (hasSameTurnServerFinalMessage(realtimeMessage, serverMessages)) {
-      return false;
-    }
-    return !hasEquivalentServerMessage(realtimeMessage, serverMessages);
-  }
-
-  return false;
-}
-
 /**
  * Compute merged messages: server + realtime, deduped by id.
  * Server messages take priority (they're the persisted source of truth).
@@ -406,7 +338,6 @@ export function computeMerged(server: NormalizedMessage[], realtime: NormalizedM
     if (serverIds.has(message.id)) return false;
     if (isConfirmedUserMessageDuplicate(message, server)) return false;
     if (isLocalInterruptDuplicate(message, server)) return false;
-    if (hasSameTurnServerFinalMessage(message, server)) return false;
     // Dedup tool_use by toolId (invocation ID) — the message envelope ID
     // may differ between WebSocket replay and server-persisted copy, but
     // the underlying tool invocation is the same.
@@ -452,9 +383,28 @@ function getUpsertKey(message: NormalizedMessage): string {
   return message.id;
 }
 
+function isAssistantRealtimeContentKind(message: NormalizedMessage): boolean {
+  if (message.kind === 'thinking') return true;
+  return message.kind === 'text' && message.role === 'assistant';
+}
+
+function isActiveRealtimeContentStream(message: NormalizedMessage, kind: MessageKind): boolean {
+  const id = String(message.id || '');
+  if (kind === 'text') {
+    return message.kind === 'stream_delta' && id.startsWith('__streaming_');
+  }
+  if (kind === 'thinking') {
+    return message.kind === 'thinking' && id.startsWith('__streaming_thinking_');
+  }
+  return false;
+}
+
 function isCompatibleRealtimeTextRun(a: NormalizedMessage, b: NormalizedMessage): boolean {
   if (a.runId != null && b.runId != null) return a.runId === b.runId;
-  const hasActiveStream = a.kind === 'stream_delta' || b.kind === 'stream_delta';
+  const hasActiveStream = (
+    isActiveRealtimeContentStream(a, b.kind) ||
+    isActiveRealtimeContentStream(b, a.kind)
+  );
   if (!hasActiveStream) return false;
   const aTime = parseTimestampMs(a.timestamp);
   const bTime = parseTimestampMs(b.timestamp);
@@ -462,25 +412,163 @@ function isCompatibleRealtimeTextRun(a: NormalizedMessage, b: NormalizedMessage)
   return Math.abs(aTime - bTime) <= 10_000;
 }
 
+type RealtimeContentDuplicate = {
+  index: number;
+  keepExisting: boolean;
+};
+
 function findDuplicateAssistantRealtimeTextIndex(
   messages: NormalizedMessage[],
   incoming: NormalizedMessage,
-): number {
-  if (incoming.kind !== 'text' || incoming.role !== 'assistant') return -1;
-  const incomingText = normalizeRealtimeText(incoming.content);
-  if (!incomingText) return -1;
+): RealtimeContentDuplicate | null {
+  if (!isAssistantRealtimeContentKind(incoming)) return null;
+  const incomingText = getMessageComparisonText(incoming);
+  if (!incomingText) return null;
+  const incomingBlockKey = incoming.kind === 'thinking' ? getThinkingBlockKey(incoming) : undefined;
 
   for (let index = messages.length - 1; index >= 0; index -= 1) {
     const existing = messages[index];
-    const isAssistantText = existing.kind === 'text' && existing.role === 'assistant';
-    const isActiveAssistantStream = existing.kind === 'stream_delta' && String(existing.id || '').startsWith('__streaming_');
-    if (!isAssistantText && !isActiveAssistantStream) continue;
+    const isAssistantContent = existing.kind === incoming.kind && isAssistantRealtimeContentKind(existing);
+    const isActiveAssistantStream = isActiveRealtimeContentStream(existing, incoming.kind);
+    if (!isAssistantContent && !isActiveAssistantStream) continue;
     if (!isCompatibleRealtimeTextRun(existing, incoming)) continue;
-    if (normalizeRealtimeText(existing.content) !== incomingText) continue;
-    return index;
+    const existingText = getMessageComparisonText(existing);
+    if (!existingText) continue;
+    if (incoming.kind === 'thinking') {
+      const existingBlockKey = getThinkingBlockKey(existing);
+      if (incomingBlockKey && existingBlockKey && incomingBlockKey !== existingBlockKey) {
+        continue;
+      }
+      if (existingText === incomingText || incomingText.startsWith(existingText)) {
+        return { index, keepExisting: false };
+      }
+      if (existingText.startsWith(incomingText)) {
+        return { index, keepExisting: true };
+      }
+      continue;
+    }
+    if (existingText !== incomingText) continue;
+    return { index, keepExisting: false };
   }
 
-  return -1;
+  return null;
+}
+
+type FinalizeStreamingKind = 'text' | 'thinking';
+
+function getStreamingMessageId(
+  sessionId: string,
+  runId: string | undefined,
+  kind: FinalizeStreamingKind,
+  blockKey?: string,
+): string {
+  const prefix = kind === 'thinking' ? '__streaming_thinking_' : '__streaming_';
+  const streamBase = streamingKey(sessionId, runId);
+  return kind === 'thinking' && blockKey
+    ? `${prefix}${streamBase}_${blockKey.replace(/[^A-Za-z0-9_-]+/g, '_')}`
+    : `${prefix}${streamBase}`;
+}
+
+function findRealtimeFinalizationOverlap(
+  messages: NormalizedMessage[],
+  currentIndex: number,
+  stream: NormalizedMessage,
+  kind: FinalizeStreamingKind,
+): { index: number; replaceExisting: boolean } | null {
+  const streamText = getMessageComparisonText(stream);
+  if (!streamText) return null;
+  const streamBlockKey = kind === 'thinking' ? getThinkingBlockKey(stream) : undefined;
+
+  const startIndex = getRealtimeTurnStartIndex(messages, currentIndex);
+  for (let index = messages.length - 1; index >= startIndex; index -= 1) {
+    if (index === currentIndex) continue;
+    const existing = messages[index];
+    if (!existing || String(existing.id || '').startsWith('__streaming_')) continue;
+    if (kind === 'text') {
+      if (existing.kind !== 'text' || existing.role !== 'assistant') continue;
+    } else if (existing.kind !== 'thinking') {
+      continue;
+    }
+    if (stream.runId != null && existing.runId != null && stream.runId !== existing.runId) {
+      continue;
+    }
+    if (kind === 'thinking') {
+      const existingBlockKey = getThinkingBlockKey(existing);
+      if (streamBlockKey && existingBlockKey && streamBlockKey !== existingBlockKey) {
+        continue;
+      }
+    }
+    const existingText = getMessageComparisonText(existing);
+    if (!existingText) continue;
+    if (kind === 'thinking') {
+      if (existingText === streamText || existingText.startsWith(streamText)) {
+        return { index, replaceExisting: false };
+      }
+      if (streamText.startsWith(existingText)) {
+        return { index, replaceExisting: true };
+      }
+      continue;
+    }
+    if (existingText === streamText) {
+      return { index, replaceExisting: false };
+    }
+  }
+  return null;
+}
+
+export function finalizeStreamingRealtimeMessages(
+  realtimeMessages: NormalizedMessage[],
+  params: {
+    sessionId: string;
+    runId?: string;
+    kind: FinalizeStreamingKind;
+    newId: string;
+    thinkingBlockId?: string;
+    thinkingBlockSeq?: number;
+  },
+): NormalizedMessage[] {
+  const streamId = getStreamingMessageId(
+    params.sessionId,
+    params.runId,
+    params.kind,
+    getThinkingBlockKey({
+      thinkingBlockId: params.thinkingBlockId,
+      thinkingBlockSeq: params.thinkingBlockSeq,
+    }),
+  );
+  const idx = realtimeMessages.findIndex(m => m.id === streamId);
+  if (idx < 0) return realtimeMessages;
+
+  const stream = {
+    ...realtimeMessages[idx],
+    runId: realtimeMessages[idx].runId ?? params.runId,
+  };
+  const role = 'assistant';
+  const overlap = findRealtimeFinalizationOverlap(realtimeMessages, idx, stream, params.kind);
+  const updated = [...realtimeMessages];
+
+  if (overlap) {
+    if (overlap.replaceExisting) {
+      updated[overlap.index] = {
+        ...stream,
+        id: updated[overlap.index].id,
+        kind: params.kind,
+        role,
+        isFinal: true,
+      };
+    }
+    updated.splice(idx, 1);
+    return updated;
+  }
+
+  updated[idx] = {
+    ...stream,
+    id: params.newId,
+    kind: params.kind,
+    role,
+    isFinal: true,
+  };
+  return updated;
 }
 
 export function upsertRealtimeMessages(
@@ -501,15 +589,18 @@ export function upsertRealtimeMessages(
         continue;
       }
     }
-    const duplicateAssistantTextIndex = findDuplicateAssistantRealtimeTextIndex(updated, message);
-    if (duplicateAssistantTextIndex >= 0) {
-      const previousKey = getUpsertKey(updated[duplicateAssistantTextIndex]);
-      updated[duplicateAssistantTextIndex] = {
+    const duplicateAssistantText = findDuplicateAssistantRealtimeTextIndex(updated, message);
+    if (duplicateAssistantText) {
+      if (duplicateAssistantText.keepExisting) {
+        continue;
+      }
+      const previousKey = getUpsertKey(updated[duplicateAssistantText.index]);
+      updated[duplicateAssistantText.index] = {
         ...message,
-        serverTailIdAtStart: message.serverTailIdAtStart ?? updated[duplicateAssistantTextIndex].serverTailIdAtStart,
+        serverTailIdAtStart: message.serverTailIdAtStart ?? updated[duplicateAssistantText.index].serverTailIdAtStart,
       };
       indexByKey.delete(previousKey);
-      indexByKey.set(getUpsertKey(message), duplicateAssistantTextIndex);
+      indexByKey.set(getUpsertKey(message), duplicateAssistantText.index);
       continue;
     }
     const key = getUpsertKey(message);
@@ -576,6 +667,7 @@ export function patchMergedStreamingMessage(
   streamId: string,
   content: string,
   msgProvider?: SessionProvider,
+  patch: Partial<Pick<NormalizedMessage, 'thinkingBlockId' | 'thinkingBlockSeq'>> = {},
 ): boolean {
   const mergedIdx = slot.merged.findIndex((message) => message.id === streamId);
   if (mergedIdx < 0) {
@@ -583,7 +675,14 @@ export function patchMergedStreamingMessage(
   }
 
   const existing = slot.merged[mergedIdx];
-  if (existing.content === content && (msgProvider == null || existing.provider === msgProvider)) {
+  const nextThinkingBlockId = patch.thinkingBlockId ?? existing.thinkingBlockId;
+  const nextThinkingBlockSeq = patch.thinkingBlockSeq ?? existing.thinkingBlockSeq;
+  if (
+    existing.content === content
+    && (msgProvider == null || existing.provider === msgProvider)
+    && existing.thinkingBlockId === nextThinkingBlockId
+    && existing.thinkingBlockSeq === nextThinkingBlockSeq
+  ) {
     return true;
   }
 
@@ -591,6 +690,8 @@ export function patchMergedStreamingMessage(
     ...existing,
     content,
     ...(msgProvider != null ? { provider: msgProvider } : {}),
+    ...(patch.thinkingBlockId !== undefined ? { thinkingBlockId: patch.thinkingBlockId } : {}),
+    ...(patch.thinkingBlockSeq !== undefined ? { thinkingBlockSeq: patch.thinkingBlockSeq } : {}),
   };
   slot.merged = slot.merged.slice();
   return true;
@@ -701,8 +802,6 @@ export function useSessionStore() {
     slot.status = 'loading';
     notify(sessionId);
 
-    const fetchStartedAt = Date.now();
-
     try {
       const params = new URLSearchParams();
       if (opts.provider) params.append('provider', opts.provider);
@@ -742,27 +841,6 @@ export function useSessionStore() {
       slot.fetchedAt = Date.now();
       slot.status = 'idle';
       slot.lastError = null;
-
-      // Prune realtime messages covered by server data.  Use the later of
-      // fetchStartedAt and the latest server message timestamp as watermark
-      // so that messages finalized DURING the fetch (race window) are also
-      // pruned when the server response already includes them.
-      if (slot.realtimeMessages.length > 0 && messages.length > 0) {
-        const latestServerTs = messages.reduce(
-          (max, m) => Math.max(max, Date.parse(m.timestamp) || 0), 0,
-        );
-        const watermark = Math.max(fetchStartedAt, latestServerTs);
-        const serverIds = new Set(messages.map(m => m.id));
-        const serverToolIds = new Set(
-          messages.filter(m => m.kind === 'tool_use' && m.toolId).map(m => m.toolId!)
-        );
-        slot.realtimeMessages = slot.realtimeMessages.filter(m => {
-          if (shouldKeepRealtimeAfterServerRefresh(m, messages)) return true;
-          if (serverIds.has(m.id)) return false;
-          if (m.kind === 'tool_use' && m.toolId && serverToolIds.has(m.toolId)) return false;
-          return (Date.parse(m.timestamp) || 0) > watermark;
-        });
-      }
 
       recomputeMergedIfNeeded(slot);
       if (data.tokenUsage) {
@@ -1132,16 +1210,6 @@ export function useSessionStore() {
       slot.total = data.total ?? slot.serverMessages.length;
       slot.hasMore = Boolean(data.hasMore);
       slot.fetchedAt = Date.now();
-      // Server is authoritative, but a post-complete refresh can race the
-      // transcript writer/read path and return a non-empty yet not-quite-final
-      // snapshot. Keep finalized local stream text until the server returns
-      // an equivalent assistant message; otherwise the UI can show "complete"
-      // while the model's visible answer disappears.
-      if (slot.realtimeMessages.length > 0 && incomingMessages.length > 0) {
-        slot.realtimeMessages = slot.realtimeMessages.filter((message) =>
-          shouldKeepRealtimeAfterServerRefresh(message, incomingMessages)
-        );
-      }
       recomputeMergedIfNeeded(slot);
       notify(sessionId);
     } catch (error) {
@@ -1225,45 +1293,64 @@ export function useSessionStore() {
   const finalizeStreaming = useCallback((sessionId: string, runId?: string) => {
     const slot = storeRef.current.get(sessionId);
     if (!slot) return;
-    const streamId = `__streaming_${streamingKey(sessionId, runId)}`;
-    const idx = slot.realtimeMessages.findIndex(m => m.id === streamId);
-    if (idx >= 0) {
-      const stream = slot.realtimeMessages[idx];
-      const newId = `text_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
-      slot.realtimeMessages = [...slot.realtimeMessages];
-      slot.realtimeMessages[idx] = {
-        ...stream,
-        id: newId,
-        kind: 'text',
-        role: 'assistant',
-        isFinal: true,
-      };
-      recomputeMergedIfNeeded(slot);
-      notify(sessionId);
-    }
+    const updated = finalizeStreamingRealtimeMessages(slot.realtimeMessages, {
+      sessionId,
+      runId,
+      kind: 'text',
+      newId: `text_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
+    });
+    if (updated === slot.realtimeMessages) return;
+    slot.realtimeMessages = updated;
+    recomputeMergedIfNeeded(slot);
+    notify(sessionId);
   }, [notify]);
 
   /**
    * Update or create a streaming thinking message (accumulated thinking so far).
    * Mirrors updateStreaming but uses kind='thinking' and a separate well-known ID.
    */
-  const updateStreamingThinking = useCallback((sessionId: string, accumulatedText: string, msgProvider: SessionProvider, runId?: string) => {
+  const updateStreamingThinking = useCallback((
+    sessionId: string,
+    accumulatedText: string,
+    msgProvider: SessionProvider,
+    runId?: string,
+    thinkingBlockId?: string,
+    thinkingBlockSeq?: number,
+  ) => {
     const slot = getSlot(sessionId);
-    const streamId = `__streaming_thinking_${streamingKey(sessionId, runId)}`;
+    const streamId = getStreamingMessageId(
+      sessionId,
+      runId,
+      'thinking',
+      getThinkingBlockKey({ thinkingBlockId, thinkingBlockSeq }),
+    );
     const idx = slot.realtimeMessages.findIndex(m => m.id === streamId);
     if (idx >= 0) {
       const existing = slot.realtimeMessages[idx];
-      if (existing.content === accumulatedText && existing.provider === msgProvider) {
+      if (
+        existing.content === accumulatedText
+        && existing.provider === msgProvider
+        && existing.thinkingBlockId === thinkingBlockId
+        && existing.thinkingBlockSeq === thinkingBlockSeq
+      ) {
         return;
       }
       // FIX: patch merged BEFORE mutating existing (same fix as updateStreaming)
-      if (!patchMergedStreamingMessage(slot, streamId, accumulatedText, msgProvider)) {
+      const blockPatch = {
+        ...(thinkingBlockId !== undefined ? { thinkingBlockId } : {}),
+        ...(thinkingBlockSeq !== undefined ? { thinkingBlockSeq } : {}),
+      };
+      if (!patchMergedStreamingMessage(slot, streamId, accumulatedText, msgProvider, blockPatch)) {
         existing.content = accumulatedText;
         existing.provider = msgProvider;
+        if (thinkingBlockId !== undefined) existing.thinkingBlockId = thinkingBlockId;
+        if (thinkingBlockSeq !== undefined) existing.thinkingBlockSeq = thinkingBlockSeq;
         forceRecomputeMerged(slot);
       } else {
         existing.content = accumulatedText;
         existing.provider = msgProvider;
+        if (thinkingBlockId !== undefined) existing.thinkingBlockId = thinkingBlockId;
+        if (thinkingBlockSeq !== undefined) existing.thinkingBlockSeq = thinkingBlockSeq;
       }
       notify(sessionId);
       return;
@@ -1277,8 +1364,11 @@ export function useSessionStore() {
         timestamp: new Date().toISOString(),
         provider: msgProvider,
         kind: 'thinking',
+        role: 'assistant',
         content: accumulatedText,
         runId,
+        ...(thinkingBlockId !== undefined ? { thinkingBlockId } : {}),
+        ...(thinkingBlockSeq !== undefined ? { thinkingBlockSeq } : {}),
         serverTailIdAtStart: serverTailId ?? undefined,
       };
       slot.realtimeMessages = [...slot.realtimeMessages, msg];
@@ -1291,23 +1381,26 @@ export function useSessionStore() {
    * Finalize streaming thinking: replace the well-known streaming thinking ID
    * with a unique ID so subsequent thinking blocks don't overwrite it.
    */
-  const finalizeStreamingThinking = useCallback((sessionId: string, runId?: string) => {
+  const finalizeStreamingThinking = useCallback((
+    sessionId: string,
+    runId?: string,
+    thinkingBlockId?: string,
+    thinkingBlockSeq?: number,
+  ) => {
     const slot = storeRef.current.get(sessionId);
     if (!slot) return;
-    const streamId = `__streaming_thinking_${streamingKey(sessionId, runId)}`;
-    const idx = slot.realtimeMessages.findIndex(m => m.id === streamId);
-    if (idx >= 0) {
-      const stream = slot.realtimeMessages[idx];
-      const newId = `thinking_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
-      slot.realtimeMessages = [...slot.realtimeMessages];
-      slot.realtimeMessages[idx] = {
-        ...stream,
-        id: newId,
-        isFinal: true,
-      };
-      recomputeMergedIfNeeded(slot);
-      notify(sessionId);
-    }
+    const updated = finalizeStreamingRealtimeMessages(slot.realtimeMessages, {
+      sessionId,
+      runId,
+      kind: 'thinking',
+      newId: `thinking_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
+      ...(thinkingBlockId !== undefined ? { thinkingBlockId } : {}),
+      ...(thinkingBlockSeq !== undefined ? { thinkingBlockSeq } : {}),
+    });
+    if (updated === slot.realtimeMessages) return;
+    slot.realtimeMessages = updated;
+    recomputeMergedIfNeeded(slot);
+    notify(sessionId);
   }, [notify]);
 
   /**


### PR DESCRIPTION
## Summary
- add stable thinkingBlockId/thinkingBlockSeq through canonical, gateway, bridge, and web protocol
- normalize provider thinking deltas to one live block identity and keep legacy fallback when fields are missing
- update live UI/store replay/finalization to merge by block key without touching history refresh paths

## Tests
- npx tsc -p tsconfig.json --noEmit
- PATH=/Users/a1/.nvm/versions/node/v22.23.1/bin:$PATH npm run build
- npx tsx --test tests/model/streaming/thinkingBlockIdentity.spec.ts tests/web/thinking-block.spec.ts tests/gateway/map-agent-event-runid.spec.ts
- npm --prefix ui test -- useSessionStore.streaming.test.ts pilotdeck-bridge.test.js