### PR TITLE
fix: recover interrupted long model streams

### DIFF
--- a/src/agent/loop/AgentLoop.ts
+++ b/src/agent/loop/AgentLoop.ts
@@ -719,7 +719,7 @@ export class AgentLoop {
       if (streamInterruption) {
         if (streamInterruptionRecoveryCount < MAX_STREAM_INTERRUPTION_RECOVERIES) {
           streamInterruptionRecoveryCount++;
-          if (streamInterruption.phase === "text") {
+          if (streamInterruption.phase === "text" && !assembled.hasPartialTextToolCall) {
             const partialTextMessage = withoutThinkingBlocks(assistantMessage);
             if (textFromMessage(partialTextMessage).trim().length > 0) {
               finalMessage = partialTextMessage;
@@ -728,9 +728,12 @@ export class AgentLoop {
               await input.onDurableMessage?.(partialTextMessage);
             }
           }
+          const recoveryPrompt = assembled.hasPartialTextToolCall
+            ? buildPartialTextToolCallRecoveryPrompt(assembled.partialTextToolCall)
+            : buildStreamInterruptionRecoveryPrompt(streamInterruption);
           pushTransientSyntheticPrompt(
-            buildStreamInterruptionRecoveryPrompt(streamInterruption),
-            "stream_interruption_recovery",
+            recoveryPrompt,
+            assembled.hasPartialTextToolCall ? "max_output_recovery" : "stream_interruption_recovery",
           );
           yield {
             type: "turn_continued",
@@ -768,7 +771,7 @@ export class AgentLoop {
       }
       streamInterruptionRecoveryCount = 0;
 
-      if (!assembled.error && !assembled.hasPartialTextToolCall && assembled.finishReason === "unknown") {
+      if (!assembled.error && assembled.hasMessageEnd && !assembled.hasPartialTextToolCall && assembled.finishReason === "unknown") {
         if (unknownFinishRecoveryCount < MAX_UNKNOWN_FINISH_RECOVERIES) {
           unknownFinishRecoveryCount++;
           const partialTextMessage = withoutThinkingBlocks(assistantMessage);

--- a/src/agent/loop/AgentLoop.ts
+++ b/src/agent/loop/AgentLoop.ts
@@ -615,13 +615,18 @@ export class AgentLoop {
       } catch (error) {
         if (input.abortSignal?.aborted) {
           const partialAssembled = assembleAssistantMessage(assembler);
-          if (partialAssembled.message.content.length > 0) {
-            finalMessage = partialAssembled.message;
-            messages.push(partialAssembled.message);
+          const safePartialMessage = safeFinalTextMessage(
+            partialAssembled.message,
+            partialAssembled.hasPartialTextToolCall || partialAssembled.hasTextFallbackToolCalls,
+            partialAssembled.toolCalls,
+          );
+          if (safePartialMessage) {
+            finalMessage = safePartialMessage;
+            messages.push(safePartialMessage);
             expireConsumedTransientPrompts();
             usage = mergeUsage(usage, partialAssembled.usage);
-            yield { type: "assistant_message", sessionId: input.sessionId, turnId: input.turnId, message: partialAssembled.message };
-            await input.onDurableMessage?.(partialAssembled.message);
+            yield { type: "assistant_message", sessionId: input.sessionId, turnId: input.turnId, message: safePartialMessage };
+            await input.onDurableMessage?.(safePartialMessage);
           }
           const result = this.createTurnResult(input, {
             type: "aborted",
@@ -667,13 +672,18 @@ export class AgentLoop {
 
       if (input.abortSignal?.aborted) {
         const partialAssembled = assembleAssistantMessage(assembler);
-        if (partialAssembled.message.content.length > 0) {
-          finalMessage = partialAssembled.message;
-          messages.push(partialAssembled.message);
+        const safePartialMessage = safeFinalTextMessage(
+          partialAssembled.message,
+          partialAssembled.hasPartialTextToolCall || partialAssembled.hasTextFallbackToolCalls,
+          partialAssembled.toolCalls,
+        );
+        if (safePartialMessage) {
+          finalMessage = safePartialMessage;
+          messages.push(safePartialMessage);
           expireConsumedTransientPrompts();
           usage = mergeUsage(usage, partialAssembled.usage);
-          yield { type: "assistant_message", sessionId: input.sessionId, turnId: input.turnId, message: partialAssembled.message };
-          await input.onDurableMessage?.(partialAssembled.message);
+          yield { type: "assistant_message", sessionId: input.sessionId, turnId: input.turnId, message: safePartialMessage };
+          await input.onDurableMessage?.(safePartialMessage);
         }
         const result = this.createTurnResult(input, {
           type: "aborted",
@@ -722,6 +732,11 @@ export class AgentLoop {
           const hasTextToolCall = assembled.hasPartialTextToolCall
             || assembled.hasTextFallbackToolCalls
             || toolCalls.length > 0;
+          if (hasTextToolCall) {
+            // Do not expose a text-encoded tool-call fragment if recovery is
+            // cancelled before the replacement response arrives.
+            finalMessage = undefined;
+          }
           if (streamInterruption.phase === "text" && !hasTextToolCall) {
             const partialTextMessage = withoutThinkingBlocks(assistantMessage);
             if (textFromMessage(partialTextMessage).trim().length > 0) {
@@ -841,6 +856,9 @@ export class AgentLoop {
       if (assembled.hasPartialTextToolCall) {
         if (maxOutputRecoveryCount < MAX_OUTPUT_RECOVERY_LIMIT) {
           maxOutputRecoveryCount++;
+          // The current assistant message contains an unsafe tool fragment;
+          // clear it before yielding so cancellation cannot return it.
+          finalMessage = undefined;
           pushTransientSyntheticPrompt(
             buildPartialTextToolCallRecoveryPrompt(assembled.partialTextToolCall),
             "max_output_recovery",

--- a/src/agent/loop/AgentLoop.ts
+++ b/src/agent/loop/AgentLoop.ts
@@ -262,6 +262,8 @@ export class AgentLoop {
     let hasAttemptedReasoningContentRetry = false;
     /** Prevent a provider that keeps rejecting text-only retries from looping forever. */
     let hasAttemptedImageStrip = false;
+    const MAX_STREAM_INTERRUPTION_RECOVERIES = 2;
+    let streamInterruptionRecoveryCount = 0;
     const largeFileRepair = new LargeFileRepair();
 
     /**
@@ -710,6 +712,59 @@ export class AgentLoop {
       }
       finalMessage = assistantMessage;
       expireConsumedTransientPrompts();
+
+      const streamInterruption = assembled.error?.streamInterruption;
+      if (streamInterruption) {
+        if (streamInterruptionRecoveryCount < MAX_STREAM_INTERRUPTION_RECOVERIES) {
+          streamInterruptionRecoveryCount++;
+          if (streamInterruption.phase === "text") {
+            const partialTextMessage = withoutThinkingBlocks(assistantMessage);
+            if (textFromMessage(partialTextMessage).trim().length > 0) {
+              finalMessage = partialTextMessage;
+              messages.push(partialTextMessage);
+              yield { type: "assistant_message", sessionId: input.sessionId, turnId: input.turnId, message: partialTextMessage };
+              await input.onDurableMessage?.(partialTextMessage);
+            }
+          }
+          pushTransientSyntheticPrompt(
+            buildStreamInterruptionRecoveryPrompt(streamInterruption),
+            "stream_interruption_recovery",
+          );
+          yield {
+            type: "turn_continued",
+            sessionId: input.sessionId,
+            turnId: input.turnId,
+            reason: "model_error",
+          };
+          continue;
+        }
+
+        const error = agentError(
+          "agent_model_error",
+          `Stream interruption recovery exhausted after ${MAX_STREAM_INTERRUPTION_RECOVERIES} attempts (${streamInterruption.phase}).`,
+          assembled.error,
+          "The model stream repeatedly disconnected. Retry the turn or switch providers.",
+        );
+        await this.dispatchLifecycle(input, "StopFailure", { error: error.message });
+        yield { type: "stop_failure", sessionId: input.sessionId, turnId: input.turnId, error: error.message };
+        const result = this.createTurnResult(input, {
+          type: "error",
+          stopReason: "model_error",
+          usage,
+          permissionDenials,
+          turns: turnCount,
+          startedAt,
+          finalMessage,
+          structuredOutput,
+          errors: [error],
+        });
+        yield await emitStatus(createModelRequestFailedStatus({ error, modelError: assembled.error }));
+        yield { type: "turn_failed", sessionId: input.sessionId, turnId: input.turnId, error };
+        await captureTurn(true);
+        yield { type: "turn_completed", sessionId: input.sessionId, turnId: input.turnId, result };
+        return { result, messages };
+      }
+      streamInterruptionRecoveryCount = 0;
 
       if (assembled.hasPartialTextToolCall) {
         if (maxOutputRecoveryCount < MAX_OUTPUT_RECOVERY_LIMIT) {
@@ -2666,6 +2721,34 @@ function textFromMessage(message: CanonicalMessage): string {
     .join("\n");
 }
 
+function withoutThinkingBlocks(message: CanonicalMessage): CanonicalMessage {
+  return {
+    ...message,
+    content: messageContent(message).filter((block) => block.type !== "thinking"),
+  };
+}
+
+function buildStreamInterruptionRecoveryPrompt(
+  interruption: NonNullable<CanonicalModelError["streamInterruption"]>,
+): string {
+  if (interruption.phase === "tool_call") {
+    const tools = interruption.activeToolCalls?.map((call) => call.name || "unknown").filter(Boolean) ?? [];
+    const toolLabel = tools.length > 0 ? ` (${tools.slice(0, 3).join(", ")})` : "";
+    return [
+      `The previous model stream disconnected while generating a tool call${toolLabel}. No incomplete tool call was executed.`,
+      "Continue the original task from the current workspace state. Inspect relevant files before writing.",
+      "Do not retry the same large atomic write. Create or extend the artifact through small focused write_file or edit_file calls, keeping each tool call well under 8K output tokens.",
+    ].join("\n");
+  }
+  if (interruption.phase === "reasoning") {
+    return "The previous model stream disconnected during reasoning. Continue the original task directly from the current workspace state; do not repeat analysis or recap.";
+  }
+  if (interruption.phase === "text") {
+    return "The previous model stream disconnected mid-response. Continue exactly where the visible response ended; do not repeat prior text or recap.";
+  }
+  return "The previous model stream disconnected before producing a response. Continue the original task directly from the current workspace state.";
+}
+
 function isMissingReasoningContentError(error: CanonicalModelError): boolean {
   return /\breasoning_content\b/i.test(error.message) &&
     /thinking\s+mode/i.test(error.message) &&
@@ -3158,6 +3241,10 @@ export function modelFailureAction(error: CanonicalModelError | undefined): {
     return modelFailureActionResult(hint, "settings", "modelNotFound", { provider: error.provider ?? "the provider", model: error.model });
   }
   if (error.code === "timeout") {
+    if (error.settingsFix?.configPath === "model.providers.<id>.retry.streamIdleTimeoutMs") {
+      const hint = `Increase streamIdleTimeoutMs for${providerLabel} in Settings → Model Provider → Advanced, or check local network/proxy and provider status.`;
+      return modelFailureActionResult(hint, "network", "streamIdleTimeout", { provider: error.provider ?? "the provider" });
+    }
     const hint = `Increase timeoutMs for${providerLabel} in Settings → Model Provider → Advanced, or check local network/proxy and provider status.`;
     return modelFailureActionResult(hint, "network", "timeout", { provider: error.provider ?? "the provider" });
   }

--- a/src/agent/loop/AgentLoop.ts
+++ b/src/agent/loop/AgentLoop.ts
@@ -768,7 +768,7 @@ export class AgentLoop {
       }
       streamInterruptionRecoveryCount = 0;
 
-      if (!assembled.error && assembled.finishReason === "unknown") {
+      if (!assembled.error && !assembled.hasPartialTextToolCall && assembled.finishReason === "unknown") {
         if (unknownFinishRecoveryCount < MAX_UNKNOWN_FINISH_RECOVERIES) {
           unknownFinishRecoveryCount++;
           const partialTextMessage = withoutThinkingBlocks(assistantMessage);

--- a/src/agent/loop/AgentLoop.ts
+++ b/src/agent/loop/AgentLoop.ts
@@ -750,6 +750,13 @@ export class AgentLoop {
           assembled.error,
           "The model stream repeatedly disconnected. Retry the turn or switch providers.",
         );
+        const exhaustedMessage = safeFinalTextMessage(assistantMessage, assembled.hasPartialTextToolCall, toolCalls);
+        if (exhaustedMessage) {
+          finalMessage = exhaustedMessage;
+          messages.push(exhaustedMessage);
+          yield { type: "assistant_message", sessionId: input.sessionId, turnId: input.turnId, message: exhaustedMessage };
+          await input.onDurableMessage?.(exhaustedMessage);
+        }
         await this.dispatchLifecycle(input, "StopFailure", { error: error.message });
         yield { type: "stop_failure", sessionId: input.sessionId, turnId: input.turnId, error: error.message };
         const result = this.createTurnResult(input, {
@@ -800,6 +807,13 @@ export class AgentLoop {
           undefined,
           "The provider repeatedly ended the stream without a recognized finish reason. Retry the turn or switch providers.",
         );
+        const exhaustedMessage = safeFinalTextMessage(assistantMessage, assembled.hasPartialTextToolCall, toolCalls);
+        if (exhaustedMessage) {
+          finalMessage = exhaustedMessage;
+          messages.push(exhaustedMessage);
+          yield { type: "assistant_message", sessionId: input.sessionId, turnId: input.turnId, message: exhaustedMessage };
+          await input.onDurableMessage?.(exhaustedMessage);
+        }
         await this.dispatchLifecycle(input, "StopFailure", { error: error.message });
         yield { type: "stop_failure", sessionId: input.sessionId, turnId: input.turnId, error: error.message };
         const result = this.createTurnResult(input, {
@@ -2781,6 +2795,18 @@ function withoutThinkingBlocks(message: CanonicalMessage): CanonicalMessage {
     ...message,
     content: messageContent(message).filter((block) => block.type !== "thinking"),
   };
+}
+
+function safeFinalTextMessage(
+  message: CanonicalMessage,
+  hasPartialTextToolCall: boolean | undefined,
+  toolCalls: CanonicalToolCall[],
+): CanonicalMessage | undefined {
+  if (hasPartialTextToolCall || toolCalls.length > 0) {
+    return undefined;
+  }
+  const textMessage = withoutThinkingBlocks(message);
+  return textFromMessage(textMessage).trim().length > 0 ? textMessage : undefined;
 }
 
 function buildStreamInterruptionRecoveryPrompt(

--- a/src/agent/loop/AgentLoop.ts
+++ b/src/agent/loop/AgentLoop.ts
@@ -857,6 +857,7 @@ export class AgentLoop {
         const detail = assembled.partialTextToolCall
           ? `${assembled.partialTextToolCall.format}/${assembled.partialTextToolCall.reason}`
           : "unknown partial text tool-call";
+        finalMessage = safeFinalTextMessage(assistantMessage, true, toolCalls);
         const result = this.createTurnResult(input, {
           type: "error",
           stopReason: "model_error",
@@ -2924,7 +2925,7 @@ function buildPartialTextToolCallRecoveryPrompt(
   partial: PartialTextToolCallInfo | undefined,
 ): string {
   const evidence = partial
-    ? `Detected partial text tool-call syntax (${partial.format}/${partial.reason}). Preview: ${partial.preview}`
+    ? `Detected partial text tool-call syntax (${partial.format}/${partial.reason}).`
     : "Detected partial text tool-call syntax.";
   return [
     "The previous response contained partial tool-call XML/text and could not be safely executed.",

--- a/src/agent/loop/AgentLoop.ts
+++ b/src/agent/loop/AgentLoop.ts
@@ -264,6 +264,8 @@ export class AgentLoop {
     let hasAttemptedImageStrip = false;
     const MAX_STREAM_INTERRUPTION_RECOVERIES = 2;
     let streamInterruptionRecoveryCount = 0;
+    const MAX_UNKNOWN_FINISH_RECOVERIES = 2;
+    let unknownFinishRecoveryCount = 0;
     const largeFileRepair = new LargeFileRepair();
 
     /**
@@ -765,6 +767,56 @@ export class AgentLoop {
         return { result, messages };
       }
       streamInterruptionRecoveryCount = 0;
+
+      if (!assembled.error && assembled.finishReason === "unknown") {
+        if (unknownFinishRecoveryCount < MAX_UNKNOWN_FINISH_RECOVERIES) {
+          unknownFinishRecoveryCount++;
+          const partialTextMessage = withoutThinkingBlocks(assistantMessage);
+          if (toolCalls.length === 0 && textFromMessage(partialTextMessage).trim().length > 0) {
+            finalMessage = partialTextMessage;
+            messages.push(partialTextMessage);
+            yield { type: "assistant_message", sessionId: input.sessionId, turnId: input.turnId, message: partialTextMessage };
+            await input.onDurableMessage?.(partialTextMessage);
+          }
+          pushTransientSyntheticPrompt(
+            buildUnknownFinishRecoveryPrompt(toolCalls),
+            "unknown_finish_recovery",
+          );
+          yield {
+            type: "turn_continued",
+            sessionId: input.sessionId,
+            turnId: input.turnId,
+            reason: "model_error",
+          };
+          continue;
+        }
+
+        const error = agentError(
+          "agent_model_error",
+          `Unknown finish reason recovery exhausted after ${MAX_UNKNOWN_FINISH_RECOVERIES} attempts.`,
+          undefined,
+          "The provider repeatedly ended the stream without a recognized finish reason. Retry the turn or switch providers.",
+        );
+        await this.dispatchLifecycle(input, "StopFailure", { error: error.message });
+        yield { type: "stop_failure", sessionId: input.sessionId, turnId: input.turnId, error: error.message };
+        const result = this.createTurnResult(input, {
+          type: "error",
+          stopReason: "model_error",
+          usage,
+          permissionDenials,
+          turns: turnCount,
+          startedAt,
+          finalMessage,
+          structuredOutput,
+          errors: [error],
+        });
+        yield await emitStatus(createModelRequestFailedStatus({ error }));
+        yield { type: "turn_failed", sessionId: input.sessionId, turnId: input.turnId, error };
+        await captureTurn(true);
+        yield { type: "turn_completed", sessionId: input.sessionId, turnId: input.turnId, result };
+        return { result, messages };
+      }
+      unknownFinishRecoveryCount = 0;
 
       if (assembled.hasPartialTextToolCall) {
         if (maxOutputRecoveryCount < MAX_OUTPUT_RECOVERY_LIMIT) {
@@ -2747,6 +2799,17 @@ function buildStreamInterruptionRecoveryPrompt(
     return "The previous model stream disconnected mid-response. Continue exactly where the visible response ended; do not repeat prior text or recap.";
   }
   return "The previous model stream disconnected before producing a response. Continue the original task directly from the current workspace state.";
+}
+
+function buildUnknownFinishRecoveryPrompt(toolCalls: CanonicalToolCall[]): string {
+  if (toolCalls.length > 0) {
+    return [
+      "The previous response ended without a recognized finish reason after generating tool calls. No tool call was executed.",
+      "Continue the original task from the current workspace state. Inspect relevant files before acting.",
+      "Do not repeat the same large atomic write. Use small focused write_file or edit_file calls.",
+    ].join("\n");
+  }
+  return "The previous response ended without a recognized finish reason. Continue exactly where the visible response ended; do not repeat prior text or recap.";
 }
 
 function isMissingReasoningContentError(error: CanonicalModelError): boolean {

--- a/src/agent/loop/AgentLoop.ts
+++ b/src/agent/loop/AgentLoop.ts
@@ -719,7 +719,10 @@ export class AgentLoop {
       if (streamInterruption) {
         if (streamInterruptionRecoveryCount < MAX_STREAM_INTERRUPTION_RECOVERIES) {
           streamInterruptionRecoveryCount++;
-          if (streamInterruption.phase === "text" && !assembled.hasPartialTextToolCall) {
+          const hasTextToolCall = assembled.hasPartialTextToolCall
+            || assembled.hasTextFallbackToolCalls
+            || toolCalls.length > 0;
+          if (streamInterruption.phase === "text" && !hasTextToolCall) {
             const partialTextMessage = withoutThinkingBlocks(assistantMessage);
             if (textFromMessage(partialTextMessage).trim().length > 0) {
               finalMessage = partialTextMessage;
@@ -728,12 +731,12 @@ export class AgentLoop {
               await input.onDurableMessage?.(partialTextMessage);
             }
           }
-          const recoveryPrompt = assembled.hasPartialTextToolCall
+          const recoveryPrompt = hasTextToolCall
             ? buildPartialTextToolCallRecoveryPrompt(assembled.partialTextToolCall)
             : buildStreamInterruptionRecoveryPrompt(streamInterruption);
           pushTransientSyntheticPrompt(
             recoveryPrompt,
-            assembled.hasPartialTextToolCall ? "max_output_recovery" : "stream_interruption_recovery",
+            hasTextToolCall ? "max_output_recovery" : "stream_interruption_recovery",
           );
           yield {
             type: "turn_continued",
@@ -750,9 +753,9 @@ export class AgentLoop {
           assembled.error,
           "The model stream repeatedly disconnected. Retry the turn or switch providers.",
         );
-        const exhaustedMessage = safeFinalTextMessage(assistantMessage, assembled.hasPartialTextToolCall, toolCalls);
+        const exhaustedMessage = safeFinalTextMessage(assistantMessage, assembled.hasPartialTextToolCall || assembled.hasTextFallbackToolCalls, toolCalls);
+        finalMessage = exhaustedMessage;
         if (exhaustedMessage) {
-          finalMessage = exhaustedMessage;
           messages.push(exhaustedMessage);
           yield { type: "assistant_message", sessionId: input.sessionId, turnId: input.turnId, message: exhaustedMessage };
           await input.onDurableMessage?.(exhaustedMessage);
@@ -807,9 +810,9 @@ export class AgentLoop {
           undefined,
           "The provider repeatedly ended the stream without a recognized finish reason. Retry the turn or switch providers.",
         );
-        const exhaustedMessage = safeFinalTextMessage(assistantMessage, assembled.hasPartialTextToolCall, toolCalls);
+        const exhaustedMessage = safeFinalTextMessage(assistantMessage, assembled.hasPartialTextToolCall || assembled.hasTextFallbackToolCalls, toolCalls);
+        finalMessage = exhaustedMessage;
         if (exhaustedMessage) {
-          finalMessage = exhaustedMessage;
           messages.push(exhaustedMessage);
           yield { type: "assistant_message", sessionId: input.sessionId, turnId: input.turnId, message: exhaustedMessage };
           await input.onDurableMessage?.(exhaustedMessage);

--- a/src/model/errors/normalizeModelError.ts
+++ b/src/model/errors/normalizeModelError.ts
@@ -288,6 +288,15 @@ function resolveUserHint(
         userHint: "Model output hit the token limit. Increase max output tokens in Settings → Model Provider or ask the agent to split the answer into smaller parts.",
       };
     case "timeout":
+      if (/stream idle timeout|no data received/i.test(message)) {
+        return {
+          userHint: `Stream stalled${provider ? ` for provider \"${provider}\"` : ""}. Increase retry.streamIdleTimeoutMs in Settings → Model Provider → Advanced, or check local network/proxy and provider status.`,
+          settingsFix: {
+            description: "Increase stream idle timeout for this provider.",
+            configPath: "model.providers.<id>.retry.streamIdleTimeoutMs",
+          },
+        };
+      }
       return {
         userHint: `Request timed out${provider ? ` for provider \"${provider}\"` : ""}. Increase provider.timeoutMs in Settings → Model Provider → Advanced, or check local network/proxy and provider status.`,
         settingsFix: {

--- a/src/model/protocol/canonical.ts
+++ b/src/model/protocol/canonical.ts
@@ -289,7 +289,7 @@ export type ProviderRetryConfig = {
   requestMaxRetries?: number;
   /** Max retries for dropped SSE streams. Default 2. */
   streamMaxRetries?: number;
-  /** First-token / idle timeout (ms) for streaming responses. Defaults through request timeout when omitted. */
+  /** First-token / idle timeout (ms) for streaming responses. Defaults to 600000ms when omitted. */
   streamIdleTimeoutMs?: number;
   /** Maximum streaming duration (ms). Default disabled. */
   maxStreamingDurationMs?: number;

--- a/src/model/protocol/errors.ts
+++ b/src/model/protocol/errors.ts
@@ -28,6 +28,19 @@ export type SettingsFix = {
   url?: string;
 };
 
+/**
+ * Safe metadata about a stream that ended before the provider completed its
+ * response. Tool argument text is deliberately never retained here.
+ */
+export type StreamInterruption = {
+  phase: "empty" | "text" | "reasoning" | "tool_call";
+  activeToolCalls?: Array<{
+    id: string;
+    name: string;
+    argumentChars: number;
+  }>;
+};
+
 export type CanonicalModelError = {
   provider: string;
   model?: string;
@@ -53,6 +66,8 @@ export type CanonicalModelError = {
   maxOutputTokens?: number;
   /** Provider-reported output space available for this prompt. */
   availableOutputTokens?: number;
+  /** Streaming response ended before its completion sentinel. */
+  streamInterruption?: StreamInterruption;
 };
 
 /**

--- a/src/model/streaming/StreamingCheckpoint.ts
+++ b/src/model/streaming/StreamingCheckpoint.ts
@@ -1,9 +1,12 @@
 import type { CanonicalModelEvent } from "../protocol/canonical.js";
+import type { StreamInterruption } from "../protocol/errors.js";
 
 export interface StreamingCheckpoint {
   partialText: string;
   tokensReceived: number;
   hasToolCalls: boolean;
+  hasReasoning: boolean;
+  activeToolCalls: Map<string, { name: string; argumentChars: number }>;
 }
 
 /**
@@ -17,6 +20,8 @@ export class StreamingCheckpointManager {
     partialText: "",
     tokensReceived: 0,
     hasToolCalls: false,
+    hasReasoning: false,
+    activeToolCalls: new Map(),
   };
 
   onEvent(event: CanonicalModelEvent): void {
@@ -26,26 +31,66 @@ export class StreamingCheckpointManager {
         this.checkpoint.tokensReceived++;
         break;
       case "thinking_delta":
+        this.checkpoint.hasReasoning = true;
         this.checkpoint.tokensReceived++;
         break;
       case "tool_call_start":
-      case "tool_call_delta":
+        this.checkpoint.hasToolCalls = true;
+        this.checkpoint.activeToolCalls.set(event.id, { name: event.name, argumentChars: 0 });
+        this.checkpoint.tokensReceived++;
+        break;
+      case "tool_call_delta": {
+        this.checkpoint.hasToolCalls = true;
+        const active = this.checkpoint.activeToolCalls.get(event.id) ?? { name: "", argumentChars: 0 };
+        active.argumentChars += event.delta.length;
+        this.checkpoint.activeToolCalls.set(event.id, active);
+        this.checkpoint.tokensReceived++;
+        break;
+      }
       case "tool_call_end":
         this.checkpoint.hasToolCalls = true;
+        this.checkpoint.activeToolCalls.delete(event.toolCall.id);
         this.checkpoint.tokensReceived++;
         break;
     }
   }
 
   get(): StreamingCheckpoint {
-    return { ...this.checkpoint };
+    return {
+      ...this.checkpoint,
+      activeToolCalls: new Map(this.checkpoint.activeToolCalls),
+    };
   }
 
   hasSubstantialContent(): boolean {
     return this.checkpoint.partialText.trim().length > 0;
   }
 
+  canContinueText(): boolean {
+    return this.hasSubstantialContent() && !this.checkpoint.hasReasoning && !this.checkpoint.hasToolCalls;
+  }
+
+  interruption(): StreamInterruption {
+    const activeToolCalls = [...this.checkpoint.activeToolCalls.entries()].map(([id, call]) => ({ id, ...call }));
+    if (this.checkpoint.hasToolCalls) {
+      return { phase: "tool_call", activeToolCalls };
+    }
+    if (this.checkpoint.partialText.trim().length > 0) {
+      return { phase: "text" };
+    }
+    if (this.checkpoint.hasReasoning) {
+      return { phase: "reasoning" };
+    }
+    return { phase: "empty" };
+  }
+
   reset(): void {
-    this.checkpoint = { partialText: "", tokensReceived: 0, hasToolCalls: false };
+    this.checkpoint = {
+      partialText: "",
+      tokensReceived: 0,
+      hasToolCalls: false,
+      hasReasoning: false,
+      activeToolCalls: new Map(),
+    };
   }
 }

--- a/src/model/streaming/StreamingCheckpoint.ts
+++ b/src/model/streaming/StreamingCheckpoint.ts
@@ -1,5 +1,6 @@
 import type { CanonicalModelEvent } from "../protocol/canonical.js";
 import type { StreamInterruption } from "../protocol/errors.js";
+import { hasTextToolCallSyntax } from "./parseTextToolCalls.js";
 
 export interface StreamingCheckpoint {
   partialText: string;
@@ -67,7 +68,10 @@ export class StreamingCheckpointManager {
   }
 
   canContinueText(): boolean {
-    return this.hasSubstantialContent() && !this.checkpoint.hasReasoning && !this.checkpoint.hasToolCalls;
+    return this.hasSubstantialContent()
+      && !hasTextToolCallSyntax(this.checkpoint.partialText)
+      && !this.checkpoint.hasReasoning
+      && !this.checkpoint.hasToolCalls;
   }
 
   interruption(): StreamInterruption {

--- a/src/model/streaming/assembleModelMessage.ts
+++ b/src/model/streaming/assembleModelMessage.ts
@@ -23,6 +23,7 @@ export type ModelMessageAssemblerState = {
   thinkingSignature?: string;
   usage: CanonicalUsage;
   finishReason?: CanonicalFinishReason;
+  hasMessageEnd: boolean;
   error?: CanonicalModelError;
   toolCalls: CanonicalToolCall[];
   hasRepairedToolCalls?: boolean;
@@ -45,6 +46,7 @@ export type AssembledAssistantMessage = {
   hasTextFallbackToolCalls?: boolean;
   textToolCallFormat?: PartialTextToolCallInfo["format"];
   hasUnparsedTextToolCall?: boolean;
+  hasMessageEnd: boolean;
 };
 
 export function createModelMessageAssemblerState(): ModelMessageAssemblerState {
@@ -54,6 +56,7 @@ export function createModelMessageAssemblerState(): ModelMessageAssemblerState {
     thinkingBuffer: "",
     thinkingReasoningContentBuffer: "",
     usage: {},
+    hasMessageEnd: false,
     toolCalls: [],
   };
 }
@@ -94,6 +97,7 @@ export function applyModelEventToAssembler(
     case "message_end":
       flushTextBuffers(state);
       state.finishReason = event.finishReason;
+      state.hasMessageEnd = true;
       return;
     case "usage":
       state.usage = mergeUsage(state.usage, event.usage);
@@ -149,6 +153,7 @@ export function assembleAssistantMessage(state: ModelMessageAssemblerState): Ass
       content: [...state.content],
     },
     finishReason: state.finishReason ?? (state.error ? "error" : "unknown"),
+    hasMessageEnd: state.hasMessageEnd,
     usage: hasUsage(state.usage) ? state.usage : undefined,
     toolCalls: [...state.toolCalls],
     error: state.error,

--- a/src/model/streaming/streamModel.ts
+++ b/src/model/streaming/streamModel.ts
@@ -184,6 +184,13 @@ export async function* streamModel(
         await delay(delayMs, options.signal);
         continue;
       }
+      if (isRetryableStreamError(error) && checkpoint.interruption().phase !== "empty") {
+        yield {
+          type: "error",
+          error: streamInterruptionError(provider, error, checkpoint),
+        };
+        return;
+      }
       throw error;
     }
 
@@ -201,6 +208,13 @@ export async function* streamModel(
         emitModelRetryProgress(options, retryReasonForError(error.code), attempt, maxRetries, delayMs, provider, currentRequest.model);
         await delay(delayMs, options.signal);
         continue;
+      }
+      if (error.retryable && checkpoint.interruption().phase !== "empty") {
+        yield {
+          type: "error",
+          error: streamInterruptionError(provider, new ModelProviderError(error), checkpoint),
+        };
+        return;
       }
       yield { type: "error", error };
       return;
@@ -383,7 +397,7 @@ async function* streamGoogleProviderRequest(params: {
       streamGuard.checkDuration();
 
       if (!sawTerminalEvent && !state.ended) {
-        yield { type: "message_end", finishReason: "unknown", raw: undefined };
+        throw new IncompleteStreamError();
       }
       return;
     } catch (error) {

--- a/src/model/streaming/streamModel.ts
+++ b/src/model/streaming/streamModel.ts
@@ -252,7 +252,6 @@ export async function* streamModel(
         checkpoint.canContinueText()
       ) {
         currentRequest = buildLiteLLMContinuationRequest(currentRequest, checkpoint.get().partialText);
-        checkpoint.reset();
         const delayMs = calculateRetryDelay(provider, attempt, retryAfterMsForError(error));
         emitModelRetryProgress(options, "continuation", attempt, maxRetries, delayMs, provider, currentRequest.model);
         await delay(delayMs, options.signal);
@@ -323,10 +322,12 @@ async function* streamGoogleProviderRequest(params: {
       requestFingerprint: requestFingerprint(currentRequest),
       metadata: currentRequest.metadata,
     };
+    const streamAbort = new AbortController();
+    const detachAbort = params.options.signal ? forwardAbort(params.options.signal, streamAbort) : undefined;
     try {
       const body = withGoogleAbortSignal(buildModelRequest(currentRequest, {
         providers: { [params.provider.id]: params.provider },
-      }) as Record<string, unknown>, params.options.signal);
+      }) as Record<string, unknown>, streamAbort.signal);
       if (process.env.PILOTDECK_DUMP_REQUEST === "1") {
         const fs = await import("node:fs");
         const os = await import("node:os");
@@ -336,16 +337,35 @@ async function* streamGoogleProviderRequest(params: {
         console.log(`[model-debug] Request dumped to ${dumpPath} (model=${currentRequest.model})`);
       }
 
+      // The Google SDK applies HttpOptions.timeout to the entire HTTP request.
+      // Streaming uses a per-read idle watchdog below, so do not give the SDK
+      // either the idle timeout or the provider's request timeout here.
       const client = (params.options.googleClientFactory ?? createGoogleClient)({
         ...params.provider,
-        timeoutMs: resolveStreamIdleTimeout(params.provider, params.options),
+        timeoutMs: undefined,
       });
-      const stream = await client.models.generateContentStream(body as unknown as GoogleRequestBody);
+      const streamIdleTimeoutMs = resolveStreamIdleTimeout(params.provider, params.options);
+      const abortForIdleTimeout = (error: StreamIdleTimeoutError) => streamAbort.abort(error);
+      const stream = await withIdleTimeout(
+        () => client.models.generateContentStream(body as unknown as GoogleRequestBody),
+        streamIdleTimeoutMs,
+        params.options.signal,
+        abortForIdleTimeout,
+      );
       const state = createGoogleStreamState();
       let sawTerminalEvent = false;
       const streamGuard = createStreamGuard(params.provider);
 
-      for await (const chunk of stream) {
+      while (true) {
+        const { value: chunk, done } = await withIdleTimeout(
+          () => stream.next(),
+          streamIdleTimeoutMs,
+          params.options.signal,
+          abortForIdleTimeout,
+        );
+        if (done) {
+          break;
+        }
         throwIfAborted(params.options.signal);
         streamGuard.checkDuration();
         for (const event of normalizeGoogleStreamEvent(chunk, state)) {
@@ -376,7 +396,6 @@ async function* streamGoogleProviderRequest(params: {
         params.checkpoint.canContinueText()
       ) {
         currentRequest = buildLiteLLMContinuationRequest(currentRequest, params.checkpoint.get().partialText);
-        params.checkpoint.reset();
         const delayMs = calculateRetryDelay(params.provider, attempt);
         emitModelRetryProgress(params.options, "continuation", attempt, params.maxRetries, delayMs, params.provider, currentRequest.model);
         await delay(delayMs, params.options.signal);
@@ -401,6 +420,8 @@ async function* streamGoogleProviderRequest(params: {
           : providerError.error,
       };
       return;
+    } finally {
+      detachAbort?.();
     }
   }
 }
@@ -643,7 +664,12 @@ async function sendProviderRequest(
     ? resolveStreamIdleTimeout(provider, options)
     : provider.timeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
   const timeout = effectiveTimeoutMs
-    ? setTimeout(() => controller.abort(new NetworkFetchError("network_timeout", `Model request timed out after ${effectiveTimeoutMs}ms.`)), effectiveTimeoutMs)
+    ? setTimeout(() => controller.abort(new NetworkFetchError(
+      "network_timeout",
+      stream
+        ? `Stream idle timeout: no data received for ${effectiveTimeoutMs}ms`
+        : `Model request timed out after ${effectiveTimeoutMs}ms.`,
+    )), effectiveTimeoutMs)
     : undefined;
 
   const finalBody = provider.extraBody
@@ -864,12 +890,23 @@ function readWithIdleTimeout(
   idleMs: number,
   signal?: AbortSignal,
 ): Promise<ReadableStreamReadResult<Uint8Array>> {
-  return new Promise<ReadableStreamReadResult<Uint8Array>>((resolve, reject) => {
+  return withIdleTimeout(() => reader.read(), idleMs, signal);
+}
+
+function withIdleTimeout<T>(
+  operation: () => Promise<T>,
+  idleMs: number,
+  signal?: AbortSignal,
+  onIdleTimeout?: (error: StreamIdleTimeoutError) => void,
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
     let settled = false;
     const timer = setTimeout(() => {
       if (!settled) {
         settled = true;
-        reject(new StreamIdleTimeoutError(idleMs));
+        const error = new StreamIdleTimeoutError(idleMs);
+        onIdleTimeout?.(error);
+        reject(error);
       }
     }, idleMs);
     if (typeof timer === "object" && "unref" in timer) {
@@ -885,7 +922,7 @@ function readWithIdleTimeout(
     if (signal) {
       signal.addEventListener("abort", onAbort, { once: true });
     }
-    reader.read().then(
+    operation().then(
       (result) => {
         if (!settled) {
           settled = true;

--- a/src/model/streaming/streamModel.ts
+++ b/src/model/streaming/streamModel.ts
@@ -383,7 +383,8 @@ async function* streamGoogleProviderRequest(params: {
         throwIfAborted(params.options.signal);
         streamGuard.checkDuration();
         for (const event of normalizeGoogleStreamEvent(chunk, state)) {
-          if (event.type === "message_end" || event.type === "error") {
+          const terminalEvent = event.type === "message_end" || event.type === "error";
+          if (terminalEvent) {
             sawTerminalEvent = true;
           }
           if (event.type === "error") {
@@ -392,6 +393,10 @@ async function* streamGoogleProviderRequest(params: {
           streamGuard.observe(event);
           params.checkpoint.onEvent(event);
           yield event;
+          if (terminalEvent) {
+            void stream.return(undefined).catch(() => undefined);
+            return;
+          }
         }
       }
       streamGuard.checkDuration();

--- a/src/model/streaming/streamModel.ts
+++ b/src/model/streaming/streamModel.ts
@@ -249,7 +249,7 @@ export async function* streamModel(
       if (
         attempt < maxRetries &&
         isRetryableStreamError(error) &&
-        checkpoint.hasSubstantialContent()
+        checkpoint.canContinueText()
       ) {
         currentRequest = buildLiteLLMContinuationRequest(currentRequest, checkpoint.get().partialText);
         checkpoint.reset();
@@ -259,13 +259,24 @@ export async function* streamModel(
         continue;
       }
 
-      if (isRetryableStreamError(error) && attempt < maxRetries) {
+      if (
+        isRetryableStreamError(error) &&
+        attempt < maxRetries &&
+        checkpoint.interruption().phase === "empty"
+      ) {
         const delayMs = calculateRetryDelay(provider, attempt, retryAfterMsForError(error));
         emitModelRetryProgress(options, retryReasonForThrownError(error), attempt, maxRetries, delayMs, provider, currentRequest.model);
         await delay(delayMs, options.signal);
         continue;
       }
 
+      if (isRetryableStreamError(error)) {
+        yield {
+          type: "error",
+          error: streamInterruptionError(provider, error, checkpoint),
+        };
+        return;
+      }
       throw error;
     }
 
@@ -325,7 +336,10 @@ async function* streamGoogleProviderRequest(params: {
         console.log(`[model-debug] Request dumped to ${dumpPath} (model=${currentRequest.model})`);
       }
 
-      const client = (params.options.googleClientFactory ?? createGoogleClient)(params.provider);
+      const client = (params.options.googleClientFactory ?? createGoogleClient)({
+        ...params.provider,
+        timeoutMs: resolveStreamIdleTimeout(params.provider, params.options),
+      });
       const stream = await client.models.generateContentStream(body as unknown as GoogleRequestBody);
       const state = createGoogleStreamState();
       let sawTerminalEvent = false;
@@ -355,10 +369,11 @@ async function* streamGoogleProviderRequest(params: {
     } catch (error) {
       throwIfGoogleAbort(error, params.options.signal);
       const providerError = toProviderError(params.provider, error);
+      const retryable = isRetryableGoogleStreamError(providerError, error);
       if (
         attempt < params.maxRetries &&
-        isRetryableGoogleStreamError(providerError, error) &&
-        params.checkpoint.hasSubstantialContent()
+        retryable &&
+        params.checkpoint.canContinueText()
       ) {
         currentRequest = buildLiteLLMContinuationRequest(currentRequest, params.checkpoint.get().partialText);
         params.checkpoint.reset();
@@ -368,14 +383,23 @@ async function* streamGoogleProviderRequest(params: {
         continue;
       }
 
-      if (isRetryableGoogleStreamError(providerError, error) && attempt < params.maxRetries) {
+      if (
+        retryable &&
+        attempt < params.maxRetries &&
+        params.checkpoint.interruption().phase === "empty"
+      ) {
         const delayMs = calculateRetryDelay(params.provider, attempt);
         emitModelRetryProgress(params.options, "network_error", attempt, params.maxRetries, delayMs, params.provider, currentRequest.model);
         await delay(delayMs, params.options.signal);
         continue;
       }
 
-      yield { type: "error", error: providerError.error };
+      yield {
+        type: "error",
+        error: retryable
+          ? streamInterruptionError(params.provider, providerError, params.checkpoint)
+          : providerError.error,
+      };
       return;
     }
   }
@@ -411,6 +435,18 @@ function toProviderError(provider: ProviderConfig, error: unknown): ModelProvide
   return new ModelProviderError(
     normalizeModelError(provider.id, provider.protocol, error, extractStatus(error)),
   );
+}
+
+function streamInterruptionError(
+  provider: ProviderConfig,
+  error: unknown,
+  checkpoint: StreamingCheckpointManager,
+): import("../protocol/errors.js").CanonicalModelError {
+  const providerError = toProviderError(provider, error).error;
+  return {
+    ...providerError,
+    streamInterruption: checkpoint.interruption(),
+  };
 }
 
 function extractStatus(error: unknown): number | undefined {
@@ -603,7 +639,9 @@ async function sendProviderRequest(
 ): Promise<Response> {
   const controller = new AbortController();
   const detachAbort = signal ? forwardAbort(signal, controller) : undefined;
-  const effectiveTimeoutMs = stream ? resolveStreamIdleTimeout(provider, options) : provider.timeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
+  const effectiveTimeoutMs = stream
+    ? resolveStreamIdleTimeout(provider, options)
+    : provider.timeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
   const timeout = effectiveTimeoutMs
     ? setTimeout(() => controller.abort(new NetworkFetchError("network_timeout", `Model request timed out after ${effectiveTimeoutMs}ms.`)), effectiveTimeoutMs)
     : undefined;
@@ -619,7 +657,7 @@ async function sendProviderRequest(
       body: JSON.stringify(finalBody),
       signal: controller.signal,
     };
-    return await sendWithEndpointFallback(provider, stream, transport, fetchOptions);
+    return await sendWithEndpointFallback(provider, stream, transport, fetchOptions, effectiveTimeoutMs);
   } catch (error) {
     if (signal?.aborted) {
       throw createAbortError(signal.reason);
@@ -649,6 +687,7 @@ async function sendWithEndpointFallback(
   stream: boolean,
   transport: ModelTransport,
   fetchOptions: RequestInit,
+  timeoutMs: number,
 ): Promise<Response> {
   const endpoints = buildProviderChatEndpointCandidates({ protocol: provider.protocol, baseUrl: provider.url });
   let lastResponse: Response | undefined;
@@ -656,7 +695,7 @@ async function sendWithEndpointFallback(
     const response = await networkFetch(endpoint, fetchOptions, {
       signal: fetchOptions.signal instanceof AbortSignal ? fetchOptions.signal : undefined,
       fetchImpl: transport === fetch ? undefined : transport,
-      timeoutMs: provider.timeoutMs,
+      timeoutMs,
       retry: { maxRetries: 0, retryOnPost: true },
     });
     if (await shouldUseEndpointResponse(provider, response, stream, endpoints.length)) {
@@ -718,7 +757,7 @@ async function safeReadJson(response: Response): Promise<unknown> {
   }
 }
 
-const DEFAULT_STREAM_IDLE_TIMEOUT_MS = LITELLM_DEFAULT_REQUEST_TIMEOUT_MS;
+const DEFAULT_STREAM_IDLE_TIMEOUT_MS = LITELLM_COMPLETION_HTTP_FALLBACK_MS;
 
 class StreamIdleTimeoutError extends Error {
   constructor(idleMs: number) {
@@ -867,16 +906,13 @@ function readWithIdleTimeout(
   });
 }
 
-function resolveStreamIdleTimeout(provider: ProviderConfig, options?: ModelRuntimeOptions): number {
+export function resolveStreamIdleTimeout(provider: ProviderConfig, options?: ModelRuntimeOptions): number {
   if (typeof options?.streamTimeoutMs === "number" && options.streamTimeoutMs > 0) {
     return options.streamTimeoutMs;
   }
   const retry = provider.retry;
   if (retry && typeof retry.streamIdleTimeoutMs === "number" && retry.streamIdleTimeoutMs > 0) {
     return retry.streamIdleTimeoutMs;
-  }
-  if (typeof provider.timeoutMs === "number" && provider.timeoutMs > 0) {
-    return provider.timeoutMs;
   }
   return DEFAULT_STREAM_IDLE_TIMEOUT_MS;
 }

--- a/src/router/RouterRuntime.ts
+++ b/src/router/RouterRuntime.ts
@@ -12,7 +12,6 @@ import {
   LITELLM_MAX_RETRY_DELAY_MS,
   LITELLM_RETRY_JITTER,
 } from "../model/streaming/streamModel.js";
-import { buildLiteLLMContinuationRequest } from "../model/streaming/continuationRequest.js";
 import {
   DEFAULT_SUBAGENT_POLICY,
   type RouterConfig,
@@ -835,37 +834,6 @@ export function createRouterRuntime(
             transientRetryCount++;
             continue;
           }
-          if (
-            hasYieldedContent &&
-            isMidStreamRateLimitError(outcome.error) &&
-            transientRetryCount < transientRetryMax
-          ) {
-            const partialText = extractPartialText(outcome.buffered);
-            if (partialText.length > 0) {
-              const midDelay = outcome.error.retryAfterMs != null
-                ? Math.min(outcome.error.retryAfterMs, transientMaxDelayMs)
-                : calculateLiteLLMRetryDelay(transientRetryCount, transientBaseDelayMs, transientMaxDelayMs);
-              console.warn(
-                `[PilotDeck] midStreamRetry: ${outcome.error.code} after partial content ` +
-                `(attempt ${transientRetryCount + 1}/${transientRetryMax}, delay=${Math.round(midDelay)}ms)`,
-              );
-              events.emit({
-                type: "pilotdeck_router_retry_progress",
-                sessionId: ctx.sessionId,
-                turnId: ctx.turnId,
-                attempt: transientRetryCount + 1,
-                maxAttempts: transientRetryMax,
-                delayMs: Math.round(midDelay),
-                reason: classifyRetryReason(outcome.error.code),
-                provider: attempt.provider,
-                model: attempt.model,
-              });
-              await abortableDelay(midDelay, ctx.abortSignal);
-              attemptRequest = buildLiteLLMContinuationRequest(attemptRequest, partialText);
-              transientRetryCount++;
-              continue;
-            }
-          }
           for (const queued of pending) {
             yield queued;
           }
@@ -1292,10 +1260,6 @@ function classifyNetworkErrorCode(error: unknown): string {
   return "network_error";
 }
 
-function isMidStreamRateLimitError(error: import("../model/index.js").CanonicalModelError): boolean {
-  return error.code === "rate_limit_error" || error.code === "overloaded_error";
-}
-
 function classifyRetryReason(errorCode: string): "rate_limit" | "server_error" | "network_error" | "zero_usage" | "overloaded" {
   if (errorCode === "rate_limit_error") return "rate_limit";
   if (errorCode === "overloaded_error") return "overloaded";
@@ -1327,14 +1291,4 @@ function createUnsupportedMediaError(
       `that supports required input modalities: ${requiredText}. Missing: ${missingText}.`,
     retryable: false,
   };
-}
-
-function extractPartialText(buffered: CanonicalModelEvent[]): string {
-  let text = "";
-  for (const ev of buffered) {
-    if (ev.type === "text_delta") {
-      text += ev.text;
-    }
-  }
-  return text;
 }

--- a/tests/agent/loop/stream-interruption-recovery.spec.ts
+++ b/tests/agent/loop/stream-interruption-recovery.spec.ts
@@ -166,6 +166,74 @@ test("stream interruption with partial Hermes tool text does not persist the fra
   assert.doesNotMatch(recoveryText?.type === "text" ? recoveryText.text : "", /deck\.mjs|partial-secret/);
 });
 
+test("cancelling stream interruption recovery does not expose the partial tool call", async () => {
+  const controller = new AbortController();
+  const partialToolText = '<tool_call>{"name":"write_file","arguments":{"path":"secret.mjs"';
+  const loop = createLoop(async function* (_decision, _request, context) {
+    if (context.abortSignal?.aborted) {
+      throw new Error("aborted");
+    }
+    yield { type: "message_start", role: "assistant" };
+    yield { type: "text_delta", text: partialToolText };
+    yield {
+      type: "error",
+      error: {
+        provider: "test",
+        protocol: "openai",
+        code: "timeout",
+        message: "Stream idle timeout",
+        retryable: true,
+        streamInterruption: { phase: "text" },
+      },
+    };
+  }, () => undefined);
+
+  const events: Array<{ type: string; result?: { finalMessage?: unknown } }> = [];
+  for await (const event of loop.run({
+    sessionId: "cancel-interrupted-partial-tool",
+    turnId: "turn-1",
+    abortSignal: controller.signal,
+    messages: [{ role: "user", content: [{ type: "text", text: "write a file" }] }],
+  })) {
+    events.push(event as typeof events[number]);
+    if (event.type === "turn_continued") {
+      controller.abort();
+    }
+  }
+
+  const completed = events.find((event) => event.type === "turn_completed");
+  assert.equal(completed?.result?.finalMessage, undefined);
+});
+
+test("cancelling partial text tool-call recovery does not expose the partial tool call", async () => {
+  const controller = new AbortController();
+  const partialToolText = '<tool_call>{"name":"write_file","arguments":{"path":"secret.mjs"';
+  const loop = createLoop(async function* (_decision, _request, context) {
+    if (context.abortSignal?.aborted) {
+      throw new Error("aborted");
+    }
+    yield { type: "message_start", role: "assistant" };
+    yield { type: "text_delta", text: partialToolText };
+    yield { type: "message_end", finishReason: "stop" };
+  }, () => undefined);
+
+  const events: Array<{ type: string; result?: { finalMessage?: unknown } }> = [];
+  for await (const event of loop.run({
+    sessionId: "cancel-partial-tool-recovery",
+    turnId: "turn-1",
+    abortSignal: controller.signal,
+    messages: [{ role: "user", content: [{ type: "text", text: "write a file" }] }],
+  })) {
+    events.push(event as typeof events[number]);
+    if (event.type === "turn_continued") {
+      controller.abort();
+    }
+  }
+
+  const completed = events.find((event) => event.type === "turn_completed");
+  assert.equal(completed?.result?.finalMessage, undefined);
+});
+
 test("stream interruption with complete text fallback tool call does not persist it as text", async () => {
   const requests: CanonicalModelRequest[] = [];
   const completeToolText = 'Prefix <tool_call>{"name":"write_file","arguments":{"path":"safe.mjs","content":"secret"}}</tool_call>';

--- a/tests/agent/loop/stream-interruption-recovery.spec.ts
+++ b/tests/agent/loop/stream-interruption-recovery.spec.ts
@@ -58,6 +58,38 @@ test("agent loop drops interrupted tool calls and continues with a chunked-write
   assert.doesNotMatch(JSON.stringify(recoveryRequest.messages), /\"content\":\"partial/);
 });
 
+test("agent loop recovers an unknown finish reason before treating the turn as successful", async () => {
+  const requests: CanonicalModelRequest[] = [];
+  const loop = createLoop(async function* (_decision, request) {
+    requests.push(request);
+    if (requests.length === 1) {
+      yield { type: "message_start", role: "assistant" };
+      yield { type: "text_delta", text: "partial" };
+      yield { type: "message_end", finishReason: "unknown" };
+      return;
+    }
+    yield { type: "message_start", role: "assistant" };
+    yield { type: "text_delta", text: "recovered" };
+    yield { type: "message_end", finishReason: "stop" };
+  }, () => undefined);
+
+  const events: Array<{ type: string }> = [];
+  for await (const event of loop.run({
+    sessionId: "unknown-finish",
+    turnId: "turn-1",
+    messages: [{ role: "user", content: [{ type: "text", text: "write an answer" }] }],
+  })) {
+    events.push(event);
+  }
+
+  assert.equal(requests.length, 2);
+  assert.ok(events.some((event) => event.type === "turn_continued"));
+  assert.ok(!events.some((event) => event.type === "unknown_finish_reason"));
+  const recoveryText = requests[1]!.messages.at(-1)?.content[0];
+  assert.equal(recoveryText?.type, "text");
+  assert.match(recoveryText?.type === "text" ? recoveryText.text : "", /without a recognized finish reason/);
+});
+
 function createLoop(
   execute: AgentRouterRuntime["execute"],
   onSchedule: () => void,

--- a/tests/agent/loop/stream-interruption-recovery.spec.ts
+++ b/tests/agent/loop/stream-interruption-recovery.spec.ts
@@ -120,6 +120,7 @@ test("unknown finish with partial Hermes tool text uses the specialized recovery
   const recoveryText = requests[1]!.messages.at(-1)?.content[0];
   assert.equal(recoveryText?.type, "text");
   assert.match(recoveryText?.type === "text" ? recoveryText.text : "", /partial tool-call XML\/text/);
+  assert.doesNotMatch(recoveryText?.type === "text" ? recoveryText.text : "", /deck\.mjs|partial-secret/);
   assert.equal(requests[1]!.messages.some((message) => message.role === "assistant"), false);
 });
 
@@ -162,6 +163,7 @@ test("stream interruption with partial Hermes tool text does not persist the fra
   const recoveryText = requests[1]!.messages.at(-1)?.content[0];
   assert.equal(recoveryText?.type, "text");
   assert.match(recoveryText?.type === "text" ? recoveryText.text : "", /partial tool-call XML\/text/);
+  assert.doesNotMatch(recoveryText?.type === "text" ? recoveryText.text : "", /deck\.mjs|partial-secret/);
 });
 
 test("stream interruption with complete text fallback tool call does not persist it as text", async () => {
@@ -203,6 +205,7 @@ test("stream interruption with complete text fallback tool call does not persist
   const recoveryText = requests[1]!.messages.at(-1)?.content[0];
   assert.equal(recoveryText?.type, "text");
   assert.match(recoveryText?.type === "text" ? recoveryText.text : "", /partial tool-call XML\/text/);
+  assert.doesNotMatch(recoveryText?.type === "text" ? recoveryText.text : "", /safe\.mjs|secret/);
 });
 
 test("stream interruption exhaustion persists the final safe text fragment", async () => {
@@ -261,6 +264,29 @@ test("unknown finish exhaustion persists the final safe text fragment", async ()
   }
 
   assert.ok(durable.some((text) => text.includes("unknown-fragment-3")));
+});
+
+test("partial text tool-call exhaustion clears unsafe finalMessage", async () => {
+  const partialToolText = '<tool_call>{"name":"write_file","arguments":{"path":"secret.mjs","content":"partial-secret"';
+  let attempt = 0;
+  const loop = createLoop(async function* () {
+    attempt++;
+    yield { type: "message_start", role: "assistant" };
+    yield { type: "text_delta", text: partialToolText };
+  }, () => undefined);
+
+  const events: Array<{ type: string; result?: { finalMessage?: unknown } }> = [];
+  for await (const event of loop.run({
+    sessionId: "partial-tool-exhausted",
+    turnId: "turn-1",
+    messages: [{ role: "user", content: [{ type: "text", text: "write a file" }] }],
+  })) {
+    events.push(event as typeof events[number]);
+  }
+
+  assert.equal(attempt, 51);
+  const completed = events.find((event) => event.type === "turn_completed");
+  assert.equal(completed?.result?.finalMessage, undefined);
 });
 
 test("stream interruption exhaustion clears unsafe finalMessage tool text", async () => {

--- a/tests/agent/loop/stream-interruption-recovery.spec.ts
+++ b/tests/agent/loop/stream-interruption-recovery.spec.ts
@@ -164,6 +164,47 @@ test("stream interruption with partial Hermes tool text does not persist the fra
   assert.match(recoveryText?.type === "text" ? recoveryText.text : "", /partial tool-call XML\/text/);
 });
 
+test("stream interruption with complete text fallback tool call does not persist it as text", async () => {
+  const requests: CanonicalModelRequest[] = [];
+  const completeToolText = 'Prefix <tool_call>{"name":"write_file","arguments":{"path":"safe.mjs","content":"secret"}}</tool_call>';
+  const loop = createLoop(async function* (_decision, request) {
+    requests.push(request);
+    if (requests.length === 1) {
+      yield { type: "message_start", role: "assistant" };
+      yield { type: "text_delta", text: completeToolText };
+      yield {
+        type: "error",
+        error: {
+          provider: "test",
+          protocol: "openai",
+          code: "timeout",
+          message: "Stream idle timeout",
+          retryable: true,
+          streamInterruption: { phase: "text" },
+        },
+      };
+      return;
+    }
+    yield { type: "message_start", role: "assistant" };
+    yield { type: "text_delta", text: "recovered" };
+    yield { type: "message_end", finishReason: "stop" };
+  }, () => undefined);
+
+  for await (const _event of loop.run({
+    sessionId: "interrupted-complete-tool",
+    turnId: "turn-1",
+    messages: [{ role: "user", content: [{ type: "text", text: "write a file" }] }],
+  })) {
+    // Consume the complete recovery flow.
+  }
+
+  assert.equal(requests.length, 2);
+  assert.equal(requests[1]!.messages.some((message) => message.role === "assistant"), false);
+  const recoveryText = requests[1]!.messages.at(-1)?.content[0];
+  assert.equal(recoveryText?.type, "text");
+  assert.match(recoveryText?.type === "text" ? recoveryText.text : "", /partial tool-call XML\/text/);
+});
+
 test("stream interruption exhaustion persists the final safe text fragment", async () => {
   const durable: string[] = [];
   let attempt = 0;
@@ -220,6 +261,37 @@ test("unknown finish exhaustion persists the final safe text fragment", async ()
   }
 
   assert.ok(durable.some((text) => text.includes("unknown-fragment-3")));
+});
+
+test("stream interruption exhaustion clears unsafe finalMessage tool text", async () => {
+  const partialToolText = '<tool_call>{"name":"write_file","arguments":{"path":"secret.mjs","content":"partial-secret-3"';
+  const loop = createLoop(async function* () {
+    yield { type: "message_start", role: "assistant" };
+    yield { type: "text_delta", text: partialToolText };
+    yield {
+      type: "error",
+      error: {
+        provider: "test",
+        protocol: "openai",
+        code: "timeout",
+        message: "Stream idle timeout",
+        retryable: true,
+        streamInterruption: { phase: "text" },
+      },
+    };
+  }, () => undefined);
+
+  const events: Array<{ type: string; result?: { finalMessage?: unknown } }> = [];
+  for await (const event of loop.run({
+    sessionId: "interrupted-unsafe-final",
+    turnId: "turn-1",
+    messages: [{ role: "user", content: [{ type: "text", text: "write a file" }] }],
+  })) {
+    events.push(event as typeof events[number]);
+  }
+
+  const completed = events.find((event) => event.type === "turn_completed");
+  assert.equal(completed?.result?.finalMessage, undefined);
 });
 
 function createLoop(

--- a/tests/agent/loop/stream-interruption-recovery.spec.ts
+++ b/tests/agent/loop/stream-interruption-recovery.spec.ts
@@ -1,0 +1,122 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { AgentLoop } from "../../../src/agent/loop/AgentLoop.js";
+import type { AgentRuntimeConfig } from "../../../src/agent/runtime/AgentRuntimeConfig.js";
+import type { AgentRouterRuntime, AgentRuntimeDependencies } from "../../../src/agent/runtime/AgentRuntimeDependencies.js";
+import type { CanonicalModelEvent, CanonicalModelRequest } from "../../../src/model/protocol/canonical.js";
+import { createDefaultPermissionContext } from "../../../src/permission/protocol/types.js";
+import { ToolRegistry } from "../../../src/tool/registry/ToolRegistry.js";
+
+test("agent loop drops interrupted tool calls and continues with a chunked-write prompt", async () => {
+  const requests: CanonicalModelRequest[] = [];
+  let scheduledToolCalls = 0;
+  const loop = createLoop(async function* (_decision, request) {
+    requests.push(request);
+    if (requests.length === 1) {
+      yield { type: "message_start", role: "assistant" };
+      yield { type: "tool_call_start", id: "call-1", name: "write_file" };
+      yield { type: "tool_call_delta", id: "call-1", delta: '{"path":"deck.mjs","content":"partial"' };
+      yield {
+        type: "error",
+        error: {
+          provider: "test",
+          protocol: "openai",
+          code: "timeout",
+          message: "Stream idle timeout",
+          retryable: true,
+          streamInterruption: {
+            phase: "tool_call",
+            activeToolCalls: [{ id: "call-1", name: "write_file", argumentChars: 39 }],
+          },
+        },
+      };
+      return;
+    }
+    yield { type: "message_start", role: "assistant" };
+    yield { type: "text_delta", text: "recovered" };
+    yield { type: "message_end", finishReason: "stop" };
+  }, () => { scheduledToolCalls += 1; });
+
+  const events: Array<{ type: string }> = [];
+  for await (const event of loop.run({
+    sessionId: "stream-interruption",
+    turnId: "turn-1",
+    messages: [{ role: "user", content: [{ type: "text", text: "write a deck builder" }] }],
+  })) {
+    events.push(event);
+  }
+
+  assert.equal(requests.length, 2);
+  assert.equal(scheduledToolCalls, 0);
+  assert.ok(events.some((event) => event.type === "turn_continued"));
+  assert.ok(!events.some((event) => event.type === "turn_failed"));
+  const recoveryRequest = requests[1]!;
+  const recoveryText = recoveryRequest.messages.at(-1)?.content[0];
+  assert.equal(recoveryText?.type, "text");
+  assert.match(recoveryText?.type === "text" ? recoveryText.text : "", /small focused write_file or edit_file calls/);
+  assert.doesNotMatch(JSON.stringify(recoveryRequest.messages), /\"content\":\"partial/);
+});
+
+function createLoop(
+  execute: AgentRouterRuntime["execute"],
+  onSchedule: () => void,
+): AgentLoop {
+  const router: AgentRouterRuntime = {
+    invalidateSticky: () => ({ orchestrating: false }),
+    decide: async ({ request }) => ({
+      provider: request.provider,
+      model: request.model,
+      scenarioType: "default",
+      isSubagent: false,
+      orchestrating: false,
+      resolvedFrom: "explicit",
+      mutations: {},
+    }),
+    execute,
+    stream: async function* (): AsyncIterable<CanonicalModelEvent> {
+      yield { type: "message_end", finishReason: "stop" };
+    },
+    materializeRequest: (decision, request) => ({ ...request, provider: decision.provider, model: decision.model }),
+    observeUsage: () => undefined,
+  };
+  const config: AgentRuntimeConfig = {
+    provider: "test",
+    model: "test-model",
+    cwd: "/workspace/project",
+    maxContextTokens: 32_768,
+    permissionMode: "bypassPermissions",
+    permissionContext: createDefaultPermissionContext({
+      cwd: "/workspace/project",
+      mode: "bypassPermissions",
+      canPrompt: false,
+      bypassAvailable: true,
+    }),
+  };
+  const context: AgentRuntimeDependencies["context"] = {
+    prepareForModel: async (input) => ({
+      messages: input.messages,
+      systemPrompt: undefined,
+      systemPromptParts: [],
+      tools: input.tools,
+      diagnostics: [],
+      boundaries: [],
+    }),
+    applyToolResults: async (input) => ({ messages: input.messages, diagnostics: [] }),
+    recoverFromModelError: async () => ({ type: "give_up", reason: "test" }),
+    captureTurn: async () => undefined,
+  };
+  return new AgentLoop(config, {
+    router,
+    tools: {
+      registry: new ToolRegistry(),
+      scheduler: {
+        async executeAll() {
+          onSchedule();
+          return [];
+        },
+      },
+    },
+    context,
+  });
+}

--- a/tests/agent/loop/stream-interruption-recovery.spec.ts
+++ b/tests/agent/loop/stream-interruption-recovery.spec.ts
@@ -90,6 +90,39 @@ test("agent loop recovers an unknown finish reason before treating the turn as s
   assert.match(recoveryText?.type === "text" ? recoveryText.text : "", /without a recognized finish reason/);
 });
 
+test("unknown finish with partial Hermes tool text uses the specialized recovery", async () => {
+  const requests: CanonicalModelRequest[] = [];
+  let scheduledToolCalls = 0;
+  const partialToolText = '<tool_call>{"name":"write_file","arguments":{"path":"deck.mjs"';
+  const loop = createLoop(async function* (_decision, request) {
+    requests.push(request);
+    if (requests.length === 1) {
+      yield { type: "message_start", role: "assistant" };
+      yield { type: "text_delta", text: partialToolText };
+      yield { type: "message_end", finishReason: "unknown" };
+      return;
+    }
+    yield { type: "message_start", role: "assistant" };
+    yield { type: "text_delta", text: "recovered" };
+    yield { type: "message_end", finishReason: "stop" };
+  }, () => { scheduledToolCalls += 1; });
+
+  for await (const _event of loop.run({
+    sessionId: "unknown-partial-tool",
+    turnId: "turn-1",
+    messages: [{ role: "user", content: [{ type: "text", text: "write a deck builder" }] }],
+  })) {
+    // Consume the complete recovery flow.
+  }
+
+  assert.equal(requests.length, 2);
+  assert.equal(scheduledToolCalls, 0);
+  const recoveryText = requests[1]!.messages.at(-1)?.content[0];
+  assert.equal(recoveryText?.type, "text");
+  assert.match(recoveryText?.type === "text" ? recoveryText.text : "", /partial tool-call XML\/text/);
+  assert.equal(requests[1]!.messages.some((message) => message.role === "assistant"), false);
+});
+
 function createLoop(
   execute: AgentRouterRuntime["execute"],
   onSchedule: () => void,

--- a/tests/agent/loop/stream-interruption-recovery.spec.ts
+++ b/tests/agent/loop/stream-interruption-recovery.spec.ts
@@ -123,6 +123,47 @@ test("unknown finish with partial Hermes tool text uses the specialized recovery
   assert.equal(requests[1]!.messages.some((message) => message.role === "assistant"), false);
 });
 
+test("stream interruption with partial Hermes tool text does not persist the fragment", async () => {
+  const requests: CanonicalModelRequest[] = [];
+  const partialToolText = '<tool_call>{"name":"write_file","arguments":{"path":"secret.mjs"';
+  const loop = createLoop(async function* (_decision, request) {
+    requests.push(request);
+    if (requests.length === 1) {
+      yield { type: "message_start", role: "assistant" };
+      yield { type: "text_delta", text: partialToolText };
+      yield {
+        type: "error",
+        error: {
+          provider: "test",
+          protocol: "openai",
+          code: "timeout",
+          message: "Stream idle timeout",
+          retryable: true,
+          streamInterruption: { phase: "text" },
+        },
+      };
+      return;
+    }
+    yield { type: "message_start", role: "assistant" };
+    yield { type: "text_delta", text: "recovered" };
+    yield { type: "message_end", finishReason: "stop" };
+  }, () => undefined);
+
+  for await (const _event of loop.run({
+    sessionId: "interrupted-partial-tool",
+    turnId: "turn-1",
+    messages: [{ role: "user", content: [{ type: "text", text: "write a file" }] }],
+  })) {
+    // Consume the complete recovery flow.
+  }
+
+  assert.equal(requests.length, 2);
+  assert.equal(requests[1]!.messages.some((message) => message.role === "assistant"), false);
+  const recoveryText = requests[1]!.messages.at(-1)?.content[0];
+  assert.equal(recoveryText?.type, "text");
+  assert.match(recoveryText?.type === "text" ? recoveryText.text : "", /partial tool-call XML\/text/);
+});
+
 function createLoop(
   execute: AgentRouterRuntime["execute"],
   onSchedule: () => void,

--- a/tests/agent/loop/stream-interruption-recovery.spec.ts
+++ b/tests/agent/loop/stream-interruption-recovery.spec.ts
@@ -164,6 +164,64 @@ test("stream interruption with partial Hermes tool text does not persist the fra
   assert.match(recoveryText?.type === "text" ? recoveryText.text : "", /partial tool-call XML\/text/);
 });
 
+test("stream interruption exhaustion persists the final safe text fragment", async () => {
+  const durable: string[] = [];
+  let attempt = 0;
+  const loop = createLoop(async function* (_decision, request) {
+    attempt++;
+    yield { type: "message_start", role: "assistant" };
+    yield { type: "text_delta", text: "final-fragment-" + attempt };
+    yield {
+      type: "error",
+      error: {
+        provider: "test",
+        protocol: "openai",
+        code: "timeout",
+        message: "Stream idle timeout",
+        retryable: true,
+        streamInterruption: { phase: "text" },
+      },
+    };
+  }, () => undefined);
+
+  for await (const _event of loop.run({
+    sessionId: "interrupted-exhausted",
+    turnId: "turn-1",
+    messages: [{ role: "user", content: [{ type: "text", text: "answer" }] }],
+    onDurableMessage: async (message) => {
+      durable.push(message.content.filter((block) => block.type === "text").map((block) => block.text).join(""));
+    },
+  })) {
+    // Consume the complete recovery flow.
+  }
+
+  assert.ok(durable.some((text) => text.includes("final-fragment-3")));
+});
+
+test("unknown finish exhaustion persists the final safe text fragment", async () => {
+  const durable: string[] = [];
+  let attempt = 0;
+  const loop = createLoop(async function* (_decision, request) {
+    attempt++;
+    yield { type: "message_start", role: "assistant" };
+    yield { type: "text_delta", text: "unknown-fragment-" + attempt };
+    yield { type: "message_end", finishReason: "unknown" };
+  }, () => undefined);
+
+  for await (const _event of loop.run({
+    sessionId: "unknown-exhausted",
+    turnId: "turn-1",
+    messages: [{ role: "user", content: [{ type: "text", text: "answer" }] }],
+    onDurableMessage: async (message) => {
+      durable.push(message.content.filter((block) => block.type === "text").map((block) => block.text).join(""));
+    },
+  })) {
+    // Consume the complete recovery flow.
+  }
+
+  assert.ok(durable.some((text) => text.includes("unknown-fragment-3")));
+});
+
 function createLoop(
   execute: AgentRouterRuntime["execute"],
   onSchedule: () => void,

--- a/tests/model/model-error-guidance.spec.ts
+++ b/tests/model/model-error-guidance.spec.ts
@@ -43,7 +43,7 @@ test("model_not_found guidance points users to local model settings", () => {
   assert.equal(action.userHintI18n.params?.provider, "modelbest-openai");
 });
 
-test("stream idle timeout is classified as timeout with network and timeoutMs guidance", () => {
+test("stream idle timeout is classified as timeout with stream idle guidance", () => {
   const error = normalizeModelError(
     "modelbest-openai",
     "openai",
@@ -51,12 +51,13 @@ test("stream idle timeout is classified as timeout with network and timeoutMs gu
   );
 
   assert.equal(error.code, "timeout");
-  assert.match(error.userHint ?? "", /timeoutMs/);
+  assert.match(error.userHint ?? "", /streamIdleTimeoutMs/);
+  assert.equal(error.settingsFix?.configPath, "model.providers.<id>.retry.streamIdleTimeoutMs");
   assert.match(error.userHint ?? "", /network|proxy|provider status/i);
 
   const action = modelFailureAction(error);
   assert.equal(action.fixTarget, "network");
-  assert.match(action.userHint, /timeoutMs/);
+  assert.match(action.userHint, /streamIdleTimeoutMs/);
   assert.match(action.userHint, /network|proxy|provider status/i);
 });
 

--- a/tests/model/streaming/StreamingCheckpoint.spec.ts
+++ b/tests/model/streaming/StreamingCheckpoint.spec.ts
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { StreamingCheckpointManager } from "../../../src/model/streaming/StreamingCheckpoint.js";
+
+test("tool-call stream interruption retains only safe call metadata", () => {
+  const checkpoint = new StreamingCheckpointManager();
+  const secretArguments = '{"path":"deck.mjs","content":"do-not-retain-this-builder"}';
+
+  checkpoint.onEvent({ type: "tool_call_start", id: "call-1", name: "write_file" });
+  checkpoint.onEvent({ type: "tool_call_delta", id: "call-1", delta: secretArguments });
+
+  assert.equal(checkpoint.canContinueText(), false);
+  assert.deepEqual(checkpoint.interruption(), {
+    phase: "tool_call",
+    activeToolCalls: [{ id: "call-1", name: "write_file", argumentChars: secretArguments.length }],
+  });
+  assert.doesNotMatch(JSON.stringify(checkpoint.interruption()), /do-not-retain-this-builder/);
+});
+
+test("text and reasoning interruptions keep distinct recovery phases", () => {
+  const text = new StreamingCheckpointManager();
+  text.onEvent({ type: "text_delta", text: "partial answer" });
+  assert.equal(text.canContinueText(), true);
+  assert.deepEqual(text.interruption(), { phase: "text" });
+
+  const reasoning = new StreamingCheckpointManager();
+  reasoning.onEvent({ type: "thinking_delta", text: "private reasoning" });
+  assert.equal(reasoning.canContinueText(), false);
+  assert.deepEqual(reasoning.interruption(), { phase: "reasoning" });
+});
+
+test("reasoning makes an otherwise text-only stream ineligible for continuation", () => {
+  const checkpoint = new StreamingCheckpointManager();
+  checkpoint.onEvent({ type: "thinking_delta", text: "reasoning" });
+  checkpoint.onEvent({ type: "text_delta", text: "partial answer" });
+
+  assert.equal(checkpoint.canContinueText(), false);
+  assert.deepEqual(checkpoint.interruption(), { phase: "text" });
+});

--- a/tests/model/streaming/StreamingCheckpoint.spec.ts
+++ b/tests/model/streaming/StreamingCheckpoint.spec.ts
@@ -30,6 +30,13 @@ test("text and reasoning interruptions keep distinct recovery phases", () => {
   assert.deepEqual(reasoning.interruption(), { phase: "reasoning" });
 });
 
+test("text tool-call syntax cannot continue across a stream interruption", () => {
+  const checkpoint = new StreamingCheckpointManager();
+  checkpoint.onEvent({ type: "text_delta", text: '<tool_call>{"name":"write_file","arguments":{"path":"secret.mjs"' });
+
+  assert.equal(checkpoint.canContinueText(), false);
+});
+
 test("reasoning makes an otherwise text-only stream ineligible for continuation", () => {
   const checkpoint = new StreamingCheckpointManager();
   checkpoint.onEvent({ type: "thinking_delta", text: "reasoning" });

--- a/tests/model/streaming/streamModelRetry.spec.ts
+++ b/tests/model/streaming/streamModelRetry.spec.ts
@@ -1,0 +1,135 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseModelConfig } from "../../../src/model/config/parseModelConfig.js";
+import type { CanonicalModelEvent, CanonicalModelRequest } from "../../../src/model/protocol/canonical.js";
+import { resolveStreamIdleTimeout, streamModel } from "../../../src/model/streaming/streamModel.js";
+
+function createConfig(input: { timeoutMs?: number; streamMaxRetries?: number; streamIdleTimeoutMs?: number } = {}) {
+  return parseModelConfig({
+    providers: {
+      test: {
+        protocol: "openai",
+        url: "https://example.test/v1",
+        apiKey: "test-key",
+        timeoutMs: input.timeoutMs,
+        retry: {
+          streamMaxRetries: input.streamMaxRetries ?? 1,
+          streamIdleTimeoutMs: input.streamIdleTimeoutMs,
+          baseDelayMs: 1,
+        },
+        models: { "test-model": {} },
+      },
+    },
+  });
+}
+
+function createRequest(): CanonicalModelRequest {
+  return {
+    provider: "test",
+    model: "test-model",
+    messages: [{ role: "user", content: [{ type: "text", text: "hello" }] }],
+  };
+}
+
+function sse(data: string): Response {
+  return new Response(data, { headers: { "content-type": "text/event-stream" } });
+}
+
+async function collect(stream: AsyncIterable<CanonicalModelEvent>): Promise<CanonicalModelEvent[]> {
+  const events: CanonicalModelEvent[] = [];
+  for await (const event of stream) events.push(event);
+  return events;
+}
+
+test("stream idle timeout defaults independently from provider request timeout", () => {
+  const config = createConfig({ timeoutMs: 1 });
+  const provider = config.providers.test!;
+
+  assert.equal(resolveStreamIdleTimeout(provider), 600_000);
+  assert.equal(resolveStreamIdleTimeout(provider, { streamTimeoutMs: 1234 }), 1234);
+  assert.equal(resolveStreamIdleTimeout({ ...provider, retry: { streamIdleTimeoutMs: 5678 } }), 5678);
+});
+
+test("stream request setup uses the stream timeout instead of provider timeout", async () => {
+  const config = createConfig({ timeoutMs: 1, streamMaxRetries: 0 });
+  const events = await collect(streamModel(createRequest(), config, {
+    streamTimeoutMs: 30,
+    fetch: async (_input, init) => {
+      await new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(resolve, 5);
+        const signal = init?.signal as AbortSignal | null;
+        signal?.addEventListener("abort", () => {
+          clearTimeout(timer);
+          reject(signal.reason);
+        }, { once: true });
+      });
+      return sse("data: [DONE]\n\n");
+    },
+  }));
+
+  assert.equal(events.some((event) => event.type === "error"), false);
+});
+
+test("retries an interrupted stream only before the first content event", async () => {
+  const config = createConfig();
+  let requests = 0;
+  const events = await collect(streamModel(createRequest(), config, {
+    fetch: async () => {
+      requests++;
+      return requests === 1 ? sse("") : sse("data: [DONE]\n\n");
+    },
+  }));
+
+  assert.equal(requests, 2);
+  assert.equal(events.some((event) => event.type === "error"), false);
+});
+
+test("continues a pure text stream after interruption", async () => {
+  const config = createConfig();
+  const requestBodies: Array<Record<string, unknown>> = [];
+  const events = await collect(streamModel(createRequest(), config, {
+    fetch: async (_input, init) => {
+      requestBodies.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
+      return requestBodies.length === 1
+        ? sse('data: {"choices":[{"delta":{"content":"partial"}}]}\n\n')
+        : sse("data: [DONE]\n\n");
+    },
+  }));
+
+  assert.equal(requestBodies.length, 2);
+  const messages = requestBodies[1]!.messages as Array<{ role: string; content: string }>;
+  assert.equal(messages.at(-2)?.role, "assistant");
+  assert.equal(messages.at(-2)?.content, "partial");
+  assert.equal(events.some((event) => event.type === "error"), false);
+});
+
+test("does not replay a stream after reasoning or tool-call output", async () => {
+  const cases = [
+    {
+      name: "reasoning",
+      payload: 'data: {"choices":[{"delta":{"reasoning_content":"think","content":"partial"}}]}\n\n',
+      phase: "text",
+    },
+    {
+      name: "tool call",
+      payload: 'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call-1","type":"function","function":{"name":"write_file","arguments":"{\\"path\\":\\"deck.mjs"}}]}}]}\n\n',
+      phase: "tool_call",
+    },
+  ] as const;
+
+  for (const item of cases) {
+    const config = createConfig();
+    let requests = 0;
+    const events = await collect(streamModel(createRequest(), config, {
+      fetch: async () => {
+        requests++;
+        return sse(item.payload);
+      },
+    }));
+
+    const error = events.find((event): event is Extract<CanonicalModelEvent, { type: "error" }> => event.type === "error");
+    assert.equal(requests, 1, item.name);
+    assert.equal(error?.error.streamInterruption?.phase, item.phase, item.name);
+  }
+});

--- a/tests/model/streaming/streamModelRetry.spec.ts
+++ b/tests/model/streaming/streamModelRetry.spec.ts
@@ -279,6 +279,28 @@ test("Google recovers a stream ending without a finish event", async () => {
   assert.equal(events.some((event) => event.type === "message_end"), false);
 });
 
+test("Google stops reading once it emits a terminal event", async () => {
+  const config = createGoogleConfig();
+  let readAfterFinish = false;
+  const googleClientFactory: GoogleClientFactory = () => ({
+    models: {
+      generateContent: async () => ({} as never),
+      generateContentStream: async () => (async function* () {
+        yield { candidates: [{ content: { parts: [{ text: "complete" }] } }] } as never;
+        yield { candidates: [{ finishReason: "STOP", content: { parts: [] } }] } as never;
+        readAfterFinish = true;
+        throw new Error("stream closed after finish");
+      })(),
+    },
+  });
+
+  const events = await collect(streamModel(createRequest(), config, { googleClientFactory }));
+
+  assert.equal(readAfterFinish, false);
+  assert.equal(events.some((event) => event.type === "error"), false);
+  assert.equal(events.filter((event) => event.type === "message_end").length, 1);
+});
+
 test("first-token timeout uses stream-idle guidance", async () => {
   const config = createConfig({ streamMaxRetries: 0 });
   await assert.rejects(

--- a/tests/model/streaming/streamModelRetry.spec.ts
+++ b/tests/model/streaming/streamModelRetry.spec.ts
@@ -2,7 +2,8 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import { parseModelConfig } from "../../../src/model/config/parseModelConfig.js";
-import type { CanonicalModelEvent, CanonicalModelRequest } from "../../../src/model/protocol/canonical.js";
+import type { CanonicalModelEvent, CanonicalModelRequest, ProviderConfig } from "../../../src/model/protocol/canonical.js";
+import type { GoogleClientFactory } from "../../../src/model/providers/google/client.js";
 import { resolveStreamIdleTimeout, streamModel } from "../../../src/model/streaming/streamModel.js";
 
 function createConfig(input: { timeoutMs?: number; streamMaxRetries?: number; streamIdleTimeoutMs?: number } = {}) {
@@ -32,6 +33,25 @@ function createRequest(): CanonicalModelRequest {
   };
 }
 
+function createGoogleConfig(input: { timeoutMs?: number; streamMaxRetries?: number; streamIdleTimeoutMs?: number } = {}) {
+  return parseModelConfig({
+    providers: {
+      test: {
+        protocol: "google",
+        url: "https://generativelanguage.googleapis.com/v1beta",
+        apiKey: "test-key",
+        timeoutMs: input.timeoutMs,
+        retry: {
+          streamMaxRetries: input.streamMaxRetries ?? 0,
+          streamIdleTimeoutMs: input.streamIdleTimeoutMs,
+          baseDelayMs: 1,
+        },
+        models: { "test-model": {} },
+      },
+    },
+  });
+}
+
 function sse(data: string): Response {
   return new Response(data, { headers: { "content-type": "text/event-stream" } });
 }
@@ -40,6 +60,10 @@ async function collect(stream: AsyncIterable<CanonicalModelEvent>): Promise<Cano
   const events: CanonicalModelEvent[] = [];
   for await (const event of stream) events.push(event);
   return events;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 test("stream idle timeout defaults independently from provider request timeout", () => {
@@ -104,6 +128,23 @@ test("continues a pure text stream after interruption", async () => {
   assert.equal(events.some((event) => event.type === "error"), false);
 });
 
+test("retains partial text if its continuation disconnects before output", async () => {
+  const config = createConfig({ streamMaxRetries: 1 });
+  let requests = 0;
+  const events = await collect(streamModel(createRequest(), config, {
+    fetch: async () => {
+      requests++;
+      return requests === 1
+        ? sse('data: {"choices":[{"delta":{"content":"partial"}}]}\n\n')
+        : sse("");
+    },
+  }));
+
+  const error = events.find((event): event is Extract<CanonicalModelEvent, { type: "error" }> => event.type === "error");
+  assert.equal(requests, 2);
+  assert.equal(error?.error.streamInterruption?.phase, "text");
+});
+
 test("does not replay a stream after reasoning or tool-call output", async () => {
   const cases = [
     {
@@ -132,4 +173,71 @@ test("does not replay a stream after reasoning or tool-call output", async () =>
     assert.equal(requests, 1, item.name);
     assert.equal(error?.error.streamInterruption?.phase, item.phase, item.name);
   }
+});
+
+test("Google streaming uses an idle watchdog instead of an absolute SDK timeout", async () => {
+  const config = createGoogleConfig({ timeoutMs: 1 });
+  const clientTimeouts: Array<number | undefined> = [];
+  const googleClientFactory: GoogleClientFactory = (provider: ProviderConfig) => {
+    clientTimeouts.push(provider.timeoutMs);
+    return {
+      models: {
+        generateContent: async () => ({} as never),
+        generateContentStream: async () => (async function* () {
+          yield { candidates: [{ content: { parts: [{ text: "a" }] } }] } as never;
+          await sleep(8);
+          yield { candidates: [{ content: { parts: [{ text: "b" }] } }] } as never;
+          await sleep(8);
+          yield { candidates: [{ finishReason: "STOP", content: { parts: [] } }] } as never;
+        })(),
+      },
+    };
+  };
+
+  const events = await collect(streamModel(createRequest(), config, {
+    streamTimeoutMs: 10,
+    googleClientFactory,
+  }));
+
+  assert.deepEqual(clientTimeouts, [undefined]);
+  assert.equal(events.some((event) => event.type === "error"), false);
+});
+
+test("Google idle watchdog interrupts a stalled iterator", async () => {
+  const config = createGoogleConfig();
+  const googleClientFactory: GoogleClientFactory = () => ({
+    models: {
+      generateContent: async () => ({} as never),
+      generateContentStream: async () => (async function* () {
+        await sleep(15);
+        yield { candidates: [{ finishReason: "STOP", content: { parts: [] } }] } as never;
+      })(),
+    },
+  });
+
+  const events = await collect(streamModel(createRequest(), config, {
+    streamTimeoutMs: 5,
+    googleClientFactory,
+  }));
+
+  const error = events.find((event): event is Extract<CanonicalModelEvent, { type: "error" }> => event.type === "error");
+  assert.equal(error?.error.code, "timeout");
+  assert.equal(error?.error.settingsFix?.configPath, "model.providers.<id>.retry.streamIdleTimeoutMs");
+});
+
+test("first-token timeout uses stream-idle guidance", async () => {
+  const config = createConfig({ streamMaxRetries: 0 });
+  await assert.rejects(
+    collect(streamModel(createRequest(), config, {
+      streamTimeoutMs: 5,
+      fetch: async (_input, init) => new Promise<Response>((_resolve, reject) => {
+        const signal = init?.signal as AbortSignal;
+        signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+      }),
+    })),
+    (error: unknown) => {
+      const providerError = error as { error?: { settingsFix?: { configPath?: string } } };
+      return providerError.error?.settingsFix?.configPath === "model.providers.<id>.retry.streamIdleTimeoutMs";
+    },
+  );
 });

--- a/tests/model/streaming/streamModelRetry.spec.ts
+++ b/tests/model/streaming/streamModelRetry.spec.ts
@@ -128,6 +128,21 @@ test("continues a pure text stream after interruption", async () => {
   assert.equal(events.some((event) => event.type === "error"), false);
 });
 
+test("does not continue text-encoded tool calls across an interruption", async () => {
+  const config = createConfig();
+  const requestBodies: Array<Record<string, unknown>> = [];
+  const events = await collect(streamModel(createRequest(), config, {
+    fetch: async (_input, init) => {
+      requestBodies.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
+      return sse('data: {"choices":[{"delta":{"content":"<tool_call>{\\"name\\":\\"write_file\\",\\"arguments\\":{\\"path\\":\\"secret.mjs\\""}}]}\n\n');
+    },
+  }));
+
+  const error = events.find((event): event is Extract<CanonicalModelEvent, { type: "error" }> => event.type === "error");
+  assert.equal(requestBodies.length, 1);
+  assert.equal(error?.error.streamInterruption?.phase, "text");
+});
+
 test("retains partial text if its continuation disconnects before output", async () => {
   const config = createConfig({ streamMaxRetries: 1 });
   let requests = 0;
@@ -277,6 +292,34 @@ test("Google recovers a stream ending without a finish event", async () => {
   const error = events.find((event): event is Extract<CanonicalModelEvent, { type: "error" }> => event.type === "error");
   assert.equal(error?.error.streamInterruption?.phase, "text");
   assert.equal(events.some((event) => event.type === "message_end"), false);
+});
+
+test("Google does not continue text-encoded tool calls across an interruption", async () => {
+  const config = createGoogleConfig({ streamMaxRetries: 1 });
+  let requests = 0;
+  const googleClientFactory: GoogleClientFactory = () => ({
+    models: {
+      generateContent: async () => ({} as never),
+      generateContentStream: async () => {
+        requests++;
+        return (async function* () {
+          yield {
+            candidates: [{
+              content: {
+                parts: [{ text: '<tool_call>{"name":"write_file","arguments":{"path":"secret.mjs"' }],
+              },
+            }],
+          } as never;
+        })();
+      },
+    },
+  });
+
+  const events = await collect(streamModel(createRequest(), config, { googleClientFactory }));
+
+  const error = events.find((event): event is Extract<CanonicalModelEvent, { type: "error" }> => event.type === "error");
+  assert.equal(requests, 1);
+  assert.equal(error?.error.streamInterruption?.phase, "text");
 });
 
 test("Google stops reading once it emits a terminal event", async () => {

--- a/tests/model/streaming/streamModelRetry.spec.ts
+++ b/tests/model/streaming/streamModelRetry.spec.ts
@@ -145,6 +145,42 @@ test("retains partial text if its continuation disconnects before output", async
   assert.equal(error?.error.streamInterruption?.phase, "text");
 });
 
+test("retains partial text when its continuation receives a terminal HTTP error", async () => {
+  const config = createConfig({ streamMaxRetries: 1 });
+  let requests = 0;
+  const events = await collect(streamModel(createRequest(), config, {
+    fetch: async () => {
+      requests++;
+      return requests === 1
+        ? sse('data: {"choices":[{"delta":{"content":"partial"}}]}\n\n')
+        : new Response(JSON.stringify({ error: { message: "rate limit exceeded" } }), { status: 429 });
+    },
+  }));
+
+  const error = events.find((event): event is Extract<CanonicalModelEvent, { type: "error" }> => event.type === "error");
+  assert.equal(requests, 2);
+  assert.equal(error?.error.code, "rate_limit_error");
+  assert.equal(error?.error.streamInterruption?.phase, "text");
+});
+
+test("retains partial text when continuation setup fails", async () => {
+  const config = createConfig({ streamMaxRetries: 1 });
+  let requests = 0;
+  const events = await collect(streamModel(createRequest(), config, {
+    fetch: async () => {
+      requests++;
+      if (requests === 1) {
+        return sse('data: {"choices":[{"delta":{"content":"partial"}}]}\n\n');
+      }
+      throw new Error("fetch failed");
+    },
+  }));
+
+  const error = events.find((event): event is Extract<CanonicalModelEvent, { type: "error" }> => event.type === "error");
+  assert.equal(requests, 2);
+  assert.equal(error?.error.streamInterruption?.phase, "text");
+});
+
 test("does not replay a stream after reasoning or tool-call output", async () => {
   const cases = [
     {
@@ -223,6 +259,24 @@ test("Google idle watchdog interrupts a stalled iterator", async () => {
   const error = events.find((event): event is Extract<CanonicalModelEvent, { type: "error" }> => event.type === "error");
   assert.equal(error?.error.code, "timeout");
   assert.equal(error?.error.settingsFix?.configPath, "model.providers.<id>.retry.streamIdleTimeoutMs");
+});
+
+test("Google recovers a stream ending without a finish event", async () => {
+  const config = createGoogleConfig();
+  const googleClientFactory: GoogleClientFactory = () => ({
+    models: {
+      generateContent: async () => ({} as never),
+      generateContentStream: async () => (async function* () {
+        yield { candidates: [{ content: { parts: [{ text: "partial" }] } }] } as never;
+      })(),
+    },
+  });
+
+  const events = await collect(streamModel(createRequest(), config, { googleClientFactory }));
+
+  const error = events.find((event): event is Extract<CanonicalModelEvent, { type: "error" }> => event.type === "error");
+  assert.equal(error?.error.streamInterruption?.phase, "text");
+  assert.equal(events.some((event) => event.type === "message_end"), false);
 });
 
 test("first-token timeout uses stream-idle guidance", async () => {

--- a/ui/src/components/settings/view/modelPool/components/ProviderCard.tsx
+++ b/ui/src/components/settings/view/modelPool/components/ProviderCard.tsx
@@ -484,7 +484,7 @@ export default function ProviderCard({
               >
                 <NumberInput
                   value={draftProvider.retry?.streamIdleTimeoutMs}
-                  placeholder="30000"
+                  placeholder="600000"
                   onChange={(v) =>
                     update({
                       retry: { ...draftProvider.retry, streamIdleTimeoutMs: v },

--- a/ui/src/i18n/locales/en/chat.json
+++ b/ui/src/i18n/locales/en/chat.json
@@ -472,6 +472,7 @@
         "auth": "Update the API key or access permissions for {{provider}} in Settings → Model Provider, or run pilotdeck setup.",
         "modelNotFound": "Choose a valid model for {{provider}} in Settings → Model Provider, or add it under model.providers.<id>.models in pilotdeck.yaml.",
         "timeout": "Increase timeoutMs for {{provider}} in Settings → Model Provider → Advanced, or check local network/proxy and provider status.",
+        "streamIdleTimeout": "Increase streamIdleTimeoutMs for {{provider}} in Settings → Model Provider → Advanced, or check local network/proxy and provider status.",
         "rateLimit": "Wait for the provider rate limit to reset, reduce concurrency, or switch to another provider/model in Settings.",
         "billing": "Top up billing/quota on the provider API side, or switch to another provider/model in Settings.",
         "contextOverflow": "Run /compact, start a new session, remove large attachments, or switch to a larger-context model in Settings.",

--- a/ui/src/i18n/locales/en/settings.json
+++ b/ui/src/i18n/locales/en/settings.json
@@ -845,7 +845,7 @@
         "providerRetry": {
           "requestMaxRetries": { "label": "Request max retries", "description": "Maximum retries for non-streaming requests." },
           "streamMaxRetries": { "label": "Stream max retries", "description": "Maximum retries for streaming requests." },
-          "streamIdleTimeoutMs": { "label": "Stream idle timeout (ms)", "description": "Abort a stream if no data is received for this duration." },
+          "streamIdleTimeoutMs": { "label": "Stream idle timeout (ms)", "description": "Abort a stream if no data is received for this duration. Defaults to 600000 ms." },
           "baseDelayMs": { "label": "Base delay (ms)", "description": "Initial delay before the first retry." },
           "maxDelayMs": { "label": "Max delay (ms)", "description": "Maximum delay between retries." }
         }

--- a/ui/src/i18n/locales/zh-CN/chat.json
+++ b/ui/src/i18n/locales/zh-CN/chat.json
@@ -460,6 +460,7 @@
         "auth": "请在“设置 → 模型 Provider”中更新 {{provider}} 的 API Key 或访问权限，或运行 pilotdeck setup。",
         "modelNotFound": "请在“设置 → 模型 Provider”中为 {{provider}} 选择有效模型，或在 pilotdeck.yaml 的 model.providers.<id>.models 下添加该模型。",
         "timeout": "请在“设置 → 模型 Provider → 高级”中增大 {{provider}} 的 timeoutMs，或检查本机网络、代理和 provider 状态。",
+        "streamIdleTimeout": "请在“设置 → 模型 Provider → 高级”中增大 {{provider}} 的 streamIdleTimeoutMs，或检查本机网络、代理和 provider 状态。",
         "rateLimit": "请等待 provider 限流窗口恢复、减少并发请求，或在设置中切换 provider/model。",
         "billing": "请在 provider API 侧充值或恢复 quota，或在设置中切换 provider/model。",
         "contextOverflow": "请运行 /compact、开启新会话、移除大型附件，或在设置中切换到更大上下文模型。",

--- a/ui/src/i18n/locales/zh-CN/settings.json
+++ b/ui/src/i18n/locales/zh-CN/settings.json
@@ -845,7 +845,7 @@
         "providerRetry": {
           "requestMaxRetries": { "label": "请求最大重试次数", "description": "非流式请求的最大重试次数。" },
           "streamMaxRetries": { "label": "流式最大重试次数", "description": "流式请求的最大重试次数。" },
-          "streamIdleTimeoutMs": { "label": "流式空闲超时（毫秒）", "description": "在此时间内没有收到数据则中止流。" },
+          "streamIdleTimeoutMs": { "label": "流式空闲超时（毫秒）", "description": "在此时间内没有收到数据则中止流。默认 600000 毫秒。" },
           "baseDelayMs": { "label": "基础延迟（毫秒）", "description": "首次重试前的初始等待时间。" },
           "maxDelayMs": { "label": "最大延迟（毫秒）", "description": "两次重试之间的最长等待时间。" }
         }


### PR DESCRIPTION
## Summary
- decouple stream idle timeout from provider request timeout with a 600s default
- recover interrupted reasoning/tool-call streams at the agent loop without retaining partial tool arguments
- keep pure-text continuation in streamModel and remove Router mid-stream continuation ownership

## Validation
- `tsc -p tsconfig.json --noEmit`
- focused stream interruption and error-guidance tests (15 passing)