### PR TITLE
fix: preserve user language in session titles

### DIFF
--- a/src/session/title/SessionTitleGenerator.ts
+++ b/src/session/title/SessionTitleGenerator.ts
@@ -5,15 +5,17 @@ export const SESSION_TITLE_MAX_INPUT_CHARS = 1200;
 export const SESSION_TITLE_MAX_OUTPUT_CHARS = 80;
 export const SESSION_TITLE_TIMEOUT_MS = 30_000;
 
-const SESSION_TITLE_SYSTEM_PROMPT = `Generate a concise, sentence-case title (3-7 words) that captures the main topic or goal of this coding session. The title should be clear enough that the user recognizes the session in a list. Use sentence case: capitalize only the first word and proper nouns.
+const SESSION_TITLE_SYSTEM_PROMPT = `Generate a concise title (3-7 words) that captures the main topic or goal of this coding session. The title should be clear enough that the user recognizes the session in a list. For Latin-script languages, use sentence case: capitalize only the first word and proper nouns.
+
+Language requirement (highest priority): write the title in the same natural language as the user's input. Do not translate the user's input into English. If the input contains multiple languages, use the language of the user's main request (or the most recent natural-language request), while leaving product names and code identifiers unchanged. If the user's language cannot be determined, write the title in the system language specified below.
 
 Return JSON with a single "title" field.
 
