### PR TITLE
fix: avoid phantom workspace artifacts

### DIFF
--- a/src/session/artifacts/FileArtifactCollector.ts
+++ b/src/session/artifacts/FileArtifactCollector.ts
@@ -126,6 +126,7 @@ export class FileArtifactCollector {
   private readonly baseline = new Map<string, FileFingerprint>();
   private readonly explicitCandidates = new Map<string, ArtifactCandidate>();
   private readonly allowedInputPaths: Set<string>;
+  private sawWorkspaceMutationCandidate = false;
 
   private constructor(options: FileArtifactCollectorOptions) {
     this.cwd = path.resolve(options.cwd);
@@ -151,6 +152,9 @@ export class FileArtifactCollector {
   }
 
   observeToolResult(result: PilotDeckToolResult): void {
+    if (canToolMutateWorkspace(result.toolName)) {
+      this.sawWorkspaceMutationCandidate = true;
+    }
     if (result.type !== "success") return;
 
     for (const item of result.content) {
@@ -167,31 +171,35 @@ export class FileArtifactCollector {
   async finish(status: FileArtifactStatus): Promise<FileArtifact[]> {
     const candidates = new Map<string, ArtifactCandidate>(this.explicitCandidates);
     const finalFingerprints = new Map<string, FileFingerprint>();
-    for (const file of await this.scanWorkspace(this.baseline)) {
-      finalFingerprints.set(file.absolutePath, file.fingerprint);
-      const before = this.baseline.get(file.absolutePath);
-      if (!before || before.sha256 !== file.fingerprint.sha256) {
-        candidates.set(file.absolutePath, {
-          absolutePath: file.absolutePath,
-          source: candidates.get(file.absolutePath)?.source ?? "workspace_diff",
-          fingerprint: file.fingerprint,
-        });
+    if (this.sawWorkspaceMutationCandidate) {
+      for (const file of await this.scanWorkspace(this.baseline)) {
+        finalFingerprints.set(file.absolutePath, file.fingerprint);
+        const before = this.baseline.get(file.absolutePath);
+        if (!before || before.sha256 !== file.fingerprint.sha256) {
+          candidates.set(file.absolutePath, {
+            absolutePath: file.absolutePath,
+            source: candidates.get(file.absolutePath)?.source ?? "workspace_diff",
+            fingerprint: file.fingerprint,
+          });
+        }
       }
-    }
-    const allowedInputFinal = new Map<string, FileFingerprint>();
-    await this.captureAllowedInputFingerprints(allowedInputFinal, this.baseline);
-    for (const [absolutePath, fingerprint] of allowedInputFinal) {
-      finalFingerprints.set(absolutePath, fingerprint);
-      const before = this.baseline.get(absolutePath);
-      if (!before || before.sha256 !== fingerprint.sha256) {
-        candidates.set(absolutePath, {
-          absolutePath,
-          source: candidates.get(absolutePath)?.source ?? "workspace_diff",
-          fingerprint,
-        });
+      const allowedInputFinal = new Map<string, FileFingerprint>();
+      await this.captureAllowedInputFingerprints(allowedInputFinal, this.baseline);
+      for (const [absolutePath, fingerprint] of allowedInputFinal) {
+        finalFingerprints.set(absolutePath, fingerprint);
+        const before = this.baseline.get(absolutePath);
+        if (!before || before.sha256 !== fingerprint.sha256) {
+          candidates.set(absolutePath, {
+            absolutePath,
+            source: candidates.get(absolutePath)?.source ?? "workspace_diff",
+            fingerprint,
+          });
+        }
       }
+      cacheWorkspaceFingerprints(this.cwd, finalFingerprints);
+    } else {
+      cacheWorkspaceFingerprints(this.cwd, this.baseline);
     }
-    cacheWorkspaceFingerprints(this.cwd, finalFingerprints);
 
     const artifacts: FileArtifact[] = [];
     for (const candidate of candidates.values()) {
@@ -326,6 +334,32 @@ function readCachedWorkspaceFingerprints(cwd: string): ReadonlyMap<string, FileF
   workspaceFingerprintCache.delete(cwd);
   workspaceFingerprintCache.set(cwd, cached);
   return cached;
+}
+
+const READ_ONLY_TOOL_NAMES = new Set([
+  "ask_user_question",
+  "enter_plan_mode",
+  "exit_plan_mode",
+  "get_current_time",
+  "glob",
+  "grep",
+  "list_mcp_resources",
+  "read_file",
+  "read_mcp_resource",
+  "read_skill",
+  "send_attachment",
+  "structured_output",
+  "task_list",
+  "task_output",
+  "task_stop",
+  "task_wait",
+  "todo_write",
+  "web_fetch",
+  "web_search",
+]);
+
+function canToolMutateWorkspace(toolName: string): boolean {
+  return !READ_ONLY_TOOL_NAMES.has(toolName.toLowerCase());
 }
 
 function cacheWorkspaceFingerprints(cwd: string, fingerprints: ReadonlyMap<string, FileFingerprint>): void {

--- a/tests/session/file-artifact-collector.spec.ts
+++ b/tests/session/file-artifact-collector.spec.ts
@@ -7,6 +7,17 @@ import { tmpdir } from "node:os";
 
 import { FileArtifactCollector } from "../../src/session/artifacts/FileArtifactCollector.js";
 
+function toolResult(toolName: string) {
+  return {
+    type: "success" as const,
+    toolCallId: `${toolName}-1`,
+    toolName,
+    content: [{ type: "text" as const, text: "ok" }],
+    startedAt: "2026-07-21T10:00:00.000Z",
+    completedAt: "2026-07-21T10:00:00.100Z",
+  };
+}
+
 test("file artifacts include every meaningful workspace change without an extension allowlist", async () => {
   const projectRoot = await mkdtemp(join(tmpdir(), "pilotdeck-artifacts-"));
   const uploadedFile = join(projectRoot, ".tmp", "chat-attachments", "source.xlsx");
@@ -49,6 +60,7 @@ test("file artifacts include every meaningful workspace change without an extens
     await writeFile(join(projectRoot, ".env"), "API_KEY=secret");
     await writeFile(join(projectRoot, "private.pem"), "secret key");
 
+    collector.observeToolResult(toolResult("bash"));
     const artifacts = await collector.finish("incomplete");
 
     const expectedPaths = [
@@ -67,6 +79,39 @@ test("file artifacts include every meaningful workspace change without an extens
     assert.equal(artifacts.find((artifact) => artifact.path === "notes.custom")?.mimeType, undefined);
     assert.ok(artifacts.every((artifact) => artifact.status === "incomplete"));
     assert.ok(artifacts.every((artifact) => artifact.sha256.length === 64));
+  } finally {
+    await rm(projectRoot, { recursive: true, force: true });
+  }
+});
+
+test("file artifact collection ignores workspace changes when no mutating tool ran", async () => {
+  const projectRoot = await mkdtemp(join(tmpdir(), "pilotdeck-artifact-no-tool-"));
+  try {
+    await mkdir(join(projectRoot, "app"), { recursive: true });
+    await writeFile(join(projectRoot, "app", "page.tsx"), "before");
+
+    const collector = await FileArtifactCollector.start({ cwd: projectRoot });
+
+    await writeFile(join(projectRoot, "app", "page.tsx"), "changed outside the agent turn");
+    await writeFile(join(projectRoot, "app", "external.txt"), "external file");
+
+    assert.deepEqual(await collector.finish("complete"), []);
+  } finally {
+    await rm(projectRoot, { recursive: true, force: true });
+  }
+});
+
+test("read-only tool results do not enable workspace-diff artifacts", async () => {
+  const projectRoot = await mkdtemp(join(tmpdir(), "pilotdeck-artifact-readonly-tool-"));
+  try {
+    await writeFile(join(projectRoot, "notes.txt"), "before");
+
+    const collector = await FileArtifactCollector.start({ cwd: projectRoot });
+
+    await writeFile(join(projectRoot, "notes.txt"), "changed outside a read-only tool");
+    collector.observeToolResult(toolResult("read_file"));
+
+    assert.deepEqual(await collector.finish("complete"), []);
   } finally {
     await rm(projectRoot, { recursive: true, force: true });
   }
@@ -95,6 +140,7 @@ test("file artifact fingerprints are reused for unchanged files across scans and
     assert.equal(hashCalls, 1, "the next turn reuses the cached workspace fingerprint");
 
     await writeFile(trackedFile, "after with a different size");
+    secondTurn.observeToolResult(toolResult("bash"));
     const artifacts = await secondTurn.finish("complete");
 
     assert.equal(hashCalls, 2, "only the changed file is re-hashed");

--- a/tests/session/turn-file-artifacts.spec.ts
+++ b/tests/session/turn-file-artifacts.spec.ts
@@ -34,6 +34,19 @@ test("TurnRunner emits and persists file artifacts before completing the turn", 
           join(projectRoot, ".pilotdeck", "work", input.sessionId, input.turnId, "builder.mjs"),
           "// internal\n",
         );
+        yield {
+          type: "tool_result",
+          sessionId: input.sessionId,
+          turnId: input.turnId,
+          result: {
+            type: "success",
+            toolCallId: "bash-1",
+            toolName: "bash",
+            content: [{ type: "text", text: "created files" }],
+            startedAt: "2026-07-21T10:00:00.000Z",
+            completedAt: "2026-07-21T10:00:00.500Z",
+          },
+        };
         yield { type: "turn_completed", sessionId: input.sessionId, turnId: input.turnId, result };
         return { result, messages: input.messages };
       },
@@ -125,4 +138,93 @@ test("TurnRunner does not collect generated files when artifacts are disabled", 
   } finally {
     await rm(generalRoot, { recursive: true, force: true });
   }
+});
+
+test("TurnRunner persists compact boundary before post-compact replacement messages", async () => {
+  const result: AgentTurnResult = {
+    type: "success",
+    sessionId: "compact-session",
+    turnId: "turn-1",
+    stopReason: "completed",
+    usage: {},
+    permissionDenials: [],
+    turns: 1,
+    startedAt: "2026-08-02T00:00:00.000Z",
+    completedAt: "2026-08-02T00:00:01.000Z",
+  };
+  const fakeLoop = {
+    async *run(input: AgentLoopInput): AsyncGenerator<AgentEvent, AgentLoopRunResult, unknown> {
+      await input.onCompactPersisted?.({
+        boundary: {
+          kind: "compact",
+          subtype: "compact_boundary",
+          compactMetadata: {
+            trigger: "auto",
+            preTokens: 120,
+            postTokens: 40,
+            messagesSummarized: 2,
+          },
+        },
+        messages: [
+          {
+            role: "assistant",
+            metadata: { compactReplacement: true },
+            content: [{ type: "text", text: "[CONTEXT COMPACTION - REFERENCE ONLY]\nsummary" }],
+          },
+          {
+            role: "user",
+            metadata: { compactReplacement: true },
+            content: [{ type: "text", text: "kept tail" }],
+          },
+        ],
+      });
+      yield { type: "turn_continued", sessionId: input.sessionId, turnId: input.turnId, reason: "auto_compact" };
+      yield { type: "turn_completed", sessionId: input.sessionId, turnId: input.turnId, result };
+      return { result, messages: input.messages };
+    },
+    snapshotFileState: () => ({}),
+  } as unknown as AgentLoop;
+  const transcript = new InMemoryTranscriptWriter();
+  const runner = new TurnRunner(
+    fakeLoop,
+    transcript,
+    undefined,
+    () => new Date("2026-08-02T00:00:01.000Z"),
+    undefined,
+    { cwd: process.cwd(), transcriptPath: "", collectFileArtifacts: false },
+  );
+
+  for await (const _event of runner.run({
+    sessionId: "compact-session",
+    turnId: "turn-1",
+    messages: [{ role: "assistant", content: [{ type: "text", text: "old context" }] }],
+    input: { type: "text", text: "continue" },
+  })) {
+    // Drain the runner.
+  }
+
+  assert.deepEqual(transcript.entries.map((entry) => entry.type), [
+    "accepted_input",
+    "control_boundary",
+    "durable_message",
+    "durable_message",
+    "turn_result",
+  ]);
+  const boundary = transcript.entries[1];
+  assert.equal(boundary?.type, "control_boundary");
+  assert.equal(
+    boundary?.type === "control_boundary" &&
+      "subtype" in boundary.boundary &&
+      boundary.boundary.subtype === "compact_boundary"
+      ? boundary.boundary.compactMetadata.postTokens
+      : undefined,
+    40,
+  );
+  const replacementEntries = transcript.entries.slice(2, 4);
+  assert.equal(
+    replacementEntries.every((entry) =>
+      entry.type === "durable_message" && entry.message.metadata?.compactReplacement === true,
+    ),
+    true,
+  );
 });

--- a/tests/web/file-artifact-history.spec.ts
+++ b/tests/web/file-artifact-history.spec.ts
@@ -18,6 +18,15 @@ test("history replay restores structured agent file artifacts", async () => {
       sessionId: sessionKey,
       now: () => new Date("2026-07-21T10:00:00.000Z"),
     });
+    await storage.transcript.recordDurableMessage(sessionKey, "turn-1", {
+      role: "user",
+      content: [{
+        type: "tool_result",
+        toolCallId: "bash-1",
+        content: [{ type: "text", text: "wrote report.xlsx" }],
+        raw: { toolName: "bash" },
+      }],
+    });
     await storage.transcript.recordFileArtifacts(sessionKey, "turn-1", [{
       id: "artifact-1",
       name: "report.xlsx",
@@ -38,6 +47,47 @@ test("history replay restores structured agent file artifacts", async () => {
     assert.equal(message.role, "assistant");
     assert.equal(message.artifacts?.[0]?.path, "report.xlsx");
     assert.equal(message.artifacts?.[0]?.operation, "created");
+  } finally {
+    await rm(projectRoot, { recursive: true, force: true });
+    await rm(pilotHome, { recursive: true, force: true });
+  }
+});
+
+test("history replay hides stale workspace-diff artifacts from turns with no tool results", async () => {
+  const projectRoot = await mkdtemp(join(tmpdir(), "pilotdeck-stale-artifact-history-project-"));
+  const pilotHome = await mkdtemp(join(tmpdir(), "pilotdeck-stale-artifact-history-home-"));
+  try {
+    const sessionKey = "web:s_stale_workspace_artifact";
+    const storage = createAgentProjectSessionStorage({
+      projectRoot,
+      pilotHome,
+      sessionId: sessionKey,
+      now: () => new Date("2026-08-02T10:00:00.000Z"),
+    });
+    await storage.transcript.recordAcceptedInput(sessionKey, "turn-1", [{
+      role: "user",
+      content: [{ type: "text", text: "hello" }],
+    }]);
+    await storage.transcript.recordDurableMessage(sessionKey, "turn-1", {
+      role: "assistant",
+      content: [{ type: "text", text: "Hello." }],
+    });
+    await storage.transcript.recordFileArtifacts(sessionKey, "turn-1", [{
+      id: "artifact-1",
+      name: "unrelated.ts",
+      path: "src/unrelated.ts",
+      operation: "updated",
+      source: "workspace_diff",
+      status: "complete",
+      size: 42,
+      sha256: "c".repeat(64),
+      mimeType: "text/plain",
+      createdAt: "2026-08-02T10:00:00.000Z",
+    }]);
+
+    const replay = await readWebSessionMessages({ sessionKey }, { projectRoot, pilotHome });
+
+    assert.equal(replay.messages.some((item) => item.kind === "file_artifacts"), false);
   } finally {
     await rm(projectRoot, { recursive: true, force: true });
     await rm(pilotHome, { recursive: true, force: true });


### PR DESCRIPTION
This PR prevents read-only or pure-chat turns from emitting workspace-diff artifacts.

- Track whether a mutating tool actually ran
- Ignore external workspace changes during read-only turns
- Preserve artifact replay behavior
- Add collector, TurnRunner, and Web history tests