### PR TITLE
fix(compaction): preserve current user request

### DIFF
--- a/src/agent/loop/AgentLoop.ts
+++ b/src/agent/loop/AgentLoop.ts
@@ -43,6 +43,7 @@ import type { AgentRuntimeDependencies } from "../runtime/AgentRuntimeDependenci
 import type { LifecycleDispatchResult } from "../../lifecycle/index.js";
 import type { PilotDeckHookEvent } from "../../extension/hooks/protocol/events.js";
 import { NullContextRuntime } from "../../context/NullContextRuntime.js";
+import { truncateHeadPreservingCheckpoint } from "../../context/compaction/CompactionEngine.js";
 import type { AgentContextRuntime } from "../../context/ContextRuntime.js";
 import type {
   CompactionResult,
@@ -2756,11 +2757,9 @@ function buildPartialTextToolCallRecoveryPrompt(
   ].join("\n");
 }
 
-/** Keep only the trailing `keepRatio` portion of the message history. */
+/** Keep a bounded tail without dropping the user request that initiated it. */
 function truncateHeadKeepRatio(messages: CanonicalMessage[], keepRatio: number): CanonicalMessage[] {
-  const ratio = Math.max(0.05, Math.min(1, keepRatio));
-  const keep = Math.max(1, Math.floor(messages.length * ratio));
-  return messages.slice(-keep);
+  return truncateHeadPreservingCheckpoint(messages, keepRatio);
 }
 
 function buildInvalidFingerprint(results: PilotDeckToolResult[]): string {

--- a/src/agent/loop/projectToolResults.ts
+++ b/src/agent/loop/projectToolResults.ts
@@ -37,7 +37,15 @@ export function projectToolResults(results: PilotDeckToolResult[]): CanonicalMes
     if (result.supplementalMessages) {
       for (const msg of result.supplementalMessages) {
         const blocks: CanonicalContentBlock[] = msg.content.map(toCanonicalSupplementalBlock);
-        messages.push({ role: "user", content: blocks });
+        messages.push({
+          role: "user",
+          content: blocks,
+          metadata: {
+            synthetic: true,
+            purpose: "tool_result_supplemental",
+            toolCallId: result.toolCallId,
+          },
+        });
       }
     }
   }

