### PR TITLE
fix(session): retain large attachment conversations

### DIFF
--- a/src/agent/session/AgentSession.ts
+++ b/src/agent/session/AgentSession.ts
@@ -14,6 +14,7 @@ import {
 } from "./AgentSessionState.js";
 import type { AgentTranscriptWriterState } from "../../session/transcript/TranscriptWriter.js";
 import type { AgentLoopSeedState } from "../loop/AgentLoop.js";
+import type { SessionMetadataValue } from "../../session/transcript/TranscriptEntry.js";
 
 export type AgentSessionOptions = {
   sessionId: string;
@@ -32,6 +33,7 @@ export type AgentSessionRuntimeReloadSnapshot = {
   transcriptPath: string;
   transcriptWriterState?: AgentTranscriptWriterState;
   fileState?: AgentLoopSeedState;
+  metadata?: SessionMetadataValue;
 };
 
 export class AgentSession {
@@ -129,6 +131,7 @@ export class AgentSession {
       transcriptPath: runtime.runtimeContext.transcriptPath,
       transcriptWriterState: runtime.transcriptWriterState,
       fileState: this.options.turnRunner.snapshotFileState(),
+      metadata: runtime.metadata,
     };
   }
 

--- a/src/agent/turn/TurnRunner.ts
+++ b/src/agent/turn/TurnRunner.ts
@@ -11,6 +11,7 @@ import type { LifecycleRuntime } from "../../lifecycle/index.js";
 import type { PermissionMode, PermissionRuleSet } from "../../permission/index.js";
 import type { AgentStatusMessageInput, AgentTranscriptWriterState } from "../../session/transcript/TranscriptWriter.js";
 import type { SessionMetadataStore } from "../../session/metadata/SessionMetadataStore.js";
+import type { SessionMetadataValue } from "../../session/transcript/TranscriptEntry.js";
 import type { SessionTitleGenerator } from "../../session/title/SessionTitleGenerator.js";
 import { createVisibleErrorStatusDetail } from "../../status/agentStatus.js";
 import { FileArtifactCollector, type FileArtifact } from "../../session/artifacts/index.js";
@@ -51,6 +52,7 @@ export type TurnRunnerRuntimeContext = {
 export type TurnRunnerRuntimeReloadSnapshot = {
   runtimeContext: TurnRunnerRuntimeContext;
   transcriptWriterState?: AgentTranscriptWriterState;
+  metadata?: SessionMetadataValue;
 };
 
 export type TurnRunnerDependencies = {
@@ -283,6 +285,7 @@ export class TurnRunner {
     return {
       runtimeContext: { ...this.runtimeContext },
       transcriptWriterState: this.transcript.snapshotState?.(),
+      metadata: this.turnDependencies.metadataStore?.getSnapshot(),
     };
   }
 

--- a/src/agent/turn/TurnRunner.ts
+++ b/src/agent/turn/TurnRunner.ts
@@ -161,6 +161,7 @@ export class TurnRunner {
         }
         const status = await this.recordTurnFailureStatus(options, error);
         yield this.toAgentStatusEvent(options, status);
+        await this.finalizeSessionMetadata(options);
         yield { type: "turn_failed", sessionId: options.sessionId, turnId: options.turnId, error };
         yield { type: "turn_completed", sessionId: options.sessionId, turnId: options.turnId, result };
         return { result, messages };
@@ -182,7 +183,7 @@ export class TurnRunner {
         }
         const status = await this.recordTurnFailureStatus(options, error);
         yield this.toAgentStatusEvent(options, status);
-        await this.flushReadySessionTitle(options, sessionTitle);
+        await this.finalizeSessionMetadata(options, sessionTitle);
         yield { type: "turn_failed", sessionId: options.sessionId, turnId: options.turnId, error };
         yield { type: "turn_completed", sessionId: options.sessionId, turnId: options.turnId, result };
         return { result, messages };
@@ -253,7 +254,7 @@ export class TurnRunner {
           yield turnCompletedEvent;
         }
         await this.transcript.recordTurnResult(options.sessionId, options.turnId, runResult.result);
-        await this.flushReadySessionTitle(options, sessionTitle);
+        await this.finalizeSessionMetadata(options, sessionTitle);
         return runResult;
       } catch (error) {
         const normalized = normalizeAgentError(error);
@@ -265,7 +266,7 @@ export class TurnRunner {
         await Promise.resolve(this.transcript.recordTurnResult(options.sessionId, options.turnId, result)).catch(() => {});
         const status = await this.recordTurnFailureStatus(options, normalized);
         yield this.toAgentStatusEvent(options, status);
-        await this.flushReadySessionTitle(options, sessionTitle);
+        await this.finalizeSessionMetadata(options, sessionTitle);
         yield { type: "turn_failed", sessionId: options.sessionId, turnId: options.turnId, error: normalized };
         yield { type: "turn_completed", sessionId: options.sessionId, turnId: options.turnId, result };
         return { result, messages };
@@ -420,6 +421,14 @@ export class TurnRunner {
       return;
     }
     await metadataStore.saveAiTitle(pending.title, options.turnId);
+  }
+
+  private async finalizeSessionMetadata(
+    options: TurnRunnerOptions,
+    pending?: PendingSessionTitle,
+  ): Promise<void> {
+    await this.flushReadySessionTitle(options, pending);
+    await this.turnDependencies.metadataStore?.reappendTail(options.turnId).catch(() => {});
   }
 }
 

--- a/src/agent/turn/TurnRunner.ts
+++ b/src/agent/turn/TurnRunner.ts
@@ -442,15 +442,12 @@ export class TurnRunner {
     if (!metadataStore) return;
 
     const snapshot = metadataStore.getSnapshot();
-    if (snapshot.title || snapshot.aiTitle || snapshot.firstPrompt || snapshot.lastPrompt) {
-      return;
-    }
     const prompt = allHumanText(acceptedMessages);
     if (!prompt) return;
 
     const boundedPrompt = prompt.slice(0, SESSION_LISTING_PROMPT_MAX_CHARS);
     await metadataStore.record(options.turnId, {
-      firstPrompt: boundedPrompt,
+      ...(snapshot.firstPrompt ? {} : { firstPrompt: boundedPrompt }),
       lastPrompt: boundedPrompt,
       updatedAt: this.now().toISOString(),
     }).catch(() => {});

--- a/src/agent/turn/TurnRunner.ts
+++ b/src/agent/turn/TurnRunner.ts
@@ -68,6 +68,8 @@ type PendingSessionTitle = {
   promise: Promise<void>;
 };
 
+const SESSION_LISTING_PROMPT_MAX_CHARS = 1_200;
+
 export class TurnRunner {
   private pendingSessionTitle: PendingSessionTitle | undefined;
 
@@ -150,6 +152,7 @@ export class TurnRunner {
       yield { type: "user_prompt_submitted", sessionId: options.sessionId, turnId: options.turnId, prompt };
       if (userPromptHooks?.effects.some((effect) => effect.type === "block")) {
         const error = agentError("agent_unsupported_feature", "UserPromptSubmit hook blocked model execution.");
+        await this.persistListingPromptMetadata(options, accepted.messages);
         const result = this.createErrorResult(
           options,
           error,
@@ -429,6 +432,28 @@ export class TurnRunner {
   ): Promise<void> {
     await this.flushReadySessionTitle(options, pending);
     await this.turnDependencies.metadataStore?.reappendTail(options.turnId).catch(() => {});
+  }
+
+  private async persistListingPromptMetadata(
+    options: TurnRunnerOptions,
+    acceptedMessages: CanonicalMessage[],
+  ): Promise<void> {
+    const metadataStore = this.turnDependencies.metadataStore;
+    if (!metadataStore) return;
+
+    const snapshot = metadataStore.getSnapshot();
+    if (snapshot.title || snapshot.aiTitle || snapshot.firstPrompt || snapshot.lastPrompt) {
+      return;
+    }
+    const prompt = allHumanText(acceptedMessages);
+    if (!prompt) return;
+
+    const boundedPrompt = prompt.slice(0, SESSION_LISTING_PROMPT_MAX_CHARS);
+    await metadataStore.record(options.turnId, {
+      firstPrompt: boundedPrompt,
+      lastPrompt: boundedPrompt,
+      updatedAt: this.now().toISOString(),
+    }).catch(() => {});
   }
 }
 

--- a/src/agent/turn/TurnRunner.ts
+++ b/src/agent/turn/TurnRunner.ts
@@ -135,6 +135,7 @@ export class TurnRunner {
         return { result, messages: options.messages };
       }
 
+      await this.persistListingPromptMetadata(options, accepted.messages);
       yield { type: "input_accepted", sessionId: options.sessionId, turnId: options.turnId, messages: accepted.messages };
 
       const prompt = inputToPromptText(options.input);
@@ -152,7 +153,6 @@ export class TurnRunner {
       yield { type: "user_prompt_submitted", sessionId: options.sessionId, turnId: options.turnId, prompt };
       if (userPromptHooks?.effects.some((effect) => effect.type === "block")) {
         const error = agentError("agent_unsupported_feature", "UserPromptSubmit hook blocked model execution.");
-        await this.persistListingPromptMetadata(options, accepted.messages);
         const result = this.createErrorResult(
           options,
           error,

--- a/src/cli/createLocalGateway.ts
+++ b/src/cli/createLocalGateway.ts
@@ -1021,6 +1021,7 @@ class ProjectRuntimeRegistry {
       transcript: storage.transcript,
       initialState: previous.state,
       seedState: previous.fileState,
+      initialMetadata: previous.metadata,
       sessionTitleGenerator: prepared.sessionTitleGenerator,
       collectFileArtifacts: this.shouldCollectFileArtifacts(prepared.runtime),
     });

--- a/src/session/metadata/SessionMetadataStore.ts
+++ b/src/session/metadata/SessionMetadataStore.ts
@@ -73,7 +73,7 @@ export class SessionMetadataStore {
     await this.options.transcript.recordSessionMetadata(
       this.options.sessionId,
       turnId,
-      { ...snapshot, updatedAt: this.now().toISOString() },
+      { ...snapshot, isSnapshot: true, updatedAt: this.now().toISOString() },
     );
   }
 

--- a/src/session/search/searchChatHistory.ts
+++ b/src/session/search/searchChatHistory.ts
@@ -4,8 +4,7 @@ import { join, resolve } from "node:path";
 import { createInterface } from "node:readline";
 import { getPilotProjectChatDir } from "../../pilot/paths.js";
 import { sanitizeSessionIdForPath } from "../storage/ProjectSessionStorage.js";
-import { parseSessionInfoFromLite, type SessionInfo } from "../storage/SessionList.js";
-import { readSessionLite } from "../storage/SessionLiteReader.js";
+import { readSessionInfo, type SessionInfo } from "../storage/SessionList.js";
 
 const ALWAYS_ON_AUXILIARY_PATTERN = /^always-on-(discovery|workspace|report)[:\-]/;
 const DEFAULT_LIMIT = 20;
@@ -283,9 +282,7 @@ async function buildSessionTitleIndex(files: SessionFileTarget[]): Promise<Map<s
   await Promise.all(files.map(async (file) => {
     const sessionId = file.path.split(/[\\/]/).pop()?.replace(/\.jsonl$/, "");
     if (!sessionId) return;
-    const lite = await readSessionLite(file.path);
-    if (!lite) return;
-    const info = parseSessionInfoFromLite(sessionId, lite, file.projectKey);
+    const info = await readSessionInfo(file.path, sessionId, file.projectKey);
     if (!info) return;
     titles.set(`${file.projectKey ?? ""}:${sessionId}`, formatSessionTitle(info));
   }));

--- a/src/session/storage/SessionList.ts
+++ b/src/session/storage/SessionList.ts
@@ -125,7 +125,12 @@ function readLatestTailSnapshot(lite: SessionLiteFile): SessionMetadataValue | u
   // full snapshot, so ordinary trailing patches cannot skip title recovery.
   if (
     latestMetadata?.isSnapshot === true
-    && (latestMetadata.title?.trim() || latestMetadata.aiTitle?.trim())
+    && (
+      latestMetadata.title?.trim()
+      || latestMetadata.aiTitle?.trim()
+      || latestMetadata.lastPrompt?.trim()
+      || latestMetadata.firstPrompt?.trim()
+    )
   ) {
     return latestMetadata;
   }

--- a/src/session/storage/SessionList.ts
+++ b/src/session/storage/SessionList.ts
@@ -109,9 +109,10 @@ function hasCompleteLatestMetadata(lite: SessionLiteFile): boolean {
     if (!metadata) return false;
     latestMetadata = metadata;
   }
-  // Metadata records are patches. Only an actual title in the newest complete
-  // tail record proves that the fast path has the accumulated title state.
-  return Boolean(latestMetadata?.title?.trim() || latestMetadata?.aiTitle?.trim());
+  // Metadata records are patches. Only `reappendTail()` writes an explicit
+  // full snapshot, so ordinary trailing patches cannot skip title recovery.
+  return latestMetadata?.isSnapshot === true
+    && Boolean(latestMetadata.title?.trim() || latestMetadata.aiTitle?.trim());
 }
 
 export function parseSessionInfoFromLite(
@@ -338,6 +339,9 @@ function parseSessionMetadataLine(line: string): SessionMetadataValue | undefine
     }
     const metadata = entry.metadata;
     const parsed: SessionMetadataValue = {};
+    if (metadata.isSnapshot === true) {
+      parsed.isSnapshot = true;
+    }
     const stringFields = [
       "title",
       "aiTitle",

--- a/src/session/storage/SessionList.ts
+++ b/src/session/storage/SessionList.ts
@@ -2,7 +2,7 @@ import { open, readdir } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import { getPilotProjectChatDir } from "../../pilot/index.js";
 import { mergeMetadata } from "../metadata/SessionMetadataStore.js";
-import { readSessionLite, type SessionLiteFile } from "./SessionLiteReader.js";
+import { readSessionLite, SESSION_LITE_READ_BYTES, type SessionLiteFile } from "./SessionLiteReader.js";
 import type { SessionMetadataValue } from "../transcript/TranscriptEntry.js";
 
 const ALWAYS_ON_AUXILIARY_PATTERN = /^always-on-(discovery|workspace|report)[:\-]/;
@@ -75,11 +75,11 @@ export async function readSessionInfo(
   if (!lite) return null;
 
   const fastInfo = parseSessionInfoFromLite(sessionId, lite, projectRoot);
-  if (fastInfo?.customTitle || fastInfo?.aiTitle) return fastInfo;
+  if (fastInfo && hasCompleteLatestMetadata(lite)) return fastInfo;
 
   // Large inline media can make the first JSONL record exceed the 64 KiB
-  // preview. A prompt alone is not authoritative, so recover metadata when
-  // the fast path did not find a title.
+  // preview. Fall back unless the preview includes a complete latest metadata
+  // record; an older head title must not hide a newer oversized tail record.
   const metadata = await readLastSessionMetadata(path);
   const metadataInfo = metadata
     ? parseSessionInfoFromMetadata(sessionId, lite, metadata, projectRoot)
@@ -92,6 +92,23 @@ export async function readSessionInfo(
     firstPrompt: metadataInfo.firstPrompt ?? fastInfo.firstPrompt,
     createdAt: metadataInfo.createdAt ?? fastInfo.createdAt,
   };
+}
+
+function hasCompleteLatestMetadata(lite: SessionLiteFile): boolean {
+  if (lite.size <= SESSION_LITE_READ_BYTES) {
+    return true;
+  }
+
+  // The tail starts at an arbitrary byte offset, so its first line can be
+  // partial. Any complete metadata record after it is necessarily newer.
+  let foundMetadata = false;
+  const lines = lite.tail.split(/\r?\n/);
+  for (const line of lines.slice(1)) {
+    if (!line.includes('"type":"session_metadata"')) continue;
+    if (!parseSessionMetadataLine(line)) return false;
+    foundMetadata = true;
+  }
+  return foundMetadata;
 }
 
 export function parseSessionInfoFromLite(

--- a/src/session/storage/SessionList.ts
+++ b/src/session/storage/SessionList.ts
@@ -75,7 +75,12 @@ export async function readSessionInfo(
   if (!lite) return null;
 
   const fastInfo = parseSessionInfoFromLite(sessionId, lite, projectRoot);
-  if (fastInfo && hasCompleteLatestMetadata(lite)) return fastInfo;
+  if (fastInfo && lite.size <= SESSION_LITE_READ_BYTES) return fastInfo;
+  const tailSnapshot = readLatestTailSnapshot(lite);
+  if (tailSnapshot) {
+    const snapshotInfo = parseSessionInfoFromMetadata(sessionId, lite, tailSnapshot, projectRoot);
+    if (snapshotInfo) return mergeSessionInfo(fastInfo, snapshotInfo);
+  }
 
   // Large inline media can make the first JSONL record exceed the 64 KiB
   // preview. Fall back unless the preview includes a complete latest metadata
@@ -84,6 +89,13 @@ export async function readSessionInfo(
   const metadataInfo = metadata
     ? parseSessionInfoFromMetadata(sessionId, lite, metadata, projectRoot)
     : null;
+  return mergeSessionInfo(fastInfo, metadataInfo);
+}
+
+function mergeSessionInfo(
+  fastInfo: SessionInfo | null,
+  metadataInfo: SessionInfo | null,
+): SessionInfo | null {
   if (!metadataInfo) return fastInfo;
   if (!fastInfo) return metadataInfo;
   return {
@@ -94,9 +106,9 @@ export async function readSessionInfo(
   };
 }
 
-function hasCompleteLatestMetadata(lite: SessionLiteFile): boolean {
+function readLatestTailSnapshot(lite: SessionLiteFile): SessionMetadataValue | undefined {
   if (lite.size <= SESSION_LITE_READ_BYTES) {
-    return true;
+    return undefined;
   }
 
   // The tail starts at an arbitrary byte offset, so its first line can be
@@ -106,13 +118,18 @@ function hasCompleteLatestMetadata(lite: SessionLiteFile): boolean {
   for (const line of lines.slice(1)) {
     if (!line.includes('"type":"session_metadata"')) continue;
     const metadata = parseSessionMetadataLine(line);
-    if (!metadata) return false;
+    if (!metadata) return undefined;
     latestMetadata = metadata;
   }
   // Metadata records are patches. Only `reappendTail()` writes an explicit
   // full snapshot, so ordinary trailing patches cannot skip title recovery.
-  return latestMetadata?.isSnapshot === true
-    && Boolean(latestMetadata.title?.trim() || latestMetadata.aiTitle?.trim());
+  if (
+    latestMetadata?.isSnapshot === true
+    && (latestMetadata.title?.trim() || latestMetadata.aiTitle?.trim())
+  ) {
+    return latestMetadata;
+  }
+  return undefined;
 }
 
 export function parseSessionInfoFromLite(

--- a/src/session/storage/SessionList.ts
+++ b/src/session/storage/SessionList.ts
@@ -1,9 +1,12 @@
-import { readdir } from "node:fs/promises";
+import { open, readdir } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import { getPilotProjectChatDir } from "../../pilot/index.js";
 import { readSessionLite, type SessionLiteFile } from "./SessionLiteReader.js";
+import type { SessionMetadataValue } from "../transcript/TranscriptEntry.js";
 
 const ALWAYS_ON_AUXILIARY_PATTERN = /^always-on-(discovery|workspace|report)[:\-]/;
+const SESSION_METADATA_SCAN_CHUNK_BYTES = 64 * 1024;
+const MAX_SESSION_METADATA_LINE_BYTES = 128 * 1024;
 
 function isInternalSession(sessionId: string): boolean {
   return ALWAYS_ON_AUXILIARY_PATTERN.test(sessionId);
@@ -46,15 +49,11 @@ export async function listProjectSessions(options: ListProjectSessionsOptions): 
     if (!name.endsWith(".jsonl")) {
       continue;
     }
-    const lite = await readSessionLite(join(chatDir, name));
-    if (!lite) {
-      continue;
-    }
     const sessionId = name.slice(0, -".jsonl".length);
     if (!options.includeInternal && isInternalSession(sessionId)) {
       continue;
     }
-    const info = parseSessionInfoFromLite(sessionId, lite, options.projectRoot);
+    const info = await readSessionInfo(join(chatDir, name), sessionId, options.projectRoot);
     if (info) {
       sessions.push(info);
     }
@@ -64,6 +63,23 @@ export async function listProjectSessions(options: ListProjectSessionsOptions): 
   const offset = Math.max(0, options.offset ?? 0);
   const limit = options.limit ?? sessions.length;
   return sessions.slice(offset, limit === 0 ? undefined : offset + limit);
+}
+
+async function readSessionInfo(
+  path: string,
+  sessionId: string,
+  projectRoot?: string,
+): Promise<SessionInfo | null> {
+  const lite = await readSessionLite(path);
+  if (!lite) return null;
+
+  const fastInfo = parseSessionInfoFromLite(sessionId, lite, projectRoot);
+  if (fastInfo) return fastInfo;
+
+  // Large inline media can make the first JSONL record exceed the 64 KiB
+  // preview. Fall back only when the fast path cannot identify the session.
+  const metadata = await readLastSessionMetadata(path);
+  return metadata ? parseSessionInfoFromMetadata(sessionId, lite, metadata, projectRoot) : null;
 }
 
 export function parseSessionInfoFromLite(
@@ -187,6 +203,117 @@ function escapeRegExp(value: string): string {
   return value.replace(/[\\^$*+?.()|[\]{}]/g, "\\$&");
 }
 
+function parseSessionInfoFromMetadata(
+  sessionId: string,
+  lite: SessionLiteFile,
+  metadata: SessionMetadataValue,
+  projectRoot?: string,
+): SessionInfo | null {
+  const summary = metadata.title ?? metadata.aiTitle ?? metadata.lastPrompt ?? metadata.firstPrompt;
+  if (!summary?.trim()) return null;
+  return {
+    sessionId,
+    summary,
+    lastModified: lite.mtime,
+    fileSize: lite.size,
+    customTitle: metadata.title,
+    aiTitle: metadata.aiTitle,
+    firstPrompt: metadata.firstPrompt,
+    cwd: projectRoot,
+    tag: metadata.tag,
+    parentSessionId: metadata.parentSessionId,
+    forkedFromTurnId: metadata.forkedFromTurnId,
+  };
+}
+
+/**
+ * Scan only for strict session_metadata records while keeping oversized JSONL
+ * records (such as base64 image inputs) out of memory.
+ */
+async function readLastSessionMetadata(path: string): Promise<SessionMetadataValue | undefined> {
+  let handle: Awaited<ReturnType<typeof open>> | undefined;
+  try {
+    handle = await open(path, "r");
+    const buffer = Buffer.allocUnsafe(SESSION_METADATA_SCAN_CHUNK_BYTES);
+    let lastMetadata: SessionMetadataValue | undefined;
+    let lineChunks: Buffer[] = [];
+    let lineBytes = 0;
+    let lineTooLarge = false;
+
+    const append = (segment: Buffer): void => {
+      if (segment.length === 0) return;
+      lineBytes += segment.length;
+      if (lineTooLarge || lineBytes > MAX_SESSION_METADATA_LINE_BYTES) {
+        lineChunks = [];
+        lineTooLarge = true;
+        return;
+      }
+      lineChunks.push(segment);
+    };
+
+    const finishLine = (): void => {
+      if (!lineTooLarge) {
+        const metadata = parseSessionMetadataLine(Buffer.concat(lineChunks).toString("utf8").replace(/\r$/, ""));
+        if (metadata) lastMetadata = metadata;
+      }
+      lineChunks = [];
+      lineBytes = 0;
+      lineTooLarge = false;
+    };
+
+    let position = 0;
+    while (true) {
+      const { bytesRead } = await handle.read(buffer, 0, buffer.length, position);
+      if (bytesRead === 0) break;
+      position += bytesRead;
+
+      let start = 0;
+      for (let newline = buffer.indexOf(0x0a, start); newline !== -1 && newline < bytesRead; newline = buffer.indexOf(0x0a, start)) {
+        append(buffer.subarray(start, newline));
+        finishLine();
+        start = newline + 1;
+      }
+      append(buffer.subarray(start, bytesRead));
+    }
+    if (lineBytes > 0 || lineChunks.length > 0) finishLine();
+    return lastMetadata;
+  } catch {
+    return undefined;
+  } finally {
+    await handle?.close().catch(() => {});
+  }
+}
+
+function parseSessionMetadataLine(line: string): SessionMetadataValue | undefined {
+  if (!line.includes('"type":"session_metadata"')) return undefined;
+  try {
+    const entry = JSON.parse(line) as unknown;
+    if (!isRecord(entry) || entry.type !== "session_metadata" || !isRecord(entry.metadata)) {
+      return undefined;
+    }
+    const metadata = entry.metadata;
+    return {
+      title: stringValue(metadata.title),
+      aiTitle: stringValue(metadata.aiTitle),
+      tag: stringValue(metadata.tag),
+      firstPrompt: stringValue(metadata.firstPrompt),
+      lastPrompt: stringValue(metadata.lastPrompt),
+      parentSessionId: stringValue(metadata.parentSessionId),
+      forkedFromTurnId: stringValue(metadata.forkedFromTurnId),
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
 /** Options for listing sessions across all known projects. */
 export type ListAllSessionsOptions = {
   pilotHome: string;
@@ -224,9 +351,7 @@ export async function listAllSessions(options: ListAllSessionsOptions): Promise<
       if (!name.endsWith(".jsonl")) continue;
       const sessionId = name.slice(0, -".jsonl".length);
       if (!options.includeInternal && isInternalSession(sessionId)) continue;
-      const lite = await readSessionLite(join(chatDir, name));
-      if (!lite) continue;
-      const info = parseSessionInfoFromLite(sessionId, lite);
+      const info = await readSessionInfo(join(chatDir, name), sessionId);
       if (info) {
         info.cwd = projectId;
         all.push(info);
@@ -269,9 +394,7 @@ export async function searchSessionsByTitle(options: SearchSessionsByTitleOption
     if (!name.endsWith(".jsonl")) continue;
     const sessionId = name.slice(0, -".jsonl".length);
     if (!options.includeInternal && isInternalSession(sessionId)) continue;
-    const lite = await readSessionLite(join(chatDir, name));
-    if (!lite) continue;
-    const info = parseSessionInfoFromLite(sessionId, lite, options.projectRoot);
+    const info = await readSessionInfo(join(chatDir, name), sessionId, options.projectRoot);
     if (!info) continue;
     const haystack = [info.customTitle, info.aiTitle, info.firstPrompt]
       .filter(Boolean)

--- a/src/session/storage/SessionList.ts
+++ b/src/session/storage/SessionList.ts
@@ -101,14 +101,17 @@ function hasCompleteLatestMetadata(lite: SessionLiteFile): boolean {
 
   // The tail starts at an arbitrary byte offset, so its first line can be
   // partial. Any complete metadata record after it is necessarily newer.
-  let foundMetadata = false;
+  let latestMetadata: SessionMetadataValue | undefined;
   const lines = lite.tail.split(/\r?\n/);
   for (const line of lines.slice(1)) {
     if (!line.includes('"type":"session_metadata"')) continue;
-    if (!parseSessionMetadataLine(line)) return false;
-    foundMetadata = true;
+    const metadata = parseSessionMetadataLine(line);
+    if (!metadata) return false;
+    latestMetadata = metadata;
   }
-  return foundMetadata;
+  // Metadata records are patches. Only an actual title in the newest complete
+  // tail record proves that the fast path has the accumulated title state.
+  return Boolean(latestMetadata?.title?.trim() || latestMetadata?.aiTitle?.trim());
 }
 
 export function parseSessionInfoFromLite(
@@ -240,6 +243,7 @@ function parseSessionInfoFromMetadata(
 ): SessionInfo | null {
   const summary = metadata.title ?? metadata.aiTitle ?? metadata.lastPrompt ?? metadata.firstPrompt;
   if (!summary?.trim()) return null;
+  const firstCreatedAt = firstJsonStringField(lite.head, "createdAt");
   return {
     sessionId,
     summary,
@@ -249,6 +253,7 @@ function parseSessionInfoFromMetadata(
     aiTitle: metadata.aiTitle,
     firstPrompt: metadata.firstPrompt,
     cwd: projectRoot,
+    createdAt: firstCreatedAt ? Date.parse(firstCreatedAt) : undefined,
     tag: metadata.tag,
     parentSessionId: metadata.parentSessionId,
     forkedFromTurnId: metadata.forkedFromTurnId,

--- a/src/session/storage/SessionList.ts
+++ b/src/session/storage/SessionList.ts
@@ -65,7 +65,7 @@ export async function listProjectSessions(options: ListProjectSessionsOptions): 
   return sessions.slice(offset, limit === 0 ? undefined : offset + limit);
 }
 
-async function readSessionInfo(
+export async function readSessionInfo(
   path: string,
   sessionId: string,
   projectRoot?: string,
@@ -248,7 +248,7 @@ async function readLastSessionMetadata(path: string): Promise<SessionMetadataVal
         lineTooLarge = true;
         return;
       }
-      lineChunks.push(segment);
+      lineChunks.push(Buffer.from(segment));
     };
 
     const finishLine = (): void => {

--- a/src/session/storage/SessionList.ts
+++ b/src/session/storage/SessionList.ts
@@ -1,6 +1,7 @@
 import { open, readdir } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import { getPilotProjectChatDir } from "../../pilot/index.js";
+import { mergeMetadata } from "../metadata/SessionMetadataStore.js";
 import { readSessionLite, type SessionLiteFile } from "./SessionLiteReader.js";
 import type { SessionMetadataValue } from "../transcript/TranscriptEntry.js";
 
@@ -74,12 +75,23 @@ export async function readSessionInfo(
   if (!lite) return null;
 
   const fastInfo = parseSessionInfoFromLite(sessionId, lite, projectRoot);
-  if (fastInfo) return fastInfo;
+  if (fastInfo?.customTitle || fastInfo?.aiTitle) return fastInfo;
 
   // Large inline media can make the first JSONL record exceed the 64 KiB
-  // preview. Fall back only when the fast path cannot identify the session.
+  // preview. A prompt alone is not authoritative, so recover metadata when
+  // the fast path did not find a title.
   const metadata = await readLastSessionMetadata(path);
-  return metadata ? parseSessionInfoFromMetadata(sessionId, lite, metadata, projectRoot) : null;
+  const metadataInfo = metadata
+    ? parseSessionInfoFromMetadata(sessionId, lite, metadata, projectRoot)
+    : null;
+  if (!metadataInfo) return fastInfo;
+  if (!fastInfo) return metadataInfo;
+  return {
+    ...fastInfo,
+    ...metadataInfo,
+    firstPrompt: metadataInfo.firstPrompt ?? fastInfo.firstPrompt,
+    createdAt: metadataInfo.createdAt ?? fastInfo.createdAt,
+  };
 }
 
 export function parseSessionInfoFromLite(
@@ -239,11 +251,21 @@ async function readLastSessionMetadata(path: string): Promise<SessionMetadataVal
     let lineChunks: Buffer[] = [];
     let lineBytes = 0;
     let lineTooLarge = false;
+    let lineIsSessionMetadata = false;
 
     const append = (segment: Buffer): void => {
       if (segment.length === 0) return;
       lineBytes += segment.length;
-      if (lineTooLarge || lineBytes > MAX_SESSION_METADATA_LINE_BYTES) {
+      if (lineTooLarge) return;
+
+      // Transcript records serialize `type` first, so the initial buffered
+      // prefix identifies metadata before a large fork `firstPrompt` forces
+      // us past the normal per-line cap.
+      if (!lineIsSessionMetadata) {
+        const prefix = Buffer.concat([...lineChunks, segment]).toString("utf8");
+        lineIsSessionMetadata = prefix.includes('"type":"session_metadata"');
+      }
+      if (!lineIsSessionMetadata && lineBytes > MAX_SESSION_METADATA_LINE_BYTES) {
         lineChunks = [];
         lineTooLarge = true;
         return;
@@ -254,11 +276,12 @@ async function readLastSessionMetadata(path: string): Promise<SessionMetadataVal
     const finishLine = (): void => {
       if (!lineTooLarge) {
         const metadata = parseSessionMetadataLine(Buffer.concat(lineChunks).toString("utf8").replace(/\r$/, ""));
-        if (metadata) lastMetadata = metadata;
+        if (metadata) lastMetadata = mergeMetadata(lastMetadata ?? {}, metadata);
       }
       lineChunks = [];
       lineBytes = 0;
       lineTooLarge = false;
+      lineIsSessionMetadata = false;
     };
 
     let position = 0;
@@ -292,15 +315,23 @@ function parseSessionMetadataLine(line: string): SessionMetadataValue | undefine
       return undefined;
     }
     const metadata = entry.metadata;
-    return {
-      title: stringValue(metadata.title),
-      aiTitle: stringValue(metadata.aiTitle),
-      tag: stringValue(metadata.tag),
-      firstPrompt: stringValue(metadata.firstPrompt),
-      lastPrompt: stringValue(metadata.lastPrompt),
-      parentSessionId: stringValue(metadata.parentSessionId),
-      forkedFromTurnId: stringValue(metadata.forkedFromTurnId),
-    };
+    const parsed: SessionMetadataValue = {};
+    const stringFields = [
+      "title",
+      "aiTitle",
+      "tag",
+      "firstPrompt",
+      "lastPrompt",
+      "parentSessionId",
+      "forkedFromTurnId",
+    ] as const;
+    for (const field of stringFields) {
+      const value = stringValue(metadata[field]);
+      if (value !== undefined) {
+        parsed[field] = value;
+      }
+    }
+    return parsed;
   } catch {
     return undefined;
   }

--- a/src/session/transcript/TranscriptEntry.ts
+++ b/src/session/transcript/TranscriptEntry.ts
@@ -104,6 +104,8 @@ export type AgentControlBoundaryTranscriptEntry = AgentTranscriptEntryBase & {
 };
 
 export type SessionMetadataValue = {
+  /** Marks a metadata entry written by `reappendTail()` as a full snapshot. */
+  isSnapshot?: true;
   title?: string;
   aiTitle?: string;
   tag?: string;

--- a/tests/session/session-list-large-input.spec.ts
+++ b/tests/session/session-list-large-input.spec.ts
@@ -221,3 +221,38 @@ test("uses firstPrompt from a titled tail snapshot for title search", async () =
     await rm(pilotHome, { recursive: true, force: true });
   }
 });
+
+test("uses a prompt-only tail snapshot without requiring a generated title", async () => {
+  const projectRoot = await mkdtemp(join(tmpdir(), "pilotdeck-session-list-project-"));
+  const pilotHome = await mkdtemp(join(tmpdir(), "pilotdeck-session-list-home-"));
+  try {
+    const chatDir = getPilotProjectChatDir(projectRoot, pilotHome);
+    await mkdir(chatDir, { recursive: true });
+
+    const sessionId = "web:s_prompt-snapshot";
+    const largeInput = entry("accepted_input", sessionId, 1, {
+      messages: [{
+        role: "user",
+        content: [
+          { type: "text", text: "First prompt" },
+          { type: "image", source: "base64", data: "x".repeat(256 * 1024) },
+        ],
+      }],
+    });
+    const snapshot = entry("session_metadata", sessionId, 2, {
+      metadata: {
+        isSnapshot: true,
+        firstPrompt: "First prompt",
+        lastPrompt: "Latest prompt",
+      },
+    });
+    await writeFile(join(chatDir, `${sessionId}.jsonl`), `${JSON.stringify(largeInput)}\n${JSON.stringify(snapshot)}\n`);
+
+    const [session] = await listProjectSessions({ projectRoot, pilotHome });
+    assert.equal(session?.summary, "Latest prompt");
+    assert.equal(session?.firstPrompt, "First prompt");
+  } finally {
+    await rm(projectRoot, { recursive: true, force: true });
+    await rm(pilotHome, { recursive: true, force: true });
+  }
+});

--- a/tests/session/session-list-large-input.spec.ts
+++ b/tests/session/session-list-large-input.spec.ts
@@ -6,7 +6,7 @@ import { tmpdir } from "node:os";
 
 import { getPilotProjectChatDir } from "../../src/pilot/paths.js";
 import { searchChatHistory } from "../../src/session/search/searchChatHistory.js";
-import { listProjectSessions } from "../../src/session/storage/SessionList.js";
+import { listProjectSessions, searchSessionsByTitle } from "../../src/session/storage/SessionList.js";
 
 const NOW = "2026-08-16T09:00:00.000Z";
 
@@ -179,6 +179,43 @@ test("does not trust a trailing metadata patch as a full title snapshot", async 
 
     const [session] = await listProjectSessions({ projectRoot, pilotHome });
     assert.equal(session?.summary, "Recovered title");
+  } finally {
+    await rm(projectRoot, { recursive: true, force: true });
+    await rm(pilotHome, { recursive: true, force: true });
+  }
+});
+
+test("uses firstPrompt from a titled tail snapshot for title search", async () => {
+  const projectRoot = await mkdtemp(join(tmpdir(), "pilotdeck-session-list-project-"));
+  const pilotHome = await mkdtemp(join(tmpdir(), "pilotdeck-session-list-home-"));
+  try {
+    const chatDir = getPilotProjectChatDir(projectRoot, pilotHome);
+    await mkdir(chatDir, { recursive: true });
+
+    const sessionId = "web:s_tail-snapshot-prompt";
+    const originalPrompt = "Original presentation prompt";
+    const largeInput = entry("accepted_input", sessionId, 1, {
+      messages: [{
+        role: "user",
+        content: [
+          { type: "text", text: originalPrompt },
+          { type: "image", source: "base64", data: "x".repeat(256 * 1024) },
+        ],
+      }],
+    });
+    const snapshot = entry("session_metadata", sessionId, 2, {
+      metadata: {
+        isSnapshot: true,
+        aiTitle: "Titled snapshot",
+        firstPrompt: originalPrompt,
+        lastPrompt: originalPrompt,
+      },
+    });
+    await writeFile(join(chatDir, `${sessionId}.jsonl`), `${JSON.stringify(largeInput)}\n${JSON.stringify(snapshot)}\n`);
+
+    const sessions = await searchSessionsByTitle({ projectRoot, pilotHome, query: "original presentation" });
+    assert.deepEqual(sessions.map((session) => session.sessionId), [sessionId]);
+    assert.equal(sessions[0]?.firstPrompt, originalPrompt);
   } finally {
     await rm(projectRoot, { recursive: true, force: true });
     await rm(pilotHome, { recursive: true, force: true });

--- a/tests/session/session-list-large-input.spec.ts
+++ b/tests/session/session-list-large-input.spec.ts
@@ -22,7 +22,7 @@ test("lists historical sessions whose large inline image hides metadata from the
     await mkdir(chatDir, { recursive: true });
 
     const largeSessionId = "web:s_large-image";
-    const largeTitle = `Generated briefing ${"m".repeat(70 * 1024)}`;
+    const largeTitle = "Recovered PilotDeck session title";
     const largeInput = entry("accepted_input", largeSessionId, 1, {
       messages: [{
         role: "user",
@@ -33,14 +33,20 @@ test("lists historical sessions whose large inline image hides metadata from the
       }],
     });
     const largeMetadata = entry("session_metadata", largeSessionId, 2, {
-      metadata: { aiTitle: largeTitle },
+      metadata: { aiTitle: largeTitle, firstPrompt: "p".repeat(130 * 1024) },
     });
-    const largeTail = entry("assistant_message", largeSessionId, 3, {
+    const modelSelectionPatch = entry("session_metadata", largeSessionId, 3, {
+      metadata: { modelSelection: { mode: "auto" } },
+    });
+    const largeTail = entry("assistant_message", largeSessionId, 4, {
       message: { role: "assistant", content: [{ type: "text", text: `findable ${"y".repeat(160 * 1024)}` }] },
+    });
+    const latestInput = entry("accepted_input", largeSessionId, 5, {
+      messages: [{ role: "user", content: [{ type: "text", text: "Latest prompt" }] }],
     });
     await writeFile(
       join(chatDir, `${largeSessionId}.jsonl`),
-      `${JSON.stringify(largeInput)}\n${JSON.stringify(largeMetadata)}\n${JSON.stringify(largeTail)}\n`,
+      `${JSON.stringify(largeInput)}\n${JSON.stringify(largeMetadata)}\n${JSON.stringify(modelSelectionPatch)}\n${JSON.stringify(largeTail)}\n${JSON.stringify(latestInput)}\n`,
     );
 
     const smallSessionId = "web:s_small";

--- a/tests/session/session-list-large-input.spec.ts
+++ b/tests/session/session-list-large-input.spec.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 
 import { getPilotProjectChatDir } from "../../src/pilot/paths.js";
+import { searchChatHistory } from "../../src/session/search/searchChatHistory.js";
 import { listProjectSessions } from "../../src/session/storage/SessionList.js";
 
 const NOW = "2026-08-16T09:00:00.000Z";
@@ -21,6 +22,7 @@ test("lists historical sessions whose large inline image hides metadata from the
     await mkdir(chatDir, { recursive: true });
 
     const largeSessionId = "web:s_large-image";
+    const largeTitle = `Generated briefing ${"m".repeat(70 * 1024)}`;
     const largeInput = entry("accepted_input", largeSessionId, 1, {
       messages: [{
         role: "user",
@@ -31,10 +33,10 @@ test("lists historical sessions whose large inline image hides metadata from the
       }],
     });
     const largeMetadata = entry("session_metadata", largeSessionId, 2, {
-      metadata: { aiTitle: "Generated briefing" },
+      metadata: { aiTitle: largeTitle },
     });
     const largeTail = entry("assistant_message", largeSessionId, 3, {
-      message: { role: "assistant", content: [{ type: "text", text: "y".repeat(160 * 1024) }] },
+      message: { role: "assistant", content: [{ type: "text", text: `findable ${"y".repeat(160 * 1024)}` }] },
     });
     await writeFile(
       join(chatDir, `${largeSessionId}.jsonl`),
@@ -48,21 +50,29 @@ test("lists historical sessions whose large inline image hides metadata from the
     );
 
     const invalidSessionId = "web:s_invalid";
+    const invalidTail = entry("assistant_message", invalidSessionId, 3, {
+      message: { role: "assistant", content: [{ type: "text", text: "z".repeat(160 * 1024) }] },
+    });
     await writeFile(
       join(chatDir, `${invalidSessionId}.jsonl`),
       `${JSON.stringify(largeInput).replace(largeSessionId, invalidSessionId)}\n`
         + '{"type":"session_metadata","metadata":{"aiTitle":\n'
-        + `${JSON.stringify(largeTail)}\n`,
+        + `${JSON.stringify(invalidTail)}\n`,
     );
 
     const sessions = await listProjectSessions({ projectRoot, pilotHome });
     assert.deepEqual(
       sessions.map((session) => [session.sessionId, session.summary]).sort((a, b) => a[0].localeCompare(b[0])),
       [
-        [largeSessionId, "Generated briefing"],
+        [largeSessionId, largeTitle],
         [smallSessionId, "Small session"],
       ],
     );
+
+    const search = await searchChatHistory({ projectRoot, pilotHome, query: "findable" });
+    assert.equal(search.matches.length, 1);
+    assert.equal(search.matches[0].sessionId, largeSessionId);
+    assert.equal(search.matches[0].sessionTitle, largeTitle);
   } finally {
     await rm(projectRoot, { recursive: true, force: true });
     await rm(pilotHome, { recursive: true, force: true });

--- a/tests/session/session-list-large-input.spec.ts
+++ b/tests/session/session-list-large-input.spec.ts
@@ -35,18 +35,18 @@ test("lists historical sessions whose large inline image hides metadata from the
     const largeMetadata = entry("session_metadata", largeSessionId, 2, {
       metadata: { aiTitle: largeTitle, firstPrompt: "p".repeat(130 * 1024) },
     });
-    const modelSelectionPatch = entry("session_metadata", largeSessionId, 3, {
-      metadata: { modelSelection: { mode: "auto" } },
-    });
-    const largeTail = entry("assistant_message", largeSessionId, 4, {
+    const largeTail = entry("assistant_message", largeSessionId, 3, {
       message: { role: "assistant", content: [{ type: "text", text: `findable ${"y".repeat(160 * 1024)}` }] },
     });
-    const latestInput = entry("accepted_input", largeSessionId, 5, {
+    const latestInput = entry("accepted_input", largeSessionId, 4, {
       messages: [{ role: "user", content: [{ type: "text", text: "Latest prompt" }] }],
+    });
+    const modelSelectionPatch = entry("session_metadata", largeSessionId, 5, {
+      metadata: { modelSelection: { mode: "auto" } },
     });
     await writeFile(
       join(chatDir, `${largeSessionId}.jsonl`),
-      `${JSON.stringify(largeInput)}\n${JSON.stringify(largeMetadata)}\n${JSON.stringify(modelSelectionPatch)}\n${JSON.stringify(largeTail)}\n${JSON.stringify(latestInput)}\n`,
+      `${JSON.stringify(largeInput)}\n${JSON.stringify(largeMetadata)}\n${JSON.stringify(largeTail)}\n${JSON.stringify(latestInput)}\n${JSON.stringify(modelSelectionPatch)}\n`,
     );
 
     const smallSessionId = "web:s_small";
@@ -109,6 +109,43 @@ test("prefers a newer oversized metadata title over an older title in the lite h
 
     const sessions = await listProjectSessions({ projectRoot, pilotHome });
     assert.deepEqual(sessions.map((session) => [session.sessionId, session.summary]), [[sessionId, "New fork title"]]);
+  } finally {
+    await rm(projectRoot, { recursive: true, force: true });
+    await rm(pilotHome, { recursive: true, force: true });
+  }
+});
+
+test("preserves createdAt when metadata recovery has no lite summary", async () => {
+  const projectRoot = await mkdtemp(join(tmpdir(), "pilotdeck-session-list-project-"));
+  const pilotHome = await mkdtemp(join(tmpdir(), "pilotdeck-session-list-home-"));
+  try {
+    const chatDir = getPilotProjectChatDir(projectRoot, pilotHome);
+    await mkdir(chatDir, { recursive: true });
+
+    const sessionId = "web:s_recovered-created-at";
+    const largeInput = entry("accepted_input", sessionId, 1, {
+      messages: [{
+        role: "user",
+        content: [
+          { type: "text", text: "Create a presentation" },
+          { type: "image", source: "base64", data: "x".repeat(2 * 1024 * 1024) },
+        ],
+      }],
+    });
+    const largeMetadata = entry("session_metadata", sessionId, 2, {
+      metadata: { aiTitle: "Recovered title", firstPrompt: "p".repeat(130 * 1024) },
+    });
+    const largeTail = entry("assistant_message", sessionId, 3, {
+      message: { role: "assistant", content: [{ type: "text", text: "y".repeat(160 * 1024) }] },
+    });
+    await writeFile(
+      join(chatDir, `${sessionId}.jsonl`),
+      `${JSON.stringify(largeInput)}\n${JSON.stringify(largeMetadata)}\n${JSON.stringify(largeTail)}\n`,
+    );
+
+    const [session] = await listProjectSessions({ projectRoot, pilotHome });
+    assert.equal(session?.summary, "Recovered title");
+    assert.equal(session?.createdAt, Date.parse(NOW));
   } finally {
     await rm(projectRoot, { recursive: true, force: true });
     await rm(pilotHome, { recursive: true, force: true });

--- a/tests/session/session-list-large-input.spec.ts
+++ b/tests/session/session-list-large-input.spec.ts
@@ -151,3 +151,36 @@ test("preserves createdAt when metadata recovery has no lite summary", async () 
     await rm(pilotHome, { recursive: true, force: true });
   }
 });
+
+test("does not trust a trailing metadata patch as a full title snapshot", async () => {
+  const projectRoot = await mkdtemp(join(tmpdir(), "pilotdeck-session-list-project-"));
+  const pilotHome = await mkdtemp(join(tmpdir(), "pilotdeck-session-list-home-"));
+  try {
+    const chatDir = getPilotProjectChatDir(projectRoot, pilotHome);
+    await mkdir(chatDir, { recursive: true });
+
+    const sessionId = "web:s_tail-patch";
+    const oldMetadata = entry("session_metadata", sessionId, 1, {
+      metadata: { title: "Old title" },
+    });
+    const filler = entry("assistant_message", sessionId, 2, {
+      message: { role: "assistant", content: [{ type: "text", text: "x".repeat(160 * 1024) }] },
+    });
+    const newMetadata = entry("session_metadata", sessionId, 3, {
+      metadata: { title: "Recovered title", firstPrompt: "p".repeat(130 * 1024) },
+    });
+    const trailingPatch = entry("session_metadata", sessionId, 4, {
+      metadata: { aiTitle: "Later title patch" },
+    });
+    await writeFile(
+      join(chatDir, `${sessionId}.jsonl`),
+      `${JSON.stringify(oldMetadata)}\n${JSON.stringify(filler)}\n${JSON.stringify(newMetadata)}\n${JSON.stringify(trailingPatch)}\n`,
+    );
+
+    const [session] = await listProjectSessions({ projectRoot, pilotHome });
+    assert.equal(session?.summary, "Recovered title");
+  } finally {
+    await rm(projectRoot, { recursive: true, force: true });
+    await rm(pilotHome, { recursive: true, force: true });
+  }
+});

--- a/tests/session/session-list-large-input.spec.ts
+++ b/tests/session/session-list-large-input.spec.ts
@@ -1,0 +1,70 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { getPilotProjectChatDir } from "../../src/pilot/paths.js";
+import { listProjectSessions } from "../../src/session/storage/SessionList.js";
+
+const NOW = "2026-08-16T09:00:00.000Z";
+
+function entry(type: string, sessionId: string, sequence: number, extra: Record<string, unknown> = {}): Record<string, unknown> {
+  return { type, sessionId, turnId: "turn-1", sequence, createdAt: NOW, ...extra };
+}
+
+test("lists historical sessions whose large inline image hides metadata from the lite preview", async () => {
+  const projectRoot = await mkdtemp(join(tmpdir(), "pilotdeck-session-list-project-"));
+  const pilotHome = await mkdtemp(join(tmpdir(), "pilotdeck-session-list-home-"));
+  try {
+    const chatDir = getPilotProjectChatDir(projectRoot, pilotHome);
+    await mkdir(chatDir, { recursive: true });
+
+    const largeSessionId = "web:s_large-image";
+    const largeInput = entry("accepted_input", largeSessionId, 1, {
+      messages: [{
+        role: "user",
+        content: [
+          { type: "text", text: "Build the briefing" },
+          { type: "image", source: "base64", data: "x".repeat(2 * 1024 * 1024) },
+        ],
+      }],
+    });
+    const largeMetadata = entry("session_metadata", largeSessionId, 2, {
+      metadata: { aiTitle: "Generated briefing" },
+    });
+    const largeTail = entry("assistant_message", largeSessionId, 3, {
+      message: { role: "assistant", content: [{ type: "text", text: "y".repeat(160 * 1024) }] },
+    });
+    await writeFile(
+      join(chatDir, `${largeSessionId}.jsonl`),
+      `${JSON.stringify(largeInput)}\n${JSON.stringify(largeMetadata)}\n${JSON.stringify(largeTail)}\n`,
+    );
+
+    const smallSessionId = "web:s_small";
+    await writeFile(
+      join(chatDir, `${smallSessionId}.jsonl`),
+      `${JSON.stringify(entry("session_metadata", smallSessionId, 1, { metadata: { aiTitle: "Small session" } }))}\n`,
+    );
+
+    const invalidSessionId = "web:s_invalid";
+    await writeFile(
+      join(chatDir, `${invalidSessionId}.jsonl`),
+      `${JSON.stringify(largeInput).replace(largeSessionId, invalidSessionId)}\n`
+        + '{"type":"session_metadata","metadata":{"aiTitle":\n'
+        + `${JSON.stringify(largeTail)}\n`,
+    );
+
+    const sessions = await listProjectSessions({ projectRoot, pilotHome });
+    assert.deepEqual(
+      sessions.map((session) => [session.sessionId, session.summary]).sort((a, b) => a[0].localeCompare(b[0])),
+      [
+        [largeSessionId, "Generated briefing"],
+        [smallSessionId, "Small session"],
+      ],
+    );
+  } finally {
+    await rm(projectRoot, { recursive: true, force: true });
+    await rm(pilotHome, { recursive: true, force: true });
+  }
+});

--- a/tests/session/session-list-large-input.spec.ts
+++ b/tests/session/session-list-large-input.spec.ts
@@ -84,3 +84,33 @@ test("lists historical sessions whose large inline image hides metadata from the
     await rm(pilotHome, { recursive: true, force: true });
   }
 });
+
+test("prefers a newer oversized metadata title over an older title in the lite head", async () => {
+  const projectRoot = await mkdtemp(join(tmpdir(), "pilotdeck-session-list-project-"));
+  const pilotHome = await mkdtemp(join(tmpdir(), "pilotdeck-session-list-home-"));
+  try {
+    const chatDir = getPilotProjectChatDir(projectRoot, pilotHome);
+    await mkdir(chatDir, { recursive: true });
+
+    const sessionId = "web:s_new-fork-title";
+    const oldMetadata = entry("session_metadata", sessionId, 1, {
+      metadata: { title: "Old parent title" },
+    });
+    const filler = entry("assistant_message", sessionId, 2, {
+      message: { role: "assistant", content: [{ type: "text", text: "x".repeat(160 * 1024) }] },
+    });
+    const newMetadata = entry("session_metadata", sessionId, 3, {
+      metadata: { title: "New fork title", firstPrompt: "p".repeat(130 * 1024) },
+    });
+    await writeFile(
+      join(chatDir, `${sessionId}.jsonl`),
+      `${JSON.stringify(oldMetadata)}\n${JSON.stringify(filler)}\n${JSON.stringify(newMetadata)}\n`,
+    );
+
+    const sessions = await listProjectSessions({ projectRoot, pilotHome });
+    assert.deepEqual(sessions.map((session) => [session.sessionId, session.summary]), [[sessionId, "New fork title"]]);
+  } finally {
+    await rm(projectRoot, { recursive: true, force: true });
+    await rm(pilotHome, { recursive: true, force: true });
+  }
+});

--- a/tests/session/turn-metadata-tail.spec.ts
+++ b/tests/session/turn-metadata-tail.spec.ts
@@ -5,6 +5,7 @@ import type { AgentEvent } from "../../src/agent/protocol/events.js";
 import type { AgentTurnResult } from "../../src/agent/protocol/result.js";
 import type { AgentLoop, AgentLoopInput, AgentLoopRunResult } from "../../src/agent/loop/AgentLoop.js";
 import { TurnRunner } from "../../src/agent/turn/TurnRunner.js";
+import type { LifecycleRuntime } from "../../src/lifecycle/index.js";
 import { SessionMetadataStore } from "../../src/session/metadata/SessionMetadataStore.js";
 import { InMemoryTranscriptWriter } from "../../src/session/transcript/InMemoryTranscriptWriter.js";
 
@@ -72,5 +73,58 @@ test("TurnRunner appends session metadata after successful and failed accepted t
     if (lastEntry?.type === "session_metadata") {
       assert.equal(lastEntry.metadata.aiTitle, "Pinned at transcript tail");
     }
+  }
+});
+
+test("TurnRunner persists a bounded prompt when a hook blocks a first turn", async () => {
+  const sessionId = "blocked-session";
+  const transcript = new InMemoryTranscriptWriter();
+  const metadataStore = new SessionMetadataStore({
+    transcript,
+    sessionId,
+    now: () => new Date(NOW),
+  });
+  const lifecycle = {
+    async dispatch() {
+      return {
+        effects: [{ type: "block", reason: "blocked by test" }],
+        messages: [],
+        events: [],
+        blockingErrors: [],
+        nonBlockingErrors: [],
+      };
+    },
+  } as unknown as LifecycleRuntime;
+  const loop = {
+    async *run(): AsyncGenerator<AgentEvent, AgentLoopRunResult, unknown> {
+      assert.fail("blocked turns must not run the model loop");
+    },
+    snapshotFileState: () => ({}),
+  } as unknown as AgentLoop;
+  const runner = new TurnRunner(
+    loop,
+    transcript,
+    undefined,
+    () => new Date(NOW),
+    lifecycle,
+    { cwd: process.cwd(), transcriptPath: "", collectFileArtifacts: false },
+    { metadataStore, autoGenerateSessionTitle: false },
+  );
+
+  const prompt = "p".repeat(2 * 1024 * 1024);
+  for await (const _event of runner.run({
+    sessionId,
+    turnId: "turn-1",
+    messages: [],
+    input: { type: "text", text: prompt },
+  })) {
+    // Exhaust the blocked turn so its metadata reappend is persisted.
+  }
+
+  const lastEntry = transcript.entries.at(-1);
+  assert.equal(lastEntry?.type, "session_metadata");
+  if (lastEntry?.type === "session_metadata") {
+    assert.equal(lastEntry.metadata.firstPrompt, prompt.slice(0, 1_200));
+    assert.equal(lastEntry.metadata.lastPrompt, prompt.slice(0, 1_200));
   }
 });

--- a/tests/session/turn-metadata-tail.spec.ts
+++ b/tests/session/turn-metadata-tail.spec.ts
@@ -4,6 +4,7 @@ import assert from "node:assert/strict";
 import type { AgentEvent } from "../../src/agent/protocol/events.js";
 import type { AgentTurnResult } from "../../src/agent/protocol/result.js";
 import type { AgentLoop, AgentLoopInput, AgentLoopRunResult } from "../../src/agent/loop/AgentLoop.js";
+import { AgentSession } from "../../src/agent/session/AgentSession.js";
 import { TurnRunner } from "../../src/agent/turn/TurnRunner.js";
 import type { LifecycleRuntime } from "../../src/lifecycle/index.js";
 import { SessionMetadataStore } from "../../src/session/metadata/SessionMetadataStore.js";
@@ -174,6 +175,62 @@ test("TurnRunner updates lastPrompt on subsequent accepted turns", async () => {
   if (lastEntry?.type === "session_metadata") {
     assert.equal(lastEntry.metadata.firstPrompt, "First prompt");
     assert.equal(lastEntry.metadata.lastPrompt, "Second prompt");
+  }
+});
+
+test("TurnRunner carries complete metadata through a runtime reload snapshot", async () => {
+  const sessionId = "reloaded-session";
+  const originalTranscript = new InMemoryTranscriptWriter();
+  const originalStore = new SessionMetadataStore({
+    transcript: originalTranscript,
+    sessionId,
+    now: () => new Date(NOW),
+  });
+  await originalStore.record("turn-1", {
+    title: "Original custom title",
+    tag: "important",
+    firstPrompt: "First prompt",
+    lastPrompt: "First prompt",
+    parentSessionId: "web:parent",
+    forkedFromTurnId: "parent-turn",
+  });
+  const loop = { snapshotFileState: () => ({}) } as unknown as AgentLoop;
+  const originalRunner = new TurnRunner(
+    loop,
+    originalTranscript,
+    undefined,
+    () => new Date(NOW),
+    undefined,
+    { cwd: process.cwd(), transcriptPath: "", collectFileArtifacts: false },
+    { metadataStore: originalStore, autoGenerateSessionTitle: false },
+  );
+
+  const originalSession = new AgentSession({ sessionId, turnRunner: originalRunner });
+  const reload = originalSession.snapshotForRuntimeReload();
+  assert.deepEqual(reload.metadata, originalStore.getSnapshot());
+
+  const reloadedTranscript = new InMemoryTranscriptWriter();
+  const reloadedStore = new SessionMetadataStore({
+    transcript: reloadedTranscript,
+    sessionId,
+    now: () => new Date(NOW),
+  });
+  reloadedStore.restoreFromReplay(reload.metadata ?? {});
+  await reloadedStore.record("turn-2", { lastPrompt: "Second prompt" });
+  await reloadedStore.saveAiTitle("Regenerated title", "turn-2");
+  await reloadedStore.reappendTail("turn-2");
+
+  const lastEntry = reloadedTranscript.entries.at(-1);
+  assert.equal(lastEntry?.type, "session_metadata");
+  if (lastEntry?.type === "session_metadata") {
+    assert.equal(lastEntry.metadata.title, "Original custom title");
+    assert.equal(lastEntry.metadata.aiTitle, "Regenerated title");
+    assert.equal(lastEntry.metadata.firstPrompt, "First prompt");
+    assert.equal(lastEntry.metadata.lastPrompt, "Second prompt");
+    assert.equal(lastEntry.metadata.tag, "important");
+    assert.equal(lastEntry.metadata.parentSessionId, "web:parent");
+    assert.equal(lastEntry.metadata.forkedFromTurnId, "parent-turn");
+    assert.equal(lastEntry.metadata.isSnapshot, true);
   }
 });
 

--- a/tests/session/turn-metadata-tail.spec.ts
+++ b/tests/session/turn-metadata-tail.spec.ts
@@ -132,6 +132,51 @@ test("TurnRunner persists a bounded prompt when title generation produces no tit
   }
 });
 
+test("TurnRunner updates lastPrompt on subsequent accepted turns", async () => {
+  const sessionId = "two-turn-session";
+  const transcript = new InMemoryTranscriptWriter();
+  const metadataStore = new SessionMetadataStore({
+    transcript,
+    sessionId,
+    now: () => new Date(NOW),
+  });
+  const loop = {
+    async *run(input: AgentLoopInput): AsyncGenerator<AgentEvent, AgentLoopRunResult, unknown> {
+      const successfulResult = result(input.sessionId);
+      yield { type: "turn_completed", sessionId: input.sessionId, turnId: input.turnId, result: successfulResult };
+      return { result: successfulResult, messages: input.messages };
+    },
+    snapshotFileState: () => ({}),
+  } as unknown as AgentLoop;
+  const runner = new TurnRunner(
+    loop,
+    transcript,
+    undefined,
+    () => new Date(NOW),
+    undefined,
+    { cwd: process.cwd(), transcriptPath: "", collectFileArtifacts: false },
+    { metadataStore, autoGenerateSessionTitle: false },
+  );
+
+  for (const [turnId, prompt] of [["turn-1", "First prompt"], ["turn-2", "Second prompt"]] as const) {
+    for await (const _event of runner.run({
+      sessionId,
+      turnId,
+      messages: [],
+      input: { type: "text", text: prompt },
+    })) {
+      // Exhaust each turn so the metadata snapshot is persisted.
+    }
+  }
+
+  const lastEntry = transcript.entries.at(-1);
+  assert.equal(lastEntry?.type, "session_metadata");
+  if (lastEntry?.type === "session_metadata") {
+    assert.equal(lastEntry.metadata.firstPrompt, "First prompt");
+    assert.equal(lastEntry.metadata.lastPrompt, "Second prompt");
+  }
+});
+
 test("TurnRunner persists a bounded prompt when a hook blocks a first turn", async () => {
   const sessionId = "blocked-session";
   const transcript = new InMemoryTranscriptWriter();

--- a/tests/session/turn-metadata-tail.spec.ts
+++ b/tests/session/turn-metadata-tail.spec.ts
@@ -72,7 +72,63 @@ test("TurnRunner appends session metadata after successful and failed accepted t
     assert.equal(lastEntry?.type, "session_metadata");
     if (lastEntry?.type === "session_metadata") {
       assert.equal(lastEntry.metadata.aiTitle, "Pinned at transcript tail");
+      assert.equal(lastEntry.metadata.isSnapshot, true);
     }
+  }
+});
+
+test("TurnRunner persists a bounded prompt when title generation produces no title", async () => {
+  const sessionId = "untitled-session";
+  const transcript = new InMemoryTranscriptWriter();
+  const metadataStore = new SessionMetadataStore({
+    transcript,
+    sessionId,
+    now: () => new Date(NOW),
+  });
+  const successfulResult = result(sessionId);
+  const loop = {
+    async *run(input: AgentLoopInput): AsyncGenerator<AgentEvent, AgentLoopRunResult, unknown> {
+      yield { type: "turn_completed", sessionId: input.sessionId, turnId: input.turnId, result: successfulResult };
+      return { result: successfulResult, messages: input.messages };
+    },
+    snapshotFileState: () => ({}),
+  } as unknown as AgentLoop;
+  const runner = new TurnRunner(
+    loop,
+    transcript,
+    undefined,
+    () => new Date(NOW),
+    undefined,
+    { cwd: process.cwd(), transcriptPath: "", collectFileArtifacts: false },
+    {
+      metadataStore,
+      autoGenerateSessionTitle: true,
+      sessionTitleGenerator: async () => null,
+    },
+  );
+
+  const prompt = "Create a briefing";
+  for await (const _event of runner.run({
+    sessionId,
+    turnId: "turn-1",
+    messages: [],
+    input: {
+      type: "blocks",
+      content: [
+        { type: "text", text: prompt },
+        { type: "image", source: "base64", data: "x".repeat(2 * 1024 * 1024), mimeType: "image/png" },
+      ],
+    },
+  })) {
+    // Exhaust the successful turn so its metadata reappend is persisted.
+  }
+
+  const lastEntry = transcript.entries.at(-1);
+  assert.equal(lastEntry?.type, "session_metadata");
+  if (lastEntry?.type === "session_metadata") {
+    assert.equal(lastEntry.metadata.firstPrompt, prompt);
+    assert.equal(lastEntry.metadata.lastPrompt, prompt);
+    assert.equal(lastEntry.metadata.isSnapshot, true);
   }
 });
 

--- a/tests/session/turn-metadata-tail.spec.ts
+++ b/tests/session/turn-metadata-tail.spec.ts
@@ -1,0 +1,76 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import type { AgentEvent } from "../../src/agent/protocol/events.js";
+import type { AgentTurnResult } from "../../src/agent/protocol/result.js";
+import type { AgentLoop, AgentLoopInput, AgentLoopRunResult } from "../../src/agent/loop/AgentLoop.js";
+import { TurnRunner } from "../../src/agent/turn/TurnRunner.js";
+import { SessionMetadataStore } from "../../src/session/metadata/SessionMetadataStore.js";
+import { InMemoryTranscriptWriter } from "../../src/session/transcript/InMemoryTranscriptWriter.js";
+
+const NOW = "2026-08-16T09:00:00.000Z";
+
+function result(sessionId: string): AgentTurnResult {
+  return {
+    type: "success",
+    sessionId,
+    turnId: "turn-1",
+    stopReason: "completed",
+    usage: {},
+    permissionDenials: [],
+    turns: 1,
+    startedAt: NOW,
+    completedAt: NOW,
+  };
+}
+
+async function runWithResult(throws: boolean): Promise<InMemoryTranscriptWriter> {
+  const sessionId = throws ? "error-session" : "success-session";
+  const transcript = new InMemoryTranscriptWriter();
+  const metadataStore = new SessionMetadataStore({
+    transcript,
+    sessionId,
+    now: () => new Date(NOW),
+  });
+  await metadataStore.saveAiTitle("Pinned at transcript tail", "title-turn");
+
+  const successfulResult = result(sessionId);
+  const loop = {
+    async *run(input: AgentLoopInput): AsyncGenerator<AgentEvent, AgentLoopRunResult, unknown> {
+      if (throws) throw new Error("model unavailable");
+      yield { type: "turn_completed", sessionId: input.sessionId, turnId: input.turnId, result: successfulResult };
+      return { result: successfulResult, messages: input.messages };
+    },
+    snapshotFileState: () => ({}),
+  } as unknown as AgentLoop;
+  const runner = new TurnRunner(
+    loop,
+    transcript,
+    undefined,
+    () => new Date(NOW),
+    undefined,
+    { cwd: process.cwd(), transcriptPath: "", collectFileArtifacts: false },
+    { metadataStore, autoGenerateSessionTitle: false },
+  );
+
+  for await (const _event of runner.run({
+    sessionId,
+    turnId: "turn-1",
+    messages: [],
+    input: { type: "text", text: "Create a briefing" },
+  })) {
+    // Exhaust the turn so the final metadata snapshot is persisted.
+  }
+  return transcript;
+}
+
+test("TurnRunner appends session metadata after successful and failed accepted turns", async () => {
+  for (const throws of [false, true]) {
+    const transcript = await runWithResult(throws);
+    const lastEntry = transcript.entries.at(-1);
+    assert.equal(lastEntry?.type, "session_metadata");
+    if (lastEntry?.type === "session_metadata") {
+      assert.equal(lastEntry.metadata.aiTitle, "Pinned at transcript tail");
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- recover historical sessions whose oversized inline media prevents lite metadata parsing
- append session metadata at terminal turn boundaries for fast future listings
- add regression coverage for large input transcripts and terminal metadata snapshots

## Tests
- npx tsx --test tests/session/session-list-large-input.spec.ts tests/session/turn-metadata-tail.spec.ts
- npx tsc -p tsconfig.json --noEmit