-Good examples:
+Examples (the title language must still follow the user's input):
 {"title": "Fix login button on mobile"}
 {"title": "Add OAuth authentication"}
-{"title": "Debug failing CI tests"}
-{"title": "Refactor API client error handling"}
+{"title": "修复移动端登录按钮"}
+{"title": "添加 OAuth 认证"}
 
 Bad (too vague): {"title": "Code changes"}
 Bad (too long): {"title": "Investigate and fix the issue where the login button does not respond on mobile devices"}
@@ -34,12 +36,15 @@ export type CreateSessionTitleGeneratorOptions = {
   modelRuntime: Pick<ModelRuntime, "complete">;
   agentModel: PilotAgentModelSelection;
   timeoutMs?: number;
+  /** Locale used when the user's input language cannot be determined. */
+  systemLanguage?: string;
 };
 
 export function createSessionTitleGenerator(
   options: CreateSessionTitleGeneratorOptions,
 ): SessionTitleGenerator {
   const timeoutMs = options.timeoutMs ?? SESSION_TITLE_TIMEOUT_MS;
+  const systemLanguage = options.systemLanguage ?? resolveSystemLanguage();
   return async ({ text, sessionId, turnId, signal }) => {
     const prompt = normalizeSessionTitleInput(text);
     if (!prompt) {
@@ -54,7 +59,7 @@ export function createSessionTitleGenerator(
         {
           provider: options.agentModel.provider,
           model: options.agentModel.model,
-          systemPrompt: SESSION_TITLE_SYSTEM_PROMPT,
+          systemPrompt: `${SESSION_TITLE_SYSTEM_PROMPT}\n\nSystem language: ${systemLanguage}`,
           messages: [
             {
               role: "user",
@@ -78,6 +83,33 @@ export function createSessionTitleGenerator(
       return null;
     }
   };
+}
+
+/** Resolve the host locale for the rare case where an input has no detectable language. */
+export function resolveSystemLanguage(): string {
+  const environmentLocale = process.env.LC_ALL ?? process.env.LC_MESSAGES ?? process.env.LANG;
+  for (const candidate of [environmentLocale, Intl.DateTimeFormat().resolvedOptions().locale]) {
+    const normalized = normalizeLocale(candidate);
+    if (normalized) {
+      return normalized;
+    }
+  }
+  return "en";
+}
+
+function normalizeLocale(value: string | undefined): string | null {
+  if (!value) {
+    return null;
+  }
+  const locale = value.split(/[.@]/, 1)[0]?.replace(/_/g, "-");
+  if (!locale || /^(?:c|posix)$/i.test(locale)) {
+    return null;
+  }
+  try {
+    return Intl.getCanonicalLocales(locale)[0] ?? null;
+  } catch {
+    return null;
+  }
 }
 
 export function normalizeSessionTitleInput(text: string): string | null {

--- a/src/session/title/SessionTitleGenerator.ts
+++ b/src/session/title/SessionTitleGenerator.ts
@@ -5,6 +5,8 @@ export const SESSION_TITLE_MAX_INPUT_CHARS = 1200;
 export const SESSION_TITLE_MAX_OUTPUT_CHARS = 80;
 export const SESSION_TITLE_TIMEOUT_MS = 30_000;
 
+const SESSION_TITLE_TRUNCATION_MARKER = " ... ";
+
 const SESSION_TITLE_SYSTEM_PROMPT = `Generate a concise title (3-7 words) that captures the main topic or goal of this coding session. The title should be clear enough that the user recognizes the session in a list. For Latin-script languages, use sentence case: capitalize only the first word and proper nouns.
 
 Language requirement (highest priority): write the title in the same natural language as the user's input. Do not translate the user's input into English. If the input contains multiple languages, use the language of the user's main request (or the most recent natural-language request), while leaving product names and code identifiers unchanged. If the user's language cannot be determined, write the title in the system language specified below.
@@ -86,9 +88,13 @@ export function createSessionTitleGenerator(
 }
 
 /** Resolve the host locale for the rare case where an input has no detectable language. */
-export function resolveSystemLanguage(): string {
-  const environmentLocale = process.env.LC_ALL ?? process.env.LC_MESSAGES ?? process.env.LANG;
-  for (const candidate of [environmentLocale, Intl.DateTimeFormat().resolvedOptions().locale]) {
+export function resolveSystemLanguage(env: Record<string, string | undefined> = process.env): string {
+  for (const candidate of [
+    env.LC_ALL,
+    env.LC_MESSAGES,
+    env.LANG,
+    Intl.DateTimeFormat().resolvedOptions().locale,
+  ]) {
     const normalized = normalizeLocale(candidate);
     if (normalized) {
       return normalized;
@@ -102,7 +108,7 @@ function normalizeLocale(value: string | undefined): string | null {
     return null;
   }
   const locale = value.split(/[.@]/, 1)[0]?.replace(/_/g, "-");
-  if (!locale || /^(?:c|posix)$/i.test(locale)) {
+  if (!locale || /^(?:c|posix|und)$/i.test(locale)) {
     return null;
   }
   try {
@@ -117,9 +123,14 @@ export function normalizeSessionTitleInput(text: string): string | null {
   if (!normalized) {
     return null;
   }
-  return normalized.length > SESSION_TITLE_MAX_INPUT_CHARS
-    ? normalized.slice(0, SESSION_TITLE_MAX_INPUT_CHARS)
-    : normalized;
+  if (normalized.length <= SESSION_TITLE_MAX_INPUT_CHARS) {
+    return normalized;
+  }
+
+  const availableChars = SESSION_TITLE_MAX_INPUT_CHARS - SESSION_TITLE_TRUNCATION_MARKER.length;
+  const headChars = Math.floor(availableChars / 2);
+  const tailChars = availableChars - headChars;
+  return `${normalized.slice(0, headChars)}${SESSION_TITLE_TRUNCATION_MARKER}${normalized.slice(-tailChars)}`;
 }
 
 function parseGeneratedTitle(content: Awaited<ReturnType<ModelRuntime["complete"]>>["content"]): string | null {

--- a/tests/session/title-generator.spec.ts
+++ b/tests/session/title-generator.spec.ts
@@ -2,7 +2,12 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import type { CanonicalModelResponse, CanonicalModelRequest } from "../../src/model/index.js";
-import { createSessionTitleGenerator } from "../../src/session/title/SessionTitleGenerator.js";
+import {
+  createSessionTitleGenerator,
+  normalizeSessionTitleInput,
+  resolveSystemLanguage,
+  SESSION_TITLE_MAX_INPUT_CHARS,
+} from "../../src/session/title/SessionTitleGenerator.js";
 
 test("session title generator asks the model to preserve the user's language", async () => {
   let request: CanonicalModelRequest | undefined;
@@ -51,6 +56,28 @@ test("session title generator includes the system language for undetectable inpu
   });
 
   assert.match(request?.systemPrompt ?? "", /System language: zh-CN/);
+});
+
+test("session title input truncation preserves the latest request", () => {
+  const latestRequest = "请修复最后出现的登录错误";
+  const input = `${"Earlier English logs ".repeat(100)} ${latestRequest}`;
+  const normalized = normalizeSessionTitleInput(input);
+
+  assert.ok(normalized);
+  assert.equal(normalized.length, SESSION_TITLE_MAX_INPUT_CHARS);
+  assert.match(normalized, /Earlier English logs/);
+  assert.match(normalized, new RegExp(`${latestRequest}$`));
+});
+
+test("system language checks every locale candidate and rejects und", () => {
+  assert.equal(
+    resolveSystemLanguage({ LC_ALL: "", LC_MESSAGES: "", LANG: "zh_CN.UTF-8" }),
+    "zh-CN",
+  );
+  assert.equal(
+    resolveSystemLanguage({ LC_ALL: "und", LC_MESSAGES: "", LANG: "zh_CN.UTF-8" }),
+    "zh-CN",
+  );
 });
 
 function textResponse(text: string): CanonicalModelResponse {

--- a/tests/session/title-generator.spec.ts
+++ b/tests/session/title-generator.spec.ts
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { CanonicalModelResponse, CanonicalModelRequest } from "../../src/model/index.js";
+import { createSessionTitleGenerator } from "../../src/session/title/SessionTitleGenerator.js";
+
+test("session title generator asks the model to preserve the user's language", async () => {
+  let request: CanonicalModelRequest | undefined;
+  const generator = createSessionTitleGenerator({
+    agentModel: { id: "main", provider: "openai", model: "gpt-main" },
+    modelRuntime: {
+      async complete(input) {
+        request = input;
+        return textResponse(JSON.stringify({ title: "修复登录流程" }));
+      },
+    },
+    systemLanguage: "en-US",
+  });
+
+  const title = await generator({
+    text: "请修复登录流程。",
+    sessionId: "s1",
+    turnId: "t1",
+    signal: new AbortController().signal,
+  });
+
+  assert.equal(title, "修复登录流程");
+  assert.match(request?.systemPrompt ?? "", /same natural language as the user's input/);
+  assert.match(request?.systemPrompt ?? "", /Do not translate.*English/);
+  assert.match(request?.systemPrompt ?? "", /System language: en-US/);
+});
+
+test("session title generator includes the system language for undetectable input", async () => {
+  let request: CanonicalModelRequest | undefined;
+  const generator = createSessionTitleGenerator({
+    agentModel: { id: "main", provider: "openai", model: "gpt-main" },
+    modelRuntime: {
+      async complete(input) {
+        request = input;
+        return textResponse(JSON.stringify({ title: "Fix login flow" }));
+      },
+    },
+    systemLanguage: "zh-CN",
+  });
+
+  await generator({
+    text: "12345",
+    sessionId: "s1",
+    turnId: "t1",
+    signal: new AbortController().signal,
+  });
+
+  assert.match(request?.systemPrompt ?? "", /System language: zh-CN/);
+});
+
+function textResponse(text: string): CanonicalModelResponse {
+  return { content: [{ type: "text", text }] } as CanonicalModelResponse;
+}


### PR DESCRIPTION
## Summary

- keep automatically generated session titles in the user's input language
- handle mixed-language input by prioritizing the main or most recent natural-language request
- fall back to the host system locale when the input language is not determinable
- add focused coverage for language-preserving and system-language fallback instructions

## Validation

- `pnpm exec tsc -p tsconfig.json --noEmit`
- `pnpm exec tsx --test tests/session/title-generator.spec.ts`
- real model validation with `provider1/deepseek-v4-flash-0731`:
  - Chinese input produced `修复自动生成标题偏向英文`
  - English input produced `Fix session title language behavior`
