### PR TITLE
fix(ui): recover from stale dynamic chunks

### DIFF
--- a/ui/public/sw.js
+++ b/ui/public/sw.js
@@ -4,7 +4,7 @@
 // Bump this token whenever a cached asset's contents change (icons, manifest).
 // The activate handler below purges every cache whose name doesn't match,
 // so existing PWAs pick up the new visuals on the next page load.
-const CACHE_NAME = 'politdeck-v1';
+const CACHE_NAME = 'pilotdeck-v2';
 const urlsToCache = [
   '/manifest.json'
 ];
@@ -18,7 +18,9 @@ self.addEventListener('install', event => {
   self.skipWaiting();
 });
 
-// Fetch event — network-first for everything except hashed assets
+// Fetch event — network-first. Hashed assets are safe to cache, but JS/CSS
+// chunks must still prefer the network so a long-lived desktop window does not
+// keep an old entry chunk that imports files removed by a newer build.
 self.addEventListener('fetch', event => {
   const url = event.request.url;
 
@@ -39,7 +41,23 @@ self.addEventListener('fetch', event => {
     return;
   }
 
-  // Hashed assets (JS/CSS in /assets/) — cache-first since filenames change per build
+  // Hashed JS/CSS chunks — network-first. If the app was rebuilt while the
+  // page stayed open, the old chunk may no longer exist; let the app-level
+  // dynamic import recovery reload into the fresh index.html.
+  if (url.includes('/assets/') && /\.(?:js|css)(?:\?|$)/.test(new URL(url).pathname)) {
+    event.respondWith(
+      fetch(event.request).then(response => {
+        if (response.ok) {
+          const clone = response.clone();
+          caches.open(CACHE_NAME).then(cache => cache.put(event.request, clone));
+        }
+        return response;
+      }).catch(() => caches.match(event.request))
+    );
+    return;
+  }
+
+  // Other hashed assets (fonts/images) — cache-first since filenames change per build
   if (url.includes('/assets/')) {
     event.respondWith(
       caches.match(event.request).then(cached => {

--- a/ui/src/main.jsx
+++ b/ui/src/main.jsx
@@ -7,6 +7,9 @@ import 'katex/dist/katex.min.css'
 
 // Initialize i18n
 import './i18n/config.js'
+import { registerDynamicImportReloadHandler } from './utils/reloadOnChunkError'
+
+registerDynamicImportReloadHandler();
 
 // Register service worker for PWA + Web Push support
 if ('serviceWorker' in navigator) {

--- a/ui/src/utils/reloadOnChunkError.test.ts
+++ b/ui/src/utils/reloadOnChunkError.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  clearDynamicImportReloadMarker,
+  isDynamicImportLoadError,
+  reloadOnceForDynamicImportError,
+} from './reloadOnChunkError';
+
+describe('dynamic import reload recovery', () => {
+  it('detects browser dynamic import fetch failures', () => {
+    expect(isDynamicImportLoadError(new TypeError('Failed to fetch dynamically imported module: http://127.0.0.1:3001/assets/index-51NXb8Tj.js'))).toBe(true);
+    expect(isDynamicImportLoadError(new Error('Loading chunk DashboardV2 failed.'))).toBe(true);
+    expect(isDynamicImportLoadError(new Error('ordinary application error'))).toBe(false);
+  });
+
+  it('reloads only once for a missing chunk', () => {
+    const win = createWindowStub();
+
+    expect(reloadOnceForDynamicImportError(new Error('Failed to fetch dynamically imported module'), win)).toBe(true);
+    expect(win.location.reload).toHaveBeenCalledTimes(1);
+
+    expect(reloadOnceForDynamicImportError(new Error('Failed to fetch dynamically imported module'), win)).toBe(false);
+    expect(win.location.reload).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears the reload marker after a successful load', () => {
+    const win = createWindowStub();
+
+    reloadOnceForDynamicImportError(new Error('Failed to fetch dynamically imported module'), win);
+    clearDynamicImportReloadMarker(win);
+
+    expect(reloadOnceForDynamicImportError(new Error('Failed to fetch dynamically imported module'), win)).toBe(true);
+    expect(win.location.reload).toHaveBeenCalledTimes(2);
+  });
+});
+
+function createWindowStub() {
+  const values = new Map<string, string>();
+  return {
+    sessionStorage: {
+      getItem: vi.fn((key: string) => values.get(key) ?? null),
+      setItem: vi.fn((key: string, value: string) => {
+        values.set(key, value);
+      }),
+      removeItem: vi.fn((key: string) => {
+        values.delete(key);
+      }),
+    },
+    location: {
+      reload: vi.fn(),
+    },
+  } as unknown as Pick<Window, 'sessionStorage' | 'location'>;
+}

--- a/ui/src/utils/reloadOnChunkError.ts
+++ b/ui/src/utils/reloadOnChunkError.ts
@@ -1,0 +1,77 @@
+const RELOAD_MARKER = 'pilotdeck:chunk-load-reloaded';
+
+const CHUNK_ERROR_PATTERNS = [
+  /failed to fetch dynamically imported module/i,
+  /importing a module script failed/i,
+  /error loading dynamically imported module/i,
+  /loading chunk \S+ failed/i,
+  /chunkloaderror/i,
+  /unable to preload css/i,
+];
+
+export function isDynamicImportLoadError(error: unknown): boolean {
+  const message = errorToText(error);
+  return CHUNK_ERROR_PATTERNS.some((pattern) => pattern.test(message));
+}
+
+export function reloadOnceForDynamicImportError(
+  error: unknown,
+  win: Pick<Window, 'sessionStorage' | 'location'> = window,
+): boolean {
+  if (!isDynamicImportLoadError(error)) return false;
+
+  try {
+    if (win.sessionStorage.getItem(RELOAD_MARKER) === '1') return false;
+    win.sessionStorage.setItem(RELOAD_MARKER, '1');
+  } catch {
+    // If sessionStorage is unavailable, still try one recovery reload.
+  }
+
+  win.location.reload();
+  return true;
+}
+
+export function clearDynamicImportReloadMarker(win: Pick<Window, 'sessionStorage'> = window): void {
+  try {
+    win.sessionStorage.removeItem(RELOAD_MARKER);
+  } catch {
+    // Ignore storage access failures.
+  }
+}
+
+export function registerDynamicImportReloadHandler(win: Window = window): () => void {
+  const onPreloadError = (event: Event) => {
+    const preloadEvent = event as Event & { payload?: unknown };
+    if (reloadOnceForDynamicImportError(preloadEvent.payload, win)) {
+      event.preventDefault();
+    }
+  };
+
+  const onUnhandledRejection = (event: PromiseRejectionEvent) => {
+    if (reloadOnceForDynamicImportError(event.reason, win)) {
+      event.preventDefault();
+    }
+  };
+
+  const onLoad = () => clearDynamicImportReloadMarker(win);
+
+  win.addEventListener('vite:preloadError', onPreloadError);
+  win.addEventListener('unhandledrejection', onUnhandledRejection);
+  win.addEventListener('load', onLoad, { once: true });
+
+  return () => {
+    win.removeEventListener('vite:preloadError', onPreloadError);
+    win.removeEventListener('unhandledrejection', onUnhandledRejection);
+    win.removeEventListener('load', onLoad);
+  };
+}
+
+function errorToText(error: unknown): string {
+  if (error instanceof Error) return `${error.name}: ${error.message}`;
+  if (typeof error === 'string') return error;
+  if (error && typeof error === 'object') {
+    const maybeMessage = (error as { message?: unknown }).message;
+    if (typeof maybeMessage === 'string') return maybeMessage;
+  }
+  return String(error ?? '');
+}


### PR DESCRIPTION
## Summary
- reload once when Vite/dynamic imports fail because an old frontend entry points at removed hashed chunks
- update the service worker so JS/CSS chunks are network-first while other hashed assets remain cache-first
- add focused coverage for dynamic import/chunk load error detection

## Test Plan
- `pnpm --dir ui exec vitest run src/utils/reloadOnChunkError.test.ts`
- `node --check ui/public/sw.js`
- `git diff --check origin/main...HEAD`
- `rg -n "^(<<<<<<<|=======|>>>>>>>)( |$)"`
- `pnpm --dir ui run build`

Note: local install/build emitted the existing Node engine warning because this machine is on Node v25.5.0 while the repo requests Node >=22.13.0 <23; the UI build still passed.