### PR TITLE
feat: add OrcaRouter as a named OpenAI-compatible provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,6 +421,25 @@ model:
       apiKey: sk-your-api-key
 ```
 
+[OrcaRouter](https://www.orcarouter.ai) exposes 150+ models from OpenAI, Anthropic,
+Google, DeepSeek, Qwen, MiniMax and others behind a single OpenAI-compatible
+endpoint. Use `orcarouter/auto` to auto-route each request, or a namespaced id
+such as `anthropic/claude-sonnet-4.6`:
+
+```yaml
+schemaVersion: 1
+agent:
+  model: orcarouter/auto
+model:
+  providers:
+    orcarouter:
+      protocol: openai
+      url: https://api.orcarouter.ai/v1
+      apiKey: ${ORCAROUTER_API_KEY}
+      models:
+        orcarouter/auto: {}
+```
+
 Native Gemini can be configured with `protocol: google`:
 
 ```yaml

--- a/README.zh.md
+++ b/README.zh.md
@@ -420,6 +420,22 @@ model:
       apiKey: sk-your-api-key
 ```
 
+[OrcaRouter](https://www.orcarouter.ai) 通过单个 OpenAI 兼容端点提供来自 OpenAI、Anthropic、Google、DeepSeek、Qwen、MiniMax 等的 150+ 模型。使用 `orcarouter/auto` 自动路由每个请求，或使用带命名空间的模型 ID（如 `anthropic/claude-sonnet-4.6`）：
+
+```yaml
+schemaVersion: 1
+agent:
+  model: orcarouter/auto
+model:
+  providers:
+    orcarouter:
+      protocol: openai
+      url: https://api.orcarouter.ai/v1
+      apiKey: ${ORCAROUTER_API_KEY}
+      models:
+        orcarouter/auto: {}
+```
+
 原生 Gemini 可以使用 `protocol: google`：
 
 ```yaml

--- a/src/model/catalog/providers.ts
+++ b/src/model/catalog/providers.ts
@@ -1141,6 +1141,14 @@ export const PROVIDER_CATALOG: ProviderCatalog = {
     models: {},
   },
 
