### PR TITLE
fix(router): support gateway-compatible judge requests

### DIFF
--- a/src/router/RouterRuntime.ts
+++ b/src/router/RouterRuntime.ts
@@ -419,6 +419,7 @@ export function createRouterRuntime(
           config: config.tokenSaver,
           messages: input.request.messages,
           judgeRuntime,
+          abortSignal: input.abortSignal,
           previousTier: input.metadata?.previousTier,
           sessionId: input.sessionId,
           telemetry,
@@ -430,6 +431,11 @@ export function createRouterRuntime(
               sessionId: input.sessionId,
               reason: tokenSaver.failureReason,
               fallbackTier: tokenSaver.tier,
+              judgeProvider: config.tokenSaver.judge.provider,
+              judgeModel: config.tokenSaver.judge.model,
+              attempts: tokenSaver.failure?.attempts ?? 1,
+              ...(tokenSaver.failure?.code ? { errorCode: tokenSaver.failure.code } : {}),
+              ...(tokenSaver.failure?.message ? { errorMessage: tokenSaver.failure.message } : {}),
             });
           }
           if (tokenSaver.selection) {
@@ -998,6 +1004,7 @@ export function createRouterRuntime(
       request,
       sessionId: ctx.sessionId,
       isMainAgent: ctx.isMainAgent,
+      abortSignal: ctx.abortSignal,
       metadata: ctx.previousTier ? { previousTier: ctx.previousTier } : undefined,
     });
     yield* execute(decision, request, ctx);

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -59,6 +59,7 @@ export {
   classifyAndRoute,
   type ClassifyAndRouteInput,
   type TokenSaverDecision,
+  type TokenSaverFailure,
 } from "./tokenSaver/classifyAndRoute.js";
 export {
   applyOrchestration,

--- a/src/router/protocol/decision.ts
+++ b/src/router/protocol/decision.ts
@@ -70,6 +70,8 @@ export type RouterDecisionInput = {
   request: import("../../model/protocol/canonical.js").CanonicalModelRequest;
   sessionId: string;
   isMainAgent: boolean;
+  /** Cancels a pending router judge request when the enclosing turn stops. */
+  abortSignal?: AbortSignal;
   metadata?: {
     lastUsage?: RouterDecisionInputUsageHint;
     explicitProvider?: string;

--- a/src/router/protocol/events.ts
+++ b/src/router/protocol/events.ts
@@ -36,6 +36,15 @@ export type RouterTokenSaverFailedEvent = {
   turnId?: string;
   reason: "timeout" | "model_error" | "parse_error";
   fallbackTier: string;
+  /** Judge model that failed or produced an unparsable response. */
+  judgeProvider?: string;
+  judgeModel?: string;
+  /** Number of classification attempts made before falling back. */
+  attempts?: number;
+  /** Provider-normalized error code, when applicable. */
+  errorCode?: string;
+  /** Sanitized provider message, when applicable. */
+  errorMessage?: string;
 };
 
 export type RouterCustomFailedEvent = {

--- a/src/router/tokenSaver/classifyAndRoute.ts
+++ b/src/router/tokenSaver/classifyAndRoute.ts
@@ -3,6 +3,7 @@ import type {
   CanonicalModelRequest,
   ModelRuntime,
 } from "../../model/index.js";
+import { ModelProviderError, ModelRequestError } from "../../model/index.js";
 import type { TelemetryClient } from "../../telemetry/index.js";
 import type { RouterModelRef, RouterTokenSaverConfig } from "../config/schema.js";
 import { extractLastUserMessage } from "./extractLastUserMessage.js";
@@ -14,6 +15,17 @@ export type TokenSaverDecision = {
   selection: RouterModelRef;
   resolvedFrom: "judge" | "default" | "fallback";
   failureReason?: "timeout" | "model_error" | "parse_error";
+  /** Diagnostic safe to persist in router events when classification falls back. */
+  failure?: TokenSaverFailure;
+};
+
+export type TokenSaverFailure = {
+  reason: NonNullable<TokenSaverDecision["failureReason"]>;
+  attempts: number;
+  /** Provider-normalized code when the judge request reached a provider. */
+  code?: string;
+  /** Sanitized provider message; never includes request content or credentials. */
+  message?: string;
 };
 
 export type ClassifyAndRouteInput = {
@@ -61,7 +73,9 @@ export async function classifyAndRoute(
       },
     ],
     maxOutputTokens: 256,
-    temperature: 0,
+    // Provider defaults are more compatible than an explicit temperature for
+    // lightweight routing requests. Some compatible gateways reject the
+    // field for particular models (including Claude-backed ones).
     thinking: { enabled: false },
     stream: false,
   };
@@ -87,6 +101,13 @@ export async function classifyAndRoute(
       await new Promise((r) => setTimeout(r, 1_000));
     }
     let timeout: NodeJS.Timeout | undefined;
+    let timedOut = false;
+    const judgeAbortController = new AbortController();
+    const forwardAbort = () => judgeAbortController.abort(input.abortSignal?.reason);
+    input.abortSignal?.addEventListener("abort", forwardAbort, { once: true });
+    if (input.abortSignal?.aborted) {
+      forwardAbort();
+    }
     try {
       input.telemetry?.trackFeatureLoopStage({
         module: "router",
@@ -103,10 +124,18 @@ export async function classifyAndRoute(
           model: config.judge.model,
         },
       });
+      const judgeRequestPromise = input.judgeRuntime.complete(judgeRequest, {
+        signal: judgeAbortController.signal,
+      });
       const response = await Promise.race([
-        input.judgeRuntime.complete(judgeRequest),
+        judgeRequestPromise,
         new Promise<never>((_, reject) => {
-          timeout = setTimeout(() => reject(new TokenSaverTimeoutError()), timeoutMs);
+          timeout = setTimeout(() => {
+            timedOut = true;
+            const timeoutError = new TokenSaverTimeoutError();
+            judgeAbortController.abort(timeoutError);
+            reject(timeoutError);
+          }, timeoutMs);
         }),
       ]);
       console.log(
@@ -145,6 +174,7 @@ export async function classifyAndRoute(
           selection: defaultTier.model,
           resolvedFrom: "fallback",
           failureReason: "parse_error",
+          failure: { reason: "parse_error", attempts: attempt },
         };
       }
 
@@ -178,6 +208,7 @@ export async function classifyAndRoute(
           selection: defaultTier.model,
           resolvedFrom: "fallback",
           failureReason: "parse_error",
+          failure: { reason: "parse_error", attempts: attempt },
         };
       }
       const selection = config.tiers[tier]?.model;
@@ -204,6 +235,7 @@ export async function classifyAndRoute(
           selection: defaultTier.model,
           resolvedFrom: "fallback",
           failureReason: "parse_error",
+          failure: { reason: "parse_error", attempts: attempt },
         };
       }
       input.telemetry?.trackFeatureLoopStage({
@@ -224,21 +256,25 @@ export async function classifyAndRoute(
       });
       return { tier, selection, resolvedFrom: "judge" };
     } catch (error) {
-      if (attempt < maxAttempts && !(error instanceof TokenSaverTimeoutError)) {
+      if (input.abortSignal?.aborted) {
+        throw error;
+      }
+      const failure = timedOut ? new TokenSaverTimeoutError() : error;
+      if (attempt < maxAttempts && shouldRetryJudgeFailure(failure)) {
         continue;
       }
-      const timedOut = error instanceof TokenSaverTimeoutError;
+      const didTimeout = failure instanceof TokenSaverTimeoutError;
       input.telemetry?.trackError(error, {
         module: "router",
         ownerModule: "router",
         executionKind: "router_judge",
         phase: "judge",
         loopStage: "model_request",
-        errorCategory: timedOut ? "runtime_error" : "model_request_error",
+        errorCategory: didTimeout ? "runtime_error" : "model_request_error",
         sessionId: input.sessionId,
-        code: timedOut ? "judge_timeout" : "judge_model_error",
+        code: didTimeout ? "judge_timeout" : "judge_model_error",
         metadata: {
-          event: timedOut ? "timeout" : "request_failed",
+          event: didTimeout ? "timeout" : "request_failed",
           attempt,
           provider: config.judge.provider,
           model: config.judge.model,
@@ -248,12 +284,14 @@ export async function classifyAndRoute(
         tier: config.defaultTier,
         selection: defaultTier.model,
         resolvedFrom: "fallback",
-        failureReason: error instanceof TokenSaverTimeoutError ? "timeout" : "model_error",
+        failureReason: didTimeout ? "timeout" : "model_error",
+        failure: describeFailure(failure, attempt),
       };
     } finally {
       if (timeout) {
         clearTimeout(timeout);
       }
+      input.abortSignal?.removeEventListener("abort", forwardAbort);
     }
   }
   return {
@@ -261,11 +299,52 @@ export async function classifyAndRoute(
     selection: defaultTier.model,
     resolvedFrom: "fallback",
     failureReason: "parse_error",
+    failure: { reason: "parse_error", attempts: maxAttempts },
   };
 }
 
 class TokenSaverTimeoutError extends Error {
   readonly name = "TokenSaverTimeoutError";
+}
+
+function describeFailure(error: unknown, attempts: number): TokenSaverFailure {
+  if (error instanceof TokenSaverTimeoutError) {
+    return { reason: "timeout", attempts, code: "judge_timeout" };
+  }
+
+  const modelError = error instanceof ModelProviderError
+    ? error.error
+    : error instanceof ModelRequestError
+      ? { code: error.code, message: error.message }
+      : error instanceof Error
+        ? { message: error.message }
+        : undefined;
+
+  return {
+    reason: "model_error",
+    attempts,
+    ...(modelError?.code ? { code: modelError.code } : {}),
+    ...(modelError?.message ? { message: sanitizeFailureMessage(modelError.message) } : {}),
+  };
+}
+
+function shouldRetryJudgeFailure(error: unknown): boolean {
+  if (error instanceof TokenSaverTimeoutError || error instanceof ModelRequestError) {
+    return false;
+  }
+  if (error instanceof ModelProviderError) {
+    return error.error.retryable;
+  }
+  return true;
+}
+
+function sanitizeFailureMessage(message: string): string {
+  return message
+    .replace(/\b(authorization\s*[:=]\s*bearer\s+|bearer\s+)[^\s,;]+/gi, "$1<redacted>")
+    .replace(/\b(api[_-]?key|token|secret|password)\s*[:=]\s*[^\s,;]+/gi, "$1=<redacted>")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, 300);
 }
 
 const SHORT_CONTINUATION_MAX_CHARS = 30;

--- a/tests/router/tokenSaver.spec.ts
+++ b/tests/router/tokenSaver.spec.ts
@@ -1,0 +1,187 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { CanonicalModelRequest, ModelRuntime } from "../../src/model/index.js";
+import { ModelProviderError } from "../../src/model/index.js";
+import { classifyAndRoute } from "../../src/router/index.js";
+
+test("records the normalized judge error when token-saver falls back", async () => {
+  let attempts = 0;
+  const judgeRuntime = {
+    complete: async () => {
+      attempts += 1;
+      throw new ModelProviderError({
+        provider: "judge-provider",
+        protocol: "openai",
+        code: "auth_error",
+        message: "API key rejected by the provider.",
+        retryable: false,
+      });
+    },
+  } as unknown as ModelRuntime;
+
+  const result = await classifyAndRoute({
+    config: config(),
+    messages: [{ role: "user", content: [{ type: "text", text: "hello" }] }],
+    judgeRuntime,
+  });
+
+  assert.equal(attempts, 1);
+  assert.deepEqual(result?.failure, {
+    reason: "model_error",
+    attempts: 1,
+    code: "auth_error",
+    message: "API key rejected by the provider.",
+  });
+});
+
+test("retries a retryable judge provider error before falling back", async () => {
+  let attempts = 0;
+  const judgeRuntime = {
+    complete: async () => {
+      attempts += 1;
+      throw new ModelProviderError({
+        provider: "judge-provider",
+        protocol: "openai",
+        code: "server_error",
+        message: "Provider temporarily unavailable.",
+        retryable: true,
+      });
+    },
+  } as unknown as ModelRuntime;
+
+  const result = await classifyAndRoute({
+    config: config(),
+    messages: [{ role: "user", content: [{ type: "text", text: "hello" }] }],
+    judgeRuntime,
+  });
+
+  assert.equal(attempts, 3);
+  assert.equal(result?.failure?.attempts, 3);
+});
+
+test("redacts credentials from a judge error before returning diagnostics", async () => {
+  const judgeRuntime = {
+    complete: async () => {
+      throw new ModelProviderError({
+        provider: "judge-provider",
+        protocol: "openai",
+        code: "auth_error",
+        message: "Authorization: Bearer super-secret-token apiKey=also-secret",
+        retryable: false,
+      });
+    },
+  } as unknown as ModelRuntime;
+
+  const result = await classifyAndRoute({
+    config: config(),
+    messages: [{ role: "user", content: [{ type: "text", text: "hello" }] }],
+    judgeRuntime,
+  });
+
+  assert.equal(
+    result?.failure?.message,
+    "Authorization: Bearer <redacted> apiKey=<redacted>",
+  );
+});
+
+test("records a plain network error message when the judge request fails", async () => {
+  const judgeRuntime = {
+    complete: async () => {
+      throw new TypeError("fetch failed");
+    },
+  } as unknown as ModelRuntime;
+
+  const result = await classifyAndRoute({
+    config: config(),
+    messages: [{ role: "user", content: [{ type: "text", text: "hello" }] }],
+    judgeRuntime,
+  });
+
+  assert.equal(result?.failure?.message, "fetch failed");
+});
+
+test("omits temperature for an Anthropic judge", async () => {
+  let request: CanonicalModelRequest | undefined;
+  const judgeRuntime = {
+    getProviderProtocol: () => "anthropic",
+    complete: async (nextRequest: CanonicalModelRequest) => {
+      request = nextRequest;
+      return {
+        role: "assistant" as const,
+        content: [{ type: "text" as const, text: "<tier>medium</tier>" }],
+        finishReason: "stop" as const,
+      };
+    },
+  } as unknown as ModelRuntime;
+
+  const result = await classifyAndRoute({
+    config: config(),
+    messages: [{ role: "user", content: [{ type: "text", text: "hello" }] }],
+    judgeRuntime,
+  });
+
+  assert.equal(result?.tier, "medium");
+  assert.equal(request?.temperature, undefined);
+});
+
+test("omits temperature for an OpenAI-compatible judge", async () => {
+  let request: CanonicalModelRequest | undefined;
+  const judgeRuntime = {
+    getProviderProtocol: () => "openai",
+    complete: async (nextRequest: CanonicalModelRequest) => {
+      request = nextRequest;
+      return {
+        role: "assistant" as const,
+        content: [{ type: "text" as const, text: "<tier>medium</tier>" }],
+        finishReason: "stop" as const,
+      };
+    },
+  } as unknown as ModelRuntime;
+
+  await classifyAndRoute({
+    config: config(),
+    messages: [{ role: "user", content: [{ type: "text", text: "hello" }] }],
+    judgeRuntime,
+  });
+
+  assert.equal(request?.temperature, undefined);
+});
+
+test("aborts the judge request when its classification timeout expires", async () => {
+  let aborted = false;
+  const judgeRuntime = {
+    complete: async (_request: unknown, options?: { signal?: AbortSignal }) =>
+      new Promise<never>((_resolve, reject) => {
+        options?.signal?.addEventListener("abort", () => {
+          aborted = true;
+          reject(options.signal?.reason);
+        }, { once: true });
+      }),
+  } as unknown as ModelRuntime;
+
+  const result = await classifyAndRoute({
+    config: { ...config(), judgeTimeoutMs: 500 },
+    messages: [{ role: "user", content: [{ type: "text", text: "hello" }] }],
+    judgeRuntime,
+  });
+
+  assert.equal(aborted, true);
+  assert.deepEqual(result?.failure, {
+    reason: "timeout",
+    attempts: 1,
+    code: "judge_timeout",
+  });
+});
+
+function config() {
+  return {
+    enabled: true,
+    judge: { id: "judge-provider/judge-model", provider: "judge-provider", model: "judge-model" },
+    defaultTier: "medium",
+    judgeTimeoutMs: 5_000,
+    tiers: {
+      medium: { model: { id: "main/main-model", provider: "main", model: "main-model" } },
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- omit explicit `temperature` from token-saver judge requests so Claude and compatible gateways that reject the parameter can classify normally
- abort judge requests on timeout or turn cancellation, and retry only retryable judge failures
- persist sanitized judge failure diagnostics in router events

## Validation
- `pnpm exec tsx --test tests/router/tokenSaver.spec.ts`
- Reproduced the reported ModelBest Anthropic gateway failure: the judge request returned HTTP 400 because `temperature` is deprecated for `claude-opus-4-8`; the updated request classifies successfully.