### PR TITLE
feat(chat): configure attachment size limit

### DIFF
--- a/ui/server/index.js
+++ b/ui/server/index.js
@@ -101,6 +101,7 @@ import {
     getSpreadsheetSheetPreviewPdf,
 } from './services/spreadsheetPreview.js';
 import { startPilotDeckConfigWatcher, stopPilotDeckConfigWatcher } from './services/pilotdeckConfigWatcher.js';
+import { getChatAttachmentLimits, readPilotDeckConfigFile } from './services/pilotdeckConfig.js';
 import { getAlwaysOnDashboardEvents } from './services/always-on-events.js';
 import agentRoutes from './routes/agent.js';
 import updateRoutes from './routes/update.js';
@@ -3008,6 +3009,12 @@ app.post('/api/projects/:projectName/upload-attachments', authenticateToken, asy
     let multerUpload;
     try {
         const multer = (await import('multer')).default;
+        let attachmentLimits = getChatAttachmentLimits();
+        try {
+            attachmentLimits = getChatAttachmentLimits(readPilotDeckConfigFile().config);
+        } catch (error) {
+            console.warn('Failed to read attachment upload limits, using defaults:', error);
+        }
         const uploadRoot = path.join(os.tmpdir(), 'pilotdeck-chat-attachments', String(req.user.id));
         const storage = multer.diskStorage({
             destination: async (_req, _file, cb) => {
@@ -3028,10 +3035,10 @@ app.post('/api/projects/:projectName/upload-attachments', authenticateToken, asy
         multerUpload = multer({
             storage,
             limits: {
-                fileSize: 20 * 1024 * 1024,
-                files: 10,
+                fileSize: attachmentLimits.maxFileSizeBytes,
+                files: attachmentLimits.maxAttachments,
             },
-        }).array('attachments', 10);
+        }).array('attachments', attachmentLimits.maxAttachments);
     } catch (error) {
         console.error('Error configuring attachment upload:', error);
         return res.status(500).json({ error: 'Internal server error' });

--- a/ui/server/routes/settings.js
+++ b/ui/server/routes/settings.js
@@ -6,8 +6,23 @@ import {
   readPermissionSettings,
   writePermissionSettings,
 } from '../services/permissionSettings.js';
+import { getChatAttachmentLimits, readPilotDeckConfigFile } from '../services/pilotdeckConfig.js';
 
 const router = express.Router();
+
+function readAttachmentUploadLimits() {
+  try {
+    return getChatAttachmentLimits(readPilotDeckConfigFile().config);
+  } catch (error) {
+    console.warn('Failed to read attachment upload limits, using defaults:', error);
+    return getChatAttachmentLimits();
+  }
+}
+
+// Shared deployment setting. This intentionally has no user-specific data.
+router.get('/attachment-upload-limits', (_req, res) => {
+  res.json(readAttachmentUploadLimits());
+});
 
 // ===============================
 // Tool Permission Settings

--- a/ui/server/routes/settings.test.js
+++ b/ui/server/routes/settings.test.js
@@ -1,0 +1,73 @@
+import express from 'express';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const nativeFetch = globalThis.fetch;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.resetModules();
+});
+
+describe('attachment upload limits settings route', () => {
+  it('returns the shared configured limit without user-specific data', async () => {
+    const { request } = await createSettingsApp({
+      maxFileSizeMB: 100,
+      maxFileSizeBytes: 100 * 1024 * 1024,
+      maxAttachments: 10,
+    });
+
+    const response = await request('/api/settings/attachment-upload-limits');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      maxFileSizeMB: 100,
+      maxFileSizeBytes: 100 * 1024 * 1024,
+      maxAttachments: 10,
+    });
+  });
+});
+
+async function createSettingsApp(limits) {
+  vi.doMock('../database/db.js', () => ({
+    apiKeysDb: {},
+    credentialsDb: {},
+    notificationPreferencesDb: {},
+    pushSubscriptionsDb: {},
+  }));
+  vi.doMock('../services/vapid-keys.js', () => ({ getPublicKey: vi.fn() }));
+  vi.doMock('../services/notification-orchestrator.js', () => ({
+    createNotificationEvent: vi.fn(),
+    notifyUserIfEnabled: vi.fn(),
+  }));
+  vi.doMock('../services/permissionSettings.js', () => ({
+    readPermissionSettings: vi.fn(),
+    writePermissionSettings: vi.fn(),
+  }));
+  vi.doMock('../services/pilotdeckConfig.js', () => ({
+    readPilotDeckConfigFile: vi.fn(() => ({ config: {} })),
+    getChatAttachmentLimits: vi.fn(() => limits),
+  }));
+
+  const { default: settingsRoutes } = await import('./settings.js');
+  const app = express();
+  app.use(express.json());
+  app.use('/api/settings', settingsRoutes);
+
+  return {
+    request: (path, init = {}) => requestStatusJson(app, path, init),
+  };
+}
+
+async function requestStatusJson(app, path, init) {
+  const server = app.listen(0);
+  try {
+    const { port } = server.address();
+    const response = await nativeFetch(`http://127.0.0.1:${port}${path}`, init);
+    return {
+      status: response.status,
+      body: await response.json(),
+    };
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+}

--- a/ui/server/services/pilotdeckConfig.js
+++ b/ui/server/services/pilotdeckConfig.js
@@ -28,6 +28,10 @@ const CONFIG_VERSION = 1;
 const PILOT_HOME_DIR = process.env.PILOT_HOME || path.join(os.homedir(), '.pilotdeck');
 const DEFAULT_CONFIG_PATH = path.join(PILOT_HOME_DIR, 'pilotdeck.yaml');
 const MASK = '********';
+export const DEFAULT_CHAT_ATTACHMENT_MAX_FILE_SIZE_MB = 20;
+export const MAX_CHAT_ATTACHMENTS = 10;
+const BYTES_PER_MEGABYTE = 1024 * 1024;
+const MAX_SAFE_CHAT_ATTACHMENT_SIZE_MB = Math.floor(Number.MAX_SAFE_INTEGER / BYTES_PER_MEGABYTE);
 
 const SECRET_KEY_RE = /(api[_-]?key|token|secret|password|auth[_-]?token|access[_-]?token|bot[_-]?token|app[_-]?token|encoding[_-]?aes[_-]?key)$/i;
 const SECRET_EXACT_KEYS = new Set(['key', 'apiKey', 'api_key', 'authToken', 'accessToken']);
@@ -42,6 +46,25 @@ function isRecord(value) {
 
 function normalizeString(value) {
   return typeof value === 'string' ? value.trim() : '';
+}
+
+function isValidChatAttachmentSizeMB(value) {
+  return Number.isSafeInteger(value)
+    && value > 0
+    && value <= MAX_SAFE_CHAT_ATTACHMENT_SIZE_MB;
+}
+
+export function getChatAttachmentLimits(config) {
+  const configuredSizeMB = config?.webui?.attachments?.maxFileSizeMB;
+  const maxFileSizeMB = isValidChatAttachmentSizeMB(configuredSizeMB)
+    ? configuredSizeMB
+    : DEFAULT_CHAT_ATTACHMENT_MAX_FILE_SIZE_MB;
+
+  return {
+    maxFileSizeMB,
+    maxFileSizeBytes: maxFileSizeMB * BYTES_PER_MEGABYTE,
+    maxAttachments: MAX_CHAT_ATTACHMENTS,
+  };
 }
 
 function deepMerge(base, override) {
@@ -94,6 +117,9 @@ export function buildDefaultPilotDeckConfig() {
       officePreview: {
         service: 'builtin',
         binaryPath: '',
+      },
+      attachments: {
+        maxFileSizeMB: DEFAULT_CHAT_ATTACHMENT_MAX_FILE_SIZE_MB,
       },
     },
     telemetry: {
@@ -288,6 +314,15 @@ function validateToolsConfig(config, errors, warnings) {
   }
 }
 
+function validateChatAttachmentConfig(config, errors) {
+  const maxFileSizeMB = config.webui?.attachments?.maxFileSizeMB;
+  if (!isValidChatAttachmentSizeMB(maxFileSizeMB)) {
+    errors.push(
+      'webui.attachments.maxFileSizeMB must be a positive safe integer that can be converted to bytes.',
+    );
+  }
+}
+
 export function validatePilotDeckConfig(config) {
   const normalized = normalizePilotDeckConfig(config);
   const errors = [];
@@ -318,6 +353,7 @@ export function validatePilotDeckConfig(config) {
   validateRouterModelRefs(normalized, errors);
   validateGatewayConfig(normalized, errors, warnings);
   validateToolsConfig(normalized, errors, warnings);
+  validateChatAttachmentConfig(normalized, errors);
 
   if (normalized.webui?.runtime?.contextWindow !== undefined) {
     warnings.push(

--- a/ui/server/services/pilotdeckConfig.test.js
+++ b/ui/server/services/pilotdeckConfig.test.js
@@ -4,6 +4,8 @@ import { join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 import {
     buildDefaultPilotDeckConfig,
+    DEFAULT_CHAT_ATTACHMENT_MAX_FILE_SIZE_MB,
+    getChatAttachmentLimits,
     readPilotDeckConfigFile,
     sanitizeProviderCredentials,
     validatePilotDeckConfig,
@@ -34,6 +36,16 @@ describe('readPilotDeckConfigFile fallback behavior', () => {
         expect(buildDefaultPilotDeckConfig().webui.officePreview).toEqual({
             service: 'builtin',
             binaryPath: '',
+        });
+    });
+
+    it('uses a 20MB chat attachment limit by default', () => {
+        const limits = getChatAttachmentLimits(buildDefaultPilotDeckConfig());
+
+        expect(limits).toEqual({
+            maxFileSizeMB: DEFAULT_CHAT_ATTACHMENT_MAX_FILE_SIZE_MB,
+            maxFileSizeBytes: 20 * 1024 * 1024,
+            maxAttachments: 10,
         });
     });
 
@@ -75,6 +87,32 @@ describe('readPilotDeckConfigFile fallback behavior', () => {
         expect(record.parseError).toEqual(expect.any(String));
         expect(record.config.schemaVersion).toBe(1);
         expect(record.config.model.providers).toEqual({});
+    });
+});
+
+describe('chat attachment upload configuration', () => {
+    it('uses a configured positive size limit', () => {
+        expect(getChatAttachmentLimits({
+            webui: { attachments: { maxFileSizeMB: 100 } },
+        })).toMatchObject({
+            maxFileSizeMB: 100,
+            maxFileSizeBytes: 100 * 1024 * 1024,
+            maxAttachments: 10,
+        });
+    });
+
+    it('rejects invalid sizes and falls back to 20MB when read defensively', () => {
+        const validation = validatePilotDeckConfig({
+            webui: { attachments: { maxFileSizeMB: 0 } },
+        });
+
+        expect(validation.valid).toBe(false);
+        expect(validation.errors).toContain(
+            'webui.attachments.maxFileSizeMB must be a positive safe integer that can be converted to bytes.',
+        );
+        expect(getChatAttachmentLimits({
+            webui: { attachments: { maxFileSizeMB: 0 } },
+        }).maxFileSizeMB).toBe(20);
     });
 });
 

--- a/ui/src/components/chat-v2/ComposerV2.tsx
+++ b/ui/src/components/chat-v2/ComposerV2.tsx
@@ -368,10 +368,13 @@ export default function ComposerV2({
 
   const hasDraftContent = input.trim().length > 0 || attachedImages.length > 0 || documentReferences.length > 0;
   const hasUploadingImages = uploadingImages.size > 0;
+  const hasInvalidAttachments = attachedImages.some((file) => imageErrors.has(file.name));
   const attachmentLimitError = imageErrors.get(MAX_ATTACHMENTS_ERROR_KEY);
-  const disabled = !hasDraftContent || isSubmitPending || hasUploadingImages;
+  const disabled = !hasDraftContent || isSubmitPending || hasUploadingImages || hasInvalidAttachments;
   const showAbortButton = isLoading && canAbortSession && !hasDraftContent;
-  const sendTitle = isSubmitPending || hasUploadingImages
+  const sendTitle = hasInvalidAttachments
+    ? (t('input.removeInvalidAttachments', { defaultValue: 'Remove attachments that exceed the configured size limit' }) as string)
+    : isSubmitPending || hasUploadingImages
     ? (t('input.sending', { defaultValue: 'Sending...' }) as string)
     : isBusySendConfirmed
       ? (t('input.queuedSendConfirmed', { defaultValue: 'Stopping current turn — sending next message' }) as string)

--- a/ui/src/components/chat/hooks/useChatComposerState.ts
+++ b/ui/src/components/chat/hooks/useChatComposerState.ts
@@ -17,6 +17,14 @@ import { grantPilotDeckToolPermission } from '../utils/chatPermissions';
 import { getDraftInputStorageKey, safeLocalStorage } from '../utils/chatStorage';
 import { buildAttachmentPathNote } from '../utils/attachmentNotes';
 import {
+  ATTACHMENT_UPLOAD_LIMITS_CHANGED_EVENT,
+  attachmentSizeLimitError,
+  DEFAULT_ATTACHMENT_UPLOAD_LIMITS,
+  isAttachmentWithinSizeLimit,
+  normalizeAttachmentUploadLimits,
+  type AttachmentUploadLimits,
+} from '../utils/attachmentUploadLimits';
+import {
   createTemporarySessionId,
   getNotificationSessionSummary,
   isTemporarySessionId,
@@ -118,7 +126,6 @@ const createFakeSubmitEvent = () => {
   return { preventDefault: () => undefined } as unknown as FormEvent<HTMLFormElement>;
 };
 
-const MAX_ATTACHMENT_SIZE_BYTES = 20 * 1024 * 1024;
 const MAX_ATTACHMENTS = 10;
 export const MAX_ATTACHMENTS_ERROR_KEY = '__max_attachments__';
 
@@ -217,6 +224,9 @@ export function useChatComposerState({
   const [documentReferences, setDocumentReferences] = useState<ContentReference[]>([]);
   const [uploadingImages, setUploadingImages] = useState<Map<string, number>>(new Map());
   const [imageErrors, setImageErrors] = useState<Map<string, string>>(new Map());
+  const [attachmentUploadLimits, setAttachmentUploadLimits] = useState<AttachmentUploadLimits>(
+    DEFAULT_ATTACHMENT_UPLOAD_LIMITS,
+  );
   const [isTextareaExpanded, setIsTextareaExpanded] = useState(false);
   const [isBusySendQueued, setIsBusySendQueued] = useState(false);
   const [isBusySendConfirmed, setIsBusySendConfirmed] = useState(false);
@@ -254,6 +264,61 @@ export function useChatComposerState({
       ...(updates.forceStart ? { forceStart: true } : {}),
     };
   }, [attachedImages, documentReferences]);
+
+  useEffect(() => {
+    let active = true;
+
+    const loadAttachmentUploadLimits = async () => {
+      try {
+        const response = await authenticatedFetch('/api/settings/attachment-upload-limits');
+        if (!response.ok) {
+          throw new Error(`Failed to load attachment upload limits (${response.status})`);
+        }
+        const limits = normalizeAttachmentUploadLimits(await response.json());
+        if (active) {
+          setAttachmentUploadLimits(limits);
+        }
+      } catch (error) {
+        console.warn('Failed to load attachment upload limits, using defaults:', error);
+        if (active) {
+          setAttachmentUploadLimits(DEFAULT_ATTACHMENT_UPLOAD_LIMITS);
+        }
+      }
+    };
+
+    const handleLimitsChanged = (event: Event) => {
+      const detail = (event as CustomEvent<unknown>).detail;
+      setAttachmentUploadLimits(normalizeAttachmentUploadLimits(detail));
+    };
+
+    void loadAttachmentUploadLimits();
+    window.addEventListener(ATTACHMENT_UPLOAD_LIMITS_CHANGED_EVENT, handleLimitsChanged);
+    return () => {
+      active = false;
+      window.removeEventListener(ATTACHMENT_UPLOAD_LIMITS_CHANGED_EVENT, handleLimitsChanged);
+    };
+  }, []);
+
+  useEffect(() => {
+    setImageErrors((previous) => {
+      const next = new Map(previous);
+      let changed = false;
+
+      for (const file of attachedImages) {
+        const error = isAttachmentWithinSizeLimit(file, attachmentUploadLimits)
+          ? undefined
+          : attachmentSizeLimitError(attachmentUploadLimits.maxFileSizeMB);
+        if (error && next.get(file.name) !== error) {
+          next.set(file.name, error);
+          changed = true;
+        } else if (!error && next.delete(file.name)) {
+          changed = true;
+        }
+      }
+
+      return changed ? next : previous;
+    });
+  }, [attachedImages, attachmentUploadLimits]);
 
   useEffect(() => {
     const handleAddDocumentReference = (event: Event) => {
@@ -696,23 +761,12 @@ export function useChatComposerState({
   }, []);
 
   const handleImageFiles = useCallback((files: File[]) => {
-    const validFiles = files.filter((file) => {
+    const attachmentFiles = files.filter((file) => {
       try {
         if (!file || typeof file !== 'object') {
           console.warn('Invalid file object:', file);
           return false;
         }
-
-        if (typeof file.size !== 'number' || file.size > MAX_ATTACHMENT_SIZE_BYTES) {
-          const fileName = file.name || 'Unknown file';
-          setImageErrors((previous) => {
-            const next = new Map(previous);
-            next.set(fileName, 'File too large (max 20MB)');
-            return next;
-          });
-          return false;
-        }
-
         return true;
       } catch (error) {
         console.error('Error validating file:', error, file);
@@ -727,9 +781,20 @@ export function useChatComposerState({
       return next;
     });
 
-    if (validFiles.length > 0) {
+    if (attachmentFiles.length > 0) {
+      setImageErrors((previous) => {
+        const next = new Map(previous);
+        attachmentFiles.forEach((file) => {
+          if (isAttachmentWithinSizeLimit(file, attachmentUploadLimits)) {
+            next.delete(file.name);
+          } else {
+            next.set(file.name, attachmentSizeLimitError(attachmentUploadLimits.maxFileSizeMB));
+          }
+        });
+        return next;
+      });
       setAttachedImages((previous) => {
-        const result = addAttachmentFiles(previous, validFiles);
+        const result = addAttachmentFiles(previous, attachmentFiles);
         if (result.droppedCount > 0) {
           setImageErrors((previousErrors) => {
             const next = new Map(previousErrors);
@@ -741,7 +806,7 @@ export function useChatComposerState({
         return result.files;
       });
     }
-  }, []);
+  }, [attachmentUploadLimits, syncQueuedBusySendSnapshot]);
 
   const handlePaste = useCallback(
     (event: ClipboardEvent<HTMLTextAreaElement>) => {
@@ -775,7 +840,6 @@ export function useChatComposerState({
   );
 
   const { getRootProps, getInputProps, isDragActive, open } = useDropzone({
-    maxSize: MAX_ATTACHMENT_SIZE_BYTES,
     multiple: true,
     onDrop: handleImageFiles,
     noClick: true,
@@ -794,6 +858,20 @@ export function useChatComposerState({
       const hasDocumentReferences = submitDocumentReferences.length > 0;
       const hasAttachments = submitAttachedImages.length > 0 || hasDocumentReferences;
       if ((!currentInput.trim() && !hasAttachments) || !selectedProject) {
+        return;
+      }
+
+      const oversizedAttachments = submitAttachedImages.filter(
+        (file) => !isAttachmentWithinSizeLimit(file, attachmentUploadLimits),
+      );
+      if (oversizedAttachments.length > 0) {
+        setImageErrors((previous) => {
+          const next = new Map(previous);
+          oversizedAttachments.forEach((file) => {
+            next.set(file.name, attachmentSizeLimitError(attachmentUploadLimits.maxFileSizeMB));
+          });
+          return next;
+        });
         return;
       }
 
@@ -1067,6 +1145,7 @@ export function useChatComposerState({
       runMode,
       permissionMode,
       basePermissionMode,
+      attachmentUploadLimits,
       resetCommandMenuState,
       scrollToBottom,
       selectedProject,

--- a/ui/src/components/chat/utils/attachmentUploadLimits.spec.ts
+++ b/ui/src/components/chat/utils/attachmentUploadLimits.spec.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_ATTACHMENT_UPLOAD_LIMITS,
+  isAttachmentWithinSizeLimit,
+  isValidAttachmentSizeMB,
+  normalizeAttachmentUploadLimits,
+} from './attachmentUploadLimits';
+
+describe('attachment upload limits', () => {
+  it('defaults to 20MB and permits a file at the configured boundary', () => {
+    expect(DEFAULT_ATTACHMENT_UPLOAD_LIMITS.maxFileSizeMB).toBe(20);
+    expect(isAttachmentWithinSizeLimit(
+      { size: 20 * 1024 * 1024 },
+      DEFAULT_ATTACHMENT_UPLOAD_LIMITS,
+    )).toBe(true);
+  });
+
+  it('uses a 100MB value returned by the settings API', () => {
+    const limits = normalizeAttachmentUploadLimits({ maxFileSizeMB: 100, maxAttachments: 10 });
+
+    expect(isAttachmentWithinSizeLimit({ size: 100 * 1024 * 1024 }, limits)).toBe(true);
+    expect(isAttachmentWithinSizeLimit({ size: 100 * 1024 * 1024 + 1 }, limits)).toBe(false);
+  });
+
+  it('falls back to 20MB for invalid settings payloads', () => {
+    expect(normalizeAttachmentUploadLimits({ maxFileSizeMB: 0 }).maxFileSizeMB).toBe(20);
+    expect(normalizeAttachmentUploadLimits({ maxFileSizeMB: 1.5 }).maxFileSizeMB).toBe(20);
+    expect(isValidAttachmentSizeMB(Number.MAX_SAFE_INTEGER)).toBe(false);
+  });
+});

--- a/ui/src/components/chat/utils/attachmentUploadLimits.ts
+++ b/ui/src/components/chat/utils/attachmentUploadLimits.ts
@@ -1,0 +1,57 @@
+export const DEFAULT_CHAT_ATTACHMENT_MAX_FILE_SIZE_MB = 20;
+export const DEFAULT_CHAT_MAX_ATTACHMENTS = 10;
+export const ATTACHMENT_UPLOAD_LIMITS_CHANGED_EVENT = 'pilotdeck:attachment-upload-limits-changed';
+
+const BYTES_PER_MEGABYTE = 1024 * 1024;
+const MAX_SAFE_ATTACHMENT_SIZE_MB = Math.floor(Number.MAX_SAFE_INTEGER / BYTES_PER_MEGABYTE);
+
+export type AttachmentUploadLimits = {
+  maxFileSizeMB: number;
+  maxFileSizeBytes: number;
+  maxAttachments: number;
+};
+
+export function isValidAttachmentSizeMB(value: unknown): value is number {
+  return Number.isSafeInteger(value)
+    && value > 0
+    && value <= MAX_SAFE_ATTACHMENT_SIZE_MB;
+}
+
+export function normalizeAttachmentUploadLimits(value: unknown): AttachmentUploadLimits {
+  const source = value && typeof value === 'object' ? value as Record<string, unknown> : {};
+  const maxFileSizeMB = isValidAttachmentSizeMB(source.maxFileSizeMB)
+    ? source.maxFileSizeMB
+    : DEFAULT_CHAT_ATTACHMENT_MAX_FILE_SIZE_MB;
+  const maxAttachments = Number.isSafeInteger(source.maxAttachments) && (source.maxAttachments as number) > 0
+    ? source.maxAttachments as number
+    : DEFAULT_CHAT_MAX_ATTACHMENTS;
+
+  return {
+    maxFileSizeMB,
+    maxFileSizeBytes: maxFileSizeMB * BYTES_PER_MEGABYTE,
+    maxAttachments,
+  };
+}
+
+export const DEFAULT_ATTACHMENT_UPLOAD_LIMITS = normalizeAttachmentUploadLimits({});
+
+export function isAttachmentWithinSizeLimit(
+  file: Pick<File, 'size'>,
+  limits: AttachmentUploadLimits,
+): boolean {
+  return typeof file.size === 'number'
+    && Number.isFinite(file.size)
+    && file.size >= 0
+    && file.size <= limits.maxFileSizeBytes;
+}
+
+export function attachmentSizeLimitError(maxFileSizeMB: number): string {
+  return `File too large (max ${maxFileSizeMB}MB)`;
+}
+
+export function dispatchAttachmentUploadLimitsChanged(limits: AttachmentUploadLimits): void {
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(new CustomEvent(ATTACHMENT_UPLOAD_LIMITS_CHANGED_EVENT, {
+    detail: limits,
+  }));
+}

--- a/ui/src/components/chat/view/subcomponents/ImageAttachment.tsx
+++ b/ui/src/components/chat/view/subcomponents/ImageAttachment.tsx
@@ -77,11 +77,16 @@ const ImageAttachment = ({ file, onRemove, uploadProgress, error }: ImageAttachm
         </div>
       )}
       {error && (
-        <div className="absolute inset-0 flex items-center justify-center bg-red-500/50">
-          <svg className="h-6 w-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-          </svg>
-        </div>
+        <>
+          <div className="absolute inset-x-0 top-0 flex h-20 items-center justify-center bg-red-500/50" title={error}>
+            <svg className="h-6 w-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </div>
+          <div role="alert" className="mt-1 max-w-44 text-xs leading-4 text-red-600 dark:text-red-400">
+            {error}
+          </div>
+        </>
       )}
       <button
         type="button"
@@ -98,5 +103,3 @@ const ImageAttachment = ({ file, onRemove, uploadProgress, error }: ImageAttachm
 };
 
 export default ImageAttachment;
-
-

--- a/ui/src/components/settings/shared/components/Inputs.tsx
+++ b/ui/src/components/settings/shared/components/Inputs.tsx
@@ -232,28 +232,42 @@ export function NumberInput({
   value,
   onChange,
   placeholder,
+  min,
+  step,
+  allowEmpty = true,
+  isValid,
 }: {
   value: number | undefined;
   onChange: (next: number | undefined) => void;
   placeholder?: string;
+  min?: number;
+  step?: number;
+  allowEmpty?: boolean;
+  isValid?: (value: number) => boolean;
 }) {
   const stringValue = value === undefined ? "" : String(value);
   return (
     <EditableInputShell
       value={stringValue}
-      canCommit={(s) => s === "" || Number.isFinite(Number(s))}
+      canCommit={(s) => {
+        if (s === "") return allowEmpty;
+        const n = Number(s);
+        return Number.isFinite(n) && (!isValid || isValid(n));
+      }}
       onCommit={(s) => {
         if (s === "") {
-          onChange(undefined);
+          if (allowEmpty) onChange(undefined);
           return;
         }
         const n = Number(s);
-        if (Number.isFinite(n)) onChange(n);
+        if (Number.isFinite(n) && (!isValid || isValid(n))) onChange(n);
       }}
     >
       {({ editing, draft, setDraft, onEditKeyDown }) => (
         <input
           type="number"
+          min={min}
+          step={step}
           value={draft}
           onChange={(e) => setDraft(e.target.value)}
           onKeyDown={onEditKeyDown}

--- a/ui/src/components/settings/view/general/ChatInputSection.tsx
+++ b/ui/src/components/settings/view/general/ChatInputSection.tsx
@@ -1,16 +1,51 @@
+import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { useUiPreferences } from "../../../../hooks/useUiPreferences";
+import { usePilotDeckConfig } from "../../../../hooks/usePilotDeckConfig";
 import {
+  DEFAULT_ATTACHMENT_UPLOAD_LIMITS,
+  dispatchAttachmentUploadLimitsChanged,
+  isValidAttachmentSizeMB,
+  normalizeAttachmentUploadLimits,
+} from "../../../chat/utils/attachmentUploadLimits";
+import {
+  ConfigSaveError,
   PageSectionHeader,
   SettingsCard,
   SettingsRow,
   SettingsSection,
   SettingsToggle,
 } from "../../shared/view";
+import { NumberInput } from "../../shared/components/Inputs";
+import type { PilotDeckConfig } from "../modelPool/types";
+import { configToYamlString, safeParseYaml } from "../modelPool/utils/configYaml";
+import { patch } from "../modelPool/utils/patch";
 
 export default function ChatInputSection() {
   const { t } = useTranslation("settings");
   const { preferences, setPreference } = useUiPreferences();
+  const { raw, setRaw, save, loading, error } = usePilotDeckConfig();
+  const config = useMemo(() => safeParseYaml(raw), [raw]);
+  const maxFileSizeMB = config?.webui?.attachments?.maxFileSizeMB
+    ?? DEFAULT_ATTACHMENT_UPLOAD_LIMITS.maxFileSizeMB;
+
+  const setAttachmentSizeLimit = (value: number | undefined) => {
+    if (!config || !isValidAttachmentSizeMB(value)) return;
+
+    const nextConfig = patch<PilotDeckConfig>(
+      config,
+      ["webui", "attachments", "maxFileSizeMB"],
+      value,
+    );
+    setRaw(configToYamlString(nextConfig));
+    void save().then((result) => {
+      if (result.ok) {
+        dispatchAttachmentUploadLimitsChanged(normalizeAttachmentUploadLimits({
+          maxFileSizeMB: value,
+        }));
+      }
+    });
+  };
 
   return (
     <section className="space-y-2.5">
@@ -76,6 +111,37 @@ export default function ChatInputSection() {
               />
             </SettingsRow>
           </SettingsCard>
+        </SettingsSection>
+
+        <SettingsSection title={t("quickSettings.sections.attachmentUpload")}>
+          <ConfigSaveError error={error} />
+          <SettingsCard>
+            <SettingsRow
+              label={t("quickSettings.attachmentMaxFileSize")}
+              description={t("quickSettings.attachmentMaxFileSizeDescription")}
+            >
+              {config ? (
+                <NumberInput
+                  value={maxFileSizeMB}
+                  placeholder="20"
+                  min={1}
+                  step={1}
+                  allowEmpty={false}
+                  isValid={isValidAttachmentSizeMB}
+                  onChange={setAttachmentSizeLimit}
+                />
+              ) : (
+                <span className="text-xs text-muted-foreground">—</span>
+              )}
+            </SettingsRow>
+          </SettingsCard>
+          {loading || !config ? (
+            <div className="text-xs text-muted-foreground">
+              {loading
+                ? t("pilotDeckConfig.loading")
+                : t("quickSettings.attachmentConfigUnavailable")}
+            </div>
+          ) : null}
         </SettingsSection>
       </div>
     </section>

--- a/ui/src/components/settings/view/modelPool/types/index.ts
+++ b/ui/src/components/settings/view/modelPool/types/index.ts
@@ -120,6 +120,9 @@ export type PilotDeckConfig = {
       service?: "builtin" | "libreoffice" | string;
       binaryPath?: string;
     };
+    attachments?: {
+      maxFileSizeMB?: number;
+    };
   };
   customEnv?: Record<string, string>;
   router?: {

--- a/ui/src/i18n/locales/en/settings.json
+++ b/ui/src/i18n/locales/en/settings.json
@@ -136,7 +136,8 @@
       "appearance": "Appearance",
       "toolDisplay": "Tool Display",
       "viewOptions": "View Options",
-      "inputSettings": "Input Settings"
+      "inputSettings": "Input Settings",
+      "attachmentUpload": "Attachment Upload"
     },
     "darkMode": "Dark Mode",
     "autoExpandTools": "Auto-expand tools",
@@ -146,6 +147,9 @@
     "autoScrollToBottom": "Auto-scroll to bottom",
     "sendByCtrlEnter": "Send by Ctrl+Enter",
     "sendByCtrlEnterDescription": "When enabled, pressing Ctrl+Enter will send the message instead of just Enter. This is useful for IME users to avoid accidental sends.",
+    "attachmentMaxFileSize": "Maximum size per attachment (MB)",
+    "attachmentMaxFileSizeDescription": "Applies to the whole deployment. All chat attachments are validated against this size after it is saved.",
+    "attachmentConfigUnavailable": "The configuration file is invalid, so the attachment size limit cannot be changed right now.",
     "dragHandle": {
       "dragging": "Dragging handle",
       "closePanel": "Close settings panel",

--- a/ui/src/i18n/locales/zh-CN/settings.json
+++ b/ui/src/i18n/locales/zh-CN/settings.json
@@ -136,7 +136,8 @@
       "appearance": "外观",
       "toolDisplay": "工具显示",
       "viewOptions": "视图选项",
-      "inputSettings": "输入设置"
+      "inputSettings": "输入设置",
+      "attachmentUpload": "附件上传"
     },
     "darkMode": "深色模式",
     "autoExpandTools": "自动展开工具",
@@ -146,6 +147,9 @@
     "autoScrollToBottom": "自动滚动到底部",
     "sendByCtrlEnter": "使用 Ctrl+Enter 发送",
     "sendByCtrlEnterDescription": "启用后，按 Ctrl+Enter 发送消息，而不是仅按 Enter。这对于使用输入法的用户可以避免意外发送。",
+    "attachmentMaxFileSize": "单个附件最大大小（MB）",
+    "attachmentMaxFileSizeDescription": "全局生效。修改后，所有聊天附件都会按此大小校验。",
+    "attachmentConfigUnavailable": "配置文件无效，暂时无法修改附件大小限制。",
     "dragHandle": {
       "dragging": "正在拖拽手柄",
       "closePanel": "关闭设置面板",


### PR DESCRIPTION
## Summary
- Add a configurable maximum attachment size in Settings → General → Chat & Input.
- Default to 20MB when the configuration is absent or invalid.
- Validate the limit in both the chat frontend and upload API.
- Keep the existing 10-file limit unchanged.

## Verification
- Attachment-limit unit tests passed.
- ESLint passed with no errors.
- Frontend build passed.
- Tested on the campus-agent test environment.