### PR TITLE
Show total context window in usage status

### DIFF
--- a/ui/src/components/chat-v2/ComposerV2.tsx
+++ b/ui/src/components/chat-v2/ComposerV2.tsx
@@ -244,8 +244,9 @@ export function getContextStatus(tokenBudget?: Record<string, unknown> | null): 
   const used = readNumber(tokenBudget?.used) ?? readNumber(tokenBudget?.displayUsed) ?? 0;
   const total = readNumber(tokenBudget?.total) ?? 0;
   const effectiveTotal = readNumber(tokenBudget?.effectiveTotal);
-  const displayTotal = effectiveTotal && effectiveTotal > 0 ? effectiveTotal : total;
-  if (displayTotal <= 0) {
+  const budgetTotal = effectiveTotal && effectiveTotal > 0 ? effectiveTotal : total;
+  const visibleTotal = total > 0 ? total : budgetTotal;
+  if (budgetTotal <= 0) {
     return {
       known: false,
       used: 0,
@@ -260,8 +261,9 @@ export function getContextStatus(tokenBudget?: Record<string, unknown> | null): 
     };
   }
 
-  // The visible count and percent must describe the resolved request budget.
-  const percent = Math.max(0, Math.round((used / displayTotal) * 100));
+  // Policy severity still follows the effective request budget, while the
+  // visible denominator shows the full model context window when available.
+  const percent = Math.max(0, Math.round((used / budgetTotal) * 100));
   const snapshotState = typeof tokenBudget?.state === 'string' ? tokenBudget.state : null;
   const tone = snapshotState === 'blocking'
     ? 'red'
@@ -276,11 +278,11 @@ export function getContextStatus(tokenBudget?: Record<string, unknown> | null): 
     known: true,
     used,
     total,
-    displayTotal,
+    displayTotal: visibleTotal,
     percent,
     percentLabel: formatContextPercentLabel(percent),
     usedLabel: formatTokenCount(used),
-    totalLabel: formatTokenCount(displayTotal),
+    totalLabel: formatTokenCount(visibleTotal),
     state: snapshotState === 'blocking' || snapshotState === 'warning' ? snapshotState : 'ok',
     tone,
   };

--- a/ui/src/components/chat-v2/MessagesPaneV2.render.test.tsx
+++ b/ui/src/components/chat-v2/MessagesPaneV2.render.test.tsx
@@ -60,6 +60,21 @@ describe('getContextStatus', () => {
     expect(status.used).toBe(12_080);
     expect(status.percentLabel).toBe('100%+');
   });
+
+  it('shows the full context window while calculating percent against the effective budget', () => {
+    const status = getContextStatus({
+      used: 38_161,
+      total: 131_072,
+      effectiveTotal: 98_304,
+      reservedOutputTokens: 32_768,
+      state: 'ok',
+    });
+
+    expect(status.displayTotal).toBe(131_072);
+    expect(status.totalLabel).toBe('131k');
+    expect(status.percentLabel).toBe('39%');
+    expect(status.tone).toBe('normal');
+  });
 });
 
 function makeMessage(index: number): ChatMessage {


### PR DESCRIPTION
## Summary
- show the full context window as the visible denominator in context usage status
- keep percentage, tone, and compact policy behavior based on the effective input budget
- add coverage for total vs effective context display

## Tests
- npm --prefix ui test -- src/components/chat-v2/MessagesPaneV2.render.test.tsx

## Notes
- npm --prefix ui run typecheck currently fails on existing React type incompatibilities unrelated to this change.