--- a/src/context/compaction/CompactionEngine.ts
+++ b/src/context/compaction/CompactionEngine.ts
@@ -779,6 +779,7 @@ function truncateTailPreservingToolPairs(
   messages: CanonicalMessage[],
   keepRatio: number,
 ): CanonicalMessage[] {
+  if (messages.length === 0) return [];
   const rawTail = truncateHead(messages, keepRatio);
   const tailStartIndex = messages.length - rawTail.length;
   let requestAnchorIndex: number | undefined;

--- a/src/context/compaction/CompactionEngine.ts
+++ b/src/context/compaction/CompactionEngine.ts
@@ -19,6 +19,7 @@ import {
   collectToolCallIds,
   collectToolResultIds,
   ensureTrailingUserMessage,
+  isRealUserRequestMessage,
   stripUnpairedToolCalls,
   stripUnpairedToolResults,
 } from "./toolPairIntegrity.js";
@@ -535,6 +536,10 @@ function planFullCompactionMessages(
   const prefix = prefixTurns.flatMap((turn) => turn.messages);
   const tail = turns.slice(tailStartTurn).flatMap((turn) => turn.messages);
   const protectedIndexes = collectProtectedGroupIndexes(prefixTurns, { protectedToolNames });
+  const requestAnchorIndex = findLatestUserRequestGroupIndex(turns, tailStartTurn);
+  if (requestAnchorIndex !== undefined && requestAnchorIndex < tailStartTurn) {
+    protectedIndexes.add(requestAnchorIndex);
+  }
   const protectedMessages: CanonicalMessage[] = [];
   const messagesToSummarize: CanonicalMessage[] = [];
 
@@ -659,8 +664,19 @@ function hasProtectedContextMessage(
 
 function isStandaloneUserRequestGroup(messages: CanonicalMessage[]): boolean {
   return messages.length === 1
-    && messages[0]!.role === "user"
-    && !isToolResultOnlyMessage(messages[0]!);
+    && isRealUserRequestMessage(messages[0]!);
+}
+
+function findLatestUserRequestGroupIndex(
+  groups: Array<{ index: number; messages: CanonicalMessage[] }>,
+  atOrBefore: number,
+): number | undefined {
+  for (let index = Math.min(atOrBefore, groups.length - 1); index >= 0; index -= 1) {
+    if (groups[index]!.messages.some(isRealUserRequestMessage)) {
+      return groups[index]!.index;
+    }
+  }
+  return undefined;
 }
 
 function isToolResultOnlyMessage(message: CanonicalMessage): boolean {
@@ -763,7 +779,18 @@ function truncateTailPreservingToolPairs(
   messages: CanonicalMessage[],
   keepRatio: number,
 ): CanonicalMessage[] {
-  const liveTail = truncateHead(messages, keepRatio);
+  const rawTail = truncateHead(messages, keepRatio);
+  const tailStartIndex = messages.length - rawTail.length;
+  let requestAnchorIndex: number | undefined;
+  for (let index = tailStartIndex; index >= 0; index -= 1) {
+    if (isRealUserRequestMessage(messages[index]!)) {
+      requestAnchorIndex = index;
+      break;
+    }
+  }
+  const liveTail = requestAnchorIndex !== undefined && requestAnchorIndex < tailStartIndex
+    ? [messages[requestAnchorIndex]!, ...rawTail]
+    : rawTail;
   const resultIds = collectToolResultIds(liveTail);
   const pairedCalls = stripUnpairedToolCalls(liveTail, resultIds);
   const callIds = collectToolCallIds(pairedCalls);

--- a/src/context/compaction/SnipEngine.ts
+++ b/src/context/compaction/SnipEngine.ts
@@ -4,6 +4,7 @@ import {
   collectToolCallIds,
   collectToolResultIds,
   ensureTrailingUserMessage,
+  isRealUserRequestMessage,
   stripUnpairedToolCalls,
   stripUnpairedToolResults,
 } from "./toolPairIntegrity.js";
@@ -125,6 +126,7 @@ export class SnipEngine {
       }
     }
     let accumulatedTailTokens = 0;
+    let tailStartIndex = turns.length;
     const tailFloor = Math.min(constrained ? 1 : this.keepTailTurns, turns.length);
     for (let index = turns.length - 1; index >= 0; index -= 1) {
       const tokens = this.tokenBudget.estimateMessagesTokens(turns[index]!);
@@ -134,7 +136,12 @@ export class SnipEngine {
         break;
       }
       keepIndexes.add(index);
+      tailStartIndex = index;
       accumulatedTailTokens += tokens;
+    }
+    const requestAnchorIndex = findLatestUserRequestGroupIndex(turns, tailStartIndex);
+    if (requestAnchorIndex !== undefined) {
+      keepIndexes.add(requestAnchorIndex);
     }
     // Protected indexes are relative to the live turn list. Checkpoint
     // messages are intentionally excluded from `turns`, so calculating these
@@ -261,17 +268,24 @@ function collectProtectedCycleIndexes(
       continue;
     }
     protectedIndexes.add(index);
-    if (index > 0 && isStandaloneUserRequest(groups[index - 1]!)) {
-      protectedIndexes.add(index - 1);
+    const requestAnchorIndex = findLatestUserRequestGroupIndex(groups, index);
+    if (requestAnchorIndex !== undefined) {
+      protectedIndexes.add(requestAnchorIndex);
     }
   }
   return protectedIndexes;
 }
 
-function isStandaloneUserRequest(messages: CanonicalMessage[]): boolean {
-  return messages.length === 1
-    && messages[0]?.role === "user"
-    && !isToolResultOnly(messages[0]);
+function findLatestUserRequestGroupIndex(
+  groups: CanonicalMessage[][],
+  atOrBefore: number,
+): number | undefined {
+  for (let index = Math.min(atOrBefore, groups.length - 1); index >= 0; index -= 1) {
+    if (groups[index]!.some(isRealUserRequestMessage)) {
+      return index;
+    }
+  }
+  return undefined;
 }
 
 function stitchKeptTurnsWithBoundaries(

--- a/src/context/compaction/toolPairIntegrity.ts
+++ b/src/context/compaction/toolPairIntegrity.ts
@@ -89,6 +89,33 @@ function isMediaReferenceWithId(
 const CONTINUATION_TEXT =
   "[system: the conversation above has been compacted. please continue with the current task.]";
 
+const INTERNAL_USER_TEXT_PREFIXES = [
+  "<compact-boundary",
+  "<snip-boundary",
+  "<memory-context>",
+  "<internal-compaction-control",
+];
+
+/** True only for an end-user request that can anchor a retained live tail. */
+export function isRealUserRequestMessage(message: CanonicalMessage): boolean {
+  if (message.role !== "user" || message.metadata?.synthetic === true) {
+    return false;
+  }
+
+  return message.content.some((block) => {
+    if (isDirectToolResultBlock(block) || isMediaReferenceWithId(block)) {
+      return false;
+    }
+    if (block.type !== "text") {
+      return true;
+    }
+    const text = block.text.trim();
+    return text.length > 0
+      && text !== CONTINUATION_TEXT
+      && !INTERNAL_USER_TEXT_PREFIXES.some((prefix) => text.startsWith(prefix));
+  });
+}
+
 /**
  * If the last message is role=assistant, append a sentinel user message so
  * providers that reject assistant-message prefill (e.g. Amazon Bedrock) do

--- a/src/context/compaction/toolPairIntegrity.ts
+++ b/src/context/compaction/toolPairIntegrity.ts
@@ -94,6 +94,7 @@ const INTERNAL_USER_TEXT_PREFIXES = [
   "<snip-boundary",
   "<memory-context>",
   "<internal-compaction-control",
+  "<hook_context",
 ];
 
 /** True only for an end-user request that can anchor a retained live tail. */

--- a/src/lifecycle/runtime/LifecycleRuntime.ts
+++ b/src/lifecycle/runtime/LifecycleRuntime.ts
@@ -50,6 +50,7 @@ function createMessagesFromEffects(effects: LifecycleDispatchResult["effects"]):
             text: `<hook_context source="${effect.source}">\n${effect.content}\n</hook_context>`,
           },
         ],
+        metadata: { synthetic: true, purpose: "hook_context" },
       });
     }
   }

