### PR TITLE
fix(chat): preserve active session state when gateway status is unavailable

### DIFF
--- a/ui/server/pilotdeck-bridge.js
+++ b/ui/server/pilotdeck-bridge.js
@@ -1396,32 +1396,31 @@ export function isSessionActiveViaGateway(sessionId) {
     return Boolean(sessionState.get(sessionId)?.active);
 }
 
+export function getFallbackSessionActivity(localState) {
+    const isProcessing = localState?.active === true ? true : null;
+    return {
+        isProcessing,
+        activeRunId: isProcessing && typeof localState?.runId === 'string'
+            ? localState.runId
+            : null,
+        activeTurnMessages: [],
+    };
+}
+
 export async function getSessionActivityViaGateway(sessionId, provider = 'pilotdeck', includeActiveTurnMessages = true) {
     if (!isPilotDeckSessionKey(sessionId)) {
         return { isProcessing: false, activeRunId: null, activeTurnMessages: [] };
     }
 
     const localState = sessionState.get(sessionId);
-    const localIsProcessing = Boolean(localState?.active);
-    const localActiveRunId = localIsProcessing && typeof localState?.runId === 'string'
-        ? localState.runId
-        : null;
     try {
         const gw = await ensureGateway();
         if (typeof gw.getActiveTurnSnapshot !== 'function') {
-            return {
-                isProcessing: localIsProcessing,
-                activeRunId: localActiveRunId,
-                activeTurnMessages: [],
-            };
+            return getFallbackSessionActivity(localState);
         }
         const snapshot = await gw.getActiveTurnSnapshot({ sessionKey: sessionId, includeEvents: includeActiveTurnMessages });
         if (!snapshot || typeof snapshot.active !== 'boolean') {
-            return {
-                isProcessing: localIsProcessing,
-                activeRunId: localActiveRunId,
-                activeTurnMessages: [],
-            };
+            return getFallbackSessionActivity(localState);
         }
         return {
             isProcessing: snapshot.active,
@@ -1434,11 +1433,7 @@ export async function getSessionActivityViaGateway(sessionId, provider = 'pilotd
         };
     } catch (error) {
         console.warn('[pilotdeck-bridge] failed to read active turn snapshot:', error?.message || error);
-        return {
-            isProcessing: localIsProcessing,
-            activeRunId: localActiveRunId,
-            activeTurnMessages: [],
-        };
+        return getFallbackSessionActivity(localState);
     }
 }
 

--- a/ui/server/pilotdeck-bridge.js
+++ b/ui/server/pilotdeck-bridge.js
@@ -1397,10 +1397,9 @@ export function isSessionActiveViaGateway(sessionId) {
 }
 
 export function getFallbackSessionActivity(localState) {
-    const isProcessing = localState?.active === true ? true : null;
     return {
-        isProcessing,
-        activeRunId: isProcessing && typeof localState?.runId === 'string'
+        isProcessing: null,
+        activeRunId: localState?.active === true && typeof localState?.runId === 'string'
             ? localState.runId
             : null,
         activeTurnMessages: [],
@@ -1433,6 +1432,9 @@ export async function getSessionActivityViaGateway(sessionId, provider = 'pilotd
         };
     } catch (error) {
         console.warn('[pilotdeck-bridge] failed to read active turn snapshot:', error?.message || error);
+        if (isGatewayUnavailableError(error)) {
+            resetGatewayConnection();
+        }
         return getFallbackSessionActivity(localState);
     }
 }

--- a/ui/server/pilotdeck-bridge.js
+++ b/ui/server/pilotdeck-bridge.js
@@ -187,6 +187,8 @@ const WEB_DEFAULT_PERMISSION_MODE =
 // ESM rewriting on fresh installs.
 /** @type {ReturnType<typeof createRemoteGateway> | null} */
 let gatewayPromise = null;
+/** @type {Awaited<ReturnType<typeof createRemoteGateway>> | null} */
+let gatewayInstance = null;
 
 async function readGatewayToken() {
     try {
@@ -230,19 +232,31 @@ async function connectWithRetry() {
 
 function ensureGateway() {
     if (!gatewayPromise) {
-        gatewayPromise = connectWithRetry().catch((error) => {
-            // Reset so the next caller retries instead of cementing the
-            // failure forever. The deadline inside connectWithRetry()
-            // already bounds individual attempts.
-            gatewayPromise = null;
-            throw error;
-        });
+        const pending = connectWithRetry()
+            .then((gateway) => {
+                if (gatewayPromise === pending) {
+                    gatewayInstance = gateway;
+                }
+                return gateway;
+            })
+            .catch((error) => {
+                // Reset only if this failed attempt is still current. A newer
+                // caller may already have started a replacement connection.
+                if (gatewayPromise === pending) {
+                    gatewayPromise = null;
+                    gatewayInstance = null;
+                }
+                throw error;
+            });
+        gatewayPromise = pending;
     }
     return gatewayPromise;
 }
 
-function resetGatewayConnection() {
+function resetGatewayConnection(expectedGateway) {
+    if (expectedGateway && gatewayInstance !== expectedGateway) return;
     gatewayPromise = null;
+    gatewayInstance = null;
 }
 
 export function isGatewayUnavailableError(error) {
@@ -1274,8 +1288,8 @@ export async function runChatViaGateway(
     } catch (error) {
         const rawMessage = error instanceof Error ? error.message : String(error);
         const gatewayUnavailable = !gw || isGatewayUnavailableError(error);
-        if (gatewayUnavailable) {
-            resetGatewayConnection();
+        if (gatewayUnavailable && gw) {
+            resetGatewayConnection(gw);
         }
         const message = gatewayUnavailable ? 'PilotDeck gateway is unavailable.' : rawMessage;
         const statusEvent = gatewayUnavailable
@@ -1412,8 +1426,9 @@ export async function getSessionActivityViaGateway(sessionId, provider = 'pilotd
     }
 
     const localState = sessionState.get(sessionId);
+    let gw = null;
     try {
-        const gw = await ensureGateway();
+        gw = await ensureGateway();
         if (typeof gw.getActiveTurnSnapshot !== 'function') {
             return getFallbackSessionActivity(localState);
         }
@@ -1432,8 +1447,8 @@ export async function getSessionActivityViaGateway(sessionId, provider = 'pilotd
         };
     } catch (error) {
         console.warn('[pilotdeck-bridge] failed to read active turn snapshot:', error?.message || error);
-        if (isGatewayUnavailableError(error)) {
-            resetGatewayConnection();
+        if (gw && isGatewayUnavailableError(error)) {
+            resetGatewayConnection(gw);
         }
         return getFallbackSessionActivity(localState);
     }

--- a/ui/server/pilotdeck-bridge.test.js
+++ b/ui/server/pilotdeck-bridge.test.js
@@ -3,9 +3,33 @@ import { describe, expect, it } from 'vitest';
 import {
     createAlwaysOnTurnEventForwarder,
     gatewayEventToFrames,
+    getFallbackSessionActivity,
     isGatewayUnavailableError,
     isTerminalAlwaysOnTurnEvent,
 } from './pilotdeck-bridge.js';
+
+describe('session activity fallback', () => {
+    it('preserves a locally known active run when the gateway snapshot is unavailable', () => {
+        expect(getFallbackSessionActivity({ active: true, runId: 'run-local' })).toEqual({
+            isProcessing: true,
+            activeRunId: 'run-local',
+            activeTurnMessages: [],
+        });
+    });
+
+    it('reports unknown instead of false when local state cannot prove inactivity', () => {
+        expect(getFallbackSessionActivity(undefined)).toEqual({
+            isProcessing: null,
+            activeRunId: null,
+            activeTurnMessages: [],
+        });
+        expect(getFallbackSessionActivity({ active: false, runId: undefined })).toEqual({
+            isProcessing: null,
+            activeRunId: null,
+            activeTurnMessages: [],
+        });
+    });
+});
 
 describe('gatewayEventToFrames agent status errors', () => {
     it('maps tool result detail availability to a mergeable tool_result frame', () => {
@@ -262,6 +286,7 @@ describe('Always-On turn notification forwarding', () => {
         expect(forwarded.filter(({ frame }) => frame.kind === 'session_created')).toHaveLength(2);
         expect(forwarded.find(({ frame }) => frame.kind === 'error')?.frame).toMatchObject({
             code: 'agent_aborted',
+            terminal: true,
         });
     });
 

--- a/ui/server/pilotdeck-bridge.test.js
+++ b/ui/server/pilotdeck-bridge.test.js
@@ -9,9 +9,9 @@ import {
 } from './pilotdeck-bridge.js';
 
 describe('session activity fallback', () => {
-    it('preserves a locally known active run when the gateway snapshot is unavailable', () => {
+    it('reports unknown while preserving a locally known run id', () => {
         expect(getFallbackSessionActivity({ active: true, runId: 'run-local' })).toEqual({
-            isProcessing: true,
+            isProcessing: null,
             activeRunId: 'run-local',
             activeTurnMessages: [],
         });

--- a/ui/src/components/chat-v2/ChatInterfaceV2.tsx
+++ b/ui/src/components/chat-v2/ChatInterfaceV2.tsx
@@ -301,7 +301,8 @@ function ChatInterfaceV2({
     // loading indicator, Stop button, and active turn replay reflect reality
     // after reconnect. The session-status handler consumes activeTurnMessages
     // and dedupes replay chunks against existing realtime state.
-    sendMessage(buildReconnectStatusMessage(selectedSession.id, activeRunId));
+    const statusMessage = buildReconnectStatusMessage(selectedSession.id, activeRunId);
+    if (statusMessage) sendMessage(statusMessage);
   }, [
     activeRunId,
     isLoading,

--- a/ui/src/components/chat-v2/reconnectRecovery.ts
+++ b/ui/src/components/chat-v2/reconnectRecovery.ts
@@ -1,4 +1,4 @@
-import { buildSessionStatusRequest } from '../chat/sessionStatusProtocol';
+import { buildSessionStatusRequestIfIdle } from '../chat/sessionStatusProtocol';
 
 export function shouldRefreshSessionOnReconnect({
   isLoading,
@@ -13,7 +13,7 @@ export function shouldRefreshSessionOnReconnect({
 }
 
 export function buildReconnectStatusMessage(sessionId: string, expectedActiveRunId: string | null) {
-  return buildSessionStatusRequest({
+  return buildSessionStatusRequestIfIdle({
     sessionId,
     provider: 'pilotdeck',
     expectedActiveRunId,

--- a/ui/src/components/chat/hooks/useChatRealtimeHandlers.test.tsx
+++ b/ui/src/components/chat/hooks/useChatRealtimeHandlers.test.tsx
@@ -325,7 +325,8 @@ describe('useChatRealtimeHandlers terminal errors', () => {
     expect(setActiveRunId).toHaveBeenLastCalledWith(null);
   });
 
-  it('keeps active UI state while session activity is unknown', () => {
+  it('keeps active UI state and retries while session activity is unknown', () => {
+    vi.useFakeTimers();
     const sessionStore = createSessionStore();
     const setSessionRuntimeState = vi.fn();
     const setIsLoading = vi.fn();
@@ -333,7 +334,7 @@ describe('useChatRealtimeHandlers terminal errors', () => {
     const setActiveRunId = vi.fn();
     const onSessionInactive = vi.fn();
     const onSessionNotProcessing = vi.fn();
-    renderHook(() => useChatRealtimeHandlers({
+    const { unmount } = renderHook(() => useChatRealtimeHandlers({
       provider,
       selectedProject: { name: 'project', fullPath: '/tmp/project' } as unknown as Project,
       selectedSession: { id: 'cron:task-1' } as unknown as ProjectSession,
@@ -371,6 +372,21 @@ describe('useChatRealtimeHandlers terminal errors', () => {
     expect(setCanAbortSession).not.toHaveBeenCalled();
     expect(onSessionInactive).not.toHaveBeenCalled();
     expect(onSessionNotProcessing).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(1200);
+    });
+    expect(mocks.sendMessage).toHaveBeenCalledWith({
+      type: 'check-session-status',
+      sessionId: 'cron:task-1',
+      provider: 'pilotdeck',
+      expectedActiveRunId: 'run-current',
+      includeActiveTurnMessages: true,
+      statusRequestId: 1,
+    });
+
+    unmount();
+    vi.useRealTimers();
   });
 
   it('ignores an inactive status response requested for a superseded run', () => {

--- a/ui/src/components/chat/hooks/useChatRealtimeHandlers.test.tsx
+++ b/ui/src/components/chat/hooks/useChatRealtimeHandlers.test.tsx
@@ -389,6 +389,44 @@ describe('useChatRealtimeHandlers terminal errors', () => {
     vi.useRealTimers();
   });
 
+  it('does not keep retrying an unknown status after the session is no longer active', () => {
+    vi.useFakeTimers();
+    const sessionStore = createSessionStore();
+    const { unmount } = renderHook(() => useChatRealtimeHandlers({
+      provider,
+      selectedProject: { name: 'project', fullPath: '/tmp/project' } as unknown as Project,
+      selectedSession: { id: 'cron:task-2' } as unknown as ProjectSession,
+      currentSessionId: 'cron:task-2',
+      setCurrentSessionId: noop,
+      setIsLoading: noop,
+      setSessionRuntimeState: noop,
+      activeRunId: null,
+      setActiveRunId: noop,
+      setCanAbortSession: noop,
+      setIsAborting: noop,
+      setClaudeStatus: noop,
+      setPilotDeckStatus: noop,
+      setTokenBudget: noop,
+      setPendingPermissionRequests: noop,
+      pendingViewSessionRef: { current: null },
+      sessionStore,
+    }));
+
+    act(() => {
+      mocks.listener?.({
+        type: 'session-status',
+        sessionId: 'cron:task-1',
+        isProcessing: null,
+      });
+      vi.advanceTimersByTime(1200);
+    });
+
+    expect(mocks.sendMessage).not.toHaveBeenCalled();
+
+    unmount();
+    vi.useRealTimers();
+  });
+
   it('ignores an inactive status response requested for a superseded run', () => {
     const sessionStore = createSessionStore();
     const setSessionRuntimeState = vi.fn();
@@ -584,5 +622,71 @@ describe('useChatRealtimeHandlers terminal errors', () => {
     expect(setSessionRuntimeState).not.toHaveBeenCalledWith('running');
     expect(setActiveRunId).toHaveBeenCalledTimes(1);
     expect(setActiveRunId).toHaveBeenCalledWith(null);
+  });
+
+  it('ignores an older inactive response even when it arrives before the latest response', () => {
+    const sessionStore = createSessionStore();
+    const setActiveRunId = vi.fn();
+    const setSessionRuntimeState = vi.fn();
+    renderHook(() => useChatRealtimeHandlers({
+      provider,
+      selectedProject: { name: 'project', fullPath: '/tmp/project' } as unknown as Project,
+      selectedSession: { id: 'cron:task-1' } as unknown as ProjectSession,
+      currentSessionId: 'cron:task-1',
+      setCurrentSessionId: noop,
+      setIsLoading: noop,
+      setSessionRuntimeState,
+      activeRunId: 'run-current',
+      setActiveRunId,
+      setCanAbortSession: noop,
+      setIsAborting: noop,
+      setClaudeStatus: noop,
+      setPilotDeckStatus: noop,
+      setTokenBudget: noop,
+      setPendingPermissionRequests: noop,
+      pendingViewSessionRef: { current: null },
+      sessionStore,
+    }));
+    const olderRequest = buildSessionStatusRequest({
+      sessionId: 'cron:task-1',
+      provider,
+      expectedActiveRunId: 'run-current',
+      includeActiveTurnMessages: false,
+    });
+    const latestRequest = buildSessionStatusRequest({
+      sessionId: 'cron:task-1',
+      provider,
+      expectedActiveRunId: 'run-current',
+      includeActiveTurnMessages: false,
+    });
+
+    act(() => {
+      mocks.listener?.({
+        type: 'session-status',
+        sessionId: 'cron:task-1',
+        statusRequestId: olderRequest.statusRequestId,
+        expectedActiveRunId: 'run-current',
+        isProcessing: false,
+      });
+    });
+
+    expect(sessionStore.cancelRunningActivities).not.toHaveBeenCalled();
+    expect(setSessionRuntimeState).not.toHaveBeenCalledWith('inactive');
+    expect(setActiveRunId).not.toHaveBeenCalledWith(null);
+
+    act(() => {
+      mocks.listener?.({
+        type: 'session-status',
+        sessionId: 'cron:task-1',
+        statusRequestId: latestRequest.statusRequestId,
+        expectedActiveRunId: 'run-current',
+        isProcessing: true,
+        activeRunId: 'run-current',
+      });
+    });
+
+    expect(sessionStore.cancelRunningActivities).not.toHaveBeenCalled();
+    expect(setSessionRuntimeState).toHaveBeenLastCalledWith('running');
+    expect(setActiveRunId).toHaveBeenLastCalledWith('run-current');
   });
 });

--- a/ui/src/components/chat/hooks/useChatRealtimeHandlers.test.tsx
+++ b/ui/src/components/chat/hooks/useChatRealtimeHandlers.test.tsx
@@ -2,7 +2,6 @@ import { act, renderHook } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Project, ProjectSession, SessionProvider } from '../../../types/app';
 import type { SessionStore } from '../../../stores/useSessionStore';
-import { createAlwaysOnTurnEventForwarder } from '../../../../server/pilotdeck-bridge.js';
 import {
   buildSessionStatusRequest,
   resetSessionStatusProtocolForTests,
@@ -46,7 +45,7 @@ describe('useChatRealtimeHandlers terminal errors', () => {
     });
   });
 
-  it('cancels running subagents when the bridge forwards agent_aborted', () => {
+  it('cancels running subagents for a terminal agent_aborted frame', () => {
     const sessionStore = createSessionStore();
     const setSessionRuntimeState = vi.fn();
     renderHook(() => useChatRealtimeHandlers({
@@ -70,18 +69,12 @@ describe('useChatRealtimeHandlers terminal errors', () => {
     }));
 
     act(() => {
-      const forward = createAlwaysOnTurnEventForwarder((_sessionId, frame) => {
-        mocks.listener?.(frame);
-      });
-      forward('always-on:turn-event', {
-        sessionKey: 'cron:task-1',
-        channelKey: 'cron',
-        event: {
-          type: 'error',
-          code: 'agent_aborted',
-          message: 'The run was stopped.',
-          recoverable: true,
-        },
+      mocks.listener?.({
+        kind: 'error',
+        sessionId: 'cron:task-1',
+        code: 'agent_aborted',
+        content: 'The run was stopped.',
+        terminal: true,
       });
     });
 
@@ -330,6 +323,54 @@ describe('useChatRealtimeHandlers terminal errors', () => {
     expect(sessionStore.cancelRunningActivities).toHaveBeenCalledWith('cron:task-1');
     expect(setSessionRuntimeState).toHaveBeenLastCalledWith('inactive');
     expect(setActiveRunId).toHaveBeenLastCalledWith(null);
+  });
+
+  it('keeps active UI state while session activity is unknown', () => {
+    const sessionStore = createSessionStore();
+    const setSessionRuntimeState = vi.fn();
+    const setIsLoading = vi.fn();
+    const setCanAbortSession = vi.fn();
+    const setActiveRunId = vi.fn();
+    const onSessionInactive = vi.fn();
+    const onSessionNotProcessing = vi.fn();
+    renderHook(() => useChatRealtimeHandlers({
+      provider,
+      selectedProject: { name: 'project', fullPath: '/tmp/project' } as unknown as Project,
+      selectedSession: { id: 'cron:task-1' } as unknown as ProjectSession,
+      currentSessionId: 'cron:task-1',
+      setCurrentSessionId: noop,
+      setIsLoading,
+      setSessionRuntimeState,
+      activeRunId: 'run-current',
+      setActiveRunId,
+      setCanAbortSession,
+      setIsAborting: noop,
+      setClaudeStatus: noop,
+      setPilotDeckStatus: noop,
+      setTokenBudget: noop,
+      setPendingPermissionRequests: noop,
+      pendingViewSessionRef: { current: null },
+      onSessionInactive,
+      onSessionNotProcessing,
+      sessionStore,
+    }));
+
+    act(() => {
+      mocks.listener?.({
+        type: 'session-status',
+        sessionId: 'cron:task-1',
+        expectedActiveRunId: 'run-current',
+        isProcessing: null,
+      });
+    });
+
+    expect(setSessionRuntimeState).toHaveBeenLastCalledWith('synchronizing');
+    expect(sessionStore.cancelRunningActivities).not.toHaveBeenCalled();
+    expect(setActiveRunId).not.toHaveBeenCalled();
+    expect(setIsLoading).not.toHaveBeenCalled();
+    expect(setCanAbortSession).not.toHaveBeenCalled();
+    expect(onSessionInactive).not.toHaveBeenCalled();
+    expect(onSessionNotProcessing).not.toHaveBeenCalled();
   });
 
   it('ignores an inactive status response requested for a superseded run', () => {

--- a/ui/src/components/chat/hooks/useChatRealtimeHandlers.ts
+++ b/ui/src/components/chat/hooks/useChatRealtimeHandlers.ts
@@ -43,7 +43,7 @@ type LatestChatMessage = {
   toolId?: string;
   result?: any;
   exitCode?: number;
-  isProcessing?: boolean;
+  isProcessing?: boolean | null;
   activeRunId?: string | null;
   expectedActiveRunId?: string | null;
   statusRequestId?: number | null;
@@ -504,6 +504,12 @@ export function useChatRealtimeHandlers({
               setSessionRuntimeState('running');
               setIsLoading(true);
               setCanAbortSession(true);
+            }
+            return;
+          }
+          if (msg.isProcessing === null) {
+            if (isCurrentSession) {
+              setSessionRuntimeState('synchronizing');
             }
             return;
           }

--- a/ui/src/components/chat/hooks/useChatRealtimeHandlers.ts
+++ b/ui/src/components/chat/hooks/useChatRealtimeHandlers.ts
@@ -352,12 +352,42 @@ export function useChatRealtimeHandlers({
   const thinkingBySessionRef = useRef<Map<string, boolean>>(new Map());
   // Dedup volatile active-turn replay chunks across reconnect/status polls.
   const activeTurnReplaySignatureRef = useRef<Map<string, string>>(new Map());
+  const sessionStatusRetryTimersRef = useRef<Map<string, number>>(new Map());
   const activeRunIdRef = useRef<string | null>(activeRunId);
   activeRunIdRef.current = activeRunId;
   const updateActiveRunId = useCallback((runId: string | null) => {
     activeRunIdRef.current = runId;
     setActiveRunId(runId);
   }, [setActiveRunId]);
+  const clearSessionStatusRetry = useCallback((sessionId: string) => {
+    const timer = sessionStatusRetryTimersRef.current.get(sessionId);
+    if (timer === undefined) return;
+    window.clearTimeout(timer);
+    sessionStatusRetryTimersRef.current.delete(sessionId);
+  }, []);
+  const scheduleSessionStatusRetry = useCallback((
+    sessionId: string,
+    expectedActiveRunId: string | null,
+  ) => {
+    if (sessionStatusRetryTimersRef.current.has(sessionId)) return;
+    const timer = window.setTimeout(() => {
+      sessionStatusRetryTimersRef.current.delete(sessionId);
+      sendMessage(buildSessionStatusRequest({
+        sessionId,
+        provider,
+        expectedActiveRunId,
+        includeActiveTurnMessages: true,
+      }));
+    }, 1200);
+    sessionStatusRetryTimersRef.current.set(sessionId, timer);
+  }, [provider, sendMessage]);
+
+  useEffect(() => () => {
+    for (const timer of sessionStatusRetryTimersRef.current.values()) {
+      window.clearTimeout(timer);
+    }
+    sessionStatusRetryTimersRef.current.clear();
+  }, []);
 
   const handleMessage = useCallback((latestMessage: LatestChatMessage, fallbackSessionId?: string | null) => {
     if (!latestMessage) return;
@@ -372,7 +402,7 @@ export function useChatRealtimeHandlers({
     /*  Legacy messages (no `kind` field) — handle and return           */
     /* ---------------------------------------------------------------- */
 
-    const msg = latestMessage as any;
+    const msg: LatestChatMessage = latestMessage;
     const clearAccumulators = () => {
       thinkingBySessionRef.current.clear();
     };
@@ -383,6 +413,10 @@ export function useChatRealtimeHandlers({
       switch (messageType) {
         case 'websocket-reconnected':
           clearAccumulators();
+          for (const timer of sessionStatusRetryTimersRef.current.values()) {
+            window.clearTimeout(timer);
+          }
+          sessionStatusRetryTimersRef.current.clear();
           if (activeViewSessionId) {
             invalidateSessionStatusResponses(activeViewSessionId);
           }
@@ -409,6 +443,16 @@ export function useChatRealtimeHandlers({
             && msg.expectedActiveRunId !== activeRunIdRef.current
           ) {
             return;
+          }
+          if (msg.isProcessing === null) {
+            scheduleSessionStatusRetry(
+              statusSessionId,
+              typeof msg.expectedActiveRunId === 'string' && msg.expectedActiveRunId.trim()
+                ? msg.expectedActiveRunId.trim()
+                : null,
+            );
+          } else {
+            clearSessionStatusRetry(statusSessionId);
           }
           const statusActiveRunId = getSessionStatusActiveRunId(msg);
 
@@ -756,6 +800,7 @@ export function useChatRealtimeHandlers({
       case 'complete': {
         if (isTerminalForSupersededRun) break;
         if (sid) {
+          clearSessionStatusRetry(sid);
           invalidateSessionStatusResponses(sid);
           activeTurnReplaySignatureRef.current.delete(sid);
           // Finalize both thinking and content streams
@@ -859,6 +904,7 @@ export function useChatRealtimeHandlers({
         }
         if (isTerminalForSupersededRun) break;
         if (sid) {
+          clearSessionStatusRetry(sid);
           invalidateSessionStatusResponses(sid);
           sessionStore.cancelRunningActivities(sid);
         }
@@ -881,14 +927,15 @@ export function useChatRealtimeHandlers({
       }
 
       case 'permission_request': {
-        if (!msg.requestId) break;
+        const requestId = msg.requestId;
+        if (!requestId) break;
         const isForCurrentSession = isForActiveView;
         if (!isForCurrentSession) break;
         onSessionProcessing?.(sid);
         setPendingPermissionRequests((prev) => {
-          if (prev.some((r: PendingPermissionRequest) => r.requestId === msg.requestId)) return prev;
+          if (prev.some((r: PendingPermissionRequest) => r.requestId === requestId)) return prev;
           return [...prev, {
-            requestId: msg.requestId,
+            requestId,
             toolName: msg.toolName || 'UnknownTool',
             input: msg.input,
             context: msg.context,
@@ -912,16 +959,17 @@ export function useChatRealtimeHandlers({
       }
 
       case 'status': {
+        if (msg.text === 'started' && msgRunId) {
+          clearSessionStatusRetry(sid);
+          invalidateSessionStatusResponses(sid);
+          if (isForActiveView) {
+            updateActiveRunId(msgRunId);
+          }
+        }
         if (msg.text && msg.text !== 'token_budget' && msg.text !== 'clear_status') {
           onSessionProcessing?.(sid);
         }
         if (!isForActiveView) break;
-        if (msg.text === 'started' && msgRunId) {
-          if (activeRunIdRef.current !== msgRunId) {
-            invalidateSessionStatusResponses(sid);
-          }
-          updateActiveRunId(msgRunId);
-        }
         if (msg.text === 'token_budget' && msg.tokenBudget) {
           setTokenBudget(msg.tokenBudget as Record<string, unknown>);
         } else if (msg.text === 'clear_status') {
@@ -969,6 +1017,8 @@ export function useChatRealtimeHandlers({
   }, [
     provider,
     sendMessage,
+    clearSessionStatusRetry,
+    scheduleSessionStatusRetry,
     selectedSession,
     currentSessionId,
     setCurrentSessionId,

--- a/ui/src/components/chat/hooks/useChatRealtimeHandlers.ts
+++ b/ui/src/components/chat/hooks/useChatRealtimeHandlers.ts
@@ -15,7 +15,7 @@ import {
 } from '../../../stores/useSessionStore';
 import { useWebSocket } from '../../../contexts/WebSocketContext';
 import {
-  buildSessionStatusRequest,
+  buildSessionStatusRequestIfIdle,
   invalidateSessionStatusResponses,
   shouldAcceptSessionStatusResponse,
 } from '../sessionStatusProtocol';
@@ -372,12 +372,13 @@ export function useChatRealtimeHandlers({
     if (sessionStatusRetryTimersRef.current.has(sessionId)) return;
     const timer = window.setTimeout(() => {
       sessionStatusRetryTimersRef.current.delete(sessionId);
-      sendMessage(buildSessionStatusRequest({
+      const request = buildSessionStatusRequestIfIdle({
         sessionId,
         provider,
         expectedActiveRunId,
         includeActiveTurnMessages: true,
-      }));
+      });
+      if (request) sendMessage(request);
     }, 1200);
     sessionStatusRetryTimersRef.current.set(sessionId, timer);
   }, [provider, sendMessage]);
@@ -444,7 +445,7 @@ export function useChatRealtimeHandlers({
           ) {
             return;
           }
-          if (msg.isProcessing === null) {
+          if (msg.isProcessing === null && isCurrentSession) {
             scheduleSessionStatusRetry(
               statusSessionId,
               typeof msg.expectedActiveRunId === 'string' && msg.expectedActiveRunId.trim()
@@ -894,12 +895,13 @@ export function useChatRealtimeHandlers({
             setSessionRuntimeState('synchronizing');
           }
           invalidateSessionStatusResponses(sid);
-          sendMessage(buildSessionStatusRequest({
+          const request = buildSessionStatusRequestIfIdle({
             sessionId: sid,
             provider,
             expectedActiveRunId: activeRunIdRef.current,
             includeActiveTurnMessages: true,
-          }));
+          });
+          if (request) sendMessage(request);
           break;
         }
         if (isTerminalForSupersededRun) break;

--- a/ui/src/components/chat/hooks/useChatSessionState.ts
+++ b/ui/src/components/chat/hooks/useChatSessionState.ts
@@ -18,7 +18,7 @@ import type { SessionStore, NormalizedMessage } from '../../../stores/useSession
 import { parseUserAttachmentNote } from '../utils/attachmentNotes';
 import { createCachedDiffCalculator, type DiffCalculator } from '../utils/messageTransforms';
 import {
-  buildSessionStatusRequest,
+  buildSessionStatusRequestIfIdle,
   invalidateSessionStatusResponses,
 } from '../sessionStatusProtocol';
 import { normalizedToChatMessages } from './useChatMessages';
@@ -798,12 +798,13 @@ export function useChatSessionState({
     // Check session status
     if (ws && !sessionIsReadOnly) {
       invalidateSessionStatusResponses(selectedSession.id);
-      sendMessage(buildSessionStatusRequest({
+      const request = buildSessionStatusRequestIfIdle({
         sessionId: selectedSession.id,
         provider,
         expectedActiveRunId: activeRunIdRef.current,
         includeActiveTurnMessages: true,
-      }));
+      });
+      if (request) sendMessage(request);
     }
 
     lastLoadedSessionKeyRef.current = sessionKey;
@@ -1096,12 +1097,13 @@ export function useChatSessionState({
     if (!ws || ws.readyState !== WebSocket.OPEN) return;
 
     const requestStatus = () => {
-      sendMessage(buildSessionStatusRequest({
+      const request = buildSessionStatusRequestIfIdle({
         sessionId: activeViewSessionId,
         provider: 'pilotdeck',
         expectedActiveRunId: activeRunIdRef.current,
         includeActiveTurnMessages: false,
-      }));
+      });
+      if (request) sendMessage(request);
     };
 
     requestStatus();

--- a/ui/src/components/chat/sessionStatusProtocol.spec.ts
+++ b/ui/src/components/chat/sessionStatusProtocol.spec.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  buildSessionStatusRequest,
+  buildSessionStatusRequestIfIdle,
+  invalidateSessionStatusResponses,
+  resetSessionStatusProtocolForTests,
+  shouldAcceptSessionStatusResponse,
+} from './sessionStatusProtocol';
+
+const options = {
+  sessionId: 'session-1',
+  provider: 'pilotdeck',
+  expectedActiveRunId: 'run-1',
+  includeActiveTurnMessages: true,
+};
+
+describe('session status request sequencing', () => {
+  beforeEach(() => {
+    resetSessionStatusProtocolForTests();
+    vi.useRealTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('keeps only one request in flight per session', () => {
+    const request = buildSessionStatusRequestIfIdle(options);
+
+    expect(request).not.toBeNull();
+    expect(buildSessionStatusRequestIfIdle(options)).toBeNull();
+    expect(shouldAcceptSessionStatusResponse('session-1', request?.statusRequestId)).toBe(true);
+    expect(buildSessionStatusRequestIfIdle(options)?.statusRequestId).toBe(2);
+  });
+
+  it('rejects an invalidated response after a newer request is issued', () => {
+    const olderRequest = buildSessionStatusRequest(options);
+    invalidateSessionStatusResponses('session-1');
+    const latestRequest = buildSessionStatusRequestIfIdle(options);
+
+    expect(latestRequest?.statusRequestId).toBe(2);
+    expect(shouldAcceptSessionStatusResponse('session-1', olderRequest.statusRequestId)).toBe(false);
+    expect(shouldAcceptSessionStatusResponse('session-1', latestRequest?.statusRequestId)).toBe(true);
+  });
+
+  it('replaces a request that has received no response within the stale timeout', () => {
+    vi.useFakeTimers();
+    const olderRequest = buildSessionStatusRequestIfIdle(options);
+
+    vi.advanceTimersByTime(15_000);
+    const latestRequest = buildSessionStatusRequestIfIdle(options);
+
+    expect(latestRequest?.statusRequestId).toBe(2);
+    expect(shouldAcceptSessionStatusResponse('session-1', olderRequest?.statusRequestId)).toBe(false);
+    expect(shouldAcceptSessionStatusResponse('session-1', latestRequest?.statusRequestId)).toBe(true);
+  });
+});

--- a/ui/src/components/chat/sessionStatusProtocol.ts
+++ b/ui/src/components/chat/sessionStatusProtocol.ts
@@ -7,12 +7,14 @@ type SessionStatusRequestOptions = {
 
 type SessionStatusSequence = {
   latestIssued: number;
+  latestIssuedAt: number;
   invalidThrough: number;
   lastHandled: number;
 };
 
 const statusSequenceBySession = new Map<string, SessionStatusSequence>();
 let nextStatusRequestId = 0;
+const STATUS_REQUEST_STALE_AFTER_MS = 15_000;
 
 function getOrCreateStatusSequence(sessionId: string): SessionStatusSequence {
   const existing = statusSequenceBySession.get(sessionId);
@@ -20,6 +22,7 @@ function getOrCreateStatusSequence(sessionId: string): SessionStatusSequence {
 
   const created = {
     latestIssued: 0,
+    latestIssuedAt: 0,
     invalidThrough: 0,
     lastHandled: 0,
   };
@@ -36,6 +39,7 @@ export function buildSessionStatusRequest({
   nextStatusRequestId += 1;
   const sequence = getOrCreateStatusSequence(sessionId);
   sequence.latestIssued = nextStatusRequestId;
+  sequence.latestIssuedAt = Date.now();
 
   return {
     type: 'check-session-status',
@@ -45,6 +49,19 @@ export function buildSessionStatusRequest({
     includeActiveTurnMessages,
     statusRequestId: nextStatusRequestId,
   };
+}
+
+export function buildSessionStatusRequestIfIdle(options: SessionStatusRequestOptions) {
+  const sequence = getOrCreateStatusSequence(options.sessionId);
+  const hasPendingRequest = sequence.latestIssued > sequence.invalidThrough
+    && sequence.latestIssued > sequence.lastHandled;
+  if (hasPendingRequest && Date.now() - sequence.latestIssuedAt < STATUS_REQUEST_STALE_AFTER_MS) {
+    return null;
+  }
+  if (hasPendingRequest) {
+    sequence.invalidThrough = Math.max(sequence.invalidThrough, sequence.latestIssued);
+  }
+  return buildSessionStatusRequest(options);
 }
 
 export function shouldAcceptSessionStatusResponse(
@@ -61,7 +78,7 @@ export function shouldAcceptSessionStatusResponse(
 
   const requestId = statusRequestId as number;
   if (
-    requestId > sequence.latestIssued
+    requestId !== sequence.latestIssued
     || requestId <= sequence.invalidThrough
     || requestId <= sequence.lastHandled
   ) {


### PR DESCRIPTION
## Summary

Follow-up fix for #482.

- Represent an unavailable Gateway activity snapshot as `unknown` instead of incorrectly reporting the session as inactive.
- Keep the UI in `synchronizing` state when activity is unknown.
- Preserve active subagents, the current run ID, loading state, and Stop capability until inactivity is authoritatively confirmed.
- Remove the frontend test’s cross-layer import of the backend bridge.
- Add separate frontend and backend contract coverage for session status and terminal abort frames.

## Problem

After the UI server restarts, its local session state may be empty while a turn is still running in the Gateway.

If the active-turn snapshot request fails, the previous fallback returned `isProcessing: false`. The frontend treated this as confirmed inactivity, cancelled running subagent activities, cleared the active run, and disabled the Stop button.

## Solution

The bridge now returns `isProcessing: null` when neither the Gateway snapshot nor local state can authoritatively determine inactivity.

The frontend handles this value as an unknown state and remains synchronizing without mutating the active run state. Only an explicit `isProcessing: false` response is allowed to mark the session inactive.

## Validation

- Targeted frontend and backend tests: 27 passed
- Backend build: passed
- UI production build: passed
- Changed-file ESLint: passed
- Backend regression suite excluding the existing `network/fetch.spec` cancellation issue: 226 passed
- Removed the two `replaceAll` TypeScript errors introduced by the previous cross-layer test import