### PR TITLE
fix(ui): improve long-running thinking status and navigation

### DIFF
--- a/ui/src/components/chat-v2/MessagesPaneV2.render.test.tsx
+++ b/ui/src/components/chat-v2/MessagesPaneV2.render.test.tsx
@@ -79,6 +79,7 @@ function createPaneElement({
   activeRunId = null,
   runMode = 'agent',
   planModeActive = false,
+  showThinking = true,
 }: {
   messages: ChatMessage[];
   activityMessages?: ChatMessage[];
@@ -87,6 +88,7 @@ function createPaneElement({
   activeRunId?: string | null;
   runMode?: ChatRunMode;
   planModeActive?: boolean;
+  showThinking?: boolean;
 }) {
   const scrollContainerRef = React.createRef<HTMLDivElement>();
 
@@ -118,6 +120,7 @@ function createPaneElement({
         activeRunId={activeRunId}
         runMode={runMode}
         planModeActive={planModeActive}
+        showThinking={showThinking}
       />
     </FindShortcutProvider>
   );
@@ -131,6 +134,7 @@ function renderPane(options: {
   activeRunId?: string | null;
   runMode?: ChatRunMode;
   planModeActive?: boolean;
+  showThinking?: boolean;
 }) {
   return render(createPaneElement(options));
 }
@@ -171,6 +175,92 @@ function SessionPaneHarness({
 }
 
 describe('MessagesPaneV2 render behavior', () => {
+  it('shows a waiting state before the model produces content', () => {
+    const now = new Date().toISOString();
+    renderPane({
+      messages: [{
+        id: 'user-waiting',
+        type: 'user',
+        content: 'Please analyze this.',
+        timestamp: now,
+      }],
+      isAssistantWorking: true,
+      sessionRuntimeState: 'running',
+    });
+
+    expect(screen.getByText('Waiting for model response...')).toBeTruthy();
+    expect(screen.queryByText('Thinking...')).toBeNull();
+  });
+
+  it('switches to thinking when live reasoning arrives even if reasoning details are hidden', () => {
+    const now = new Date().toISOString();
+    renderPane({
+      messages: [
+        {
+          id: 'user-thinking',
+          type: 'user',
+          content: 'Please analyze this.',
+          timestamp: now,
+        },
+        {
+          id: '__streaming_thinking_session_run',
+          type: 'assistant',
+          content: 'I am comparing the available approaches.',
+          timestamp: now,
+          isThinking: true,
+          isStreaming: true,
+        },
+      ],
+      isAssistantWorking: true,
+      sessionRuntimeState: 'running',
+      showThinking: false,
+    });
+
+    expect(screen.getByText('Thinking...')).toBeTruthy();
+    expect(screen.queryByText('Waiting for model response...')).toBeNull();
+    expect(screen.queryByText('I am comparing the available approaches.')).toBeNull();
+  });
+
+  it('lets the live thinking status row collapse and restore the scrollable reasoning window', () => {
+    const now = new Date().toISOString();
+    const thinkingContent = Array.from(
+      { length: 12 },
+      (_, index) => `Live thinking line ${index + 1}`,
+    ).join('\n');
+    renderPane({
+      messages: [
+        {
+          id: 'user-live-thinking',
+          type: 'user',
+          content: 'Please think this through.',
+          timestamp: now,
+        },
+        {
+          id: '__streaming_thinking_session_live',
+          type: 'assistant',
+          content: thinkingContent,
+          timestamp: now,
+          isThinking: true,
+          isStreaming: true,
+        },
+      ],
+      isAssistantWorking: true,
+      sessionRuntimeState: 'running',
+    });
+
+    const toggle = screen.getByRole('button', { name: 'Thinking...' });
+    expect(toggle.getAttribute('aria-expanded')).toBe('true');
+    expect(screen.getByRole('region', { name: 'Live thinking content' })).toBeTruthy();
+
+    fireEvent.click(toggle);
+    expect(toggle.getAttribute('aria-expanded')).toBe('false');
+    expect(screen.queryByRole('region', { name: 'Live thinking content' })).toBeNull();
+
+    fireEvent.click(toggle);
+    expect(toggle.getAttribute('aria-expanded')).toBe('true');
+    expect(screen.getByRole('region', { name: 'Live thinking content' })).toBeTruthy();
+  });
+
   it('stops an unfinished subagent from an older run while the next run is active', () => {
     const now = new Date().toISOString();
     const messages: ChatMessage[] = [

--- a/ui/src/components/chat-v2/MessagesPaneV2.render.test.tsx
+++ b/ui/src/components/chat-v2/MessagesPaneV2.render.test.tsx
@@ -80,6 +80,7 @@ function createPaneElement({
   runMode = 'agent',
   planModeActive = false,
   showThinking = true,
+  inlineThinking = false,
 }: {
   messages: ChatMessage[];
   activityMessages?: ChatMessage[];
@@ -89,6 +90,7 @@ function createPaneElement({
   runMode?: ChatRunMode;
   planModeActive?: boolean;
   showThinking?: boolean;
+  inlineThinking?: boolean;
 }) {
   const scrollContainerRef = React.createRef<HTMLDivElement>();
 
@@ -121,6 +123,7 @@ function createPaneElement({
         runMode={runMode}
         planModeActive={planModeActive}
         showThinking={showThinking}
+        inlineThinking={inlineThinking}
       />
     </FindShortcutProvider>
   );
@@ -135,6 +138,7 @@ function renderPane(options: {
   runMode?: ChatRunMode;
   planModeActive?: boolean;
   showThinking?: boolean;
+  inlineThinking?: boolean;
 }) {
   return render(createPaneElement(options));
 }
@@ -250,7 +254,9 @@ describe('MessagesPaneV2 render behavior', () => {
 
     const toggle = screen.getByRole('button', { name: 'Thinking...' });
     expect(toggle.getAttribute('aria-expanded')).toBe('true');
-    expect(screen.getByRole('region', { name: 'Live thinking content' })).toBeTruthy();
+    const liveThinkingRegion = screen.getByRole('region', { name: 'Live thinking content' });
+    expect(liveThinkingRegion).toBeTruthy();
+    expect(liveThinkingRegion.closest('[role="status"]')).toBeNull();
 
     fireEvent.click(toggle);
     expect(toggle.getAttribute('aria-expanded')).toBe('false');
@@ -258,6 +264,72 @@ describe('MessagesPaneV2 render behavior', () => {
 
     fireEvent.click(toggle);
     expect(toggle.getAttribute('aria-expanded')).toBe('true');
+    expect(screen.getByRole('region', { name: 'Live thinking content' })).toBeTruthy();
+  });
+
+  it('expands live reasoning when thinking details are enabled during a run', () => {
+    const now = new Date().toISOString();
+    const messages: ChatMessage[] = [
+      {
+        id: 'user-toggle-thinking',
+        type: 'user',
+        content: 'Please think this through.',
+        timestamp: now,
+      },
+      {
+        id: '__streaming_thinking_toggle_details',
+        type: 'assistant',
+        content: 'Reasoning that becomes visible later.',
+        timestamp: now,
+        isThinking: true,
+        isStreaming: true,
+      },
+    ];
+    const options = {
+      messages,
+      isAssistantWorking: true,
+      sessionRuntimeState: 'running' as const,
+    };
+    const view = renderPane({ ...options, showThinking: false });
+
+    expect(screen.queryByRole('region', { name: 'Live thinking content' })).toBeNull();
+
+    view.rerender(createPaneElement({ ...options, showThinking: true }));
+
+    expect(screen.getByRole('button', { name: 'Thinking...' }).getAttribute('aria-expanded')).toBe('true');
+    expect(screen.getByRole('region', { name: 'Live thinking content' })).toBeTruthy();
+  });
+
+  it('expands the reasoning window when switching away from inline thinking during a run', () => {
+    const now = new Date().toISOString();
+    const messages: ChatMessage[] = [
+      {
+        id: 'user-toggle-inline-thinking',
+        type: 'user',
+        content: 'Please think this through.',
+        timestamp: now,
+      },
+      {
+        id: '__streaming_thinking_toggle_inline',
+        type: 'assistant',
+        content: 'Reasoning that moves out of the inline message.',
+        timestamp: now,
+        isThinking: true,
+        isStreaming: true,
+      },
+    ];
+    const options = {
+      messages,
+      isAssistantWorking: true,
+      sessionRuntimeState: 'running' as const,
+    };
+    const view = renderPane({ ...options, inlineThinking: true });
+
+    expect(screen.queryByRole('region', { name: 'Live thinking content' })).toBeNull();
+
+    view.rerender(createPaneElement({ ...options, inlineThinking: false }));
+
+    expect(screen.getByRole('button', { name: 'Thinking...' }).getAttribute('aria-expanded')).toBe('true');
     expect(screen.getByRole('region', { name: 'Live thinking content' })).toBeTruthy();
   });
 
@@ -1121,8 +1193,9 @@ describe('MessagesPaneV2 render behavior', () => {
     const firstStatusContainer = firstStatus.closest('[role="status"]');
     expect(firstStatusContainer).not.toBeNull();
     if (!firstStatusContainer) throw new Error('Expected first inline status container');
-    expect(firstStatusContainer.parentElement?.className).toContain('mt-2');
-    expect(firstStatusContainer.parentElement?.className).toContain('gap-2');
+    const firstProcessRow = firstStatusContainer.closest('.process-live-status');
+    expect(firstProcessRow?.parentElement?.className).toContain('mt-2');
+    expect(firstProcessRow?.parentElement?.className).toContain('gap-2');
     const expandButton = firstStatusContainer.querySelector('button');
     expect(expandButton).not.toBeNull();
 

--- a/ui/src/components/chat-v2/MessagesPaneV2.tsx
+++ b/ui/src/components/chat-v2/MessagesPaneV2.tsx
@@ -690,8 +690,8 @@ function MessagesPaneV2({
       return Boolean(subagentId && currentRunSubagentIds.has(subagentId));
     }) || null;
   }, [activeRunId, currentRunSubagentIds, sessionRuntimeState, subagentActivities]);
-  const streamingThinkingContent = useMemo(() => {
-    if (!showThinking || !isAssistantWorking) {
+  const liveThinkingContent = useMemo(() => {
+    if (!isAssistantWorking) {
       return null;
     }
     for (let i = visibleMessages.length - 1; i >= 0; i--) {
@@ -702,12 +702,13 @@ function MessagesPaneV2({
       if (msg.type === 'user') break;
     }
     return null;
-  }, [showThinking, isAssistantWorking, visibleMessages]);
+  }, [isAssistantWorking, visibleMessages]);
+  const streamingThinkingContent = showThinking ? liveThinkingContent : null;
   const liveStatusStep = useMemo<ProcessTraceStep>(() => {
-    if (streamingThinkingContent) {
+    if (liveThinkingContent) {
       return {
         id: 'live-thinking',
-        title: t('working.thinking', { defaultValue: 'thinking' }),
+        title: t('working.thinking', { defaultValue: 'Thinking...' }),
         phase: 'thinking',
         state: 'running',
       };
@@ -727,7 +728,7 @@ function MessagesPaneV2({
     hasPendingToolUse,
     nonSubagentLiveActivities,
     runningSubagentActivity,
-    streamingThinkingContent,
+    liveThinkingContent,
     t,
     workingStatus,
   ]);
@@ -1309,16 +1310,24 @@ function MessagesPaneV2({
           ) : null}
 
           {shouldRenderBottomLiveStatus ? (
-            <>
-              <ProcessLiveStatus step={liveStatusStep}>
-                {liveProcessDetailMessages.length > 0 && liveProcessGroups.length === 0
-                  ? renderLiveProcessDetailMessages(liveProcessDetailMessages, 'bottom-live-process')
-                  : null}
-              </ProcessLiveStatus>
-              {!inlineThinking && streamingThinkingContent ? (
-                <StreamingThinkingPreview content={streamingThinkingContent} />
-              ) : null}
-            </>
+            <ProcessLiveStatus
+              key={liveStatusStep.id}
+              step={liveStatusStep}
+              defaultExpanded={Boolean(!inlineThinking && streamingThinkingContent)}
+              contentClassName={!inlineThinking && streamingThinkingContent ? 'pl-0' : undefined}
+            >
+              {(liveProcessDetailMessages.length > 0 && liveProcessGroups.length === 0)
+                || (!inlineThinking && streamingThinkingContent) ? (
+                  <>
+                    {liveProcessDetailMessages.length > 0 && liveProcessGroups.length === 0
+                      ? renderLiveProcessDetailMessages(liveProcessDetailMessages, 'bottom-live-process')
+                      : null}
+                    {!inlineThinking && streamingThinkingContent ? (
+                      <StreamingThinkingPreview content={streamingThinkingContent} scrollable />
+                    ) : null}
+                  </>
+                ) : null}
+            </ProcessLiveStatus>
           ) : null}
         </div>
       )}
@@ -1471,9 +1480,9 @@ function getLiveStatusStep(
         state: 'running',
       }
     : {
-        id: 'live-thinking',
-        title: t('working.thinking', { defaultValue: 'Connecting...' }),
-        phase: 'thinking',
+        id: 'live-waiting-for-model',
+        title: t('working.waitingForModel', { defaultValue: 'Waiting for model response...' }),
+        phase: 'generation',
         state: 'running',
       };
 }

--- a/ui/src/components/chat-v2/MessagesPaneV2.tsx
+++ b/ui/src/components/chat-v2/MessagesPaneV2.tsx
@@ -402,17 +402,12 @@ function MessagesPaneV2({
 
   const handleProcessExpandedChange = useCallback((processKey: string, expanded: boolean) => {
     setExpandedProcessRows((currentRows) => {
-      const currentExpanded = currentRows.get(processKey) ?? false;
-      if (currentExpanded === expanded) {
+      if (currentRows.get(processKey) === expanded) {
         return currentRows;
       }
 
       const nextRows = new Map(currentRows);
-      if (expanded) {
-        nextRows.set(processKey, true);
-      } else {
-        nextRows.delete(processKey);
-      }
+      nextRows.set(processKey, expanded);
       return nextRows;
     });
   }, []);
@@ -690,19 +685,20 @@ function MessagesPaneV2({
       return Boolean(subagentId && currentRunSubagentIds.has(subagentId));
     }) || null;
   }, [activeRunId, currentRunSubagentIds, sessionRuntimeState, subagentActivities]);
-  const liveThinkingContent = useMemo(() => {
+  const liveThinkingMessage = useMemo(() => {
     if (!isAssistantWorking) {
       return null;
     }
     for (let i = visibleMessages.length - 1; i >= 0; i--) {
       const msg = visibleMessages[i];
       if (isStreamingThinkingMessage(msg) && typeof msg.content === 'string' && msg.content.trim()) {
-        return msg.content;
+        return msg;
       }
       if (msg.type === 'user') break;
     }
     return null;
   }, [isAssistantWorking, visibleMessages]);
+  const liveThinkingContent = liveThinkingMessage?.content || null;
   const streamingThinkingContent = showThinking ? liveThinkingContent : null;
   const liveStatusStep = useMemo<ProcessTraceStep>(() => {
     if (liveThinkingContent) {
@@ -734,6 +730,11 @@ function MessagesPaneV2({
   ]);
   const hasOpenEndedLiveProcessGroup = liveProcessGroups.some((group) => group.isRunning);
   const shouldRenderBottomLiveStatus = isAssistantWorking && !hasOpenEndedLiveProcessGroup;
+  const showStreamingThinkingPanel = Boolean(!inlineThinking && streamingThinkingContent);
+  const bottomLiveProcessKey = liveThinkingMessage
+    ? `live-thinking:${activeRunId || liveThinkingMessage.id || messageWindowScope}`
+    : `bottom-live:${liveStatusStep.id || 'working'}`;
+  const bottomLiveStatusExpanded = isProcessExpanded(bottomLiveProcessKey, showStreamingThinkingPanel);
 
   const bumpHeightVersion = useCallback(() => {
     if (heightVersionRafRef.current !== null) return;
@@ -1311,18 +1312,18 @@ function MessagesPaneV2({
 
           {shouldRenderBottomLiveStatus ? (
             <ProcessLiveStatus
-              key={liveStatusStep.id}
               step={liveStatusStep}
-              defaultExpanded={Boolean(!inlineThinking && streamingThinkingContent)}
-              contentClassName={!inlineThinking && streamingThinkingContent ? 'pl-0' : undefined}
+              expanded={bottomLiveStatusExpanded}
+              onExpandedChange={(expanded) => handleProcessExpandedChange(bottomLiveProcessKey, expanded)}
+              contentClassName={showStreamingThinkingPanel ? 'pl-0' : undefined}
             >
               {(liveProcessDetailMessages.length > 0 && liveProcessGroups.length === 0)
-                || (!inlineThinking && streamingThinkingContent) ? (
+                || showStreamingThinkingPanel ? (
                   <>
                     {liveProcessDetailMessages.length > 0 && liveProcessGroups.length === 0
                       ? renderLiveProcessDetailMessages(liveProcessDetailMessages, 'bottom-live-process')
                       : null}
-                    {!inlineThinking && streamingThinkingContent ? (
+                    {showStreamingThinkingPanel && streamingThinkingContent ? (
                       <StreamingThinkingPreview content={streamingThinkingContent} scrollable />
                     ) : null}
                   </>

--- a/ui/src/components/chat-v2/ProcessTrace.test.tsx
+++ b/ui/src/components/chat-v2/ProcessTrace.test.tsx
@@ -1,0 +1,52 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { StreamingThinkingPreview } from './ProcessTrace';
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('StreamingThinkingPreview', () => {
+  const content = Array.from({ length: 12 }, (_, index) => `Thinking line ${index + 1}`).join('\n');
+
+  it('keeps the compact tail for non-scrollable previews', () => {
+    render(<StreamingThinkingPreview content={content} />);
+
+    expect(screen.queryByText('Thinking line 1')).toBeNull();
+    expect(screen.getByText('Thinking line 12')).toBeTruthy();
+    expect(screen.queryByRole('region', { name: 'Live thinking content' })).toBeNull();
+  });
+
+  it('shows the full live reasoning in a scrollable window without extra controls', () => {
+    render(<StreamingThinkingPreview content={content} scrollable />);
+
+    const region = screen.getByRole('region', { name: 'Live thinking content' });
+    expect(region.textContent).toContain('Thinking line 1');
+    expect(region.textContent).toContain('Thinking line 12');
+    expect(screen.queryByRole('button')).toBeNull();
+  });
+
+  it('pauses live following while the user reads older reasoning and resumes at the bottom', () => {
+    const view = render(<StreamingThinkingPreview content={content} scrollable />);
+
+    const region = screen.getByRole('region', { name: 'Live thinking content' });
+    Object.defineProperty(region, 'scrollHeight', { configurable: true, value: 600 });
+    Object.defineProperty(region, 'clientHeight', { configurable: true, value: 200 });
+    region.scrollTop = 100;
+    fireEvent.scroll(region);
+
+    view.rerender(
+      <StreamingThinkingPreview content={`${content}\nA newly streamed thinking line`} scrollable />,
+    );
+    expect(region.scrollTop).toBe(100);
+
+    region.scrollTop = 400;
+    fireEvent.scroll(region);
+    view.rerender(
+      <StreamingThinkingPreview content={`${content}\nA newly streamed thinking line\nAnother line`} scrollable />,
+    );
+
+    expect(region.scrollTop).toBe(600);
+  });
+});

--- a/ui/src/components/chat-v2/ProcessTrace.tsx
+++ b/ui/src/components/chat-v2/ProcessTrace.tsx
@@ -125,26 +125,26 @@ export function ProcessLiveStatus({
 
   return (
     <div
-      role="status"
-      aria-live="polite"
       className={`process-live-status ${compact ? 'py-0' : 'pb-1'} text-[14px] leading-relaxed text-neutral-400 dark:text-neutral-500 ${className}`}
     >
-      {hasDetails ? (
-        <button
-          type="button"
-          aria-expanded={expanded}
-          onClick={() => setExpanded((value) => !value)}
-          className={`group inline-flex min-w-0 max-w-full items-start gap-2 text-left transition hover:text-neutral-600 dark:hover:text-neutral-300 ${
-            isRunning ? 'animate-pulse' : ''
-          }`}
-        >
-          {statusContent}
-        </button>
-      ) : (
-        <div className={`inline-flex min-w-0 max-w-full items-start gap-2 ${isRunning ? 'animate-pulse' : ''}`}>
-          {statusContent}
-        </div>
-      )}
+      <div role="status" aria-live="polite">
+        {hasDetails ? (
+          <button
+            type="button"
+            aria-expanded={expanded}
+            onClick={() => setExpanded((value) => !value)}
+            className={`group inline-flex min-w-0 max-w-full items-start gap-2 text-left transition hover:text-neutral-600 dark:hover:text-neutral-300 ${
+              isRunning ? 'animate-pulse' : ''
+            }`}
+          >
+            {statusContent}
+          </button>
+        ) : (
+          <div className={`inline-flex min-w-0 max-w-full items-start gap-2 ${isRunning ? 'animate-pulse' : ''}`}>
+            {statusContent}
+          </div>
+        )}
+      </div>
       {expanded && hasDetails ? (
         <div className={`mt-1.5 space-y-1.5 ${contentClassName ?? 'pl-5'}`}>
           {children}

--- a/ui/src/components/chat-v2/ProcessTrace.tsx
+++ b/ui/src/components/chat-v2/ProcessTrace.tsx
@@ -1,4 +1,5 @@
-import { useState, type ReactNode } from 'react';
+import { useLayoutEffect, useRef, useState, type ReactNode, type WheelEvent } from 'react';
+import { useTranslation } from 'react-i18next';
 import {
   Activity,
   AlertCircle,
@@ -70,6 +71,7 @@ export function ProcessLiveStatus({
   expanded: controlledExpanded,
   onExpandedChange,
   className = '',
+  contentClassName,
 }: {
   step: ProcessTraceStep;
   children?: ReactNode;
@@ -78,6 +80,7 @@ export function ProcessLiveStatus({
   expanded?: boolean;
   onExpandedChange?: (expanded: boolean) => void;
   className?: string;
+  contentClassName?: string;
 }) {
   const [uncontrolledExpanded, setUncontrolledExpanded] = useState(defaultExpanded);
   const expanded = controlledExpanded ?? uncontrolledExpanded;
@@ -143,7 +146,7 @@ export function ProcessLiveStatus({
         </div>
       )}
       {expanded && hasDetails ? (
-        <div className="mt-1.5 space-y-1.5 pl-5">
+        <div className={`mt-1.5 space-y-1.5 ${contentClassName ?? 'pl-5'}`}>
           {children}
         </div>
       ) : null}
@@ -310,31 +313,85 @@ export function ProcessTrace({
 export function StreamingThinkingPreview({
   content,
   maxLines = 10,
+  scrollable = false,
 }: {
   content: string;
   maxLines?: number;
+  scrollable?: boolean;
 }) {
+  const { t } = useTranslation('chat');
+  const followLatestRef = useRef(true);
+  const viewportRef = useRef<HTMLDivElement>(null);
   const lines = content.split('\n');
   const visibleLines = lines.slice(-maxLines);
   const hasOverflow = lines.length > maxLines;
 
-  return (
-    <div
-      className="relative mt-1 overflow-hidden px-3 py-2 font-mono text-xs leading-relaxed text-neutral-500 dark:text-neutral-400"
-      style={
-        hasOverflow
-          ? {
-              maskImage: 'linear-gradient(to bottom, transparent 0%, black 25%)',
-              WebkitMaskImage: 'linear-gradient(to bottom, transparent 0%, black 25%)',
-            }
-          : undefined
-      }
-    >
-      {visibleLines.map((line, i) => (
-        <div key={i} className="whitespace-pre-wrap break-words">
-          {line || '\u00A0'}
+  useLayoutEffect(() => {
+    if (!scrollable || !followLatestRef.current) return;
+    const viewport = viewportRef.current;
+    if (viewport) {
+      viewport.scrollTop = viewport.scrollHeight;
+    }
+  }, [content, scrollable]);
+
+  const handleScroll = () => {
+    const viewport = viewportRef.current;
+    if (!viewport) return;
+    const distanceFromBottom = viewport.scrollHeight - viewport.scrollTop - viewport.clientHeight;
+    followLatestRef.current = distanceFromBottom <= 24;
+  };
+
+  const handleWheel = (event: WheelEvent<HTMLDivElement>) => {
+    const viewport = viewportRef.current;
+    if (!viewport) return;
+    if (event.deltaY < 0) {
+      followLatestRef.current = false;
+    }
+    const canScrollUp = event.deltaY < 0 && viewport.scrollTop > 0;
+    const canScrollDown = event.deltaY > 0
+      && viewport.scrollTop + viewport.clientHeight < viewport.scrollHeight;
+    if (canScrollUp || canScrollDown) {
+      event.stopPropagation();
+    }
+  };
+
+  if (scrollable) {
+    return (
+      <div className="mt-1 px-3 py-2 font-mono text-xs leading-relaxed text-neutral-500 dark:text-neutral-400">
+        <div
+          ref={viewportRef}
+          role="region"
+          tabIndex={0}
+          aria-label={t('thinking.liveContentLabel', { defaultValue: 'Live thinking content' })}
+          onScroll={handleScroll}
+          onWheel={handleWheel}
+          className="max-h-64 overflow-y-auto whitespace-pre-wrap break-words border-l-2 border-neutral-200 pl-3 outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:border-neutral-700"
+        >
+          {content}
         </div>
-      ))}
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative mt-1 px-3 py-2 font-mono text-xs leading-relaxed text-neutral-500 dark:text-neutral-400">
+      <div
+        className="overflow-hidden"
+        style={
+          hasOverflow
+            ? {
+                maskImage: 'linear-gradient(to bottom, transparent 0%, black 25%)',
+                WebkitMaskImage: 'linear-gradient(to bottom, transparent 0%, black 25%)',
+              }
+            : undefined
+        }
+      >
+        {visibleLines.map((line, i) => (
+          <div key={i} className="whitespace-pre-wrap break-words">
+            {line || '\u00A0'}
+          </div>
+        ))}
+      </div>
     </div>
   );
 }

--- a/ui/src/components/chat-v2/SubagentDetailMessageFlow.render.test.tsx
+++ b/ui/src/components/chat-v2/SubagentDetailMessageFlow.render.test.tsx
@@ -122,11 +122,14 @@ describe('SubagentDetailMessageFlow', () => {
     fireEvent.click(screen.getByRole('button', { name: /Explored 1 file|已探索 1 个文件/i }));
 
     const status = screen.getByRole('status');
+    const processRow = status.closest('.process-live-status');
 
     expect(screen.getAllByText('Completed thought one.')).toHaveLength(1);
     expect(screen.getAllByText('Completed thought two.')).toHaveLength(1);
-    expect(status.textContent).toContain('Completed thought one.');
-    expect(status.textContent).toContain('Completed thought two.');
+    expect(processRow?.textContent).toContain('Completed thought one.');
+    expect(processRow?.textContent).toContain('Completed thought two.');
+    expect(status.textContent).not.toContain('Completed thought one.');
+    expect(status.textContent).not.toContain('Completed thought two.');
     expect(screen.queryByText('Thought through next step')).toBeNull();
     expect(screen.getByText(/Explored 1 file|已探索 1 个文件/i)).toBeTruthy();
   });

--- a/ui/src/i18n/locales/en/chat.json
+++ b/ui/src/i18n/locales/en/chat.json
@@ -57,7 +57,8 @@
   "working": {
     "default": "Working",
     "processing": "Processing",
-    "thinking": "thinking",
+    "thinking": "Thinking...",
+    "waitingForModel": "Waiting for model response...",
     "callingModel": "Calling model...",
     "executingTool": "Running tool...",
     "generating": "Generating response",
@@ -158,7 +159,8 @@
   "thinking": {
     "title": "Thinking...",
     "completed": "Thought process",
-    "emoji": "💭 Thinking..."
+    "emoji": "💭 Thinking...",
+    "liveContentLabel": "Live thinking content"
   },
   "json": {
     "response": "JSON Response"

--- a/ui/src/i18n/locales/zh-CN/chat.json
+++ b/ui/src/i18n/locales/zh-CN/chat.json
@@ -57,7 +57,8 @@
   "working": {
     "default": "处理中",
     "processing": "处理中",
-    "thinking": "连接中...",
+    "thinking": "思考中...",
+    "waitingForModel": "等待模型响应...",
     "callingModel": "调用模型中...",
     "executingTool": "执行工具中...",
     "generating": "正在生成回复",
@@ -158,7 +159,8 @@
   "thinking": {
     "title": "思考中...",
     "completed": "思考过程",
-    "emoji": "💭 思考中..."
+    "emoji": "💭 思考中...",
+    "liveContentLabel": "实时思考内容"
   },
   "json": {
     "response": "JSON 响应"


### PR DESCRIPTION
## Summary

Improve the chat experience for models that produce long reasoning streams.

## Changes

- Show `Waiting for model response` before the first model output.
- Switch to `Thinking...` when live reasoning begins instead of showing `Connecting...`.
- Display live reasoning in a fixed-height, scrollable window.
- Follow the latest reasoning content while the user remains at the bottom.
- Pause auto-follow when the user scrolls up and resume when they return to the bottom.
- Allow the entire `Thinking...` status row to collapse and expand the live reasoning window.
- Keep completed historical thought-process behavior unchanged.
- Add Chinese and English translations.
- Add regression coverage for status transitions, scrolling, and collapsing.

## Validation

- Targeted component tests pass.
- Production build passes.
- ESLint reports no new errors.