--- a/src/model/protocol/canonical.ts
+++ b/src/model/protocol/canonical.ts
@@ -140,6 +140,8 @@ export type CanonicalMessageMetadata = {
   transient?: boolean;
   /** Stable id used by the agent loop to expire transient synthetic prompts. */
   transientId?: string;
+  /** Originating tool call for projected supplemental result messages. */
+  toolCallId?: string;
   /** Message replaces compacted history and is omitted from the visible transcript. */
   compactReplacement?: boolean;
   /** Compaction id of the effective replacement snapshot persisted in the transcript. */

--- a/tests/context/autoCompaction.spec.ts
+++ b/tests/context/autoCompaction.spec.ts
@@ -10,6 +10,7 @@ import {
 import { MicroCompactionEngine } from "../../src/context/compaction/MicroCompactionEngine.js";
 import { SnipEngine } from "../../src/context/compaction/SnipEngine.js";
 import { isRealUserRequestMessage } from "../../src/context/compaction/toolPairIntegrity.js";
+import { projectToolResults } from "../../src/agent/loop/projectToolResults.js";
 import { TokenBudgetManager } from "../../src/context/budget/TokenBudgetManager.js";
 import type { CanonicalMessage, CanonicalModelRequest } from "../../src/model/index.js";
 
@@ -391,6 +392,32 @@ test("query anchoring excludes synthetic and internal user messages", () => {
     content: [{ type: "text", text: "Actual request" }],
   }), true);
   assert.equal(internalMessages.every((message) => !isRealUserRequestMessage(message)), true);
+});
+
+test("query anchoring excludes inline supplemental media from tool results", () => {
+  const projected = projectToolResults([{
+    type: "success",
+    toolCallId: "read-file-1",
+    toolName: "read_file",
+    content: [{ type: "text", text: "Rendered PDF pages." }],
+    supplementalMessages: [{
+      role: "user",
+      isMeta: true,
+      content: [{ type: "image", mimeType: "image/png", data: "aW1hZ2U=", bytes: 5 }],
+    }],
+    startedAt: "2026-01-01T00:00:00.000Z",
+    completedAt: "2026-01-01T00:00:01.000Z",
+  }]);
+
+  const supplemental = projected[1]!;
+  assert.equal(supplemental.metadata?.synthetic, true);
+  assert.equal(supplemental.metadata?.purpose, "tool_result_supplemental");
+  assert.equal(supplemental.metadata?.toolCallId, "read-file-1");
+  assert.equal(isRealUserRequestMessage(supplemental), false);
+});
+
+test("emergency head truncation preserves empty history", () => {
+  assert.deepEqual(truncateHeadPreservingCheckpoint([], 0.1), []);
 });
 
 test("full compaction targets 60% of the effective input budget", async () => {

--- a/tests/context/autoCompaction.spec.ts
+++ b/tests/context/autoCompaction.spec.ts
@@ -373,6 +373,7 @@ test("query anchoring excludes synthetic and internal user messages", () => {
     { role: "user", content: [{ type: "text", text: "<memory-context>memory</memory-context>" }] },
     { role: "user", content: [{ type: "text", text: "<compact-boundary trigger=\"auto\" />" }] },
     { role: "user", content: [{ type: "text", text: "<snip-boundary turnsSnipped=\"1\" />" }] },
+    { role: "user", content: [{ type: "text", text: "<hook_context source=\"UserPromptSubmit\">Injected context</hook_context>" }] },
     {
       role: "user",
       content: [{ type: "text", text: "retry the generated response" }],
@@ -418,6 +419,19 @@ test("query anchoring excludes inline supplemental media from tool results", () 
 
 test("emergency head truncation preserves empty history", () => {
   assert.deepEqual(truncateHeadPreservingCheckpoint([], 0.1), []);
+});
+
+test("request anchoring skips hook context before a multi-turn tool cycle", () => {
+  const messages: CanonicalMessage[] = [
+    { role: "user", content: [{ type: "text", text: "Actual user request" }] },
+    { role: "user", content: [{ type: "text", text: "<hook_context source=\"UserPromptSubmit\">Injected context</hook_context>" }] },
+    { role: "assistant", content: [{ type: "tool_call", id: "hook-cycle", name: "read_file", input: { path: "a.txt" } }] },
+    { role: "user", content: [{ type: "tool_result", toolCallId: "hook-cycle", content: [{ type: "text", text: "tool output" }] }] },
+  ];
+
+  const result = truncateHeadPreservingCheckpoint(messages, 0.1);
+  assert.match(textFrom(result), /Actual user request/);
+  assert.doesNotMatch(textFrom(result), /Injected context/);
 });
 
 test("full compaction targets 60% of the effective input budget", async () => {

--- a/tests/context/autoCompaction.spec.ts
+++ b/tests/context/autoCompaction.spec.ts
@@ -3,9 +3,13 @@ import test from "node:test";
 
 import { DefaultContextRuntime } from "../../src/context/DefaultContextRuntime.js";
 import { AutoCompactionPolicy } from "../../src/context/compaction/AutoCompactionPolicy.js";
-import { CompactionEngine } from "../../src/context/compaction/CompactionEngine.js";
+import {
+  CompactionEngine,
+  truncateHeadPreservingCheckpoint,
+} from "../../src/context/compaction/CompactionEngine.js";
 import { MicroCompactionEngine } from "../../src/context/compaction/MicroCompactionEngine.js";
 import { SnipEngine } from "../../src/context/compaction/SnipEngine.js";
+import { isRealUserRequestMessage } from "../../src/context/compaction/toolPairIntegrity.js";
 import { TokenBudgetManager } from "../../src/context/budget/TokenBudgetManager.js";
 import type { CanonicalMessage, CanonicalModelRequest } from "../../src/model/index.js";
 
@@ -315,6 +319,78 @@ test("targeted snip can prune tool cycles inside one user task", () => {
   assert.equal(callIds.includes("cycle-0"), false);
   assert.equal(callIds.includes("cycle-5"), true);
   assert.deepEqual(resultIds, callIds);
+  const requestIndex = result.messages.findIndex((message) =>
+    textFrom([message]) === "Inspect each repository file."
+  );
+  const retainedTailIndex = result.messages.findIndex((message) =>
+    message.content.some((block) => block.type === "tool_call" && block.id === "cycle-5")
+  );
+  assert.ok(requestIndex >= 0);
+  assert.ok(retainedTailIndex > requestIndex);
+});
+
+test("emergency head truncation keeps the latest task query", () => {
+  const messages: CanonicalMessage[] = [
+    { role: "user", content: [{ type: "text", text: "Old completed request" }] },
+    { role: "assistant", content: [{ type: "text", text: "Old request completed" }] },
+    { role: "user", content: [{ type: "text", text: "Current request must survive" }] },
+  ];
+  for (let index = 0; index < 4; index += 1) {
+    messages.push(
+      {
+        role: "assistant",
+        content: [{ type: "tool_call", id: `truncate-${index}`, name: "read_file", input: { path: `file-${index}` } }],
+      },
+      {
+        role: "user",
+        content: [{
+          type: "tool_result",
+          toolCallId: `truncate-${index}`,
+          content: [{ type: "text", text: `result-${index}` }],
+        }],
+      },
+    );
+  }
+
+  const result = truncateHeadPreservingCheckpoint(messages, 0.1);
+  const callIds = result.flatMap((message) => message.content.flatMap((block) =>
+    block.type === "tool_call" ? [block.id] : [],
+  ));
+  const resultIds = result.flatMap((message) => message.content.flatMap((block) =>
+    block.type === "tool_result" ? [block.toolCallId] : [],
+  ));
+
+  assert.match(textFrom(result), /Current request must survive/);
+  assert.doesNotMatch(textFrom(result), /Old completed request/);
+  assert.ok(result.length > 0);
+  assert.deepEqual(resultIds, callIds);
+});
+
+test("query anchoring excludes synthetic and internal user messages", () => {
+  const internalMessages: CanonicalMessage[] = [
+    { role: "user", content: [{ type: "tool_result", toolCallId: "tool-1", content: [] }] },
+    { role: "user", content: [{ type: "text", text: "<memory-context>memory</memory-context>" }] },
+    { role: "user", content: [{ type: "text", text: "<compact-boundary trigger=\"auto\" />" }] },
+    { role: "user", content: [{ type: "text", text: "<snip-boundary turnsSnipped=\"1\" />" }] },
+    {
+      role: "user",
+      content: [{ type: "text", text: "retry the generated response" }],
+      metadata: { synthetic: true },
+    },
+    {
+      role: "user",
+      content: [{
+        type: "text",
+        text: "[system: the conversation above has been compacted. please continue with the current task.]",
+      }],
+    },
+  ];
+
+  assert.equal(isRealUserRequestMessage({
+    role: "user",
+    content: [{ type: "text", text: "Actual request" }],
+  }), true);
+  assert.equal(internalMessages.every((message) => !isRealUserRequestMessage(message)), true);
 });
 
 test("full compaction targets 60% of the effective input budget", async () => {

--- a/tests/context/compaction-engine.spec.ts
+++ b/tests/context/compaction-engine.spec.ts
@@ -577,6 +577,15 @@ test("auto full compaction summarizes older tool groups inside one user task", a
   assert.ok(findToolCall(summaryRequests[0]!.messages, "tail-fetch"));
   assert.ok(findToolCall(result.messages, "tail-fetch"));
   assert.equal(findToolResult(result.messages, "old-search-0"), undefined);
+  const requestIndex = result.messages.findIndex((message) =>
+    summaryText(message) === "Solve one WCB task with searches and fetches."
+  );
+  const retainedTailIndex = result.messages.findIndex((message) =>
+    message.content.some((block) => block.type === "tool_call" && block.id === "tail-fetch")
+  );
+  assert.ok(requestIndex >= 0);
+  assert.ok(retainedTailIndex > requestIndex);
+  assert.equal(result.messages[requestIndex - 1]?.role, "assistant");
   assert.match(summaryText(result.result?.summaryMessage), /^\[CONTEXT COMPACTION - REFERENCE ONLY\]/);
   assert.deepEqual(events.map((event) => event.type), ["compact_started", "compact_completed"]);
   if (events[0]?.type !== "compact_started" || events[1]?.type !== "compact_completed") {


### PR DESCRIPTION
## Summary
- preserve the latest real user request during full and emergency compaction
- keep request anchors while retaining tool-pair integrity
- add regression coverage for snip and emergency truncation paths

## Validation
- `git diff --check` passed
- targeted compaction tests and real-provider compaction E2E were already completed before this commit

## Scope
- compaction implementation and regression tests only