+  orcarouter: {
+    displayName: "OrcaRouter",
+    protocol: "openai",
+    defaultUrl: "https://api.orcarouter.ai/v1",
+    apiKeyEnvVar: "ORCAROUTER_API_KEY",
+    models: {},
+  },
+
   ollama: {
     displayName: "Ollama",
     protocol: "openai",

--- a/tests/model/config/parseModelConfig.spec.ts
+++ b/tests/model/config/parseModelConfig.spec.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import { parseModelConfig } from "../../../src/model/config/parseModelConfig.js";
+import { buildProviderChatEndpoint } from "../../../src/model/providerEndpoint.js";
 
 test("catalog provider resolves api key from default env var when apiKey is omitted", () => {
   const config = parseModelConfig({
@@ -110,4 +111,27 @@ test("catalog model aliases keep their declared provider image capability", () =
     config.providers.openai.models["gpt-4o-2024-11-20"].multimodal.input,
     ["text", "image"],
   );
+});
+
+test("orcarouter catalog provider resolves default URL, protocol and env api key", () => {
+  const config = parseModelConfig({
+    providers: {
+      orcarouter: {
+        models: { "orcarouter/fusion": {} },
+      },
+    },
+  }, { env: { ORCAROUTER_API_KEY: "sk-orca-test" } });
+
+  assert.equal(config.providers.orcarouter.url, "https://api.orcarouter.ai/v1");
+  assert.equal(config.providers.orcarouter.protocol, "openai");
+  assert.equal(config.providers.orcarouter.apiKey, "sk-orca-test");
+});
+
+test("orcarouter chat endpoint is built from the gateway base URL", () => {
+  const endpoint = buildProviderChatEndpoint({
+    protocol: "openai",
+    baseUrl: "https://api.orcarouter.ai/v1",
+  });
+
+  assert.equal(endpoint, "https://api.orcarouter.ai/v1/chat/completions");
 });

--- a/ui/src/shared/catalogProviders.test.ts
+++ b/ui/src/shared/catalogProviders.test.ts
@@ -56,4 +56,20 @@ describe('catalogProviders maxOutputTokens', () => {
     expect(ollama?.models.find((model) => model.id === 'qwen3:0.6b')?.maxContextTokens).toBe(40_960);
     expect(ollama?.models.find((model) => model.id === 'llama3.1:8b')?.maxOutputTokens).toBe(8_192);
   });
+
+  it('exposes OrcaRouter as an OpenAI-compatible gateway provider', () => {
+    const orcarouter = findCatalogProviderById('orcarouter');
+
+    expect(orcarouter?.protocol).toBe('openai');
+    expect(orcarouter?.defaultUrl).toBe('https://api.orcarouter.ai/v1');
+    expect(orcarouter?.modelListUrl).toBe('https://api.orcarouter.ai/v1/models');
+    expect(orcarouter?.modelListRequiresApiKey).toBe(true);
+    expect(orcarouter?.models.map((model) => model.id)).toEqual([
+      'orcarouter/fusion',
+      'orcarouter/auto',
+      'anthropic/claude-sonnet-4.6',
+      'deepseek/deepseek-v4-pro',
+      'google/gemini-2.5-pro',
+    ]);
+  });
 });

--- a/ui/src/shared/catalogProviders.ts
+++ b/ui/src/shared/catalogProviders.ts
@@ -126,6 +126,21 @@ export const CATALOG_PROVIDERS: CatalogProvider[] = [
     ],
   },
   {
+    id: 'orcarouter',
+    displayName: 'OrcaRouter',
+    protocol: 'openai',
+    defaultUrl: 'https://api.orcarouter.ai/v1',
+    modelListUrl: 'https://api.orcarouter.ai/v1/models',
+    modelListRequiresApiKey: true,
+    models: [
+      { id: 'orcarouter/fusion', displayName: 'OrcaRouter Fusion', maxContextTokens: 200000 },
+      { id: 'orcarouter/auto', displayName: 'OrcaRouter Auto', maxContextTokens: 200000 },
+      { id: 'anthropic/claude-sonnet-4.6', displayName: 'Claude Sonnet 4.6', supportsImage: true, maxContextTokens: 200000 },
+      { id: 'deepseek/deepseek-v4-pro', displayName: 'DeepSeek V4 Pro', maxContextTokens: 1048576 },
+      { id: 'google/gemini-2.5-pro', displayName: 'Gemini 2.5 Pro', supportsImage: true, maxContextTokens: 1048576 },
+    ],
+  },
+  {
     id: 'ollama',
     displayName: 'Ollama',
     protocol: 'openai',


### PR DESCRIPTION
Adds [OrcaRouter](https://www.orcarouter.ai) as a named provider. With one API key, users get 150+ models from OpenAI, Anthropic, Google, DeepSeek, Qwen, MiniMax and xAI behind a single endpoint. Because the provider catalog entry is a thin base-URL swap, any PilotDeck pipeline/agent that uses it also inherits OrcaRouter's gateway-level, zero-trust security controls for AI agents — with no application code changes. The gateway screens every prompt and response and governs every tool call on a default-deny basis, across four layers:

- **Scoped keys** — bind a key to specific models, IPs, spend caps, and expiry.
- **Guardrails** — screen for PII, secret leakage, prompt injection, and unsafe output.
- **Agent firewall** — tool allow-lists with per-argument validation.
- **Audit trail** — a record of every match, verdict, and approval decision.

I'm an engineer on the OrcaRouter team.

## Summary

Registers OrcaRouter as a first-class, named OpenAI-compatible provider, mirroring the existing OpenRouter aggregator entry so the onboarding/settings provider picker, model-config resolution and docs stay consistent. With a single `ORCAROUTER_API_KEY` (keys start with `sk-orca-`) users can pick `orcarouter/auto` (auto-routes each request) or namespaced ids such as `anthropic/claude-sonnet-4.6` against `https://api.orcarouter.ai/v1`.

## Changes

- `src/model/catalog/providers.ts` — engine catalog entry: `orcarouter` (`protocol: openai`, default URL `https://api.orcarouter.ai/v1`, `ORCAROUTER_API_KEY`), so `parseModelConfig` resolves URL/protocol/env key like the built-in providers.
- `ui/src/shared/catalogProviders.ts` — UI mirror entry with `modelListUrl: https://api.orcarouter.ai/v1/models` (dynamic model list) and a few curated model examples.
- `tests/model/config/parseModelConfig.spec.ts` — 2 tests: catalog default resolution + chat endpoint construction.
- `ui/src/shared/catalogProviders.test.ts` — 1 test for the UI provider entry.
- `README.md` / `README.zh.md` — OrcaRouter config example (`orcarouter/auto` + namespaced ids).

The endpoint plumbing needs no changes: `protocol: "openai"` already builds `/chat/completions` and `/models` from the base URL, and OrcaRouter accepts both auto-routing and `vendor/model` namespaced ids.

## Verification

| Check | Command | Result |
|-------|---------|--------|
| Engine model tests | `tsx --test tests/model/**/*.spec.ts` | ✅ 21 passed (incl. 2 new OrcaRouter tests) |
| UI provider catalog tests | `vitest run src/shared/catalogProviders.test.ts` | ✅ 5 passed (incl. 1 new OrcaRouter test) |
| Type check (changed files) | `tsc --noEmit` (engine + ui) | ✅ no errors in changed files |
| Live models list | `GET https://api.orcarouter.ai/v1/models` | ✅ 200, 205 models |
| Live chat completion (`orcarouter/auto`) | `POST https://api.orcarouter.ai/v1/chat/completions` | ✅ 200, replied `ORCA-OK` |
| Live chat completion (`anthropic/claude-sonnet-4.6`) | `POST https://api.orcarouter.ai/v1/chat/completions` | ✅ 200, replied `ORCA-OK` |
