### PR TITLE
fix(ui): sort projects by recent activity

### DIFF
--- a/src/web/client/protocol.ts
+++ b/src/web/client/protocol.ts
@@ -355,6 +355,7 @@ export type WebProjectSummary = {
   fullPath: string;
   sessionCount: number;
   lastActivity?: number;
+  createdAt?: number;
 };
 
 export type WebListProjectsResult = {

--- a/src/web/server/listProjects.ts
+++ b/src/web/server/listProjects.ts
@@ -51,7 +51,7 @@ export async function listWebProjects(
     if (resolve(fullPath) === resolve(options.pilotHome)) {
       continue;
     }
-    const summary = await summarizeProject(fullPath, options);
+    const summary = await summarizeProject(fullPath, options, dir);
     projects.push(summary);
   }
 
@@ -63,15 +63,70 @@ export async function describeWebProject(
   projectKey: string,
   options: ListWebProjectsOptions,
 ): Promise<WebProjectSummary> {
-  return summarizeProject(projectKey, options);
+  const projectStorageDir = await resolveProjectStorageDir(projectKey, options);
+  return summarizeProject(projectKey, options, projectStorageDir);
+}
+
+async function resolveProjectStorageDir(
+  projectRoot: string,
+  options: ListWebProjectsOptions,
+): Promise<string | undefined> {
+  const projectsDir = resolve(options.pilotHome, "projects");
+  const candidate = resolve(projectsDir, createProjectId(projectRoot));
+  let legacyCandidate: string | undefined;
+  try {
+    if ((await stat(candidate)).isDirectory()) {
+      try {
+        const marker = (await readFile(resolve(candidate, ".cwd"), "utf8")).trim();
+        if (marker && resolve(marker) === resolve(projectRoot)) {
+          return candidate;
+        }
+        if (!marker) legacyCandidate = candidate;
+      } catch {
+        // Legacy project directories may not have a marker.
+        legacyCandidate = candidate;
+      }
+    }
+  } catch {
+    // Fall through to .cwd marker lookup for collision-resistant IDs.
+  }
+
+  let entries;
+  try {
+    entries = await readdir(projectsDir, { withFileTypes: true });
+  } catch {
+    return undefined;
+  }
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    try {
+      const marker = (await readFile(resolve(projectsDir, entry.name, ".cwd"), "utf8")).trim();
+      if (marker && resolve(marker) === resolve(projectRoot)) {
+        return resolve(projectsDir, entry.name);
+      }
+    } catch {
+      // Ignore missing or unreadable markers.
+    }
+  }
+  return legacyCandidate;
 }
 
 async function summarizeProject(
   projectRoot: string,
   options: ListWebProjectsOptions,
+  projectStorageDir?: string,
 ): Promise<WebProjectSummary> {
   let sessionCount = 0;
   let lastActivity: number | undefined;
+  let createdAt: number | undefined;
+  if (projectStorageDir) {
+    try {
+      const storageStats = await stat(projectStorageDir);
+      createdAt = storageStats.birthtimeMs || storageStats.ctimeMs;
+    } catch {
+      createdAt = undefined;
+    }
+  }
   try {
     const sessions = await listProjectSessions({
       projectRoot,
@@ -88,6 +143,7 @@ async function summarizeProject(
     fullPath: projectRoot,
     sessionCount,
     lastActivity,
+    createdAt,
   };
 }
 

--- a/tests/web/list-projects-created-at.spec.ts
+++ b/tests/web/list-projects-created-at.spec.ts
@@ -1,0 +1,49 @@
+import { mkdir, stat, writeFile } from "node:fs/promises";
+import { mkdtemp } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createCollisionResistantProjectId, createProjectId } from "../../src/pilot/paths.js";
+import { describeWebProject, listWebProjects } from "../../src/web/server/listProjects.js";
+
+test("project summaries expose registration creation time for list and describe", async () => {
+  const root = await mkdtemp(join(tmpdir(), "pilotdeck-created-at-"));
+  const pilotHome = join(root, ".pilotdeck");
+  const projectRoot = join(root, "workspace");
+  const projectId = createProjectId(projectRoot);
+  const storageDir = join(pilotHome, "projects", projectId);
+  await mkdir(projectRoot, { recursive: true });
+  await mkdir(storageDir, { recursive: true });
+  await writeFile(join(storageDir, ".cwd"), `${projectRoot}\n`, "utf8");
+  const expectedCreatedAt = (await stat(storageDir)).birthtimeMs;
+
+  const listed = await listWebProjects({ pilotHome });
+  const described = await describeWebProject(projectRoot, { pilotHome });
+
+  assert.equal(listed.projects[0]?.createdAt, expectedCreatedAt);
+  assert.equal(described.createdAt, expectedCreatedAt);
+});
+
+test("describe resolves the marked project when legacy ids collide", async () => {
+  const root = await mkdtemp(join(tmpdir(), "pilotdeck-created-at-collision-"));
+  const pilotHome = join(root, ".pilotdeck");
+  const firstProjectRoot = join(root, "a-b");
+  const secondProjectRoot = join(root, "a b");
+  const legacyId = createProjectId(firstProjectRoot);
+  const collisionResistantId = createCollisionResistantProjectId(secondProjectRoot);
+  const firstStorageDir = join(pilotHome, "projects", legacyId);
+  const secondStorageDir = join(pilotHome, "projects", collisionResistantId);
+
+  await mkdir(firstProjectRoot, { recursive: true });
+  await mkdir(secondProjectRoot, { recursive: true });
+  await mkdir(firstStorageDir, { recursive: true });
+  await mkdir(secondStorageDir, { recursive: true });
+  await writeFile(join(firstStorageDir, ".cwd"), `${firstProjectRoot}\n`, "utf8");
+  await writeFile(join(secondStorageDir, ".cwd"), `${secondProjectRoot}\n`, "utf8");
+
+  const expectedCreatedAt = (await stat(secondStorageDir)).birthtimeMs;
+  const described = await describeWebProject(secondProjectRoot, { pilotHome });
+
+  assert.equal(described.createdAt, expectedCreatedAt);
+});

--- a/ui/server/projects.js
+++ b/ui/server/projects.js
@@ -135,6 +135,15 @@ async function readMarkedProjectPaths() {
     return result;
 }
 
+async function readProjectCreatedAt(projectId) {
+    try {
+        const stats = await fs.stat(path.join(resolvePilotHome(process.env), 'projects', projectId));
+        return stats.birthtimeMs || stats.ctimeMs;
+    } catch {
+        return undefined;
+    }
+}
+
 async function getProjects(progressCallback = null) {
     const gateway = await getPilotDeckGateway();
     const { projects: webProjects } = await gateway.listProjects();
@@ -199,13 +208,23 @@ async function getProjects(progressCallback = null) {
             });
         }
 
-        const sessionsResult = await gateway
-            .listSessions({ projectKey: fullPath, limit: 5 })
-            .catch(() => ({ sessions: [] }));
+        let sessionsResult;
+        let sessionPreviewSucceeded = true;
+        try {
+            sessionsResult = await gateway.listSessions({ projectKey: fullPath, limit: 5 });
+        } catch {
+            sessionsResult = { sessions: [] };
+            sessionPreviewSucceeded = false;
+        }
         const sessions = (sessionsResult.sessions || []).map((session) =>
             toLegacySession(session, name),
         );
         applyCustomSessionNames(sessions, 'claude');
+        const latestSessionActivity = (sessionsResult.sessions || []).reduce(
+            (latest, session) => Math.max(latest, Number(session.lastModified) || 0),
+            0,
+        );
+        const projectCreatedAt = project.createdAt ?? await readProjectCreatedAt(name);
 
         const taskmaster = await detectTaskMaster(fullPath).catch(() => ({
             hasTaskmaster: false,
@@ -216,7 +235,14 @@ async function getProjects(progressCallback = null) {
             displayName: projectDisplayName(fullPath),
             fullPath,
             path: fullPath,
-            lastActivity: project.lastActivity,
+            // A project's activity is the newest interaction in one of its
+            // sessions. For an untouched project, use its registration
+            // directory creation time instead of a mutable summary time.
+            lastActivity: latestSessionActivity > 0
+                ? latestSessionActivity
+                : sessionPreviewSucceeded && (project.sessionCount ?? sessions.length) === 0
+                    ? projectCreatedAt
+                    : project.lastActivity,
             sessions,
             sessionMeta: {
                 total: project.sessionCount ?? sessions.length,
@@ -248,14 +274,18 @@ async function getProjects(progressCallback = null) {
         // Without this, sessionMeta.hasMore was hardcoded `false` and the
         // sidebar would silently truncate to the first 5 sessions even
         // when dozens existed under ~/.pilotdeck/projects/<encoded>/chats/.
-        const [generalSessionsResult, generalSummary] = await Promise.all([
-            generalGateway
-                .listSessions({ projectKey: generalHome, limit: 5 })
-                .catch(() => ({ sessions: [] })),
-            generalGateway
-                .describeProject({ projectKey: generalHome })
-                .catch(() => null),
-        ]);
+        const sessionsPromise = generalGateway
+            .listSessions({ projectKey: generalHome, limit: 5 })
+            .then((sessionsResult) => ({ sessionsResult, succeeded: true }))
+            .catch(() => ({ sessionsResult: { sessions: [] }, succeeded: false }));
+        const summaryPromise = generalGateway
+            .describeProject({ projectKey: generalHome })
+            .then((summary) => ({ summary, succeeded: true }))
+            .catch(() => ({ summary: null, succeeded: false }));
+        const [
+            { sessionsResult: generalSessionsResult, succeeded: generalSessionPreviewSucceeded },
+            { summary: generalSummary, succeeded: generalSummarySucceeded },
+        ] = await Promise.all([sessionsPromise, summaryPromise]);
         generalSessions = (generalSessionsResult.sessions || []).map((session) =>
             toLegacySession(session, 'general'),
         );
@@ -263,7 +293,16 @@ async function getProjects(progressCallback = null) {
         generalTotal = typeof generalSummary?.sessionCount === 'number'
             ? generalSummary.sessionCount
             : generalSessions.length;
-        generalLastActivity = generalSummary?.lastActivity;
+        const latestGeneralSessionActivity = (generalSessionsResult.sessions || []).reduce(
+            (latest, session) => Math.max(latest, Number(session.lastModified) || 0),
+            0,
+        );
+        generalLastActivity = latestGeneralSessionActivity > 0
+            ? latestGeneralSessionActivity
+            : generalSessionPreviewSucceeded && generalSummarySucceeded
+                && (generalSummary?.sessionCount ?? generalSessions.length) === 0
+                ? generalSummary?.createdAt
+                : generalSummary?.lastActivity;
     } catch {
         generalSessions = [];
         generalTotal = 0;
@@ -283,6 +322,11 @@ async function getProjects(progressCallback = null) {
         },
         taskmaster: { hasTaskmaster: false },
     });
+
+    result.sort((left, right) =>
+        (right.lastActivity ?? Number.NEGATIVE_INFINITY)
+        - (left.lastActivity ?? Number.NEGATIVE_INFINITY),
+    );
 
     return result;
 }

--- a/ui/server/projects.test.js
+++ b/ui/server/projects.test.js
@@ -1,0 +1,147 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const gateway = vi.hoisted(() => ({
+    describeProject: vi.fn(),
+    listProjects: vi.fn(),
+    listSessions: vi.fn(),
+}));
+
+vi.mock('./pilotdeck-bridge.js', () => ({
+    getPilotDeckGateway: vi.fn(async () => gateway),
+}));
+
+vi.mock('./database/db.js', () => ({
+    applyCustomSessionNames: vi.fn(),
+}));
+
+import { getProjects } from './projects.js';
+
+const originalPilotHome = process.env.PILOT_HOME;
+
+function deferred() {
+    let resolve;
+    const promise = new Promise((promiseResolve) => {
+        resolve = promiseResolve;
+    });
+    return { promise, resolve };
+}
+
+describe('getProjects', () => {
+    beforeAll(() => {
+        process.env.PILOT_HOME = '/tmp/pilotdeck-project-sort-test';
+    });
+
+    afterAll(() => {
+        if (originalPilotHome === undefined) {
+            delete process.env.PILOT_HOME;
+        } else {
+            process.env.PILOT_HOME = originalPilotHome;
+        }
+    });
+
+    beforeEach(() => {
+        gateway.describeProject.mockReset();
+        gateway.listProjects.mockReset();
+        gateway.listSessions.mockReset();
+
+        gateway.listSessions.mockResolvedValue({ sessions: [] });
+        gateway.describeProject.mockResolvedValue({
+            sessionCount: 0,
+            lastActivity: 200,
+        });
+    });
+
+    it('sorts projects by the newest session interaction and puts missing activity last', async () => {
+        gateway.listSessions.mockImplementation(async ({ projectKey }) => ({
+            sessions: projectKey === '/workspace/alpha'
+                ? [{ sessionId: 'alpha-session', lastModified: 400 }]
+                : projectKey === '/workspace/zeta'
+                    ? [{ sessionId: 'zeta-session', lastModified: 50 }]
+                    : [],
+        }));
+        gateway.listProjects.mockResolvedValueOnce({
+            projects: [
+                {
+                    projectKey: '/workspace/alpha',
+                    name: 'alpha',
+                    fullPath: '/workspace/alpha',
+                    sessionCount: 1,
+                    lastActivity: 100,
+                },
+                {
+                    projectKey: '/workspace/dormant',
+                    name: 'dormant',
+                    fullPath: '/workspace/dormant',
+                    sessionCount: 0,
+                    createdAt: 250,
+                    lastActivity: 999,
+                },
+                {
+                    projectKey: '/workspace/zeta',
+                    name: 'zeta',
+                    fullPath: '/workspace/zeta',
+                    sessionCount: 1,
+                    lastActivity: 300,
+                },
+            ],
+        });
+
+        const projects = await getProjects();
+
+        expect(projects.map((project) => project.name)).toEqual([
+            'workspace-alpha',
+            'workspace-dormant',
+            'workspace-zeta',
+            'general',
+        ]);
+        expect(projects.find((project) => project.name === 'workspace-alpha')?.lastActivity).toBe(400);
+        expect(projects.find((project) => project.name === 'workspace-dormant')?.lastActivity).toBe(250);
+    });
+
+    it('keeps the project summary activity when the session preview fails', async () => {
+        gateway.listProjects.mockResolvedValue({
+            projects: [{
+                projectKey: '/workspace/active',
+                name: 'active',
+                fullPath: '/workspace/active',
+                sessionCount: 2,
+                lastActivity: 400,
+                createdAt: 100,
+            }],
+        });
+        gateway.listSessions.mockRejectedValue(new Error('gateway unavailable'));
+
+        const projects = await getProjects();
+
+        expect(projects.find((project) => project.name === 'workspace-active')?.lastActivity).toBe(400);
+    });
+
+    it('starts General session preview and summary requests concurrently', async () => {
+        const sessions = deferred();
+        const summary = deferred();
+        gateway.listProjects.mockResolvedValue({ projects: [] });
+        gateway.listSessions.mockImplementation(({ projectKey }) => {
+            if (projectKey === process.env.PILOT_HOME) return sessions.promise;
+            return Promise.resolve({ sessions: [] });
+        });
+        gateway.describeProject.mockImplementation(({ projectKey }) => {
+            if (projectKey === process.env.PILOT_HOME) return summary.promise;
+            return Promise.resolve({ sessionCount: 0 });
+        });
+
+        const projectsPromise = getProjects();
+        try {
+            await vi.waitFor(() => expect(gateway.listSessions).toHaveBeenCalledWith({
+                projectKey: process.env.PILOT_HOME,
+                limit: 5,
+            }));
+            expect(gateway.describeProject).toHaveBeenCalledWith({
+                projectKey: process.env.PILOT_HOME,
+            });
+        } finally {
+            sessions.resolve({ sessions: [] });
+            summary.resolve({ sessionCount: 0, createdAt: 100 });
+            await projectsPromise;
+        }
+    });
+});


### PR DESCRIPTION
## Summary
- derive each project activity from its newest session interaction (`lastModified`)
- sort `/api/projects` project entries by that activity descending
- use the PilotDeck project registration directory creation time (`createdAt`) only when a successful session preview confirms the project has no sessions
- preserve the Gateway summary `lastActivity` when the session preview fails
- populate `createdAt` consistently for both `list_projects` and `describe_project`
- add regressions for failed previews and describe-project creation metadata

## Testing
- `pnpm --dir ui exec vitest run server/projects.test.js`
- `tsx --test tests/web/list-projects-created-at.spec.ts`
- `git diff --check`

Evidence: CURRENT_ONLY