### PR TITLE
fix(ui): dedupe optimistic user messages

### DIFF
--- a/ui/server/index.js
+++ b/ui/server/index.js
@@ -2474,6 +2474,11 @@ function handleChatConnection(ws, request) {
                     if (userVisibleInput) {
                         const nowIso = new Date().toISOString();
                         const provider = data.options?.providerHint || 'pilotdeck';
+                        const optimisticImages = Array.isArray(data.options?.images)
+                            ? data.options.images
+                                .map((image) => typeof image === 'string' ? image : image?.data)
+                                .filter((image) => typeof image === 'string')
+                            : [];
                         const optimisticUserFrame = createNormalizedMessage({
                             id: `local_ws_user_${crypto.randomUUID()}`,
                             sessionId: commandSessionId,
@@ -2484,6 +2489,7 @@ function handleChatConnection(ws, request) {
                             ...(Array.isArray(data.options?.attachments) && data.options.attachments.length > 0
                                 ? { attachments: data.options.attachments }
                                 : {}),
+                            ...(optimisticImages.length > 0 ? { images: optimisticImages } : {}),
                             timestamp: nowIso,
                         });
                         const optimisticStatusFrame = createNormalizedMessage({

--- a/ui/server/index.js
+++ b/ui/server/index.js
@@ -111,7 +111,7 @@ import userRoutes from './routes/user.js';
 import pluginsRoutes from './routes/plugins.js';
 import messagesRoutes from './routes/messages.js';
 import { closeMemoryServices, startMemoryScheduler, stopMemoryScheduler } from './services/memoryService.js';
-import { createNormalizedMessage } from './pilotdeck-message.js';
+import { createNormalizedMessage, createOptimisticUserFrames } from './pilotdeck-message.js';
 import { startEnabledPluginServers, stopAllPlugins, getPluginPort } from './utils/plugin-process-manager.js';
 import { initializeDatabase, sessionNamesDb, applyCustomSessionNames, userDb } from './database/db.js';
 import { configureWebPush } from './services/vapid-keys.js';
@@ -2474,31 +2474,11 @@ function handleChatConnection(ws, request) {
                     if (userVisibleInput) {
                         const nowIso = new Date().toISOString();
                         const provider = data.options?.providerHint || 'pilotdeck';
-                        const optimisticImages = Array.isArray(data.options?.images)
-                            ? data.options.images
-                                .map((image) => typeof image === 'string' ? image : image?.data)
-                                .filter((image) => typeof image === 'string')
-                            : [];
-                        const optimisticUserFrame = createNormalizedMessage({
-                            id: `local_ws_user_${crypto.randomUUID()}`,
+                        const [optimisticUserFrame, optimisticStatusFrame] = createOptimisticUserFrames({
                             sessionId: commandSessionId,
                             provider,
-                            kind: 'text',
-                            role: 'user',
-                            content: userVisibleInput,
-                            ...(Array.isArray(data.options?.attachments) && data.options.attachments.length > 0
-                                ? { attachments: data.options.attachments }
-                                : {}),
-                            ...(optimisticImages.length > 0 ? { images: optimisticImages } : {}),
-                            timestamp: nowIso,
-                        });
-                        const optimisticStatusFrame = createNormalizedMessage({
-                            id: `local_ws_status_${crypto.randomUUID()}`,
-                            sessionId: commandSessionId,
-                            provider,
-                            kind: 'status',
-                            text: 'Processing',
-                            canInterrupt: true,
+                            userVisibleInput,
+                            options: data.options,
                             timestamp: nowIso,
                         });
                         // The submitting tab already rendered its optimistic user row.

--- a/ui/server/pilotdeck-bridge.js
+++ b/ui/server/pilotdeck-bridge.js
@@ -1137,7 +1137,7 @@ export async function runChatViaGateway(
         );
     }
 
-    const runId = randomUUID();
+    const runId = resolveTurnRunId(options?.runId);
     if (!staleRunId) {
         state.runId = runId;
         state.active = true;
@@ -1336,6 +1336,11 @@ export async function runChatViaGateway(
     } finally {
         clearActiveRunIfCurrent(state, runId);
     }
+}
+
+export function resolveTurnRunId(value) {
+    const requestedRunId = typeof value === 'string' ? value.trim() : '';
+    return requestedRunId || randomUUID();
 }
 
 async function recordGatewayStatusMessage(gateway, { sessionKey, turnId, projectKey, event, text, detail }) {

--- a/ui/server/pilotdeck-bridge.test.js
+++ b/ui/server/pilotdeck-bridge.test.js
@@ -6,8 +6,21 @@ import {
     getFallbackSessionActivity,
     isGatewayUnavailableError,
     isTerminalAlwaysOnTurnEvent,
+    resolveTurnRunId,
     uiFilesToAttachments,
 } from './pilotdeck-bridge.js';
+
+describe('turn run identity', () => {
+    it('reuses a non-empty client run id', () => {
+        expect(resolveTurnRunId('  run-user-1  ')).toBe('run-user-1');
+    });
+
+    it('generates a UUID when a legacy client omits the run id', () => {
+        expect(resolveTurnRunId(undefined)).toMatch(
+            /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+        );
+    });
+});
 
 describe('web attachment conversion', () => {
     it('marks uploaded files with the web channel key', () => {

--- a/ui/server/pilotdeck-message.js
+++ b/ui/server/pilotdeck-message.js
@@ -27,3 +27,47 @@ export function createNormalizedMessage(fields) {
     provider: fields.provider || 'pilotdeck',
   };
 }
+
+export function createOptimisticUserFrames({
+  sessionId,
+  provider = 'pilotdeck',
+  userVisibleInput,
+  options = {},
+  timestamp = new Date().toISOString(),
+}) {
+  const runId = typeof options.runId === 'string'
+    ? options.runId.trim() || undefined
+    : undefined;
+  const images = Array.isArray(options.images)
+    ? options.images
+      .map((image) => typeof image === 'string' ? image : image?.data)
+      .filter((image) => typeof image === 'string')
+    : [];
+
+  return [
+    createNormalizedMessage({
+      id: `local_ws_user_${crypto.randomUUID()}`,
+      sessionId,
+      provider,
+      kind: 'text',
+      role: 'user',
+      content: userVisibleInput,
+      ...(runId ? { runId } : {}),
+      ...(Array.isArray(options.attachments) && options.attachments.length > 0
+        ? { attachments: options.attachments }
+        : {}),
+      ...(images.length > 0 ? { images } : {}),
+      timestamp,
+    }),
+    createNormalizedMessage({
+      id: `local_ws_status_${crypto.randomUUID()}`,
+      sessionId,
+      provider,
+      kind: 'status',
+      text: 'Processing',
+      canInterrupt: true,
+      ...(runId ? { runId } : {}),
+      timestamp,
+    }),
+  ];
+}

--- a/ui/server/pilotdeck-message.test.js
+++ b/ui/server/pilotdeck-message.test.js
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { createOptimisticUserFrames } from './pilotdeck-message.js';
+
+describe('sibling optimistic user frames', () => {
+  it('preserves the command run id, images, and attachments', () => {
+    const [userFrame, statusFrame] = createOptimisticUserFrames({
+      sessionId: 'web:session-1',
+      userVisibleInput: 'Review these.',
+      timestamp: '2026-08-18T00:00:00.000Z',
+      options: {
+        runId: 'run-user-1',
+        images: [{ data: 'data:image/png;base64,one' }],
+        attachments: [{ name: 'report.pdf', path: '/tmp/report.pdf' }],
+      },
+    });
+
+    expect(userFrame).toMatchObject({
+      kind: 'text',
+      role: 'user',
+      runId: 'run-user-1',
+      images: ['data:image/png;base64,one'],
+      attachments: [{ name: 'report.pdf', path: '/tmp/report.pdf' }],
+    });
+    expect(statusFrame).toMatchObject({
+      kind: 'status',
+      runId: 'run-user-1',
+    });
+  });
+
+  it('keeps legacy sibling frames identity-less when the command has no run id', () => {
+    const [userFrame] = createOptimisticUserFrames({
+      sessionId: 'web:session-1',
+      userVisibleInput: 'Continue.',
+    });
+
+    expect(userFrame.runId).toBeUndefined();
+  });
+});

--- a/ui/src/components/chat/hooks/useChatComposerState.ts
+++ b/ui/src/components/chat/hooks/useChatComposerState.ts
@@ -18,6 +18,7 @@ import { getDraftInputStorageKey, safeLocalStorage } from '../utils/chatStorage'
 import { buildAttachmentPathNote } from '../utils/attachmentNotes';
 import {
   createTemporarySessionId,
+  createUserTurnRunId,
   getNotificationSessionSummary,
   isTemporarySessionId,
   startSessionCommand,
@@ -956,12 +957,14 @@ export function useChatComposerState({
 
       const effectiveSessionId = submitTargetSessionId;
       const sessionToActivate = effectiveSessionId || optimisticSessionId;
+      const runId = createUserTurnRunId();
 
       const userMessage: ChatMessage = {
         type: 'user',
         content: userVisibleInput,
         images: uploadedImages as any,
         attachments: [...uploadedFiles, ...documentReferenceAttachments] as any,
+        runId,
         timestamp: new Date(),
       };
 
@@ -1018,6 +1021,7 @@ export function useChatComposerState({
         sendMessage,
         selectedProject,
         command: messageContent,
+        runId,
         userVisibleInput,
         sessionId: effectiveSessionId,
         temporarySessionId: sessionToActivate,

--- a/ui/src/components/chat/hooks/useChatSessionState.spec.ts
+++ b/ui/src/components/chat/hooks/useChatSessionState.spec.ts
@@ -1,5 +1,30 @@
 import { describe, expect, it } from 'vitest';
-import { resolveConversationScrollTop } from './useChatSessionState';
+import type { SessionProvider } from '../../../types/app';
+import type { ChatMessage } from '../types/types';
+import { chatMessageToNormalized, resolveConversationScrollTop } from './useChatSessionState';
+
+describe('chatMessageToNormalized', () => {
+  it('preserves user turn identity on optimistic rows', () => {
+    const message: ChatMessage = {
+      type: 'user',
+      content: 'Continue.',
+      runId: 'run-user-1',
+      turnId: 'turn-user-1',
+      timestamp: new Date('2026-08-18T00:00:00.000Z'),
+    };
+
+    expect(chatMessageToNormalized(
+      message,
+      'web:session-1',
+      'pilotdeck' as SessionProvider,
+    )).toMatchObject({
+      kind: 'text',
+      role: 'user',
+      runId: 'run-user-1',
+      turnId: 'turn-user-1',
+    });
+  });
+});
 
 describe('resolveConversationScrollTop', () => {
   it('keeps a conversation pinned to the bottom when it was near the bottom', () => {

--- a/ui/src/components/chat/hooks/useChatSessionState.ts
+++ b/ui/src/components/chat/hooks/useChatSessionState.ts
@@ -156,7 +156,7 @@ export function getStreamContentKey(messages: ChatMessage[]): string {
 /*  Helper: Convert a ChatMessage to a NormalizedMessage for the store */
 /* ------------------------------------------------------------------ */
 
-function chatMessageToNormalized(
+export function chatMessageToNormalized(
   msg: ChatMessage,
   sessionId: string,
   provider: SessionProvider,
@@ -167,7 +167,14 @@ function chatMessageToNormalized(
     : typeof msg.timestamp === 'number'
       ? new Date(msg.timestamp).toISOString()
       : String(msg.timestamp);
-  const base = { id, sessionId, timestamp: ts, provider };
+  const base = {
+    id,
+    sessionId,
+    timestamp: ts,
+    provider,
+    ...(msg.runId ? { runId: msg.runId } : {}),
+    ...(msg.turnId ? { turnId: msg.turnId } : {}),
+  };
 
   if (msg.isToolUse) {
     return {

--- a/ui/src/components/chat/utils/attachmentNotes.spec.ts
+++ b/ui/src/components/chat/utils/attachmentNotes.spec.ts
@@ -59,6 +59,22 @@ describe('attachment path notes', () => {
     }]);
   });
 
+  it('preserves a colon and space in a legacy attachment path', () => {
+    const parsed = parseUserAttachmentNote([
+      'Review this report',
+      '',
+      marker,
+      '- report.pdf: /tmp/Project: Docs/report.pdf',
+      '[End files attached by user]',
+    ].join('\n'));
+
+    expect(parsed.attachments).toEqual([{
+      name: 'report.pdf',
+      path: '/tmp/Project: Docs/report.pdf',
+      mimeType: 'application/pdf',
+    }]);
+  });
+
   it('round trips colons in both attachment names and paths', () => {
     const parsed = parseUserAttachmentNote([
       'Review this report',

--- a/ui/src/components/chat/utils/attachmentNotes.spec.ts
+++ b/ui/src/components/chat/utils/attachmentNotes.spec.ts
@@ -18,7 +18,7 @@ describe('attachment path notes', () => {
       '',
       '',
       marker,
-      '- 报告.xlsx: .tmp/chat-attachments/run/1-报告.xlsx',
+      '- attachment-json: {"name":"报告.xlsx","path":".tmp/chat-attachments/run/1-报告.xlsx"}',
       '[End files attached by user]',
       '',
     ].join('\n'));
@@ -57,6 +57,25 @@ describe('attachment path notes', () => {
       path: filePath,
       mimeType: 'application/pdf',
     }]);
+  });
+
+  it('round trips colons in both attachment names and paths', () => {
+    const parsed = parseUserAttachmentNote([
+      'Review this report',
+      buildAttachmentPathNote([{
+        name: 'report: final.pdf',
+        path: '/tmp/project: docs/report: final.pdf',
+      }]),
+    ].join(''));
+
+    expect(parsed).toEqual({
+      content: 'Review this report',
+      attachments: [{
+        name: 'report: final.pdf',
+        path: '/tmp/project: docs/report: final.pdf',
+        mimeType: 'application/pdf',
+      }],
+    });
   });
 
   it.each([

--- a/ui/src/components/chat/utils/attachmentNotes.spec.ts
+++ b/ui/src/components/chat/utils/attachmentNotes.spec.ts
@@ -42,6 +42,23 @@ describe('attachment path notes', () => {
     }]);
   });
 
+  it('preserves a colon in the attachment filename', () => {
+    const filePath = '/tmp/1-report__final.pdf';
+    const parsed = parseUserAttachmentNote([
+      'Review this report',
+      '',
+      marker,
+      `- report: final.pdf: ${filePath}`,
+      '[End files attached by user]',
+    ].join('\n'));
+
+    expect(parsed.attachments).toEqual([{
+      name: 'report: final.pdf',
+      path: filePath,
+      mimeType: 'application/pdf',
+    }]);
+  });
+
   it.each([
     ['PDF metadata', '[PDF attachment: C:\\work\\brief.pdf, 42 bytes]'],
     ['inline text content', '<attachment path="C:\\work\\notes.txt">'],

--- a/ui/src/components/chat/utils/attachmentNotes.spec.ts
+++ b/ui/src/components/chat/utils/attachmentNotes.spec.ts
@@ -78,6 +78,20 @@ describe('attachment path notes', () => {
     });
   });
 
+  it('round trips an end marker substring inside a JSON attachment path', () => {
+    const filePath = '/tmp/[End files attached by user]/report.pdf';
+    const parsed = parseUserAttachmentNote([
+      'Review this report',
+      buildAttachmentPathNote([{ name: 'report.pdf', path: filePath }]),
+    ].join(''));
+
+    expect(parsed.attachments).toEqual([{
+      name: 'report.pdf',
+      path: filePath,
+      mimeType: 'application/pdf',
+    }]);
+  });
+
   it.each([
     ['PDF metadata', '[PDF attachment: C:\\work\\brief.pdf, 42 bytes]'],
     ['inline text content', '<attachment path="C:\\work\\notes.txt">'],

--- a/ui/src/components/chat/utils/attachmentNotes.ts
+++ b/ui/src/components/chat/utils/attachmentNotes.ts
@@ -12,6 +12,7 @@ import {
 
 const ATTACHMENT_NOTE_MARKER = '[Files attached by user and available for reading in the project:]';
 const ATTACHMENT_NOTE_END_MARKER = '[End files attached by user]';
+const ATTACHMENT_NOTE_JSON_PREFIX = '- attachment-json: ';
 // Older transcripts have no end marker. Their next canonical text block may
 // be concatenated directly onto the final path during history projection.
 const LEGACY_ATTACHMENT_NOTE_TERMINATORS = [
@@ -30,8 +31,40 @@ type AttachmentPathNoteFile = {
 export function buildAttachmentPathNote(files: AttachmentPathNoteFile[]): string {
   if (files.length === 0) return '';
 
-  const lines = files.map((file) => `- ${file.name}: ${file.path}`);
+  const lines = files.map((file) => (
+    `${ATTACHMENT_NOTE_JSON_PREFIX}${JSON.stringify({ name: file.name, path: file.path })}`
+  ));
   return `\n\n${ATTACHMENT_NOTE_MARKER}\n${lines.join('\n')}\n${ATTACHMENT_NOTE_END_MARKER}\n`;
+}
+
+function parseAttachmentPathNoteLine(line: string): AttachmentPathNoteFile | null {
+  if (line.startsWith(ATTACHMENT_NOTE_JSON_PREFIX)) {
+    try {
+      const parsed = JSON.parse(line.slice(ATTACHMENT_NOTE_JSON_PREFIX.length)) as {
+        name?: unknown;
+        path?: unknown;
+      };
+      if (
+        typeof parsed.name !== 'string'
+        || typeof parsed.path !== 'string'
+        || !parsed.name.trim()
+        || !parsed.path.trim()
+      ) {
+        return null;
+      }
+      return { name: parsed.name, path: parsed.path };
+    } catch {
+      return null;
+    }
+  }
+
+  if (!line.startsWith('- ')) return null;
+  const separator = line.lastIndexOf(': ');
+  if (separator < 0) return null;
+
+  const name = line.slice(2, separator).trim();
+  const filePath = line.slice(separator + 2).trim();
+  return name && filePath ? { name, path: filePath } : null;
 }
 
 function sliceBeforeFirstMarker(value: string, markers: string[]): string {
@@ -96,13 +129,9 @@ export function parseUserAttachmentNote(content: unknown): {
 
   for (const rawLine of note.split(/\r?\n/)) {
     const line = rawLine.trim();
-    if (!line.startsWith('- ')) continue;
-    const separator = line.lastIndexOf(': ');
-    if (separator < 0) continue;
-
-    const name = line.slice(2, separator).trim();
-    const filePath = line.slice(separator + 2).trim();
-    if (!name || !filePath) continue;
+    const attachment = parseAttachmentPathNoteLine(line);
+    if (!attachment) continue;
+    const { name, path: filePath } = attachment;
     const mimeType = inferAttachmentMimeType(name, filePath);
     if (isImageAttachmentMime(mimeType)) continue;
 

--- a/ui/src/components/chat/utils/attachmentNotes.ts
+++ b/ui/src/components/chat/utils/attachmentNotes.ts
@@ -121,25 +121,29 @@ export function parseUserAttachmentNote(content: unknown): {
   }
 
   const visibleContent = text.slice(0, markerIndex).trimEnd();
-  const note = sliceBeforeFirstMarker(
-    text.slice(markerIndex + ATTACHMENT_NOTE_MARKER.length),
-    LEGACY_ATTACHMENT_NOTE_TERMINATORS,
-  );
+  const note = text.slice(markerIndex + ATTACHMENT_NOTE_MARKER.length);
   const attachments: ChatAttachment[] = [];
 
   for (const rawLine of note.split(/\r?\n/)) {
-    const line = rawLine.trim();
-    const attachment = parseAttachmentPathNoteLine(line);
-    if (!attachment) continue;
-    const { name, path: filePath } = attachment;
-    const mimeType = inferAttachmentMimeType(name, filePath);
-    if (isImageAttachmentMime(mimeType)) continue;
+    let line = rawLine.trim();
+    if (line === ATTACHMENT_NOTE_END_MARKER) break;
+    let reachedLegacyTerminator = false;
+    if (!line.startsWith(ATTACHMENT_NOTE_JSON_PREFIX)) {
+      const legacyLine = sliceBeforeFirstMarker(line, LEGACY_ATTACHMENT_NOTE_TERMINATORS);
+      reachedLegacyTerminator = legacyLine.length !== line.length;
+      line = legacyLine.trim();
+      if (!line && reachedLegacyTerminator) break;
+    }
 
-    attachments.push({
-      name,
-      path: filePath,
-      mimeType,
-    });
+    const attachment = parseAttachmentPathNoteLine(line);
+    if (attachment) {
+      const { name, path: filePath } = attachment;
+      const mimeType = inferAttachmentMimeType(name, filePath);
+      if (!isImageAttachmentMime(mimeType)) {
+        attachments.push({ name, path: filePath, mimeType });
+      }
+    }
+    if (reachedLegacyTerminator) break;
   }
 
   return { content: visibleContent, attachments: [...attachments, ...selectionAttachments] };

--- a/ui/src/components/chat/utils/attachmentNotes.ts
+++ b/ui/src/components/chat/utils/attachmentNotes.ts
@@ -97,7 +97,7 @@ export function parseUserAttachmentNote(content: unknown): {
   for (const rawLine of note.split(/\r?\n/)) {
     const line = rawLine.trim();
     if (!line.startsWith('- ')) continue;
-    const separator = line.indexOf(': ');
+    const separator = line.lastIndexOf(': ');
     if (separator < 0) continue;
 
     const name = line.slice(2, separator).trim();

--- a/ui/src/components/chat/utils/attachmentNotes.ts
+++ b/ui/src/components/chat/utils/attachmentNotes.ts
@@ -59,12 +59,40 @@ function parseAttachmentPathNoteLine(line: string): AttachmentPathNoteFile | nul
   }
 
   if (!line.startsWith('- ')) return null;
-  const separator = line.lastIndexOf(': ');
+  const separator = findLegacyAttachmentSeparator(line);
   if (separator < 0) return null;
 
   const name = line.slice(2, separator).trim();
   const filePath = line.slice(separator + 2).trim();
   return name && filePath ? { name, path: filePath } : null;
+}
+
+function isLikelyLegacyAttachmentPath(value: string): boolean {
+  return value.startsWith('/')
+    || value.startsWith('\\')
+    || /^[A-Za-z]:[\\/]/.test(value)
+    || value.startsWith('./')
+    || value.startsWith('../');
+}
+
+function findLegacyAttachmentSeparator(line: string): number {
+  const firstSeparator = line.indexOf(': ', 2);
+  if (firstSeparator < 0) return -1;
+
+  // Legacy notes originally used the first delimiter. Prefer it whenever it
+  // clearly starts a path, then allow colon-containing filenames on common
+  // absolute-path records.
+  if (isLikelyLegacyAttachmentPath(line.slice(firstSeparator + 2).trim())) {
+    return firstSeparator;
+  }
+  for (let separator = line.indexOf(': ', firstSeparator + 2);
+    separator >= 0;
+    separator = line.indexOf(': ', separator + 2)) {
+    if (isLikelyLegacyAttachmentPath(line.slice(separator + 2).trim())) {
+      return separator;
+    }
+  }
+  return firstSeparator;
 }
 
 function sliceBeforeFirstMarker(value: string, markers: string[]): string {

--- a/ui/src/components/chat/utils/sessionLauncher.spec.ts
+++ b/ui/src/components/chat/utils/sessionLauncher.spec.ts
@@ -16,7 +16,15 @@ describe('sessionLauncher turn identity', () => {
   it('falls back when Web Crypto is unavailable on an insecure origin', () => {
     vi.stubGlobal('crypto', undefined);
 
-    expect(createUserTurnRunId()).toMatch(/^web-turn-\d+-[a-z0-9]+$/);
+    expect(createUserTurnRunId()).toMatch(/^web-turn-\d+-\d+$/);
+  });
+
+  it('uses getRandomValues when randomUUID is unavailable', () => {
+    vi.stubGlobal('crypto', {
+      getRandomValues: (bytes: Uint8Array) => bytes.fill(0),
+    });
+
+    expect(createUserTurnRunId()).toBe('00000000-0000-4000-8000-000000000000');
   });
 
   it('forwards the optimistic user run id in the command options', () => {

--- a/ui/src/components/chat/utils/sessionLauncher.spec.ts
+++ b/ui/src/components/chat/utils/sessionLauncher.spec.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Project } from '../../../types/app';
+import { createUserTurnRunId, startSessionCommand } from './sessionLauncher';
+
+describe('sessionLauncher turn identity', () => {
+  it('creates UUID identities for new user turns', () => {
+    expect(createUserTurnRunId()).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+    );
+  });
+
+  it('forwards the optimistic user run id in the command options', () => {
+    const sendMessage = vi.fn();
+
+    startSessionCommand({
+      sendMessage,
+      selectedProject: { name: 'PilotDeck', path: '/workspace/PilotDeck' } as Project,
+      command: 'Continue.',
+      runId: 'run-user-1',
+      sessionId: 'web:session-1',
+    });
+
+    expect(sendMessage).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'pilotdeck-command',
+      options: expect.objectContaining({
+        sessionId: 'web:session-1',
+        runId: 'run-user-1',
+      }),
+    }));
+  });
+});

--- a/ui/src/components/chat/utils/sessionLauncher.spec.ts
+++ b/ui/src/components/chat/utils/sessionLauncher.spec.ts
@@ -1,12 +1,22 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { Project } from '../../../types/app';
 import { createUserTurnRunId, startSessionCommand } from './sessionLauncher';
 
 describe('sessionLauncher turn identity', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   it('creates UUID identities for new user turns', () => {
     expect(createUserTurnRunId()).toMatch(
       /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
     );
+  });
+
+  it('falls back when Web Crypto is unavailable on an insecure origin', () => {
+    vi.stubGlobal('crypto', undefined);
+
+    expect(createUserTurnRunId()).toMatch(/^web-turn-\d+-[a-z0-9]+$/);
   });
 
   it('forwards the optimistic user run id in the command options', () => {

--- a/ui/src/components/chat/utils/sessionLauncher.ts
+++ b/ui/src/components/chat/utils/sessionLauncher.ts
@@ -30,6 +30,7 @@ const VALID_PERMISSION_MODES = new Set<PermissionMode>([
   'bypassPermissions',
   'plan',
 ]);
+let fallbackRunIdCounter = 0;
 
 export const isTemporarySessionId = (sessionId: string | null | undefined) =>
   Boolean(sessionId && sessionId.startsWith('new-session-'));
@@ -42,7 +43,15 @@ export function createUserTurnRunId(): string {
   if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
     return crypto.randomUUID();
   }
-  return `web-turn-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  if (typeof crypto !== 'undefined' && typeof crypto.getRandomValues === 'function') {
+    const bytes = crypto.getRandomValues(new Uint8Array(16));
+    bytes[6] = (bytes[6] & 0x0f) | 0x40;
+    bytes[8] = (bytes[8] & 0x3f) | 0x80;
+    const hex = Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('');
+    return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+  }
+  fallbackRunIdCounter += 1;
+  return `web-turn-${Date.now()}-${fallbackRunIdCounter}`;
 }
 
 export function getNotificationSessionSummary(

--- a/ui/src/components/chat/utils/sessionLauncher.ts
+++ b/ui/src/components/chat/utils/sessionLauncher.ts
@@ -39,7 +39,10 @@ export function createTemporarySessionId(): string {
 }
 
 export function createUserTurnRunId(): string {
-  return crypto.randomUUID();
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `web-turn-${Date.now()}-${Math.random().toString(36).slice(2)}`;
 }
 
 export function getNotificationSessionSummary(

--- a/ui/src/components/chat/utils/sessionLauncher.ts
+++ b/ui/src/components/chat/utils/sessionLauncher.ts
@@ -6,6 +6,7 @@ type StartSessionOptions = {
   sendMessage: (message: unknown) => void;
   selectedProject: Project;
   command: string;
+  runId?: string;
   userVisibleInput?: string;
   sessionId?: string | null;
   temporarySessionId?: string;
@@ -35,6 +36,10 @@ export const isTemporarySessionId = (sessionId: string | null | undefined) =>
 
 export function createTemporarySessionId(): string {
   return `new-session-${Date.now()}`;
+}
+
+export function createUserTurnRunId(): string {
+  return crypto.randomUUID();
 }
 
 export function getNotificationSessionSummary(
@@ -83,6 +88,7 @@ export function startSessionCommand({
   sendMessage,
   selectedProject,
   command,
+  runId,
   userVisibleInput,
   sessionId,
   temporarySessionId,
@@ -111,6 +117,7 @@ export function startSessionCommand({
       ...(sessionId ? { sessionId, resume: true } : {}),
       projectPath: resolvedProjectPath,
       cwd: resolvedProjectPath,
+      ...(runId ? { runId } : {}),
       toolsSettings,
       ...(runMode ? { runMode } : {}),
       permissionMode,

--- a/ui/src/stores/useSessionStore.requests.spec.tsx
+++ b/ui/src/stores/useSessionStore.requests.spec.tsx
@@ -48,6 +48,14 @@ function serverMessage(id: string, content: string): NormalizedMessage {
   };
 }
 
+function userMessage(id: string, content: string, timestamp: string): NormalizedMessage {
+  return {
+    ...serverMessage(id, content),
+    timestamp,
+    role: 'user',
+  };
+}
+
 describe('useSessionStore server request ordering', () => {
   beforeEach(() => {
     mocks.authenticatedFetch.mockReset();
@@ -235,5 +243,42 @@ describe('useSessionStore server request ordering', () => {
     const slot = result.current.getSessionSlot('session-1');
     expect(slot?._serverLoadingGeneration).toBeNull();
     expect(slot?.status).toBe('streaming');
+  });
+
+  it('does not confirm an optimistic send from older history loaded after it', async () => {
+    const initial = deferred<TestResponse>();
+    mocks.authenticatedFetch.mockImplementationOnce(() => initial.promise);
+
+    const { result } = renderHook(() => useSessionStore());
+    let initialRequest!: ReturnType<typeof result.current.fetchFromServer>;
+    act(() => {
+      initialRequest = result.current.fetchFromServer('session-1');
+      result.current.appendRealtime(
+        'session-1',
+        userMessage('local_new_send', 'Continue.', '2026-08-04T00:00:05.000Z'),
+      );
+    });
+
+    expect(result.current.getSessionSlot('session-1')?.realtimeMessages[0]).toMatchObject({
+      id: 'local_new_send',
+      serverTailIdAtStart: null,
+      serverHistoryPendingAtStart: true,
+    });
+
+    await act(async () => {
+      initial.resolve(response({
+        messages: [userMessage('persisted-old-send', 'Continue.', '2026-08-04T00:00:00.000Z')],
+        total: 1,
+      }));
+      await initialRequest;
+    });
+
+    expect(result.current.getSessionSlot('session-1')?.realtimeMessages).toEqual([
+      expect.objectContaining({
+        id: 'local_new_send',
+        serverTailIdAtStart: 'persisted-old-send',
+        serverHistoryPendingAtStart: false,
+      }),
+    ]);
   });
 });

--- a/ui/src/stores/useSessionStore.requests.spec.tsx
+++ b/ui/src/stores/useSessionStore.requests.spec.tsx
@@ -406,9 +406,10 @@ describe('useSessionStore server request ordering', () => {
       );
     });
 
-    expect(result.current.getSessionSlot('session-1')?.realtimeMessages[0]).not.toHaveProperty(
-      'serverHistoryPendingAtStart',
-    );
+    expect(result.current.getSessionSlot('session-1')?.realtimeMessages[0]).toMatchObject({
+      serverTailIdAtStart: null,
+      serverHistoryPendingAtStart: true,
+    });
 
     await act(async () => {
       initial.resolve(response({
@@ -454,7 +455,12 @@ describe('useSessionStore server request ordering', () => {
     });
 
     expect(result.current.getSessionSlot('session-1')?.realtimeMessages).toEqual([
-      expect.objectContaining({ id: 'local_new_user', runId: 'run-new' }),
+      expect.objectContaining({
+        id: 'local_new_user',
+        runId: 'run-new',
+        serverTailIdAtStart: 'persisted-old-user',
+        serverHistoryPendingAtStart: false,
+      }),
     ]);
   });
 });

--- a/ui/src/stores/useSessionStore.requests.spec.tsx
+++ b/ui/src/stores/useSessionStore.requests.spec.tsx
@@ -48,11 +48,17 @@ function serverMessage(id: string, content: string): NormalizedMessage {
   };
 }
 
-function userMessage(id: string, content: string, timestamp: string): NormalizedMessage {
+function userMessage(
+  id: string,
+  content: string,
+  timestamp: string,
+  overrides: Partial<NormalizedMessage> = {},
+): NormalizedMessage {
   return {
     ...serverMessage(id, content),
     timestamp,
     role: 'user',
+    ...overrides,
   };
 }
 
@@ -381,6 +387,74 @@ describe('useSessionStore server request ordering', () => {
         serverTailIdAtStart: 'persisted-old-send',
         serverHistoryPendingAtStart: false,
       }),
+    ]);
+  });
+
+  it('confirms an id-bearing optimistic send during the initial fetch', async () => {
+    const initial = deferred<TestResponse>();
+    mocks.authenticatedFetch.mockImplementationOnce(() => initial.promise);
+
+    const { result } = renderHook(() => useSessionStore());
+    let initialRequest!: ReturnType<typeof result.current.fetchFromServer>;
+    act(() => {
+      initialRequest = result.current.fetchFromServer('session-1');
+      result.current.appendRealtime(
+        'session-1',
+        userMessage('local_user', 'Continue.', '2026-08-04T00:00:05.000Z', {
+          runId: 'run-user-1',
+        }),
+      );
+    });
+
+    expect(result.current.getSessionSlot('session-1')?.realtimeMessages[0]).not.toHaveProperty(
+      'serverHistoryPendingAtStart',
+    );
+
+    await act(async () => {
+      initial.resolve(response({
+        messages: [userMessage('persisted-user', 'Continue.', '2026-08-04T00:00:00.000Z', {
+          turnId: 'run-user-1',
+          runId: 'run-user-1',
+        })],
+        total: 1,
+      }));
+      await initialRequest;
+    });
+
+    expect(result.current.getSessionSlot('session-1')?.realtimeMessages).toEqual([]);
+  });
+
+  it('keeps a different id-bearing optimistic send during refresh cleanup', async () => {
+    const refresh = deferred<TestResponse>();
+    mocks.authenticatedFetch.mockImplementationOnce(() => refresh.promise);
+
+    const { result } = renderHook(() => useSessionStore());
+    act(() => {
+      result.current.appendRealtime(
+        'session-1',
+        userMessage('local_new_user', 'Continue.', '2026-08-04T00:00:05.000Z', {
+          runId: 'run-new',
+        }),
+      );
+    });
+
+    let refreshRequest!: ReturnType<typeof result.current.refreshFromServer>;
+    act(() => {
+      refreshRequest = result.current.refreshFromServer('session-1');
+    });
+    await act(async () => {
+      refresh.resolve(response({
+        messages: [userMessage('persisted-old-user', 'Continue.', '2026-08-04T00:00:00.000Z', {
+          turnId: 'run-old',
+          runId: 'run-old',
+        })],
+        total: 1,
+      }));
+      await refreshRequest;
+    });
+
+    expect(result.current.getSessionSlot('session-1')?.realtimeMessages).toEqual([
+      expect.objectContaining({ id: 'local_new_user', runId: 'run-new' }),
     ]);
   });
 });

--- a/ui/src/stores/useSessionStore.requests.spec.tsx
+++ b/ui/src/stores/useSessionStore.requests.spec.tsx
@@ -281,4 +281,106 @@ describe('useSessionStore server request ordering', () => {
       }),
     ]);
   });
+
+  it('treats a sibling optimistic send as pending before history loading starts', async () => {
+    const initial = deferred<TestResponse>();
+    mocks.authenticatedFetch.mockImplementationOnce(() => initial.promise);
+
+    const { result } = renderHook(() => useSessionStore());
+    act(() => {
+      result.current.appendRealtime(
+        'session-1',
+        userMessage('local_ws_user_new_send', 'Continue.', '2026-08-04T00:00:05.000Z'),
+      );
+    });
+
+    expect(result.current.getSessionSlot('session-1')?.realtimeMessages[0]).toMatchObject({
+      id: 'local_ws_user_new_send',
+      serverTailIdAtStart: null,
+      serverHistoryPendingAtStart: true,
+    });
+
+    let initialRequest!: ReturnType<typeof result.current.fetchFromServer>;
+    act(() => {
+      initialRequest = result.current.fetchFromServer('session-1');
+    });
+    await act(async () => {
+      initial.resolve(response({
+        messages: [userMessage('persisted-old-send', 'Continue.', '2026-08-04T00:00:00.000Z')],
+        total: 1,
+      }));
+      await initialRequest;
+    });
+
+    expect(result.current.getSessionSlot('session-1')?.realtimeMessages).toEqual([
+      expect.objectContaining({
+        id: 'local_ws_user_new_send',
+        serverTailIdAtStart: 'persisted-old-send',
+        serverHistoryPendingAtStart: false,
+      }),
+    ]);
+  });
+
+  it('keeps optimistic history pending across an empty initial response', async () => {
+    const initial = deferred<TestResponse>();
+    const refresh = deferred<TestResponse>();
+    mocks.authenticatedFetch
+      .mockImplementationOnce(() => initial.promise)
+      .mockImplementationOnce(() => refresh.promise);
+
+    const { result } = renderHook(() => useSessionStore());
+    let initialRequest!: ReturnType<typeof result.current.fetchFromServer>;
+    act(() => {
+      initialRequest = result.current.fetchFromServer('session-1');
+      result.current.appendRealtime(
+        'session-1',
+        userMessage('local_new_send', 'Continue.', '2026-08-04T00:00:05.000Z'),
+      );
+    });
+    await act(async () => {
+      initial.resolve(response({ messages: [], total: 0 }));
+      await initialRequest;
+    });
+
+    expect(result.current.getSessionSlot('session-1')?.realtimeMessages[0]).toMatchObject({
+      id: 'local_new_send',
+      serverTailIdAtStart: null,
+      serverHistoryPendingAtStart: true,
+    });
+    act(() => {
+      result.current.appendRealtime(
+        'session-1',
+        userMessage('local_after_empty', 'Another message', '2026-08-04T00:00:06.000Z'),
+      );
+    });
+    expect(result.current.getSessionSlot('session-1')?.realtimeMessages[1]).toMatchObject({
+      id: 'local_after_empty',
+      serverHistoryPendingAtStart: true,
+    });
+
+    let refreshRequest!: ReturnType<typeof result.current.refreshFromServer>;
+    act(() => {
+      refreshRequest = result.current.refreshFromServer('session-1');
+    });
+    await act(async () => {
+      refresh.resolve(response({
+        messages: [userMessage('persisted-old-send', 'Continue.', '2026-08-04T00:00:00.000Z')],
+        total: 1,
+      }));
+      await refreshRequest;
+    });
+
+    expect(result.current.getSessionSlot('session-1')?.realtimeMessages).toEqual([
+      expect.objectContaining({
+        id: 'local_new_send',
+        serverTailIdAtStart: 'persisted-old-send',
+        serverHistoryPendingAtStart: false,
+      }),
+      expect.objectContaining({
+        id: 'local_after_empty',
+        serverTailIdAtStart: 'persisted-old-send',
+        serverHistoryPendingAtStart: false,
+      }),
+    ]);
+  });
 });

--- a/ui/src/stores/useSessionStore.streaming.test.ts
+++ b/ui/src/stores/useSessionStore.streaming.test.ts
@@ -269,7 +269,17 @@ describe('computeMerged', () => {
           kind: 'content-reference',
           name: 'notes.md',
           path: 'notes.md',
-          contentReference: { id: 'content-reference-1' },
+          contentReference: {
+            schemaVersion: 1,
+            kind: 'content-reference',
+            id: 'content-reference-1',
+            selectionMode: 'text',
+            source: { relativePath: 'notes.md', fileName: 'notes.md' },
+            renderer: { id: 'text', backend: 'builtin', locatorQuality: 'semantic' },
+            createdAt: '2026-08-16T09:00:00.000Z',
+            locator: { surface: 'document', quote: { exact: 'selection' } },
+            selectedText: 'selection',
+          },
         }],
       }),
     ];
@@ -332,6 +342,69 @@ describe('computeMerged', () => {
     expect(computeMerged(server, realtime).map((message) => message.id)).toEqual([
       'persisted-first-user',
       'local_second',
+    ]);
+  });
+
+  it('matches persisted user messages to identical optimistic sends one-to-one', () => {
+    const server = [
+      textMessage('persisted-first-user', 'Continue.', '2026-08-16T09:00:00.050Z', {
+        role: 'user',
+      }),
+    ];
+    const realtime = [
+      textMessage('local_first', 'Continue.', '2026-08-16T09:00:00.000Z', { role: 'user' }),
+      textMessage('local_second', 'Continue.', '2026-08-16T09:00:00.100Z', { role: 'user' }),
+    ];
+
+    expect(computeMerged(server, realtime).map((message) => message.id)).toEqual([
+      'persisted-first-user',
+      'local_second',
+    ]);
+  });
+
+  it('keeps optimistic messages whose image input order differs from the persisted message', () => {
+    const server = [
+      textMessage('persisted-user', 'Compare these images.', '2026-08-16T09:00:00.050Z', {
+        role: 'user',
+        images: ['data:image/png;base64,first', 'data:image/png;base64,second'],
+      }),
+    ];
+    const realtime = [
+      textMessage('local_ws_user', 'Compare these images.', '2026-08-16T09:00:00.000Z', {
+        role: 'user',
+        images: ['data:image/png;base64,second', 'data:image/png;base64,first'],
+      }),
+    ];
+
+    expect(computeMerged(server, realtime).map((message) => message.id)).toEqual([
+      'persisted-user',
+      'local_ws_user',
+    ]);
+  });
+
+  it('keeps optimistic messages whose attachment input order differs from the persisted message', () => {
+    const server = [
+      textMessage('persisted-user', 'Compare these files.', '2026-08-16T09:00:00.050Z', {
+        role: 'user',
+        attachments: [
+          { name: 'first.pdf', path: '.tmp/first.pdf' },
+          { name: 'second.pdf', path: '.tmp/second.pdf' },
+        ],
+      }),
+    ];
+    const realtime = [
+      textMessage('local_user', 'Compare these files.', '2026-08-16T09:00:00.000Z', {
+        role: 'user',
+        attachments: [
+          { name: 'second.pdf', path: '.tmp/second.pdf' },
+          { name: 'first.pdf', path: '.tmp/first.pdf' },
+        ],
+      }),
+    ];
+
+    expect(computeMerged(server, realtime).map((message) => message.id)).toEqual([
+      'persisted-user',
+      'local_user',
     ]);
   });
 

--- a/ui/src/stores/useSessionStore.streaming.test.ts
+++ b/ui/src/stores/useSessionStore.streaming.test.ts
@@ -363,6 +363,119 @@ describe('computeMerged', () => {
     ]);
   });
 
+  it('confirms an optimistic user row only from the same persisted turn identity', () => {
+    const server = [
+      textMessage('persisted-user', 'Continue.\n\n[Files attached by user]', '2026-08-16T09:00:30.000Z', {
+        role: 'user',
+        turnId: 'run-user-1',
+        runId: 'run-user-1',
+      }),
+    ];
+    const realtime = [
+      textMessage('local_user', 'Continue.', '2026-08-16T09:00:00.000Z', {
+        role: 'user',
+        runId: 'run-user-1',
+      }),
+    ];
+
+    expect(computeMerged(server, realtime)).toEqual(server);
+    expect(getRealtimeMessagesToKeepAfterServerRefresh(realtime, server)).toEqual([]);
+  });
+
+  it('does not let an older same-text turn confirm a new optimistic send', () => {
+    const server = [
+      textMessage('persisted-old-user', 'Continue.', '2026-08-16T09:00:05.000Z', {
+        role: 'user',
+        turnId: 'run-old',
+        runId: 'run-old',
+      }),
+    ];
+    const realtime = [
+      textMessage('local_new_user', 'Continue.', '2026-08-16T09:00:05.100Z', {
+        role: 'user',
+        runId: 'run-new',
+      }),
+    ];
+
+    expect(computeMerged(server, realtime).map((message) => message.id)).toEqual([
+      'persisted-old-user',
+      'local_new_user',
+    ]);
+    expect(getRealtimeMessagesToKeepAfterServerRefresh(realtime, server)).toEqual(realtime);
+  });
+
+  it('keeps an unpersisted retry while confirming a same-text send by run id', () => {
+    const server = [
+      textMessage('persisted-second-user', 'Continue.', '2026-08-16T09:00:00.100Z', {
+        role: 'user',
+        turnId: 'run-second',
+        runId: 'run-second',
+      }),
+    ];
+    const realtime = [
+      textMessage('local_failed_first', 'Continue.', '2026-08-16T09:00:00.000Z', {
+        role: 'user',
+        runId: 'run-first',
+      }),
+      textMessage('local_confirmed_second', 'Continue.', '2026-08-16T09:00:00.100Z', {
+        role: 'user',
+        runId: 'run-second',
+      }),
+    ];
+
+    expect(computeMerged(server, realtime).map((message) => message.id)).toEqual([
+      'persisted-second-user',
+      'local_failed_first',
+    ]);
+  });
+
+  it('confirms same-text queued sends by run id regardless of message order', () => {
+    const server = [
+      textMessage('persisted-second-user', 'Continue.', '2026-08-16T09:00:09.000Z', {
+        role: 'user',
+        turnId: 'run-second',
+        runId: 'run-second',
+      }),
+      textMessage('persisted-first-user', 'Continue.', '2026-08-16T09:00:00.000Z', {
+        role: 'user',
+        turnId: 'run-first',
+        runId: 'run-first',
+      }),
+    ];
+    const realtime = [
+      textMessage('local_first', 'Continue.', '2026-08-16T08:59:51.000Z', {
+        role: 'user',
+        runId: 'run-first',
+      }),
+      textMessage('local_second', 'Continue.', '2026-08-16T09:00:05.000Z', {
+        role: 'user',
+        runId: 'run-second',
+      }),
+    ];
+
+    expect(computeMerged(server, realtime)).toEqual(server);
+    expect(getRealtimeMessagesToKeepAfterServerRefresh(realtime, server)).toEqual([]);
+  });
+
+  it('does not mix exact-id and legacy user confirmation', () => {
+    const identitylessServer = [
+      textMessage('persisted-legacy-user', 'Continue.', '2026-08-16T09:00:00.050Z', {
+        role: 'user',
+      }),
+    ];
+    const identifiedRealtime = [
+      textMessage('local_identified', 'Continue.', '2026-08-16T09:00:00.000Z', {
+        role: 'user',
+        runId: 'run-new',
+      }),
+    ];
+
+    expect(computeMerged(identitylessServer, identifiedRealtime).map((message) => message.id)).toEqual([
+      'persisted-legacy-user',
+      'local_identified',
+    ]);
+  });
+
   it('matches a persisted send to the closest optimistic timestamp', () => {
     const server = [
       textMessage('persisted-second-user', 'Continue.', '2026-08-16T09:00:00.100Z', {

--- a/ui/src/stores/useSessionStore.streaming.test.ts
+++ b/ui/src/stores/useSessionStore.streaming.test.ts
@@ -10,6 +10,7 @@ import {
   cancelRunningAgentActivities,
   createRafNotifyScheduler,
   getFinalizedSubagentThinkingId,
+  getRealtimeMessagesToKeepAfterServerRefresh,
   getUnpersistedRealtimeTurnMessages,
   isRealtimeMessageRepresentedOnServer,
   patchMergedStreamingMessage,
@@ -362,6 +363,23 @@ describe('computeMerged', () => {
     ]);
   });
 
+  it('matches a persisted send to the closest optimistic timestamp', () => {
+    const server = [
+      textMessage('persisted-second-user', 'Continue.', '2026-08-16T09:00:00.100Z', {
+        role: 'user',
+      }),
+    ];
+    const realtime = [
+      textMessage('local_failed_first', 'Continue.', '2026-08-16T09:00:00.000Z', { role: 'user' }),
+      textMessage('local_confirmed_second', 'Continue.', '2026-08-16T09:00:00.100Z', { role: 'user' }),
+    ];
+
+    expect(computeMerged(server, realtime).map((message) => message.id)).toEqual([
+      'persisted-second-user',
+      'local_failed_first',
+    ]);
+  });
+
   it('keeps the second identical optimistic send during server-refresh cleanup', () => {
     const server = [
       textMessage('persisted-first-user', 'Continue.', '2026-08-16T09:00:00.050Z', {
@@ -372,13 +390,25 @@ describe('computeMerged', () => {
       textMessage('local_first', 'Continue.', '2026-08-16T09:00:00.000Z', { role: 'user' }),
       textMessage('local_second', 'Continue.', '2026-08-16T09:00:00.100Z', { role: 'user' }),
     ];
-    const consumedServerUserIndexes = new Set<number>();
-
-    const retained = realtime.filter((message) => (
-      shouldKeepRealtimeAfterServerRefresh(message, server, consumedServerUserIndexes)
-    ));
+    const retained = getRealtimeMessagesToKeepAfterServerRefresh(realtime, server);
 
     expect(retained.map((message) => message.id)).toEqual(['local_second']);
+  });
+
+  it('uses the closest optimistic timestamp during refresh cleanup', () => {
+    const server = [
+      textMessage('persisted-second-user', 'Continue.', '2026-08-16T09:00:00.100Z', {
+        role: 'user',
+      }),
+    ];
+    const realtime = [
+      textMessage('local_failed_first', 'Continue.', '2026-08-16T09:00:00.000Z', { role: 'user' }),
+      textMessage('local_confirmed_second', 'Continue.', '2026-08-16T09:00:00.100Z', { role: 'user' }),
+    ];
+
+    expect(getRealtimeMessagesToKeepAfterServerRefresh(realtime, server).map((message) => message.id)).toEqual([
+      'local_failed_first',
+    ]);
   });
 
   it('keeps optimistic messages whose image input order differs from the persisted message', () => {

--- a/ui/src/stores/useSessionStore.streaming.test.ts
+++ b/ui/src/stores/useSessionStore.streaming.test.ts
@@ -380,6 +380,46 @@ describe('computeMerged', () => {
     ]);
   });
 
+  it('does not confirm a new identical send from the captured server tail', () => {
+    const server = [
+      textMessage('persisted-previous-user', 'Continue.', '2026-08-16T09:00:00.000Z', {
+        role: 'user',
+      }),
+    ];
+    const realtime = [
+      textMessage('local_new_send', 'Continue.', '2026-08-16T09:00:05.000Z', {
+        role: 'user',
+        serverTailIdAtStart: 'persisted-previous-user',
+      }),
+    ];
+
+    expect(computeMerged(server, realtime).map((message) => message.id)).toEqual([
+      'persisted-previous-user',
+      'local_new_send',
+    ]);
+    expect(getRealtimeMessagesToKeepAfterServerRefresh(realtime, server)).toEqual(realtime);
+  });
+
+  it('confirms an identical send persisted after the captured server tail', () => {
+    const server = [
+      textMessage('persisted-previous-user', 'Continue.', '2026-08-16T09:00:00.000Z', {
+        role: 'user',
+      }),
+      textMessage('persisted-new-user', 'Continue.', '2026-08-16T09:00:05.050Z', {
+        role: 'user',
+      }),
+    ];
+    const realtime = [
+      textMessage('local_new_send', 'Continue.', '2026-08-16T09:00:05.000Z', {
+        role: 'user',
+        serverTailIdAtStart: 'persisted-previous-user',
+      }),
+    ];
+
+    expect(computeMerged(server, realtime)).toEqual(server);
+    expect(getRealtimeMessagesToKeepAfterServerRefresh(realtime, server)).toEqual([]);
+  });
+
   it('keeps the second identical optimistic send during server-refresh cleanup', () => {
     const server = [
       textMessage('persisted-first-user', 'Continue.', '2026-08-16T09:00:00.050Z', {

--- a/ui/src/stores/useSessionStore.streaming.test.ts
+++ b/ui/src/stores/useSessionStore.streaming.test.ts
@@ -424,8 +424,8 @@ describe('computeMerged', () => {
     ];
 
     expect(computeMerged(server, realtime).map((message) => message.id)).toEqual([
-      'persisted-second-user',
       'local_failed_first',
+      'persisted-second-user',
     ]);
   });
 
@@ -471,8 +471,8 @@ describe('computeMerged', () => {
     ];
 
     expect(computeMerged(identitylessServer, identifiedRealtime).map((message) => message.id)).toEqual([
-      'persisted-legacy-user',
       'local_identified',
+      'persisted-legacy-user',
     ]);
   });
 
@@ -488,8 +488,8 @@ describe('computeMerged', () => {
     ];
 
     expect(computeMerged(server, realtime).map((message) => message.id)).toEqual([
-      'persisted-second-user',
       'local_failed_first',
+      'persisted-second-user',
     ]);
   });
 
@@ -604,8 +604,8 @@ describe('computeMerged', () => {
     ];
 
     expect(computeMerged(server, realtime).map((message) => message.id)).toEqual([
-      'persisted-user',
       'local_ws_user',
+      'persisted-user',
     ]);
   });
 
@@ -630,8 +630,8 @@ describe('computeMerged', () => {
     ];
 
     expect(computeMerged(server, realtime).map((message) => message.id)).toEqual([
-      'persisted-user',
       'local_user',
+      'persisted-user',
     ]);
   });
 

--- a/ui/src/stores/useSessionStore.streaming.test.ts
+++ b/ui/src/stores/useSessionStore.streaming.test.ts
@@ -404,6 +404,34 @@ describe('computeMerged', () => {
     expect(getRealtimeMessagesToKeepAfterServerRefresh(realtime, server)).toEqual(realtime);
   });
 
+  it('keeps an id-bearing optimistic send after its captured history tail despite clock skew', () => {
+    const server = [
+      textMessage('persisted-old-user', 'Old prompt', '2026-08-16T09:00:00.000Z', {
+        role: 'user',
+        turnId: 'run-old',
+        runId: 'run-old',
+      }),
+      textMessage('persisted-old-answer', 'Old answer', '2026-08-16T09:00:01.000Z', {
+        role: 'assistant',
+        turnId: 'run-old',
+        runId: 'run-old',
+      }),
+    ];
+    const realtime = [
+      textMessage('local_new_user', 'New prompt', '2026-08-16T08:00:00.000Z', {
+        role: 'user',
+        runId: 'run-new',
+        serverTailIdAtStart: 'persisted-old-answer',
+      }),
+    ];
+
+    expect(computeMerged(server, realtime).map((message) => message.id)).toEqual([
+      'persisted-old-user',
+      'persisted-old-answer',
+      'local_new_user',
+    ]);
+  });
+
   it('keeps an unpersisted retry while confirming a same-text send by run id', () => {
     const server = [
       textMessage('persisted-second-user', 'Continue.', '2026-08-16T09:00:00.100Z', {

--- a/ui/src/stores/useSessionStore.streaming.test.ts
+++ b/ui/src/stores/useSessionStore.streaming.test.ts
@@ -212,6 +212,63 @@ describe('patchMergedStreamingMessage', () => {
 });
 
 describe('computeMerged', () => {
+  it('deduplicates an optimistic user message from its persisted attachment prompt', () => {
+    const server = [
+      textMessage(
+        'persisted-user',
+        [
+          'Transcribe this audio.',
+          '',
+          '[Files attached by user and available for reading in the project:]',
+          '- meeting.wav: .tmp/meeting.wav',
+          '[End files attached by user]',
+          '',
+          '[Registered attachment files in this session:]',
+          '- meeting.wav: .tmp/meeting.wav',
+          'Use the audio transcription tool for this attachment.',
+        ].join('\n'),
+        '2026-08-16T09:00:00.050Z',
+        { role: 'user' },
+      ),
+    ];
+    const realtime = [
+      textMessage('local_user', 'Transcribe this audio.', '2026-08-16T09:00:00.000Z', {
+        role: 'user',
+      }),
+    ];
+
+    expect(computeMerged(server, realtime).map((message) => message.id)).toEqual([
+      'persisted-user',
+    ]);
+  });
+
+  it('deduplicates an optimistic user message from its persisted content reference prompt', () => {
+    const server = [
+      textMessage(
+        'persisted-user',
+        [
+          'Summarize this selection.',
+          '',
+          '[Content references selected by user:]',
+          '1. TEXT reference',
+          '   Source: notes.md',
+          '   Reference JSON: {"schemaVersion":1}',
+        ].join('\n'),
+        '2026-08-16T09:00:00.050Z',
+        { role: 'user' },
+      ),
+    ];
+    const realtime = [
+      textMessage('local_user', 'Summarize this selection.', '2026-08-16T09:00:00.000Z', {
+        role: 'user',
+      }),
+    ];
+
+    expect(computeMerged(server, realtime).map((message) => message.id)).toEqual([
+      'persisted-user',
+    ]);
+  });
+
   it('deduplicates a persisted gateway failure from its same-turn realtime status', () => {
     const persisted: NormalizedMessage = {
       id: 'persisted-gateway-failure',

--- a/ui/src/stores/useSessionStore.streaming.test.ts
+++ b/ui/src/stores/useSessionStore.streaming.test.ts
@@ -432,6 +432,32 @@ describe('computeMerged', () => {
     ]);
   });
 
+  it('preserves realtime turn order while anchoring optimistic users after the server tail', () => {
+    const server = [
+      textMessage('persisted-old-answer', 'Old answer', '2026-08-16T09:00:01.000Z'),
+    ];
+    const realtime = [
+      textMessage('local_first_user', 'First prompt', '2026-08-16T08:00:00.000Z', {
+        role: 'user',
+        runId: 'run-first',
+        serverTailIdAtStart: 'persisted-old-answer',
+      }),
+      streamingMessage('web:s_test', 'First answer'),
+      textMessage('local_second_user', 'Second prompt', '2026-08-16T08:00:01.000Z', {
+        role: 'user',
+        runId: 'run-second',
+        serverTailIdAtStart: 'persisted-old-answer',
+      }),
+    ];
+
+    expect(computeMerged(server, realtime).map((message) => message.id)).toEqual([
+      'persisted-old-answer',
+      'local_first_user',
+      '__streaming_web:s_test',
+      'local_second_user',
+    ]);
+  });
+
   it('keeps an unpersisted retry while confirming a same-text send by run id', () => {
     const server = [
       textMessage('persisted-second-user', 'Continue.', '2026-08-16T09:00:00.100Z', {

--- a/ui/src/stores/useSessionStore.streaming.test.ts
+++ b/ui/src/stores/useSessionStore.streaming.test.ts
@@ -380,6 +380,31 @@ describe('computeMerged', () => {
     ]);
   });
 
+  it('maximizes confirmed sends before minimizing timestamp distance', () => {
+    const server = [
+      textMessage('tail-before-sends', 'Previous answer', '2026-08-16T08:59:49.000Z'),
+      textMessage('persisted-first-user', 'Continue.', '2026-08-16T09:00:00.000Z', {
+        role: 'user',
+      }),
+      textMessage('persisted-second-user', 'Continue.', '2026-08-16T09:00:09.000Z', {
+        role: 'user',
+      }),
+    ];
+    const realtime = [
+      textMessage('local_first', 'Continue.', '2026-08-16T08:59:51.000Z', {
+        role: 'user',
+        serverTailIdAtStart: 'tail-before-sends',
+      }),
+      textMessage('local_second', 'Continue.', '2026-08-16T09:00:05.000Z', {
+        role: 'user',
+        serverTailIdAtStart: 'tail-before-sends',
+      }),
+    ];
+
+    expect(computeMerged(server, realtime)).toEqual(server);
+    expect(getRealtimeMessagesToKeepAfterServerRefresh(realtime, server)).toEqual([]);
+  });
+
   it('does not confirm a new identical send from the captured server tail', () => {
     const server = [
       textMessage('persisted-previous-user', 'Continue.', '2026-08-16T09:00:00.000Z', {

--- a/ui/src/stores/useSessionStore.streaming.test.ts
+++ b/ui/src/stores/useSessionStore.streaming.test.ts
@@ -362,6 +362,25 @@ describe('computeMerged', () => {
     ]);
   });
 
+  it('keeps the second identical optimistic send during server-refresh cleanup', () => {
+    const server = [
+      textMessage('persisted-first-user', 'Continue.', '2026-08-16T09:00:00.050Z', {
+        role: 'user',
+      }),
+    ];
+    const realtime = [
+      textMessage('local_first', 'Continue.', '2026-08-16T09:00:00.000Z', { role: 'user' }),
+      textMessage('local_second', 'Continue.', '2026-08-16T09:00:00.100Z', { role: 'user' }),
+    ];
+    const consumedServerUserIndexes = new Set<number>();
+
+    const retained = realtime.filter((message) => (
+      shouldKeepRealtimeAfterServerRefresh(message, server, consumedServerUserIndexes)
+    ));
+
+    expect(retained.map((message) => message.id)).toEqual(['local_second']);
+  });
+
   it('keeps optimistic messages whose image input order differs from the persisted message', () => {
     const server = [
       textMessage('persisted-user', 'Compare these images.', '2026-08-16T09:00:00.050Z', {

--- a/ui/src/stores/useSessionStore.streaming.test.ts
+++ b/ui/src/stores/useSessionStore.streaming.test.ts
@@ -234,6 +234,10 @@ describe('computeMerged', () => {
     const realtime = [
       textMessage('local_user', 'Transcribe this audio.', '2026-08-16T09:00:00.000Z', {
         role: 'user',
+        attachments: [{
+          name: 'meeting.wav',
+          path: '.tmp/meeting.wav',
+        }],
       }),
     ];
 
@@ -252,7 +256,7 @@ describe('computeMerged', () => {
           '[Content references selected by user:]',
           '1. TEXT reference',
           '   Source: notes.md',
-          '   Reference JSON: {"schemaVersion":1}',
+          '   Reference JSON: {"schemaVersion":1,"kind":"content-reference","id":"content-reference-1","selectionMode":"text","source":{"relativePath":"notes.md","fileName":"notes.md"},"renderer":{"id":"text","backend":"builtin","locatorQuality":"semantic"},"createdAt":"2026-08-16T09:00:00.000Z","locator":{"surface":"document","quote":{"exact":"selection"}},"selectedText":"selection"}',
         ].join('\n'),
         '2026-08-16T09:00:00.050Z',
         { role: 'user' },
@@ -261,11 +265,73 @@ describe('computeMerged', () => {
     const realtime = [
       textMessage('local_user', 'Summarize this selection.', '2026-08-16T09:00:00.000Z', {
         role: 'user',
+        attachments: [{
+          kind: 'content-reference',
+          name: 'notes.md',
+          path: 'notes.md',
+          contentReference: { id: 'content-reference-1' },
+        }],
       }),
     ];
 
     expect(computeMerged(server, realtime).map((message) => message.id)).toEqual([
       'persisted-user',
+    ]);
+  });
+
+  it('keeps a second same-text optimistic message with different attachments', () => {
+    const server = [
+      textMessage(
+        'persisted-first-user',
+        [
+          'Please review the attached file(s).',
+          '',
+          '[Files attached by user and available for reading in the project:]',
+          '- first.pdf: .tmp/first.pdf',
+          '[End files attached by user]',
+        ].join('\n'),
+        '2026-08-16T09:00:00.050Z',
+        { role: 'user' },
+      ),
+    ];
+    const realtime = [
+      textMessage('local_first', 'Please review the attached file(s).', '2026-08-16T09:00:00.000Z', {
+        role: 'user',
+        attachments: [{ name: 'first.pdf', path: '.tmp/first.pdf' }],
+      }),
+      textMessage('local_second', 'Please review the attached file(s).', '2026-08-16T09:00:00.100Z', {
+        role: 'user',
+        attachments: [{ name: 'second.pdf', path: '.tmp/second.pdf' }],
+      }),
+    ];
+
+    expect(computeMerged(server, realtime).map((message) => message.id)).toEqual([
+      'persisted-first-user',
+      'local_second',
+    ]);
+  });
+
+  it('keeps a second same-text optimistic message with different image inputs', () => {
+    const server = [
+      textMessage('persisted-first-user', 'Describe this image.', '2026-08-16T09:00:00.050Z', {
+        role: 'user',
+        images: ['data:image/png;base64,first'],
+      }),
+    ];
+    const realtime = [
+      textMessage('local_first', 'Describe this image.', '2026-08-16T09:00:00.000Z', {
+        role: 'user',
+        images: ['data:image/png;base64,first'],
+      }),
+      textMessage('local_second', 'Describe this image.', '2026-08-16T09:00:00.100Z', {
+        role: 'user',
+        images: ['data:image/png;base64,second'],
+      }),
+    ];
+
+    expect(computeMerged(server, realtime).map((message) => message.id)).toEqual([
+      'persisted-first-user',
+      'local_second',
     ]);
   });
 

--- a/ui/src/stores/useSessionStore.ts
+++ b/ui/src/stores/useSessionStore.ts
@@ -157,10 +157,10 @@ export interface NormalizedMessage {
   /** True when the corresponding transcript entry has non-text prefill content. */
   forkUnsupportedContent?: boolean;
   forkUnsupportedReason?: string;
-  // Streaming-only: id of slot.serverMessages tail at the moment the
-  // streaming row was created. computeMerged uses this for an id-based
-  // same-turn-snapshot test instead of a timestamp window.
-  serverTailIdAtStart?: string;
+  // Server-history tail captured when a live row was created. A null value
+  // means the history was empty. Reconciliation uses this as a turn boundary
+  // so an older persisted row cannot confirm a newer optimistic send.
+  serverTailIdAtStart?: string | null;
 }
 
 // ─── Per-session slot ────────────────────────────────────────────────────────
@@ -339,6 +339,34 @@ function isOptimisticUserMessage(message: NormalizedMessage): boolean {
     && message.id.startsWith('local_');
 }
 
+function captureOptimisticUserServerTail(
+  message: NormalizedMessage,
+  serverMessages: NormalizedMessage[],
+): NormalizedMessage {
+  if (!isOptimisticUserMessage(message) || message.serverTailIdAtStart !== undefined) {
+    return message;
+  }
+
+  return {
+    ...message,
+    serverTailIdAtStart: serverMessages[serverMessages.length - 1]?.id ?? null,
+  };
+}
+
+function isServerMessageAfterOptimisticTail(
+  realtimeMessage: NormalizedMessage,
+  serverMessages: NormalizedMessage[],
+  serverIndex: number,
+): boolean {
+  const tailId = realtimeMessage.serverTailIdAtStart;
+  // Rows created before tail tracking was introduced retain the legacy
+  // timestamp-based reconciliation behavior.
+  if (tailId === undefined || tailId === null) return true;
+
+  const tailIndex = serverMessages.findIndex((message) => message.id === tailId);
+  return tailIndex >= 0 && serverIndex > tailIndex;
+}
+
 function findConfirmedUserMessageDuplicateIndex(
   realtimeMessage: NormalizedMessage,
   serverMessages: NormalizedMessage[],
@@ -353,6 +381,7 @@ function findConfirmedUserMessageDuplicateIndex(
 
   for (let index = 0; index < serverMessages.length; index += 1) {
     if (consumedServerIndexes?.has(index)) continue;
+    if (!isServerMessageAfterOptimisticTail(realtimeMessage, serverMessages, index)) continue;
     const serverMessage = serverMessages[index];
     if (serverMessage.kind !== 'text' || serverMessage.role !== 'user') {
       continue;
@@ -394,7 +423,8 @@ function getConfirmedRealtimeUserIndexes(
 ): Set<number> {
   const consumedRealtimeIndexes = new Set<number>();
 
-  for (const serverMessage of serverMessages) {
+  for (let serverIndex = 0; serverIndex < serverMessages.length; serverIndex += 1) {
+    const serverMessage = serverMessages[serverIndex];
     if (serverMessage.kind !== 'text' || serverMessage.role !== 'user') continue;
     const serverIdentity = getConfirmedUserMessageIdentity(serverMessage);
     if (!serverIdentity.text) continue;
@@ -407,6 +437,7 @@ function getConfirmedRealtimeUserIndexes(
       if (consumedRealtimeIndexes.has(index)) continue;
       const realtimeMessage = realtimeMessages[index];
       if (!isOptimisticUserMessage(realtimeMessage)) continue;
+      if (!isServerMessageAfterOptimisticTail(realtimeMessage, serverMessages, serverIndex)) continue;
 
       const realtimeIdentity = getConfirmedUserMessageIdentity(realtimeMessage);
       if (
@@ -821,7 +852,10 @@ export function upsertRealtimeMessages(
       indexByKey.set(key, updated.length);
       updated.push(message);
     } else {
-      updated[existingIndex] = message;
+      const existingTailId = updated[existingIndex].serverTailIdAtStart;
+      updated[existingIndex] = existingTailId === undefined
+        ? message
+        : { ...message, serverTailIdAtStart: existingTailId };
     }
   }
   return updated;
@@ -1169,7 +1203,8 @@ export function useSessionStore() {
    */
   const appendRealtime = useCallback((sessionId: string, msg: NormalizedMessage) => {
     const slot = getSlot(sessionId);
-    let updated = upsertRealtimeMessages(slot.realtimeMessages, [msg]);
+    const capturedMessage = captureOptimisticUserServerTail(msg, slot.serverMessages);
+    let updated = upsertRealtimeMessages(slot.realtimeMessages, [capturedMessage]);
     if (updated.length > MAX_REALTIME_MESSAGES) {
       updated = updated.slice(-MAX_REALTIME_MESSAGES);
     }
@@ -1409,7 +1444,10 @@ export function useSessionStore() {
   const appendRealtimeBatch = useCallback((sessionId: string, msgs: NormalizedMessage[]) => {
     if (msgs.length === 0) return;
     const slot = getSlot(sessionId);
-    let updated = upsertRealtimeMessages(slot.realtimeMessages, msgs);
+    const capturedMessages = msgs.map((message) => (
+      captureOptimisticUserServerTail(message, slot.serverMessages)
+    ));
+    let updated = upsertRealtimeMessages(slot.realtimeMessages, capturedMessages);
     if (updated.length > MAX_REALTIME_MESSAGES) {
       updated = updated.slice(-MAX_REALTIME_MESSAGES);
     }

--- a/ui/src/stores/useSessionStore.ts
+++ b/ui/src/stores/useSessionStore.ts
@@ -872,12 +872,7 @@ function mergeUnconfirmedOptimisticUsers(
   server: NormalizedMessage[],
   extra: NormalizedMessage[],
 ): NormalizedMessage[] {
-  const optimisticUsers = extra.filter(isOptimisticUserMessage);
-  if (optimisticUsers.length === 0) return [...server, ...extra];
-
-  const remainingExtra = extra.filter((message) => !isOptimisticUserMessage(message));
-  const result: NormalizedMessage[] = [];
-  let userIndex = 0;
+  if (!extra.some(isOptimisticUserMessage)) return [...server, ...extra];
 
   const getTailBoundary = (message: NormalizedMessage): number => {
     const tailId = message.serverTailIdAtStart;
@@ -891,27 +886,42 @@ function mergeUnconfirmedOptimisticUsers(
     return tailIndex >= 0 ? tailIndex + 1 : server.length;
   };
 
-  for (let serverIndex = 0; serverIndex < server.length; serverIndex += 1) {
-    const serverMessage = server[serverIndex];
-    const serverTimestamp = parseTimestampMs(serverMessage.timestamp);
-    while (userIndex < optimisticUsers.length) {
-      const optimisticUser = optimisticUsers[userIndex];
-      const optimisticTimestamp = parseTimestampMs(optimisticUser.timestamp);
-      if (
-        serverIndex < getTailBoundary(optimisticUser)
-        || optimisticTimestamp == null
-        || serverTimestamp == null
-        || optimisticTimestamp > serverTimestamp
-      ) {
-        break;
+  const getInsertionIndex = (message: NormalizedMessage): number => {
+    const optimisticTimestamp = parseTimestampMs(message.timestamp);
+    if (optimisticTimestamp == null) return server.length;
+
+    for (let serverIndex = getTailBoundary(message); serverIndex < server.length; serverIndex += 1) {
+      const serverTimestamp = parseTimestampMs(server[serverIndex].timestamp);
+      if (serverTimestamp == null || optimisticTimestamp <= serverTimestamp) {
+        return serverIndex;
       }
-      result.push(optimisticUser);
-      userIndex += 1;
     }
-    result.push(serverMessage);
+    return server.length;
+  };
+
+  // Retain the arrival order of a realtime turn (user, streaming answer,
+  // next user) while anchoring each optimistic user after its server tail.
+  const extrasByServerIndex = new Map<number, NormalizedMessage[]>();
+  let previousInsertionIndex: number | null = null;
+  for (const message of extra) {
+    let insertionIndex = isOptimisticUserMessage(message)
+      ? getInsertionIndex(message)
+      : previousInsertionIndex ?? server.length;
+    if (previousInsertionIndex != null) {
+      insertionIndex = Math.max(insertionIndex, previousInsertionIndex);
+    }
+    const messages = extrasByServerIndex.get(insertionIndex) || [];
+    messages.push(message);
+    extrasByServerIndex.set(insertionIndex, messages);
+    previousInsertionIndex = insertionIndex;
   }
 
-  return [...result, ...optimisticUsers.slice(userIndex), ...remainingExtra];
+  const result: NormalizedMessage[] = [];
+  for (let serverIndex = 0; serverIndex <= server.length; serverIndex += 1) {
+    result.push(...(extrasByServerIndex.get(serverIndex) || []));
+    if (serverIndex < server.length) result.push(server[serverIndex]);
+  }
+  return result;
 }
 
 /**

--- a/ui/src/stores/useSessionStore.ts
+++ b/ui/src/stores/useSessionStore.ts
@@ -348,7 +348,6 @@ function captureOptimisticUserServerTail(
 ): NormalizedMessage {
   if (
     !isOptimisticUserMessage(message)
-    || getMessageTurnId(message)
     || message.serverTailIdAtStart !== undefined
   ) {
     return message;
@@ -594,7 +593,6 @@ function settlePendingOptimisticServerTail(
 ): NormalizedMessage {
   if (
     !isOptimisticUserMessage(message)
-    || getMessageTurnId(message)
     || !message.serverHistoryPendingAtStart
     || serverMessages.length === 0
   ) return message;
@@ -881,13 +879,27 @@ function mergeUnconfirmedOptimisticUsers(
   const result: NormalizedMessage[] = [];
   let userIndex = 0;
 
-  for (const serverMessage of server) {
+  const getTailBoundary = (message: NormalizedMessage): number => {
+    const tailId = message.serverTailIdAtStart;
+    // Historical fixtures and externally-created realtime rows may predate
+    // tail capture. Keep their timestamp-based placement for compatibility.
+    if (tailId === undefined) return 0;
+    if (tailId === null) {
+      return message.serverHistoryPendingAtStart ? server.length : 0;
+    }
+    const tailIndex = server.findIndex((serverMessage) => serverMessage.id === tailId);
+    return tailIndex >= 0 ? tailIndex + 1 : server.length;
+  };
+
+  for (let serverIndex = 0; serverIndex < server.length; serverIndex += 1) {
+    const serverMessage = server[serverIndex];
     const serverTimestamp = parseTimestampMs(serverMessage.timestamp);
     while (userIndex < optimisticUsers.length) {
       const optimisticUser = optimisticUsers[userIndex];
       const optimisticTimestamp = parseTimestampMs(optimisticUser.timestamp);
       if (
-        optimisticTimestamp == null
+        serverIndex < getTailBoundary(optimisticUser)
+        || optimisticTimestamp == null
         || serverTimestamp == null
         || optimisticTimestamp > serverTimestamp
       ) {

--- a/ui/src/stores/useSessionStore.ts
+++ b/ui/src/stores/useSessionStore.ts
@@ -11,6 +11,7 @@ import { useCallback, useMemo, useRef, useState } from 'react';
 import type { SessionProvider } from '../types/app';
 import { authenticatedFetch, readAgentStatusErrorFromResponse } from '../utils/api';
 import { parseUserAttachmentNote } from '../components/chat/utils/attachmentNotes';
+import type { ChatAttachment } from '../components/chat/types/types';
 
 // ─── NormalizedMessage (mirrors server/adapters/types.js) ────────────────────
 
@@ -57,23 +58,7 @@ export interface NormalizedMessage {
   contentI18n?: { key: string; params?: Record<string, unknown> };
   userHintI18n?: { key: string; params?: Record<string, unknown> };
   images?: string[];
-  attachments?: Array<{
-    kind?: 'file' | 'document-selection';
-    name: string;
-    path?: string;
-    size?: number;
-    mimeType?: string;
-    fileName?: string;
-    filePath?: string;
-    source?: 'pdf' | 'office-pdf';
-    pageNumbers?: number[];
-    selectedText?: string;
-    surroundingText?: string;
-    occurrenceIndex?: number | null;
-    createdAt?: string;
-    truncated?: boolean;
-    contentReference?: { id?: string };
-  }>;
+  attachments?: ChatAttachment[];
   artifacts?: Array<{
     id: string;
     name: string;
@@ -303,15 +288,14 @@ function getConfirmedUserMessageIdentity(message: NormalizedMessage): {
   images: string[];
 } {
   const parsed = parseUserAttachmentNote(message.content);
-  const attachments = [
-    ...(message.attachments || []),
-    ...parsed.attachments,
-  ];
+  const attachments = message.attachments?.length
+    ? message.attachments
+    : parsed.attachments;
 
   return {
     text: normalizeRealtimeText(parsed.content),
-    attachments: [...new Set(attachments.map(getUserAttachmentIdentity))].sort(),
-    images: Array.isArray(message.images) ? [...message.images].sort() : [],
+    attachments: attachments.map(getUserAttachmentIdentity),
+    images: Array.isArray(message.images) ? message.images : [],
   };
 }
 
@@ -349,26 +333,29 @@ function getSameTurnServerCandidates(
   return serverMessages.filter((message) => getMessageTurnId(message) === realtimeTurnId);
 }
 
-function isConfirmedUserMessageDuplicate(
+function isOptimisticUserMessage(message: NormalizedMessage): boolean {
+  return message.kind === 'text'
+    && message.role === 'user'
+    && message.id.startsWith('local_');
+}
+
+function findConfirmedUserMessageDuplicateIndex(
   realtimeMessage: NormalizedMessage,
   serverMessages: NormalizedMessage[],
-): boolean {
-  if (
-    realtimeMessage.kind !== 'text'
-    || realtimeMessage.role !== 'user'
-    || !realtimeMessage.id.startsWith('local_')
-  ) {
-    return false;
-  }
+  consumedServerIndexes?: Set<number>,
+): number {
+  if (!isOptimisticUserMessage(realtimeMessage)) return -1;
 
   const realtimeIdentity = getConfirmedUserMessageIdentity(realtimeMessage);
-  if (!realtimeIdentity.text) return false;
+  if (!realtimeIdentity.text) return -1;
 
   const realtimeTimestamp = parseTimestampMs(realtimeMessage.timestamp);
 
-  return serverMessages.some((serverMessage) => {
+  for (let index = 0; index < serverMessages.length; index += 1) {
+    if (consumedServerIndexes?.has(index)) continue;
+    const serverMessage = serverMessages[index];
     if (serverMessage.kind !== 'text' || serverMessage.role !== 'user') {
-      return false;
+      continue;
     }
 
     const serverIdentity = getConfirmedUserMessageIdentity(serverMessage);
@@ -376,20 +363,29 @@ function isConfirmedUserMessageDuplicate(
       serverIdentity.text !== realtimeIdentity.text
       || !haveSameUserMessageInputs(serverIdentity, realtimeIdentity)
     ) {
-      return false;
+      continue;
     }
 
     if (realtimeTimestamp == null) {
-      return true;
+      return index;
     }
 
     const serverTimestamp = parseTimestampMs(serverMessage.timestamp);
     if (serverTimestamp == null) {
-      return true;
+      return index;
     }
 
-    return Math.abs(serverTimestamp - realtimeTimestamp) <= 10_000;
-  });
+    if (Math.abs(serverTimestamp - realtimeTimestamp) <= 10_000) return index;
+  }
+
+  return -1;
+}
+
+function isConfirmedUserMessageDuplicate(
+  realtimeMessage: NormalizedMessage,
+  serverMessages: NormalizedMessage[],
+): boolean {
+  return findConfirmedUserMessageDuplicateIndex(realtimeMessage, serverMessages) >= 0;
 }
 
 /**
@@ -557,11 +553,7 @@ export function isRealtimeMessageRepresentedOnServer(
   // Local user bubbles must only match through isConfirmedUserMessageDuplicate,
   // which includes attachment and image input identity. The generic text path
   // below would otherwise collapse distinct queued sends with the same text.
-  if (
-    realtimeMessage.kind === 'text'
-    && realtimeMessage.role === 'user'
-    && realtimeMessage.id.startsWith('local_')
-  ) {
+  if (isOptimisticUserMessage(realtimeMessage)) {
     return false;
   }
 
@@ -655,7 +647,18 @@ export function computeMerged(server: NormalizedMessage[], realtime: NormalizedM
     return server;
   }
   if (server.length === 0) return realtime;
+  const consumedServerUserIndexes = new Set<number>();
   const extra = realtime.filter((message) => {
+    if (isOptimisticUserMessage(message)) {
+      const duplicateIndex = findConfirmedUserMessageDuplicateIndex(
+        message,
+        server,
+        consumedServerUserIndexes,
+      );
+      if (duplicateIndex < 0) return true;
+      consumedServerUserIndexes.add(duplicateIndex);
+      return false;
+    }
     return !isRealtimeMessageRepresentedOnServer(message, server);
   });
   if (extra.length === 0) return server;

--- a/ui/src/stores/useSessionStore.ts
+++ b/ui/src/stores/useSessionStore.ts
@@ -10,6 +10,7 @@
 import { useCallback, useMemo, useRef, useState } from 'react';
 import type { SessionProvider } from '../types/app';
 import { authenticatedFetch, readAgentStatusErrorFromResponse } from '../utils/api';
+import { parseUserAttachmentNote } from '../components/chat/utils/attachmentNotes';
 
 // ─── NormalizedMessage (mirrors server/adapters/types.js) ────────────────────
 
@@ -271,6 +272,10 @@ function normalizeRealtimeText(value?: string): string {
   return typeof value === 'string' ? value.replace(/\s+/g, ' ').trim() : '';
 }
 
+function normalizeUserMessageText(value?: string): string {
+  return normalizeRealtimeText(parseUserAttachmentNote(value).content);
+}
+
 function parseTimestampMs(value?: string): number | null {
   if (!value) return null;
   const parsed = Date.parse(value);
@@ -305,7 +310,7 @@ function isConfirmedUserMessageDuplicate(
     return false;
   }
 
-  const realtimeText = normalizeRealtimeText(realtimeMessage.content);
+  const realtimeText = normalizeUserMessageText(realtimeMessage.content);
   if (!realtimeText) return false;
 
   const realtimeTimestamp = parseTimestampMs(realtimeMessage.timestamp);
@@ -315,7 +320,7 @@ function isConfirmedUserMessageDuplicate(
       return false;
     }
 
-    if (normalizeRealtimeText(serverMessage.content) !== realtimeText) {
+    if (normalizeUserMessageText(serverMessage.content) !== realtimeText) {
       return false;
     }
 

--- a/ui/src/stores/useSessionStore.ts
+++ b/ui/src/stores/useSessionStore.ts
@@ -346,7 +346,11 @@ function captureOptimisticUserServerTail(
   serverMessages: NormalizedMessage[],
   serverHistoryPending: boolean,
 ): NormalizedMessage {
-  if (!isOptimisticUserMessage(message) || message.serverTailIdAtStart !== undefined) {
+  if (
+    !isOptimisticUserMessage(message)
+    || getMessageTurnId(message)
+    || message.serverTailIdAtStart !== undefined
+  ) {
     return message;
   }
 
@@ -381,6 +385,7 @@ function getConfirmedUserMessageMatchDistance(
   serverMessages: NormalizedMessage[],
   serverIndex: number,
 ): number | null {
+  if (getMessageTurnId(realtimeMessage) || getMessageTurnId(serverMessage)) return null;
   if (!isServerMessageAfterOptimisticTail(realtimeMessage, serverMessages, serverIndex)) return null;
   if (
     serverIdentity.text !== realtimeIdentity.text
@@ -407,17 +412,28 @@ function getConfirmedUserMessageMatchDistance(
 function findConfirmedUserMessageDuplicateIndex(
   realtimeMessage: NormalizedMessage,
   serverMessages: NormalizedMessage[],
-  consumedServerIndexes?: Set<number>,
 ): number {
   if (!isOptimisticUserMessage(realtimeMessage)) return -1;
+
+  const realtimeTurnId = getMessageTurnId(realtimeMessage);
+  if (realtimeTurnId) {
+    return serverMessages.findIndex((message) => (
+      message.kind === 'text'
+      && message.role === 'user'
+      && getMessageTurnId(message) === realtimeTurnId
+    ));
+  }
 
   const realtimeIdentity = getConfirmedUserMessageIdentity(realtimeMessage);
   if (!realtimeIdentity.text) return -1;
 
   for (let index = 0; index < serverMessages.length; index += 1) {
-    if (consumedServerIndexes?.has(index)) continue;
     const serverMessage = serverMessages[index];
-    if (serverMessage.kind !== 'text' || serverMessage.role !== 'user') {
+    if (
+      serverMessage.kind !== 'text'
+      || serverMessage.role !== 'user'
+      || getMessageTurnId(serverMessage)
+    ) {
       continue;
     }
 
@@ -446,9 +462,23 @@ function getConfirmedRealtimeUserIndexes(
   serverMessages: NormalizedMessage[],
   realtimeMessages: NormalizedMessage[],
 ): Set<number> {
+  const persistedUserTurnIds = new Set(
+    serverMessages
+      .filter((message) => message.kind === 'text' && message.role === 'user')
+      .map(getMessageTurnId)
+      .filter((turnId): turnId is string => Boolean(turnId)),
+  );
+  const confirmedRealtimeIndexes = new Set<number>();
+  realtimeMessages.forEach((message, index) => {
+    const turnId = isOptimisticUserMessage(message) ? getMessageTurnId(message) : null;
+    if (turnId && persistedUserTurnIds.has(turnId)) {
+      confirmedRealtimeIndexes.add(index);
+    }
+  });
+
   const realtimeCandidates = realtimeMessages
     .map((message, index) => ({ message, index }))
-    .filter(({ message }) => isOptimisticUserMessage(message))
+    .filter(({ message }) => isOptimisticUserMessage(message) && !getMessageTurnId(message))
     .map(({ message, index }) => ({
       message,
       index,
@@ -457,14 +487,20 @@ function getConfirmedRealtimeUserIndexes(
     .filter(({ identity }) => Boolean(identity.text));
   const serverCandidates = serverMessages
     .map((message, index) => ({ message, index }))
-    .filter(({ message }) => message.kind === 'text' && message.role === 'user')
+    .filter(({ message }) => (
+      message.kind === 'text'
+      && message.role === 'user'
+      && !getMessageTurnId(message)
+    ))
     .map(({ message, index }) => ({
       message,
       index,
       identity: getConfirmedUserMessageIdentity(message),
     }))
     .filter(({ identity }) => Boolean(identity.text));
-  if (realtimeCandidates.length === 0 || serverCandidates.length === 0) return new Set();
+  if (realtimeCandidates.length === 0 || serverCandidates.length === 0) {
+    return confirmedRealtimeIndexes;
+  }
 
   const rowCount = realtimeCandidates.length;
   const unmatchedCost = (rowCount + 1) * (CONFIRMED_USER_WINDOW_MS + 1);
@@ -483,7 +519,6 @@ function getConfirmedRealtimeUserIndexes(
     ...Array.from({ length: rowCount }, () => unmatchedCost),
   ]);
   const assignment = findMinimumCostAssignment(costs);
-  const confirmedRealtimeIndexes = new Set<number>();
   assignment.forEach((column, row) => {
     if (column >= 0 && column < serverCandidates.length && costs[row][column] < unmatchedCost) {
       confirmedRealtimeIndexes.add(realtimeCandidates[row].index);
@@ -559,6 +594,7 @@ function settlePendingOptimisticServerTail(
 ): NormalizedMessage {
   if (
     !isOptimisticUserMessage(message)
+    || getMessageTurnId(message)
     || !message.serverHistoryPendingAtStart
     || serverMessages.length === 0
   ) return message;

--- a/ui/src/stores/useSessionStore.ts
+++ b/ui/src/stores/useSessionStore.ts
@@ -557,7 +557,11 @@ function settlePendingOptimisticServerTail(
   message: NormalizedMessage,
   serverMessages: NormalizedMessage[],
 ): NormalizedMessage {
-  if (!isOptimisticUserMessage(message) || !message.serverHistoryPendingAtStart) return message;
+  if (
+    !isOptimisticUserMessage(message)
+    || !message.serverHistoryPendingAtStart
+    || serverMessages.length === 0
+  ) return message;
   return {
     ...message,
     serverTailIdAtStart: serverMessages[serverMessages.length - 1]?.id ?? null,
@@ -1227,10 +1231,6 @@ export function useSessionStore() {
             return (Date.parse(m.timestamp) || 0) > watermark;
           })
           .map((message) => settlePendingOptimisticServerTail(message, messages));
-      } else if (slot.realtimeMessages.length > 0) {
-        slot.realtimeMessages = slot.realtimeMessages.map((message) => (
-          settlePendingOptimisticServerTail(message, messages)
-        ));
       }
 
       recomputeMergedIfNeeded(slot);
@@ -1321,7 +1321,7 @@ export function useSessionStore() {
     const capturedMessage = captureOptimisticUserServerTail(
       msg,
       slot.serverMessages,
-      slot._serverAppliedGeneration === 0 && slot._serverLoadingGeneration !== null,
+      slot.serverMessages.length === 0,
     );
     let updated = upsertRealtimeMessages(slot.realtimeMessages, [capturedMessage]);
     if (updated.length > MAX_REALTIME_MESSAGES) {
@@ -1567,7 +1567,7 @@ export function useSessionStore() {
       captureOptimisticUserServerTail(
         message,
         slot.serverMessages,
-        slot._serverAppliedGeneration === 0 && slot._serverLoadingGeneration !== null,
+        slot.serverMessages.length === 0,
       )
     ));
     let updated = upsertRealtimeMessages(slot.realtimeMessages, capturedMessages);

--- a/ui/src/stores/useSessionStore.ts
+++ b/ui/src/stores/useSessionStore.ts
@@ -629,11 +629,22 @@ export function getUnpersistedRealtimeTurnMessages(
 export function shouldKeepRealtimeAfterServerRefresh(
   realtimeMessage: NormalizedMessage,
   serverMessages: NormalizedMessage[],
+  consumedServerUserIndexes?: Set<number>,
 ): boolean {
   if (realtimeMessage.id.startsWith('__streaming_')) {
     return true;
   }
   if (!PERSISTED_RENDERABLE_KINDS.has(realtimeMessage.kind)) return false;
+  if (isOptimisticUserMessage(realtimeMessage)) {
+    const duplicateIndex = findConfirmedUserMessageDuplicateIndex(
+      realtimeMessage,
+      serverMessages,
+      consumedServerUserIndexes,
+    );
+    if (duplicateIndex < 0) return true;
+    consumedServerUserIndexes?.add(duplicateIndex);
+    return false;
+  }
   return !isRealtimeMessageRepresentedOnServer(realtimeMessage, serverMessages);
 }
 
@@ -1021,8 +1032,9 @@ export function useSessionStore() {
         const serverToolIds = new Set(
           messages.filter(m => m.kind === 'tool_use' && m.toolId).map(m => m.toolId!)
         );
+        const consumedServerUserIndexes = new Set<number>();
         slot.realtimeMessages = slot.realtimeMessages.filter(m => {
-          if (shouldKeepRealtimeAfterServerRefresh(m, messages)) return true;
+          if (shouldKeepRealtimeAfterServerRefresh(m, messages, consumedServerUserIndexes)) return true;
           if (serverIds.has(m.id)) return false;
           if (m.kind === 'tool_use' && m.toolId && serverToolIds.has(m.toolId)) return false;
           return (Date.parse(m.timestamp) || 0) > watermark;
@@ -1433,8 +1445,9 @@ export function useSessionStore() {
       // an equivalent assistant message; otherwise the UI can show "complete"
       // while the model's visible answer disappears.
       if (slot.realtimeMessages.length > 0 && incomingMessages.length > 0) {
+        const consumedServerUserIndexes = new Set<number>();
         slot.realtimeMessages = slot.realtimeMessages.filter((message) =>
-          shouldKeepRealtimeAfterServerRefresh(message, incomingMessages)
+          shouldKeepRealtimeAfterServerRefresh(message, incomingMessages, consumedServerUserIndexes)
         );
       }
       recomputeMergedIfNeeded(slot);

--- a/ui/src/stores/useSessionStore.ts
+++ b/ui/src/stores/useSessionStore.ts
@@ -904,7 +904,7 @@ function mergeUnconfirmedOptimisticUsers(
   const extrasByServerIndex = new Map<number, NormalizedMessage[]>();
   let previousInsertionIndex: number | null = null;
   for (const message of extra) {
-    let insertionIndex = isOptimisticUserMessage(message)
+    let insertionIndex: number = isOptimisticUserMessage(message)
       ? getInsertionIndex(message)
       : previousInsertionIndex ?? server.length;
     if (previousInsertionIndex != null) {

--- a/ui/src/stores/useSessionStore.ts
+++ b/ui/src/stores/useSessionStore.ts
@@ -72,6 +72,7 @@ export interface NormalizedMessage {
     occurrenceIndex?: number | null;
     createdAt?: string;
     truncated?: boolean;
+    contentReference?: { id?: string };
   }>;
   artifacts?: Array<{
     id: string;
@@ -272,8 +273,58 @@ function normalizeRealtimeText(value?: string): string {
   return typeof value === 'string' ? value.replace(/\s+/g, ' ').trim() : '';
 }
 
-function normalizeUserMessageText(value?: string): string {
-  return normalizeRealtimeText(parseUserAttachmentNote(value).content);
+function getUserAttachmentIdentity(
+  attachment: NonNullable<NormalizedMessage['attachments']>[number],
+): string {
+  const kind = attachment.kind || 'file';
+  const path = attachment.path || attachment.filePath || attachment.name;
+
+  if (kind === 'content-reference') {
+    return [kind, attachment.contentReference?.id || path].join('\0');
+  }
+
+  if (kind === 'document-selection') {
+    return [
+      kind,
+      path,
+      (attachment.pageNumbers || []).join(','),
+      normalizeRealtimeText(attachment.selectedText),
+      normalizeRealtimeText(attachment.surroundingText),
+      attachment.occurrenceIndex ?? '',
+    ].join('\0');
+  }
+
+  return [kind, path].join('\0');
+}
+
+function getConfirmedUserMessageIdentity(message: NormalizedMessage): {
+  text: string;
+  attachments: string[];
+  images: string[];
+} {
+  const parsed = parseUserAttachmentNote(message.content);
+  const attachments = [
+    ...(message.attachments || []),
+    ...parsed.attachments,
+  ];
+
+  return {
+    text: normalizeRealtimeText(parsed.content),
+    attachments: [...new Set(attachments.map(getUserAttachmentIdentity))].sort(),
+    images: Array.isArray(message.images) ? [...message.images].sort() : [],
+  };
+}
+
+function haveSameUserMessageInputs(
+  left: ReturnType<typeof getConfirmedUserMessageIdentity>,
+  right: ReturnType<typeof getConfirmedUserMessageIdentity>,
+): boolean {
+  if (left.attachments.length !== right.attachments.length || left.images.length !== right.images.length) {
+    return false;
+  }
+
+  return left.attachments.every((identity, index) => identity === right.attachments[index])
+    && left.images.every((image, index) => image === right.images[index]);
 }
 
 function parseTimestampMs(value?: string): number | null {
@@ -310,8 +361,8 @@ function isConfirmedUserMessageDuplicate(
     return false;
   }
 
-  const realtimeText = normalizeUserMessageText(realtimeMessage.content);
-  if (!realtimeText) return false;
+  const realtimeIdentity = getConfirmedUserMessageIdentity(realtimeMessage);
+  if (!realtimeIdentity.text) return false;
 
   const realtimeTimestamp = parseTimestampMs(realtimeMessage.timestamp);
 
@@ -320,7 +371,11 @@ function isConfirmedUserMessageDuplicate(
       return false;
     }
 
-    if (normalizeUserMessageText(serverMessage.content) !== realtimeText) {
+    const serverIdentity = getConfirmedUserMessageIdentity(serverMessage);
+    if (
+      serverIdentity.text !== realtimeIdentity.text
+      || !haveSameUserMessageInputs(serverIdentity, realtimeIdentity)
+    ) {
       return false;
     }
 
@@ -498,6 +553,17 @@ export function isRealtimeMessageRepresentedOnServer(
   if (serverMessages.some((message) => message.id === realtimeMessage.id)) return true;
   if (isConfirmedUserMessageDuplicate(realtimeMessage, serverMessages)) return true;
   if (isLocalInterruptDuplicate(realtimeMessage, serverMessages)) return true;
+
+  // Local user bubbles must only match through isConfirmedUserMessageDuplicate,
+  // which includes attachment and image input identity. The generic text path
+  // below would otherwise collapse distinct queued sends with the same text.
+  if (
+    realtimeMessage.kind === 'text'
+    && realtimeMessage.role === 'user'
+    && realtimeMessage.id.startsWith('local_')
+  ) {
+    return false;
+  }
 
   const candidates = getSameTurnServerCandidates(realtimeMessage, serverMessages);
   switch (realtimeMessage.kind) {

--- a/ui/src/stores/useSessionStore.ts
+++ b/ui/src/stores/useSessionStore.ts
@@ -870,6 +870,38 @@ export function getRealtimeMessagesToKeepAfterServerRefresh(
     .map((message) => settlePendingOptimisticServerTail(message, serverMessages));
 }
 
+function mergeUnconfirmedOptimisticUsers(
+  server: NormalizedMessage[],
+  extra: NormalizedMessage[],
+): NormalizedMessage[] {
+  const optimisticUsers = extra.filter(isOptimisticUserMessage);
+  if (optimisticUsers.length === 0) return [...server, ...extra];
+
+  const remainingExtra = extra.filter((message) => !isOptimisticUserMessage(message));
+  const result: NormalizedMessage[] = [];
+  let userIndex = 0;
+
+  for (const serverMessage of server) {
+    const serverTimestamp = parseTimestampMs(serverMessage.timestamp);
+    while (userIndex < optimisticUsers.length) {
+      const optimisticUser = optimisticUsers[userIndex];
+      const optimisticTimestamp = parseTimestampMs(optimisticUser.timestamp);
+      if (
+        optimisticTimestamp == null
+        || serverTimestamp == null
+        || optimisticTimestamp > serverTimestamp
+      ) {
+        break;
+      }
+      result.push(optimisticUser);
+      userIndex += 1;
+    }
+    result.push(serverMessage);
+  }
+
+  return [...result, ...optimisticUsers.slice(userIndex), ...remainingExtra];
+}
+
 /**
  * Compute merged messages: server + realtime, deduped by id.
  * Server messages take priority (they're the persisted source of truth).
@@ -909,12 +941,11 @@ export function computeMerged(server: NormalizedMessage[], realtime: NormalizedM
     const tailIdChanged = streamMsg.serverTailIdAtStart !== undefined
       && lastServer.id !== streamMsg.serverTailIdAtStart;
     if (isAssistantText && tailIdChanged) {
-      return [...server.slice(0, -1), ...extra];
+      return mergeUnconfirmedOptimisticUsers(server.slice(0, -1), extra);
     }
   }
 
-  const result = [...server, ...extra];
-  return result;
+  return mergeUnconfirmedOptimisticUsers(server, extra);
 }
 
 function getUpsertKey(message: NormalizedMessage): string {

--- a/ui/src/stores/useSessionStore.ts
+++ b/ui/src/stores/useSessionStore.ts
@@ -161,6 +161,8 @@ export interface NormalizedMessage {
   // means the history was empty. Reconciliation uses this as a turn boundary
   // so an older persisted row cannot confirm a newer optimistic send.
   serverTailIdAtStart?: string | null;
+  /** The optimistic row was created before its initial history request completed. */
+  serverHistoryPendingAtStart?: boolean;
 }
 
 // ─── Per-session slot ────────────────────────────────────────────────────────
@@ -342,6 +344,7 @@ function isOptimisticUserMessage(message: NormalizedMessage): boolean {
 function captureOptimisticUserServerTail(
   message: NormalizedMessage,
   serverMessages: NormalizedMessage[],
+  serverHistoryPending: boolean,
 ): NormalizedMessage {
   if (!isOptimisticUserMessage(message) || message.serverTailIdAtStart !== undefined) {
     return message;
@@ -350,6 +353,7 @@ function captureOptimisticUserServerTail(
   return {
     ...message,
     serverTailIdAtStart: serverMessages[serverMessages.length - 1]?.id ?? null,
+    ...(serverHistoryPending ? { serverHistoryPendingAtStart: true } : {}),
   };
 }
 
@@ -367,6 +371,39 @@ function isServerMessageAfterOptimisticTail(
   return tailIndex >= 0 && serverIndex > tailIndex;
 }
 
+const CONFIRMED_USER_WINDOW_MS = 10_000;
+
+function getConfirmedUserMessageMatchDistance(
+  realtimeMessage: NormalizedMessage,
+  realtimeIdentity: ReturnType<typeof getConfirmedUserMessageIdentity>,
+  serverMessage: NormalizedMessage,
+  serverIdentity: ReturnType<typeof getConfirmedUserMessageIdentity>,
+  serverMessages: NormalizedMessage[],
+  serverIndex: number,
+): number | null {
+  if (!isServerMessageAfterOptimisticTail(realtimeMessage, serverMessages, serverIndex)) return null;
+  if (
+    serverIdentity.text !== realtimeIdentity.text
+    || !haveSameUserMessageInputs(serverIdentity, realtimeIdentity)
+  ) {
+    return null;
+  }
+
+  const realtimeTimestamp = parseTimestampMs(realtimeMessage.timestamp);
+  const serverTimestamp = parseTimestampMs(serverMessage.timestamp);
+  if (realtimeMessage.serverHistoryPendingAtStart) {
+    // The initial response is allowed to confirm a send that landed while it
+    // was in flight, but history from before the optimistic send is not.
+    if (realtimeTimestamp == null || serverTimestamp == null || serverTimestamp < realtimeTimestamp) {
+      return null;
+    }
+  }
+  if (realtimeTimestamp == null || serverTimestamp == null) return CONFIRMED_USER_WINDOW_MS;
+
+  const distance = Math.abs(serverTimestamp - realtimeTimestamp);
+  return distance <= CONFIRMED_USER_WINDOW_MS ? distance : null;
+}
+
 function findConfirmedUserMessageDuplicateIndex(
   realtimeMessage: NormalizedMessage,
   serverMessages: NormalizedMessage[],
@@ -377,34 +414,22 @@ function findConfirmedUserMessageDuplicateIndex(
   const realtimeIdentity = getConfirmedUserMessageIdentity(realtimeMessage);
   if (!realtimeIdentity.text) return -1;
 
-  const realtimeTimestamp = parseTimestampMs(realtimeMessage.timestamp);
-
   for (let index = 0; index < serverMessages.length; index += 1) {
     if (consumedServerIndexes?.has(index)) continue;
-    if (!isServerMessageAfterOptimisticTail(realtimeMessage, serverMessages, index)) continue;
     const serverMessage = serverMessages[index];
     if (serverMessage.kind !== 'text' || serverMessage.role !== 'user') {
       continue;
     }
 
     const serverIdentity = getConfirmedUserMessageIdentity(serverMessage);
-    if (
-      serverIdentity.text !== realtimeIdentity.text
-      || !haveSameUserMessageInputs(serverIdentity, realtimeIdentity)
-    ) {
-      continue;
-    }
-
-    if (realtimeTimestamp == null) {
-      return index;
-    }
-
-    const serverTimestamp = parseTimestampMs(serverMessage.timestamp);
-    if (serverTimestamp == null) {
-      return index;
-    }
-
-    if (Math.abs(serverTimestamp - realtimeTimestamp) <= 10_000) return index;
+    if (getConfirmedUserMessageMatchDistance(
+      realtimeMessage,
+      realtimeIdentity,
+      serverMessage,
+      serverIdentity,
+      serverMessages,
+      index,
+    ) != null) return index;
   }
 
   return -1;
@@ -421,48 +446,123 @@ function getConfirmedRealtimeUserIndexes(
   serverMessages: NormalizedMessage[],
   realtimeMessages: NormalizedMessage[],
 ): Set<number> {
-  const consumedRealtimeIndexes = new Set<number>();
+  const realtimeCandidates = realtimeMessages
+    .map((message, index) => ({ message, index }))
+    .filter(({ message }) => isOptimisticUserMessage(message))
+    .map(({ message, index }) => ({
+      message,
+      index,
+      identity: getConfirmedUserMessageIdentity(message),
+    }))
+    .filter(({ identity }) => Boolean(identity.text));
+  const serverCandidates = serverMessages
+    .map((message, index) => ({ message, index }))
+    .filter(({ message }) => message.kind === 'text' && message.role === 'user')
+    .map(({ message, index }) => ({
+      message,
+      index,
+      identity: getConfirmedUserMessageIdentity(message),
+    }))
+    .filter(({ identity }) => Boolean(identity.text));
+  if (realtimeCandidates.length === 0 || serverCandidates.length === 0) return new Set();
 
-  for (let serverIndex = 0; serverIndex < serverMessages.length; serverIndex += 1) {
-    const serverMessage = serverMessages[serverIndex];
-    if (serverMessage.kind !== 'text' || serverMessage.role !== 'user') continue;
-    const serverIdentity = getConfirmedUserMessageIdentity(serverMessage);
-    if (!serverIdentity.text) continue;
-
-    let closestRealtimeIndex = -1;
-    let closestTimestampDistance = Number.POSITIVE_INFINITY;
-    const serverTimestamp = parseTimestampMs(serverMessage.timestamp);
-
-    for (let index = 0; index < realtimeMessages.length; index += 1) {
-      if (consumedRealtimeIndexes.has(index)) continue;
-      const realtimeMessage = realtimeMessages[index];
-      if (!isOptimisticUserMessage(realtimeMessage)) continue;
-      if (!isServerMessageAfterOptimisticTail(realtimeMessage, serverMessages, serverIndex)) continue;
-
-      const realtimeIdentity = getConfirmedUserMessageIdentity(realtimeMessage);
-      if (
-        realtimeIdentity.text !== serverIdentity.text
-        || !haveSameUserMessageInputs(realtimeIdentity, serverIdentity)
-      ) {
-        continue;
-      }
-
-      const realtimeTimestamp = parseTimestampMs(realtimeMessage.timestamp);
-      const timestampDistance = serverTimestamp != null && realtimeTimestamp != null
-        ? Math.abs(serverTimestamp - realtimeTimestamp)
-        : Number.POSITIVE_INFINITY;
-      if (
-        timestampDistance > 10_000
-        || (closestRealtimeIndex >= 0 && timestampDistance >= closestTimestampDistance)
-      ) continue;
-      closestRealtimeIndex = index;
-      closestTimestampDistance = timestampDistance;
+  const rowCount = realtimeCandidates.length;
+  const unmatchedCost = (rowCount + 1) * (CONFIRMED_USER_WINDOW_MS + 1);
+  const forbiddenCost = unmatchedCost * 2;
+  const costs = realtimeCandidates.map(({ message, identity }) => [
+    ...serverCandidates.map((server) => (
+      getConfirmedUserMessageMatchDistance(
+        message,
+        identity,
+        server.message,
+        server.identity,
+        serverMessages,
+        server.index,
+      ) ?? forbiddenCost
+    )),
+    ...Array.from({ length: rowCount }, () => unmatchedCost),
+  ]);
+  const assignment = findMinimumCostAssignment(costs);
+  const confirmedRealtimeIndexes = new Set<number>();
+  assignment.forEach((column, row) => {
+    if (column >= 0 && column < serverCandidates.length && costs[row][column] < unmatchedCost) {
+      confirmedRealtimeIndexes.add(realtimeCandidates[row].index);
     }
+  });
+  return confirmedRealtimeIndexes;
+}
 
-    if (closestRealtimeIndex >= 0) consumedRealtimeIndexes.add(closestRealtimeIndex);
+/** Hungarian assignment for a rectangular matrix with rows <= columns. */
+function findMinimumCostAssignment(costs: number[][]): number[] {
+  const rowCount = costs.length;
+  const columnCount = costs[0]?.length ?? 0;
+  const rowPotential = Array(rowCount + 1).fill(0);
+  const columnPotential = Array(columnCount + 1).fill(0);
+  const matchedRowByColumn = Array(columnCount + 1).fill(0);
+  const previousColumn = Array(columnCount + 1).fill(0);
+
+  for (let row = 1; row <= rowCount; row += 1) {
+    matchedRowByColumn[0] = row;
+    let currentColumn = 0;
+    const minimumReducedCost = Array(columnCount + 1).fill(Number.POSITIVE_INFINITY);
+    const used = Array(columnCount + 1).fill(false);
+
+    do {
+      used[currentColumn] = true;
+      const currentRow = matchedRowByColumn[currentColumn];
+      let delta = Number.POSITIVE_INFINITY;
+      let nextColumn = 0;
+      for (let column = 1; column <= columnCount; column += 1) {
+        if (used[column]) continue;
+        const reducedCost = costs[currentRow - 1][column - 1]
+          - rowPotential[currentRow]
+          - columnPotential[column];
+        if (reducedCost < minimumReducedCost[column]) {
+          minimumReducedCost[column] = reducedCost;
+          previousColumn[column] = currentColumn;
+        }
+        if (minimumReducedCost[column] < delta) {
+          delta = minimumReducedCost[column];
+          nextColumn = column;
+        }
+      }
+      for (let column = 0; column <= columnCount; column += 1) {
+        if (used[column]) {
+          rowPotential[matchedRowByColumn[column]] += delta;
+          columnPotential[column] -= delta;
+        } else {
+          minimumReducedCost[column] -= delta;
+        }
+      }
+      currentColumn = nextColumn;
+    } while (matchedRowByColumn[currentColumn] !== 0);
+
+    do {
+      const nextColumn = previousColumn[currentColumn];
+      matchedRowByColumn[currentColumn] = matchedRowByColumn[nextColumn];
+      currentColumn = nextColumn;
+    } while (currentColumn !== 0);
   }
 
-  return consumedRealtimeIndexes;
+  const assignment = Array(rowCount).fill(-1);
+  for (let column = 1; column <= columnCount; column += 1) {
+    if (matchedRowByColumn[column] > 0) {
+      assignment[matchedRowByColumn[column] - 1] = column - 1;
+    }
+  }
+  return assignment;
+}
+
+function settlePendingOptimisticServerTail(
+  message: NormalizedMessage,
+  serverMessages: NormalizedMessage[],
+): NormalizedMessage {
+  if (!isOptimisticUserMessage(message) || !message.serverHistoryPendingAtStart) return message;
+  return {
+    ...message,
+    serverTailIdAtStart: serverMessages[serverMessages.length - 1]?.id ?? null,
+    serverHistoryPendingAtStart: false,
+  };
 }
 
 /**
@@ -722,10 +822,12 @@ export function getRealtimeMessagesToKeepAfterServerRefresh(
   serverMessages: NormalizedMessage[],
 ): NormalizedMessage[] {
   const confirmedRealtimeIndexes = getConfirmedRealtimeUserIndexes(serverMessages, realtimeMessages);
-  return realtimeMessages.filter((message, index) => {
-    if (isOptimisticUserMessage(message)) return !confirmedRealtimeIndexes.has(index);
-    return shouldKeepRealtimeAfterServerRefresh(message, serverMessages);
-  });
+  return realtimeMessages
+    .filter((message, index) => {
+      if (isOptimisticUserMessage(message)) return !confirmedRealtimeIndexes.has(index);
+      return shouldKeepRealtimeAfterServerRefresh(message, serverMessages);
+    })
+    .map((message) => settlePendingOptimisticServerTail(message, serverMessages));
 }
 
 /**
@@ -853,9 +955,16 @@ export function upsertRealtimeMessages(
       updated.push(message);
     } else {
       const existingTailId = updated[existingIndex].serverTailIdAtStart;
-      updated[existingIndex] = existingTailId === undefined
+      const existingHistoryPending = updated[existingIndex].serverHistoryPendingAtStart;
+      updated[existingIndex] = existingTailId === undefined && existingHistoryPending === undefined
         ? message
-        : { ...message, serverTailIdAtStart: existingTailId };
+        : {
+            ...message,
+            ...(existingTailId !== undefined ? { serverTailIdAtStart: existingTailId } : {}),
+            ...(existingHistoryPending !== undefined
+              ? { serverHistoryPendingAtStart: existingHistoryPending }
+              : {}),
+          };
     }
   }
   return updated;
@@ -1107,15 +1216,21 @@ export function useSessionStore() {
           messages.filter(m => m.kind === 'tool_use' && m.toolId).map(m => m.toolId!)
         );
         const confirmedRealtimeIndexes = getConfirmedRealtimeUserIndexes(messages, slot.realtimeMessages);
-        slot.realtimeMessages = slot.realtimeMessages.filter((m, index) => {
-          if (isOptimisticUserMessage(m)) {
-            return !confirmedRealtimeIndexes.has(index);
-          }
-          if (shouldKeepRealtimeAfterServerRefresh(m, messages)) return true;
-          if (serverIds.has(m.id)) return false;
-          if (m.kind === 'tool_use' && m.toolId && serverToolIds.has(m.toolId)) return false;
-          return (Date.parse(m.timestamp) || 0) > watermark;
-        });
+        slot.realtimeMessages = slot.realtimeMessages
+          .filter((m, index) => {
+            if (isOptimisticUserMessage(m)) {
+              return !confirmedRealtimeIndexes.has(index);
+            }
+            if (shouldKeepRealtimeAfterServerRefresh(m, messages)) return true;
+            if (serverIds.has(m.id)) return false;
+            if (m.kind === 'tool_use' && m.toolId && serverToolIds.has(m.toolId)) return false;
+            return (Date.parse(m.timestamp) || 0) > watermark;
+          })
+          .map((message) => settlePendingOptimisticServerTail(message, messages));
+      } else if (slot.realtimeMessages.length > 0) {
+        slot.realtimeMessages = slot.realtimeMessages.map((message) => (
+          settlePendingOptimisticServerTail(message, messages)
+        ));
       }
 
       recomputeMergedIfNeeded(slot);
@@ -1203,7 +1318,11 @@ export function useSessionStore() {
    */
   const appendRealtime = useCallback((sessionId: string, msg: NormalizedMessage) => {
     const slot = getSlot(sessionId);
-    const capturedMessage = captureOptimisticUserServerTail(msg, slot.serverMessages);
+    const capturedMessage = captureOptimisticUserServerTail(
+      msg,
+      slot.serverMessages,
+      slot._serverAppliedGeneration === 0 && slot._serverLoadingGeneration !== null,
+    );
     let updated = upsertRealtimeMessages(slot.realtimeMessages, [capturedMessage]);
     if (updated.length > MAX_REALTIME_MESSAGES) {
       updated = updated.slice(-MAX_REALTIME_MESSAGES);
@@ -1445,7 +1564,11 @@ export function useSessionStore() {
     if (msgs.length === 0) return;
     const slot = getSlot(sessionId);
     const capturedMessages = msgs.map((message) => (
-      captureOptimisticUserServerTail(message, slot.serverMessages)
+      captureOptimisticUserServerTail(
+        message,
+        slot.serverMessages,
+        slot._serverAppliedGeneration === 0 && slot._serverLoadingGeneration !== null,
+      )
     ));
     let updated = upsertRealtimeMessages(slot.realtimeMessages, capturedMessages);
     if (updated.length > MAX_REALTIME_MESSAGES) {

--- a/ui/src/stores/useSessionStore.ts
+++ b/ui/src/stores/useSessionStore.ts
@@ -388,6 +388,52 @@ function isConfirmedUserMessageDuplicate(
   return findConfirmedUserMessageDuplicateIndex(realtimeMessage, serverMessages) >= 0;
 }
 
+function getConfirmedRealtimeUserIndexes(
+  serverMessages: NormalizedMessage[],
+  realtimeMessages: NormalizedMessage[],
+): Set<number> {
+  const consumedRealtimeIndexes = new Set<number>();
+
+  for (const serverMessage of serverMessages) {
+    if (serverMessage.kind !== 'text' || serverMessage.role !== 'user') continue;
+    const serverIdentity = getConfirmedUserMessageIdentity(serverMessage);
+    if (!serverIdentity.text) continue;
+
+    let closestRealtimeIndex = -1;
+    let closestTimestampDistance = Number.POSITIVE_INFINITY;
+    const serverTimestamp = parseTimestampMs(serverMessage.timestamp);
+
+    for (let index = 0; index < realtimeMessages.length; index += 1) {
+      if (consumedRealtimeIndexes.has(index)) continue;
+      const realtimeMessage = realtimeMessages[index];
+      if (!isOptimisticUserMessage(realtimeMessage)) continue;
+
+      const realtimeIdentity = getConfirmedUserMessageIdentity(realtimeMessage);
+      if (
+        realtimeIdentity.text !== serverIdentity.text
+        || !haveSameUserMessageInputs(realtimeIdentity, serverIdentity)
+      ) {
+        continue;
+      }
+
+      const realtimeTimestamp = parseTimestampMs(realtimeMessage.timestamp);
+      const timestampDistance = serverTimestamp != null && realtimeTimestamp != null
+        ? Math.abs(serverTimestamp - realtimeTimestamp)
+        : Number.POSITIVE_INFINITY;
+      if (
+        timestampDistance > 10_000
+        || (closestRealtimeIndex >= 0 && timestampDistance >= closestTimestampDistance)
+      ) continue;
+      closestRealtimeIndex = index;
+      closestTimestampDistance = timestampDistance;
+    }
+
+    if (closestRealtimeIndex >= 0) consumedRealtimeIndexes.add(closestRealtimeIndex);
+  }
+
+  return consumedRealtimeIndexes;
+}
+
 /**
  * The backend pushes a synthetic `interrupted` notice the moment abort fires
 
@@ -629,23 +675,26 @@ export function getUnpersistedRealtimeTurnMessages(
 export function shouldKeepRealtimeAfterServerRefresh(
   realtimeMessage: NormalizedMessage,
   serverMessages: NormalizedMessage[],
-  consumedServerUserIndexes?: Set<number>,
 ): boolean {
   if (realtimeMessage.id.startsWith('__streaming_')) {
     return true;
   }
   if (!PERSISTED_RENDERABLE_KINDS.has(realtimeMessage.kind)) return false;
   if (isOptimisticUserMessage(realtimeMessage)) {
-    const duplicateIndex = findConfirmedUserMessageDuplicateIndex(
-      realtimeMessage,
-      serverMessages,
-      consumedServerUserIndexes,
-    );
-    if (duplicateIndex < 0) return true;
-    consumedServerUserIndexes?.add(duplicateIndex);
-    return false;
+    return !isConfirmedUserMessageDuplicate(realtimeMessage, serverMessages);
   }
   return !isRealtimeMessageRepresentedOnServer(realtimeMessage, serverMessages);
+}
+
+export function getRealtimeMessagesToKeepAfterServerRefresh(
+  realtimeMessages: NormalizedMessage[],
+  serverMessages: NormalizedMessage[],
+): NormalizedMessage[] {
+  const confirmedRealtimeIndexes = getConfirmedRealtimeUserIndexes(serverMessages, realtimeMessages);
+  return realtimeMessages.filter((message, index) => {
+    if (isOptimisticUserMessage(message)) return !confirmedRealtimeIndexes.has(index);
+    return shouldKeepRealtimeAfterServerRefresh(message, serverMessages);
+  });
 }
 
 /**
@@ -658,18 +707,9 @@ export function computeMerged(server: NormalizedMessage[], realtime: NormalizedM
     return server;
   }
   if (server.length === 0) return realtime;
-  const consumedServerUserIndexes = new Set<number>();
-  const extra = realtime.filter((message) => {
-    if (isOptimisticUserMessage(message)) {
-      const duplicateIndex = findConfirmedUserMessageDuplicateIndex(
-        message,
-        server,
-        consumedServerUserIndexes,
-      );
-      if (duplicateIndex < 0) return true;
-      consumedServerUserIndexes.add(duplicateIndex);
-      return false;
-    }
+  const confirmedRealtimeIndexes = getConfirmedRealtimeUserIndexes(server, realtime);
+  const extra = realtime.filter((message, index) => {
+    if (isOptimisticUserMessage(message)) return !confirmedRealtimeIndexes.has(index);
     return !isRealtimeMessageRepresentedOnServer(message, server);
   });
   if (extra.length === 0) return server;
@@ -1032,9 +1072,12 @@ export function useSessionStore() {
         const serverToolIds = new Set(
           messages.filter(m => m.kind === 'tool_use' && m.toolId).map(m => m.toolId!)
         );
-        const consumedServerUserIndexes = new Set<number>();
-        slot.realtimeMessages = slot.realtimeMessages.filter(m => {
-          if (shouldKeepRealtimeAfterServerRefresh(m, messages, consumedServerUserIndexes)) return true;
+        const confirmedRealtimeIndexes = getConfirmedRealtimeUserIndexes(messages, slot.realtimeMessages);
+        slot.realtimeMessages = slot.realtimeMessages.filter((m, index) => {
+          if (isOptimisticUserMessage(m)) {
+            return !confirmedRealtimeIndexes.has(index);
+          }
+          if (shouldKeepRealtimeAfterServerRefresh(m, messages)) return true;
           if (serverIds.has(m.id)) return false;
           if (m.kind === 'tool_use' && m.toolId && serverToolIds.has(m.toolId)) return false;
           return (Date.parse(m.timestamp) || 0) > watermark;
@@ -1445,9 +1488,9 @@ export function useSessionStore() {
       // an equivalent assistant message; otherwise the UI can show "complete"
       // while the model's visible answer disappears.
       if (slot.realtimeMessages.length > 0 && incomingMessages.length > 0) {
-        const consumedServerUserIndexes = new Set<number>();
-        slot.realtimeMessages = slot.realtimeMessages.filter((message) =>
-          shouldKeepRealtimeAfterServerRefresh(message, incomingMessages, consumedServerUserIndexes)
+        slot.realtimeMessages = getRealtimeMessagesToKeepAfterServerRefresh(
+          slot.realtimeMessages,
+          incomingMessages,
         );
       }
       recomputeMergedIfNeeded(slot);


### PR DESCRIPTION
## Summary
- normalize optimistic and persisted user text before realtime reconciliation
- ignore attachment and content-reference prompt payloads when deduplicating
- add regressions for both persisted prompt shapes

## Verification
- `npm --prefix ui test -- --run src/stores/useSessionStore.streaming.test.ts`
- `npm --prefix ui run build`