### PR TITLE
feat: expose model speed capability

### DIFF
--- a/docs/dialog-improvement-api.md
+++ b/docs/dialog-improvement-api.md
@@ -403,7 +403,7 @@ type ModelsResponse = {
 - `speed`：Provider 请求速度参数，范围 `0..1`；仅在模型显式声明支持且目标 Provider 有对应适配时返回。Google Provider 当前不支持该字段。
 - 未显式声明 `supportsThinking` 的模型按协议默认支持 reasoning；显式 `supportsThinking: false` 时不返回 reasoning。
 - 自定义 OpenAI-compatible provider 只有在 provider 配置显式设置 `speedMapping: openai_service_tier` 后才会返回 speed；自定义 Anthropic-compatible provider 对应设置 `speedMapping: anthropic_speed`。
-- `speed < 0.5` 使用 OpenAI 默认 service tier（省略 `service_tier`）/ Anthropic `speed: "standard"`；`speed >= 0.5` 映射为 OpenAI `service_tier: "priority"` / Anthropic `speed: "fast"`。Anthropic fast mode 同时自动添加 beta header `fast-mode-2026-02-01`。
+- `speed < 0.5` 使用 OpenAI 和 Anthropic 默认速度（省略 `service_tier` / `speed`）；`speed >= 0.5` 映射为 OpenAI `service_tier: "priority"` / Anthropic `speed: "fast"`。Anthropic fast mode 同时自动添加 beta header `fast-mode-2026-02-01`。
 - `range` 使用 `min`、`max`、`step`；`enum` 使用 `values`。
 - 未返回的能力表示该模型不支持对应参数。
 - Router 开启且支持 auto 时，接口可返回 `{ provider: "router", model: "auto" }` 虚拟条目。

--- a/docs/dialog-improvement-api.md
+++ b/docs/dialog-improvement-api.md
@@ -383,6 +383,7 @@ type ModelCatalogItem = {
   capabilities: {
     reasoning?: ModelCapability;
     temperature?: ModelCapability;
+    speed?: ModelCapability;
   };
 };
 
@@ -399,6 +400,8 @@ type ModelsResponse = {
 
 - `reasoning`：推理强度，归一化范围 `0..1`。
 - `temperature`：采样温度，范围 `0..1`。
+- `speed`：Provider 请求速度参数，范围 `0..1`；仅在模型显式声明支持时返回。
+- 未显式声明 `supportsThinking` 的模型按协议默认支持 reasoning；显式 `supportsThinking: false` 时不返回 reasoning。
 - `range` 使用 `min`、`max`、`step`；`enum` 使用 `values`。
 - 未返回的能力表示该模型不支持对应参数。
 - Router 开启且支持 auto 时，接口可返回 `{ provider: "router", model: "auto" }` 虚拟条目。
@@ -418,6 +421,7 @@ type SessionModelSelection =
       model: string;
       reasoning?: number;
       temperature?: number;
+      speed?: number;
     };
 
 type SessionModelResponse = {
@@ -430,6 +434,7 @@ type SessionModelResponse = {
     source: "session" | "router" | "default";
     reasoning?: number;
     temperature?: number;
+    speed?: number;
   };
 };
 ```
@@ -450,7 +455,7 @@ type SetSessionModelRequest = {
 };
 ```
 
-`mode=model` 时校验模型存在、可用，并校验 reasoning、temperature。`mode=auto` 仅在 Router 开启时允许，否则返回 `ROUTER_AUTO_UNAVAILABLE`。
+`mode=model` 时校验模型存在、可用，并校验 reasoning、temperature、speed。`mode=auto` 仅在 Router 开启时允许，否则返回 `ROUTER_AUTO_UNAVAILABLE`。
 
 设置写入会话 metadata，对后续 turn 持续生效；会话恢复后继续生效。成功返回 `SessionModelResponse`。
 
@@ -494,6 +499,7 @@ type SessionModelOverride = {
   model: string;
   reasoning?: number;
   temperature?: number;
+  speed?: number;
 };
 
 type UploadedAttachmentRef = {
@@ -520,7 +526,7 @@ type SubmitTurnRequest = {
 服务端校验：
 
 - `modelOverride.provider/model` 必须存在且可用。
-- reasoning、temperature 必须满足模型 capabilities。
+- reasoning、temperature、speed 必须满足模型 capabilities；speed 使用 `0..1` 的统一数值语义。
 - `uploadedAttachments` 必须属于同一 `projectKey`、状态为 completed 且未过期。
 - `mode` 和 `basePermissionMode` 必须属于声明枚举。
 - 校验失败时不得启动模型调用。
@@ -538,6 +544,7 @@ type ModelSelectionChangedEvent = {
   parameters?: {
     reasoning?: number;
     temperature?: number;
+    speed?: number;
   };
   runId?: string;
 };

--- a/docs/dialog-improvement-api.md
+++ b/docs/dialog-improvement-api.md
@@ -403,7 +403,7 @@ type ModelsResponse = {
 - `speed`：Provider 请求速度参数，范围 `0..1`；仅在模型显式声明支持且目标 Provider 有对应适配时返回。Google Provider 当前不支持该字段。
 - 未显式声明 `supportsThinking` 的模型按协议默认支持 reasoning；显式 `supportsThinking: false` 时不返回 reasoning。
 - 自定义 OpenAI-compatible provider 只有在 provider 配置显式设置 `speedMapping: openai_service_tier` 后才会返回 speed；自定义 Anthropic-compatible provider 对应设置 `speedMapping: anthropic_speed`。
-- `speed < 0.5` 映射为 OpenAI `service_tier: "fast"` / Anthropic `speed: "standard"`；`speed >= 0.5` 映射为 OpenAI `service_tier: "priority"` / Anthropic `speed: "fast"`。
+- `speed < 0.5` 使用 OpenAI 默认 service tier（省略 `service_tier`）/ Anthropic `speed: "standard"`；`speed >= 0.5` 映射为 OpenAI `service_tier: "priority"` / Anthropic `speed: "fast"`。Anthropic fast mode 同时自动添加 beta header `fast-mode-2026-02-01`。
 - `range` 使用 `min`、`max`、`step`；`enum` 使用 `values`。
 - 未返回的能力表示该模型不支持对应参数。
 - Router 开启且支持 auto 时，接口可返回 `{ provider: "router", model: "auto" }` 虚拟条目。

--- a/docs/dialog-improvement-api.md
+++ b/docs/dialog-improvement-api.md
@@ -402,6 +402,8 @@ type ModelsResponse = {
 - `temperature`：采样温度，范围 `0..1`。
 - `speed`：Provider 请求速度参数，范围 `0..1`；仅在模型显式声明支持且目标 Provider 有对应适配时返回。Google Provider 当前不支持该字段。
 - 未显式声明 `supportsThinking` 的模型按协议默认支持 reasoning；显式 `supportsThinking: false` 时不返回 reasoning。
+- 自定义 OpenAI-compatible provider 只有在 provider 配置显式设置 `speedMapping: openai_service_tier` 后才会返回 speed；自定义 Anthropic-compatible provider 对应设置 `speedMapping: anthropic_speed`。
+- `speed < 0.5` 映射为 OpenAI `service_tier: "fast"` / Anthropic `speed: "standard"`；`speed >= 0.5` 映射为 OpenAI `service_tier: "priority"` / Anthropic `speed: "fast"`。
 - `range` 使用 `min`、`max`、`step`；`enum` 使用 `values`。
 - 未返回的能力表示该模型不支持对应参数。
 - Router 开启且支持 auto 时，接口可返回 `{ provider: "router", model: "auto" }` 虚拟条目。

--- a/docs/dialog-improvement-api.md
+++ b/docs/dialog-improvement-api.md
@@ -400,7 +400,7 @@ type ModelsResponse = {
 
 - `reasoning`：推理强度，归一化范围 `0..1`。
 - `temperature`：采样温度，范围 `0..1`。
-- `speed`：Provider 请求速度参数，范围 `0..1`；仅在模型显式声明支持时返回。
+- `speed`：Provider 请求速度参数，范围 `0..1`；仅在模型显式声明支持且目标 Provider 有对应适配时返回。Google Provider 当前不支持该字段。
 - 未显式声明 `supportsThinking` 的模型按协议默认支持 reasoning；显式 `supportsThinking: false` 时不返回 reasoning。
 - `range` 使用 `min`、`max`、`step`；`enum` 使用 `values`。
 - 未返回的能力表示该模型不支持对应参数。

--- a/docs/trd-dialog-improvement.md
+++ b/docs/trd-dialog-improvement.md
@@ -217,6 +217,8 @@ type UploadedAttachmentRef = {
 
 协议默认将未显式声明的模型视为支持 reasoning；模型可通过 `capabilities.supportsThinking: false` 关闭。speed 通过 `capabilities.supportsSpeed: true` 显式开启。
 
+自定义兼容 provider 还必须显式声明 `speedMapping`：OpenAI 使用 `openai_service_tier`，Anthropic 使用 `anthropic_speed`。统一 speed 在 adapter 层转换为 provider 原生枚举；`speed < 0.5` 为低档，`speed >= 0.5` 为高档。Google 不声明 speed。
+
 `includeAuto` 仅在 Router 开启时允许，返回虚拟模型 `router/auto`。
 
 ### 9.2 `submit_turn` 扩展
@@ -247,7 +249,7 @@ type GatewaySubmitTurnInput = ExistingGatewaySubmitTurnInput & {
 
 `submit_turn.modelOverride` 只覆盖本轮，不修改会话保存值。模型解析顺序：本轮 `modelOverride` > 会话保存模型 > Router auto/路由决策 > `agent.model` 默认模型。
 
-`provider/model` 不存在或不可用返回 `INVALID_MODEL_OVERRIDE`；reasoning、temperature 或 speed 不满足模型能力返回 `UNSUPPORTED_MODEL_PARAMETER`。未声明支持的参数不发送给 Provider。支持 speed 的 Provider 适配器将统一 speed 字段作为顶层请求参数透传到目标协议；Google Provider 不声明或接收 speed。
+`provider/model` 不存在或不可用返回 `INVALID_MODEL_OVERRIDE`；reasoning、temperature 或 speed 不满足模型能力返回 `UNSUPPORTED_MODEL_PARAMETER`。未声明支持的参数不发送给 Provider。speed 必须在 canonical request 入口通过 `0..1` 校验，再由支持 speed 的 Provider adapter 映射为原生字段；Google Provider 不声明或接收 speed。
 
 模型确定后发出 `model_selection_changed`，包含 provider、model、来源（session/router/default）和已生效参数。
 

--- a/docs/trd-dialog-improvement.md
+++ b/docs/trd-dialog-improvement.md
@@ -213,7 +213,9 @@ type UploadedAttachmentRef = {
 
 `GET /api/models?projectKey=&query=&provider=&includeAuto=`
 
-返回 provider、model、displayName、available 以及 reasoning（推理强度）和 temperature 的能力声明。对话框统一使用 0..1 的数值语义；每个模型可通过能力声明限制可用范围、步长或枚举值，后端负责把 0..1 值映射为 Provider 所需参数。temperature 统一范围为 0..1。
+返回 provider、model、displayName、available 以及 reasoning（推理强度）、temperature 和可选 speed 的能力声明。对话框统一使用 0..1 的数值语义；每个模型可通过能力声明限制可用范围、步长或枚举值，后端负责把 0..1 值映射为 Provider 所需参数。temperature 和 speed 统一范围为 0..1；speed 需要模型显式声明支持。
+
+协议默认将未显式声明的模型视为支持 reasoning；模型可通过 `capabilities.supportsThinking: false` 关闭。speed 通过 `capabilities.supportsSpeed: true` 显式开启。
 
 `includeAuto` 仅在 Router 开启时允许，返回虚拟模型 `router/auto`。
 
@@ -225,6 +227,7 @@ type SessionModelOverride = {
   model: string;
   reasoning?: number;
   temperature?: number;
+  speed?: number;
 };
 type GatewaySubmitTurnInput = ExistingGatewaySubmitTurnInput & {
   modelOverride?: SessionModelOverride;
@@ -244,7 +247,7 @@ type GatewaySubmitTurnInput = ExistingGatewaySubmitTurnInput & {
 
 `submit_turn.modelOverride` 只覆盖本轮，不修改会话保存值。模型解析顺序：本轮 `modelOverride` > 会话保存模型 > Router auto/路由决策 > `agent.model` 默认模型。
 
-`provider/model` 不存在或不可用返回 `INVALID_MODEL_OVERRIDE`；reasoning 或 temperature 不满足模型能力返回 `UNSUPPORTED_MODEL_PARAMETER`。未声明支持的参数不发送给 Provider。Provider 适配器负责映射统一字段到目标协议字段。
+`provider/model` 不存在或不可用返回 `INVALID_MODEL_OVERRIDE`；reasoning、temperature 或 speed 不满足模型能力返回 `UNSUPPORTED_MODEL_PARAMETER`。未声明支持的参数不发送给 Provider。Provider 适配器将统一 speed 字段作为顶层请求参数透传到目标协议。
 
 模型确定后发出 `model_selection_changed`，包含 provider、model、来源（session/router/default）和已生效参数。
 

--- a/docs/trd-dialog-improvement.md
+++ b/docs/trd-dialog-improvement.md
@@ -217,7 +217,7 @@ type UploadedAttachmentRef = {
 
 协议默认将未显式声明的模型视为支持 reasoning；模型可通过 `capabilities.supportsThinking: false` 关闭。speed 通过 `capabilities.supportsSpeed: true` 显式开启。
 
-自定义兼容 provider 还必须显式声明 `speedMapping`：OpenAI 使用 `openai_service_tier`，Anthropic 使用 `anthropic_speed`。统一 speed 在 adapter 层转换为 provider 原生枚举；`speed < 0.5` 为低档，`speed >= 0.5` 为高档。Google 不声明 speed。
+自定义兼容 provider 还必须显式声明 `speedMapping`：OpenAI 使用 `openai_service_tier`，Anthropic 使用 `anthropic_speed`。统一 speed 在 adapter 层转换为 provider 原生枚举；OpenAI 低档省略 `service_tier`、高档使用 `priority`；Anthropic 低档使用 `standard`、高档使用 `fast`。Anthropic fast mode 自动合并 beta header `fast-mode-2026-02-01`。Google 不声明 speed。
 
 `includeAuto` 仅在 Router 开启时允许，返回虚拟模型 `router/auto`。
 

--- a/docs/trd-dialog-improvement.md
+++ b/docs/trd-dialog-improvement.md
@@ -217,7 +217,7 @@ type UploadedAttachmentRef = {
 
 协议默认将未显式声明的模型视为支持 reasoning；模型可通过 `capabilities.supportsThinking: false` 关闭。speed 通过 `capabilities.supportsSpeed: true` 显式开启。
 
-自定义兼容 provider 还必须显式声明 `speedMapping`：OpenAI 使用 `openai_service_tier`，Anthropic 使用 `anthropic_speed`。统一 speed 在 adapter 层转换为 provider 原生枚举；OpenAI 低档省略 `service_tier`、高档使用 `priority`；Anthropic 低档使用 `standard`、高档使用 `fast`。Anthropic fast mode 自动合并 beta header `fast-mode-2026-02-01`。Google 不声明 speed。
+自定义兼容 provider 还必须显式声明 `speedMapping`：OpenAI 使用 `openai_service_tier`，Anthropic 使用 `anthropic_speed`。统一 speed 在 adapter 层转换为 provider 原生字段；OpenAI 和 Anthropic 低档都省略对应字段、高档分别使用 `priority` 和 `fast`。Anthropic fast mode 自动合并 beta header `fast-mode-2026-02-01`。Google 不声明 speed。
 
 `includeAuto` 仅在 Router 开启时允许，返回虚拟模型 `router/auto`。
 

--- a/docs/trd-dialog-improvement.md
+++ b/docs/trd-dialog-improvement.md
@@ -213,7 +213,7 @@ type UploadedAttachmentRef = {
 
 `GET /api/models?projectKey=&query=&provider=&includeAuto=`
 
-返回 provider、model、displayName、available 以及 reasoning（推理强度）、temperature 和可选 speed 的能力声明。对话框统一使用 0..1 的数值语义；每个模型可通过能力声明限制可用范围、步长或枚举值，后端负责把 0..1 值映射为 Provider 所需参数。temperature 和 speed 统一范围为 0..1；speed 需要模型显式声明支持。
+返回 provider、model、displayName、available 以及 reasoning（推理强度）、temperature 和可选 speed 的能力声明。对话框统一使用 0..1 的数值语义；每个模型可通过能力声明限制可用范围、步长或枚举值，后端负责把 0..1 值映射为 Provider 所需参数。temperature 和 speed 统一范围为 0..1；speed 需要模型显式声明支持，且 Google Provider 当前不支持该字段。
 
 协议默认将未显式声明的模型视为支持 reasoning；模型可通过 `capabilities.supportsThinking: false` 关闭。speed 通过 `capabilities.supportsSpeed: true` 显式开启。
 
@@ -247,7 +247,7 @@ type GatewaySubmitTurnInput = ExistingGatewaySubmitTurnInput & {
 
 `submit_turn.modelOverride` 只覆盖本轮，不修改会话保存值。模型解析顺序：本轮 `modelOverride` > 会话保存模型 > Router auto/路由决策 > `agent.model` 默认模型。
 
-`provider/model` 不存在或不可用返回 `INVALID_MODEL_OVERRIDE`；reasoning、temperature 或 speed 不满足模型能力返回 `UNSUPPORTED_MODEL_PARAMETER`。未声明支持的参数不发送给 Provider。Provider 适配器将统一 speed 字段作为顶层请求参数透传到目标协议。
+`provider/model` 不存在或不可用返回 `INVALID_MODEL_OVERRIDE`；reasoning、temperature 或 speed 不满足模型能力返回 `UNSUPPORTED_MODEL_PARAMETER`。未声明支持的参数不发送给 Provider。支持 speed 的 Provider 适配器将统一 speed 字段作为顶层请求参数透传到目标协议；Google Provider 不声明或接收 speed。
 
 模型确定后发出 `model_selection_changed`，包含 provider、model、来源（session/router/default）和已生效参数。
 

--- a/src/agent/loop/AgentLoop.ts
+++ b/src/agent/loop/AgentLoop.ts
@@ -1870,6 +1870,7 @@ export class AgentLoop {
       toolChoice: this.config.toolChoice,
       maxOutputTokens: this.config.maxOutputTokens,
       temperature: input.modelOverride?.temperature ?? this.config.temperature,
+      speed: input.modelOverride?.speed,
       thinking: input.modelOverride?.thinking ?? this.config.thinking,
       stream: true,
       metadata: this.config.metadata,

--- a/src/agent/protocol/input.ts
+++ b/src/agent/protocol/input.ts
@@ -7,6 +7,7 @@ export type AgentModelOverride = {
   provider: string;
   model: string;
   temperature?: number;
+  speed?: number;
   thinking?: import("../../model/index.js").CanonicalThinkingConfig;
 };
 

--- a/src/cli/createLocalGateway.ts
+++ b/src/cli/createLocalGateway.ts
@@ -322,6 +322,7 @@ export function createLocalGateway(options: CreateLocalGatewayOptions = {}): Cre
         source: "session" as const,
         reasoning: explicit.reasoning,
         temperature: explicit.temperature,
+        speed: explicit.speed,
       } : {
         provider: snapshot.agent.model.provider,
         model: snapshot.agent.model.model,

--- a/src/gateway/client/InProcessGateway.ts
+++ b/src/gateway/client/InProcessGateway.ts
@@ -498,6 +498,7 @@ export class InProcessGateway implements Gateway {
             source: modelSelection.source,
             reasoning: modelSelection.selection.reasoning,
             temperature: modelSelection.selection.temperature,
+            speed: modelSelection.selection.speed,
             runId,
           };
           this.recordActiveTurnEvent(input.sessionKey, event);
@@ -525,6 +526,7 @@ export class InProcessGateway implements Gateway {
                 provider: modelSelection.selection.provider,
                 model: modelSelection.selection.model,
                 temperature: modelSelection.selection.temperature,
+                speed: modelSelection.selection.speed,
                 ...(modelSelection.selection.reasoning !== undefined ? {
                   thinking: {
                     enabled: modelSelection.selection.reasoning > 0,

--- a/src/gateway/dialog/modelCatalog.ts
+++ b/src/gateway/dialog/modelCatalog.ts
@@ -30,7 +30,7 @@ export function listModelCatalog(input: ModelCatalogListInput, env: NodeJS.Proce
           .filter(([, mode]) => !resolveThinkingPlan({ mode, enabled: mode !== "off" }, provider, model).unsupportedReason)
           .map(([value]) => value)
         : [];
-      const speed = model.capabilities.supportsSpeed === true && provider.protocol !== "google";
+      const speed = model.capabilities.supportsSpeed === true && provider.speedMapping !== undefined;
       items.push({
         id: `${providerId}/${modelId}`,
         provider: providerId,

--- a/src/gateway/dialog/modelCatalog.ts
+++ b/src/gateway/dialog/modelCatalog.ts
@@ -30,7 +30,7 @@ export function listModelCatalog(input: ModelCatalogListInput, env: NodeJS.Proce
           .filter(([, mode]) => !resolveThinkingPlan({ mode, enabled: mode !== "off" }, provider, model).unsupportedReason)
           .map(([value]) => value)
         : [];
-      const speed = model.capabilities.supportsSpeed === true;
+      const speed = model.capabilities.supportsSpeed === true && provider.protocol !== "google";
       items.push({
         id: `${providerId}/${modelId}`,
         provider: providerId,

--- a/src/gateway/dialog/modelCatalog.ts
+++ b/src/gateway/dialog/modelCatalog.ts
@@ -30,6 +30,7 @@ export function listModelCatalog(input: ModelCatalogListInput, env: NodeJS.Proce
           .filter(([, mode]) => !resolveThinkingPlan({ mode, enabled: mode !== "off" }, provider, model).unsupportedReason)
           .map(([value]) => value)
         : [];
+      const speed = model.capabilities.supportsSpeed === true;
       items.push({
         id: `${providerId}/${modelId}`,
         provider: providerId,
@@ -39,6 +40,7 @@ export function listModelCatalog(input: ModelCatalogListInput, env: NodeJS.Proce
         capabilities: {
           ...(reasoning.length > 0 ? { reasoning: { type: "enum" as const, values: reasoning } } : {}),
           temperature: { type: "range", min: 0, max: 1, step: 0.1 },
+          ...(speed ? { speed: { type: "range" as const, min: 0, max: 1, step: 0.1 } } : {}),
         },
       });
     }
@@ -71,6 +73,12 @@ export function validateExplicitModelSelection(projectKey: string, selection: Ex
   if (!item || !item.available) throw new DialogGatewayError("INVALID_MODEL_OVERRIDE", `Model is unavailable: ${selection.provider}/${selection.model}`);
   if (selection.temperature !== undefined && (!Number.isFinite(selection.temperature) || selection.temperature < 0 || selection.temperature > 1)) {
     throw new DialogGatewayError("UNSUPPORTED_MODEL_PARAMETER", "temperature must be between 0 and 1.");
+  }
+  if (selection.speed !== undefined && (!Number.isFinite(selection.speed) || selection.speed < 0 || selection.speed > 1)) {
+    throw new DialogGatewayError("UNSUPPORTED_MODEL_PARAMETER", "speed must be between 0 and 1.");
+  }
+  if (selection.speed !== undefined && !item.capabilities.speed) {
+    throw new DialogGatewayError("UNSUPPORTED_MODEL_PARAMETER", `speed is not supported by ${item.id}.`);
   }
   if (selection.reasoning !== undefined && !item.capabilities.reasoning?.values?.includes(selection.reasoning)) {
     throw new DialogGatewayError("UNSUPPORTED_MODEL_PARAMETER", `reasoning=${selection.reasoning} is not supported by ${item.id}.`);

--- a/src/gateway/protocol/types.ts
+++ b/src/gateway/protocol/types.ts
@@ -150,6 +150,7 @@ export type GatewayEvent = GatewayTurnScopedEventMetadata & (
       source: "turn" | "session" | "router" | "default";
       reasoning?: number;
       temperature?: number;
+      speed?: number;
     }
   | { type: "assistant_text_delta"; text: string }
   | { type: "assistant_attachment"; attachment: GatewayOutboundAttachment }
@@ -424,6 +425,7 @@ export type ModelCatalogItem = {
   capabilities: {
     reasoning?: ModelNumericCapability;
     temperature?: ModelNumericCapability;
+    speed?: ModelNumericCapability;
   };
 };
 
@@ -445,6 +447,7 @@ export type ExplicitModelSelection = {
   model: string;
   reasoning?: number;
   temperature?: number;
+  speed?: number;
 };
 
 export type SessionModelSelection = { mode: "auto" } | ExplicitModelSelection;
@@ -459,6 +462,7 @@ export type SessionModelResult = SessionModelInput & {
     source: "session" | "router" | "default";
     reasoning?: number;
     temperature?: number;
+    speed?: number;
   };
 };
 

--- a/src/model/config/parseModelConfig.ts
+++ b/src/model/config/parseModelConfig.ts
@@ -7,6 +7,7 @@ import type {
   ModelProtocol,
   ProviderConfig,
   ProviderRetryConfig,
+  SpeedMapping,
 } from "../protocol/canonical.js";
 import { mergeCapabilities, type ModelCapabilities } from "../protocol/capabilities.js";
 import { ModelConfigError } from "../protocol/errors.js";
@@ -99,9 +100,33 @@ function parseProvider(providerId: string, rawProvider: unknown, env?: Credentia
     timeoutMs: readOptionalPositiveNumber(provider.timeoutMs, "timeoutMs"),
     headers: readStringRecord(provider.headers, "headers"),
     extraBody: isRecord(provider.extraBody) ? (provider.extraBody as Record<string, unknown>) : undefined,
+    speedMapping: parseSpeedMapping(provider.speedMapping, providerId, protocol, catalogProvider !== undefined),
     retry: parseRetryConfig(provider.retry),
     models,
   };
+}
+
+function parseSpeedMapping(
+  raw: unknown,
+  providerId: string,
+  protocol: ModelProtocol,
+  isCatalogProvider: boolean,
+): SpeedMapping | undefined {
+  if (raw !== undefined) {
+    if (raw === "openai_service_tier" && (protocol === "openai" || protocol === "openai-responses")) return raw;
+    if (raw === "anthropic_speed" && protocol === "anthropic") return raw;
+    throw new ModelConfigError(
+      "invalid_config_value",
+      "speedMapping must match the provider protocol: openai_service_tier for OpenAI or anthropic_speed for Anthropic.",
+      { providerId },
+    );
+  }
+  if (!isCatalogProvider) return undefined;
+  if (providerId === "openai" && (protocol === "openai" || protocol === "openai-responses")) {
+    return "openai_service_tier";
+  }
+  if (providerId === "anthropic" && protocol === "anthropic") return "anthropic_speed";
+  return undefined;
 }
 
 function resolveProviderApiKey(

--- a/src/model/config/parseModelConfig.ts
+++ b/src/model/config/parseModelConfig.ts
@@ -217,6 +217,7 @@ function parseCapabilities(
     "supportsStreaming",
     "supportsParallelToolCalls",
     "supportsThinking",
+    "supportsSpeed",
     "supportsJsonSchema",
     "supportsSystemPrompt",
     "supportsPromptCache",

--- a/src/model/config/schema.ts
+++ b/src/model/config/schema.ts
@@ -13,6 +13,7 @@ export type RawProviderConfig = {
   timeoutMs?: unknown;
   headers?: unknown;
   extraBody?: unknown;
+  speedMapping?: unknown;
   retry?: unknown;
   models?: unknown;
 };

--- a/src/model/index.ts
+++ b/src/model/index.ts
@@ -93,6 +93,7 @@ export type {
   ModelProtocol,
   ProviderConfig,
   ProviderRetryConfig,
+  SpeedMapping,
 } from "./protocol/canonical.js";
 export {
   flattenToolResultBlockText,

--- a/src/model/protocol/canonical.ts
+++ b/src/model/protocol/canonical.ts
@@ -300,6 +300,8 @@ export type ProviderRetryConfig = {
   jitter?: number;
 };
 
+export type SpeedMapping = "openai_service_tier" | "anthropic_speed";
+
 export type ProviderConfig = {
   id: string;
   protocol: ModelProtocol;
@@ -309,6 +311,8 @@ export type ProviderConfig = {
   headers: Record<string, string>;
   /** Arbitrary fields merged into every request body (e.g. OpenRouter provider preferences). */
   extraBody?: Record<string, unknown>;
+  /** Explicit native mapping for the normalized model speed preference. */
+  speedMapping?: SpeedMapping;
   retry?: ProviderRetryConfig;
   models: Record<string, ModelDefinition>;
 };

--- a/src/model/protocol/canonical.ts
+++ b/src/model/protocol/canonical.ts
@@ -215,6 +215,7 @@ export type CanonicalModelRequest = {
   toolChoice?: CanonicalToolChoice;
   maxOutputTokens?: number;
   temperature?: number;
+  speed?: number;
   thinking?: CanonicalThinkingConfig;
   stream?: boolean;
   metadata?: Record<string, unknown>;

--- a/src/model/protocol/capabilities.ts
+++ b/src/model/protocol/capabilities.ts
@@ -3,6 +3,7 @@ export type ModelCapabilities = {
   supportsStreaming: boolean;
   supportsParallelToolCalls: boolean;
   supportsThinking: boolean;
+  supportsSpeed?: boolean;
   supportsJsonSchema: boolean;
   supportsSystemPrompt: boolean;
   supportsPromptCache: boolean;
@@ -14,7 +15,7 @@ export const DEFAULT_MODEL_CAPABILITIES: ModelCapabilities = {
   supportsToolUse: false,
   supportsStreaming: true,
   supportsParallelToolCalls: false,
-  supportsThinking: false,
+  supportsThinking: true,
   supportsJsonSchema: false,
   supportsSystemPrompt: true,
   supportsPromptCache: false,

--- a/src/model/providers/anthropic/defaults.ts
+++ b/src/model/providers/anthropic/defaults.ts
@@ -5,7 +5,7 @@ export const ANTHROPIC_DEFAULT_CAPABILITIES: ModelCapabilities = {
   supportsToolUse: true,
   supportsStreaming: true,
   supportsParallelToolCalls: false,
-  supportsThinking: false,
+  supportsThinking: true,
   supportsJsonSchema: true,
   supportsSystemPrompt: true,
   supportsPromptCache: true,

--- a/src/model/providers/anthropic/request.ts
+++ b/src/model/providers/anthropic/request.ts
@@ -19,6 +19,7 @@ export type AnthropicRequestBody = {
   tools?: AnthropicTool[];
   tool_choice?: Record<string, unknown>;
   temperature?: number;
+  speed?: number;
   thinking?: {
     type: "enabled" | "adaptive";
     budget_tokens?: number;
@@ -97,6 +98,7 @@ export function buildAnthropicRequest(
     tools: tools.length > 0 ? tools : undefined,
     tool_choice: toolChoice,
     temperature: request.temperature,
+    speed: model.capabilities.supportsSpeed === true ? request.speed : undefined,
     thinking: thinkingPlan.enabled && thinkingPlan.thinkingType
       ? {
           type: thinkingPlan.thinkingType === "adaptive" ? "adaptive" : "enabled",

--- a/src/model/providers/anthropic/request.ts
+++ b/src/model/providers/anthropic/request.ts
@@ -21,7 +21,7 @@ export type AnthropicRequestBody = {
   tools?: AnthropicTool[];
   tool_choice?: Record<string, unknown>;
   temperature?: number;
-  speed?: "standard" | "fast";
+  speed?: "fast";
   thinking?: {
     type: "enabled" | "adaptive";
     budget_tokens?: number;

--- a/src/model/providers/anthropic/request.ts
+++ b/src/model/providers/anthropic/request.ts
@@ -6,10 +6,12 @@ import type {
   CanonicalToolChoice,
   CanonicalToolSchema,
   ModelDefinition,
+  ProviderConfig,
 } from "../../protocol/canonical.js";
 import { resolveThinkingPlan, throwIfUnsupportedThinkingPlan } from "../../thinking/registry.js";
 import { messageContent } from "../../protocol/clone.js";
 import { formatToolResultReferenceText } from "../toolResultReferenceText.js";
+import { hasSpeedMapping, mapSpeedToAnthropicSpeed } from "../../request/speedMapping.js";
 
 export type AnthropicRequestBody = {
   model: string;
@@ -19,7 +21,7 @@ export type AnthropicRequestBody = {
   tools?: AnthropicTool[];
   tool_choice?: Record<string, unknown>;
   temperature?: number;
-  speed?: number;
+  speed?: "standard" | "fast";
   thinking?: {
     type: "enabled" | "adaptive";
     budget_tokens?: number;
@@ -51,8 +53,9 @@ export const ANTHROPIC_STRUCTURED_OUTPUT_TOOL_NAME = "__output__";
 export function buildAnthropicRequest(
   request: CanonicalModelRequest,
   model: ModelDefinition,
+  provider?: ProviderConfig,
 ): AnthropicRequestBody {
-  const thinkingPlan = resolveThinkingPlan(request.thinking, { id: "anthropic", protocol: "anthropic", url: "", apiKey: "", headers: {}, models: {} }, model);
+  const thinkingPlan = resolveThinkingPlan(request.thinking, provider ?? { id: "anthropic", protocol: "anthropic", url: "", apiKey: "", headers: {}, models: {} }, model);
   throwIfUnsupportedThinkingPlan(thinkingPlan, request);
   // A3: lower outputSchema → forced hidden tool. This goes BEFORE the
   // user-supplied tools so the dispatch order is stable, but Anthropic
@@ -98,7 +101,10 @@ export function buildAnthropicRequest(
     tools: tools.length > 0 ? tools : undefined,
     tool_choice: toolChoice,
     temperature: request.temperature,
-    speed: model.capabilities.supportsSpeed === true ? request.speed : undefined,
+    speed: request.speed !== undefined && model.capabilities.supportsSpeed === true
+      && hasSpeedMapping(provider?.speedMapping, "anthropic_speed")
+      ? mapSpeedToAnthropicSpeed(request.speed)
+      : undefined,
     thinking: thinkingPlan.enabled && thinkingPlan.thinkingType
       ? {
           type: thinkingPlan.thinkingType === "adaptive" ? "adaptive" : "enabled",

--- a/src/model/providers/google/request.ts
+++ b/src/model/providers/google/request.ts
@@ -24,7 +24,7 @@ import { cleanSchemaForGoogle, normalizeGoogleToolSchema } from "./schema.js";
 import { resolveThinkingPlan, throwIfUnsupportedThinkingPlan } from "../../thinking/registry.js";
 import { formatToolResultReferenceText } from "../toolResultReferenceText.js";
 
-export type GoogleRequestBody = GenerateContentParameters & { speed?: number };
+export type GoogleRequestBody = GenerateContentParameters;
 
 export function buildGoogleRequest(
   request: CanonicalModelRequest,
@@ -50,7 +50,6 @@ export function buildGoogleRequest(
     model: normalizeGoogleModelId(request.model),
     contents: sanitizeGoogleContents(toGoogleContents(request.messages)),
     config: compactObject(config) as GenerateContentConfig,
-    speed: model.capabilities.supportsSpeed === true ? request.speed : undefined,
   };
 }
 

--- a/src/model/providers/google/request.ts
+++ b/src/model/providers/google/request.ts
@@ -24,7 +24,7 @@ import { cleanSchemaForGoogle, normalizeGoogleToolSchema } from "./schema.js";
 import { resolveThinkingPlan, throwIfUnsupportedThinkingPlan } from "../../thinking/registry.js";
 import { formatToolResultReferenceText } from "../toolResultReferenceText.js";
 
-export type GoogleRequestBody = GenerateContentParameters;
+export type GoogleRequestBody = GenerateContentParameters & { speed?: number };
 
 export function buildGoogleRequest(
   request: CanonicalModelRequest,
@@ -50,6 +50,7 @@ export function buildGoogleRequest(
     model: normalizeGoogleModelId(request.model),
     contents: sanitizeGoogleContents(toGoogleContents(request.messages)),
     config: compactObject(config) as GenerateContentConfig,
+    speed: model.capabilities.supportsSpeed === true ? request.speed : undefined,
   };
 }
 

--- a/src/model/providers/openai-responses/request.ts
+++ b/src/model/providers/openai-responses/request.ts
@@ -21,7 +21,7 @@ export type OpenAIResponsesRequestBody = {
   max_output_tokens: number;
   stream?: boolean;
   temperature?: number;
-  service_tier?: "fast" | "priority";
+  service_tier?: "priority";
   metadata?: Record<string, unknown>;
   tools?: OpenAIResponsesTool[];
   tool_choice?: unknown;

--- a/src/model/providers/openai-responses/request.ts
+++ b/src/model/providers/openai-responses/request.ts
@@ -20,6 +20,7 @@ export type OpenAIResponsesRequestBody = {
   max_output_tokens: number;
   stream?: boolean;
   temperature?: number;
+  speed?: number;
   metadata?: Record<string, unknown>;
   tools?: OpenAIResponsesTool[];
   tool_choice?: unknown;
@@ -80,6 +81,7 @@ export function buildOpenAIResponsesRequest(
     tools: request.tools?.map(toResponsesTool),
     tool_choice: toResponsesToolChoice(request.toolChoice),
     temperature: request.temperature,
+    speed: model.capabilities.supportsSpeed === true ? request.speed : undefined,
     stream: request.stream,
     metadata: request.metadata
       ? Object.fromEntries(

--- a/src/model/providers/openai-responses/request.ts
+++ b/src/model/providers/openai-responses/request.ts
@@ -12,6 +12,7 @@ import { messageContent } from "../../protocol/clone.js";
 import { normalizeOpenAISchema } from "../openai/schema.js";
 import { resolveThinkingPlan, throwIfUnsupportedThinkingPlan } from "../../thinking/registry.js";
 import { formatToolResultReferenceText } from "../toolResultReferenceText.js";
+import { hasSpeedMapping, mapSpeedToOpenAIServiceTier } from "../../request/speedMapping.js";
 
 export type OpenAIResponsesRequestBody = {
   model: string;
@@ -20,7 +21,7 @@ export type OpenAIResponsesRequestBody = {
   max_output_tokens: number;
   stream?: boolean;
   temperature?: number;
-  speed?: number;
+  service_tier?: "fast" | "priority";
   metadata?: Record<string, unknown>;
   tools?: OpenAIResponsesTool[];
   tool_choice?: unknown;
@@ -81,7 +82,10 @@ export function buildOpenAIResponsesRequest(
     tools: request.tools?.map(toResponsesTool),
     tool_choice: toResponsesToolChoice(request.toolChoice),
     temperature: request.temperature,
-    speed: model.capabilities.supportsSpeed === true ? request.speed : undefined,
+    service_tier: request.speed !== undefined && model.capabilities.supportsSpeed === true
+      && hasSpeedMapping(_provider?.speedMapping, "openai_service_tier")
+      ? mapSpeedToOpenAIServiceTier(request.speed)
+      : undefined,
     stream: request.stream,
     metadata: request.metadata
       ? Object.fromEntries(

--- a/src/model/providers/openai/defaults.ts
+++ b/src/model/providers/openai/defaults.ts
@@ -5,7 +5,7 @@ export const OPENAI_DEFAULT_CAPABILITIES: ModelCapabilities = {
   supportsToolUse: true,
   supportsStreaming: true,
   supportsParallelToolCalls: true,
-  supportsThinking: false,
+  supportsThinking: true,
   supportsJsonSchema: true,
   supportsSystemPrompt: true,
   supportsPromptCache: false,

--- a/src/model/providers/openai/request.ts
+++ b/src/model/providers/openai/request.ts
@@ -16,6 +16,7 @@ import { cleanSchemaForGoogle, normalizeGoogleToolSchema } from "../google/schem
 import { normalizeOpenAISchema } from "./schema.js";
 import { resolveThinkingPlan, throwIfUnsupportedThinkingPlan } from "../../thinking/registry.js";
 import { formatToolResultReferenceText } from "../toolResultReferenceText.js";
+import { hasSpeedMapping, mapSpeedToOpenAIServiceTier } from "../../request/speedMapping.js";
 
 export type OpenAIRequestBody = {
   model: string;
@@ -24,7 +25,7 @@ export type OpenAIRequestBody = {
   tools?: OpenAITool[];
   tool_choice?: unknown;
   temperature?: number;
-  speed?: number;
+  service_tier?: "fast" | "priority";
   stream?: boolean;
   metadata?: Record<string, unknown>;
   reasoning?: { effort?: string };
@@ -85,7 +86,10 @@ export function buildOpenAIRequest(
     tools: request.tools?.map((tool) => toOpenAITool(tool, googleOpenAICompatible)),
     tool_choice: toOpenAIToolChoice(request.toolChoice),
     temperature: thinkingPlan.omitTemperature ? undefined : request.temperature,
-    speed: model.capabilities.supportsSpeed === true ? request.speed : undefined,
+    service_tier: request.speed !== undefined && model.capabilities.supportsSpeed === true
+      && hasSpeedMapping(provider?.speedMapping, "openai_service_tier")
+      ? mapSpeedToOpenAIServiceTier(request.speed)
+      : undefined,
     stream: request.stream,
     metadata: request.metadata
       ? Object.fromEntries(

--- a/src/model/providers/openai/request.ts
+++ b/src/model/providers/openai/request.ts
@@ -25,7 +25,7 @@ export type OpenAIRequestBody = {
   tools?: OpenAITool[];
   tool_choice?: unknown;
   temperature?: number;
-  service_tier?: "fast" | "priority";
+  service_tier?: "priority";
   stream?: boolean;
   metadata?: Record<string, unknown>;
   reasoning?: { effort?: string };

--- a/src/model/providers/openai/request.ts
+++ b/src/model/providers/openai/request.ts
@@ -24,6 +24,7 @@ export type OpenAIRequestBody = {
   tools?: OpenAITool[];
   tool_choice?: unknown;
   temperature?: number;
+  speed?: number;
   stream?: boolean;
   metadata?: Record<string, unknown>;
   reasoning?: { effort?: string };
@@ -84,6 +85,7 @@ export function buildOpenAIRequest(
     tools: request.tools?.map((tool) => toOpenAITool(tool, googleOpenAICompatible)),
     tool_choice: toOpenAIToolChoice(request.toolChoice),
     temperature: thinkingPlan.omitTemperature ? undefined : request.temperature,
+    speed: model.capabilities.supportsSpeed === true ? request.speed : undefined,
     stream: request.stream,
     metadata: request.metadata
       ? Object.fromEntries(

--- a/src/model/request/buildModelRequest.ts
+++ b/src/model/request/buildModelRequest.ts
@@ -21,7 +21,7 @@ export function buildModelRequest(
   const { provider, model } = validateModelRequest(request, config);
 
   if (provider.protocol === "anthropic") {
-    return buildAnthropicRequest(request, model);
+    return buildAnthropicRequest(request, model, provider);
   }
 
   if (provider.protocol === "google") {

--- a/src/model/request/speedMapping.ts
+++ b/src/model/request/speedMapping.ts
@@ -1,0 +1,17 @@
+import type { SpeedMapping } from "../protocol/canonical.js";
+
+export type OpenAISpeedTier = "fast" | "priority";
+export type AnthropicSpeed = "standard" | "fast";
+
+/** Normalize the shared 0..1 preference to the provider's discrete tiers. */
+export function mapSpeedToOpenAIServiceTier(speed: number): OpenAISpeedTier {
+  return speed >= 0.5 ? "priority" : "fast";
+}
+
+export function mapSpeedToAnthropicSpeed(speed: number): AnthropicSpeed {
+  return speed >= 0.5 ? "fast" : "standard";
+}
+
+export function hasSpeedMapping(mapping: SpeedMapping | undefined, expected: SpeedMapping): boolean {
+  return mapping === expected;
+}

--- a/src/model/request/speedMapping.ts
+++ b/src/model/request/speedMapping.ts
@@ -1,11 +1,12 @@
 import type { SpeedMapping } from "../protocol/canonical.js";
 
-export type OpenAISpeedTier = "fast" | "priority";
+export type OpenAISpeedTier = "priority";
 export type AnthropicSpeed = "standard" | "fast";
 
 /** Normalize the shared 0..1 preference to the provider's discrete tiers. */
-export function mapSpeedToOpenAIServiceTier(speed: number): OpenAISpeedTier {
-  return speed >= 0.5 ? "priority" : "fast";
+export function mapSpeedToOpenAIServiceTier(speed: number): OpenAISpeedTier | undefined {
+  if (speed >= 0.5) return "priority";
+  return undefined;
 }
 
 export function mapSpeedToAnthropicSpeed(speed: number): AnthropicSpeed {

--- a/src/model/request/speedMapping.ts
+++ b/src/model/request/speedMapping.ts
@@ -1,7 +1,7 @@
 import type { SpeedMapping } from "../protocol/canonical.js";
 
 export type OpenAISpeedTier = "priority";
-export type AnthropicSpeed = "standard" | "fast";
+export type AnthropicSpeed = "fast";
 
 /** Normalize the shared 0..1 preference to the provider's discrete tiers. */
 export function mapSpeedToOpenAIServiceTier(speed: number): OpenAISpeedTier | undefined {
@@ -9,8 +9,9 @@ export function mapSpeedToOpenAIServiceTier(speed: number): OpenAISpeedTier | un
   return undefined;
 }
 
-export function mapSpeedToAnthropicSpeed(speed: number): AnthropicSpeed {
-  return speed >= 0.5 ? "fast" : "standard";
+export function mapSpeedToAnthropicSpeed(speed: number): AnthropicSpeed | undefined {
+  if (speed >= 0.5) return "fast";
+  return undefined;
 }
 
 export function hasSpeedMapping(mapping: SpeedMapping | undefined, expected: SpeedMapping): boolean {

--- a/src/model/request/validateModelRequest.ts
+++ b/src/model/request/validateModelRequest.ts
@@ -17,12 +17,20 @@ export function validateModelRequest(
     throw new ModelRequestError("provider_not_found", `Provider ${request.provider} does not exist.`);
   }
 
+  if (request.speed !== undefined && (!Number.isFinite(request.speed) || request.speed < 0 || request.speed > 1)) {
+    throw new ModelRequestError("invalid_speed", "speed must be between 0 and 1.");
+  }
+
   const model = provider.models[request.model];
   if (!model) {
     throw new ModelRequestError(
       "model_not_found",
       `Model ${request.model} does not exist in provider ${request.provider}.`,
     );
+  }
+
+  if (request.speed !== undefined && (model.capabilities.supportsSpeed !== true || provider.speedMapping === undefined)) {
+    throw new ModelRequestError("unsupported_speed", `Model ${request.model} does not support speed for provider ${request.provider}.`);
   }
 
   if (request.stream && !model.capabilities.supportsStreaming) {

--- a/src/model/streaming/streamModel.ts
+++ b/src/model/streaming/streamModel.ts
@@ -606,7 +606,7 @@ async function sendProviderRequest(
   try {
     const fetchOptions: RequestInit = {
       method: "POST",
-      headers: buildProviderHeaders(provider),
+      headers: buildProviderHeaders(provider, finalBody),
       body: JSON.stringify(finalBody),
       signal: controller.signal,
     };
@@ -678,7 +678,7 @@ async function shouldUseEndpointResponse(
   }
 }
 
-export function buildProviderHeaders(provider: ProviderConfig): HeadersInit {
+export function buildProviderHeaders(provider: ProviderConfig, body?: unknown): HeadersInit {
   const headers: Record<string, string> = {
     "content-type": "application/json",
     ...provider.headers,
@@ -693,11 +693,30 @@ export function buildProviderHeaders(provider: ProviderConfig): HeadersInit {
   if (provider.protocol === "anthropic") {
     headers["x-api-key"] = apiKey;
     headers["anthropic-version"] = headers["anthropic-version"] ?? "2023-06-01";
+    if (provider.speedMapping === "anthropic_speed" && isFastAnthropicRequest(body)) {
+      appendAnthropicBeta(headers, "fast-mode-2026-02-01");
+    }
   } else {
     headers.authorization = headers.authorization ?? `Bearer ${apiKey}`;
   }
 
   return headers;
+}
+
+function isFastAnthropicRequest(body: unknown): boolean {
+  return typeof body === "object" && body !== null
+    && (body as { speed?: unknown }).speed === "fast";
+}
+
+function appendAnthropicBeta(headers: Record<string, string>, beta: string): void {
+  const existingKey = Object.keys(headers).find((key) => key.toLowerCase() === "anthropic-beta");
+  const key = existingKey ?? "anthropic-beta";
+  const values = (headers[key] ?? "")
+    .split(",")
+    .map((value) => value.trim())
+    .filter(Boolean);
+  if (!values.includes(beta)) values.push(beta);
+  headers[key] = values.join(", ");
 }
 
 async function safeReadJson(response: Response): Promise<unknown> {

--- a/src/session/transcript/TranscriptEntry.ts
+++ b/src/session/transcript/TranscriptEntry.ts
@@ -114,7 +114,7 @@ export type SessionMetadataValue = {
   /** Persisted dialog model preference. Null is an explicit clear tombstone. */
   modelSelection?:
     | { mode: "auto" }
-    | { mode: "model"; provider: string; model: string; reasoning?: number; temperature?: number }
+    | { mode: "model"; provider: string; model: string; reasoning?: number; temperature?: number; speed?: number }
     | null;
   linkedPullRequest?: {
     number: number;

--- a/src/web/client/protocol.ts
+++ b/src/web/client/protocol.ts
@@ -46,7 +46,7 @@ type WebGatewayEventMetadata = {
 
 export type WebGatewayEvent = WebGatewayEventMetadata & (
   | { type: "turn_started"; runId: string }
-  | { type: "model_selection_changed"; provider: string; model: string; source: "turn" | "session" | "router" | "default"; reasoning?: number; temperature?: number }
+  | { type: "model_selection_changed"; provider: string; model: string; source: "turn" | "session" | "router" | "default"; reasoning?: number; temperature?: number; speed?: number }
   | { type: "assistant_text_delta"; text: string }
   | { type: "assistant_thinking_delta"; text: string }
   | { type: "file_artifacts"; artifacts: import("../../session/artifacts/FileArtifact.js").FileArtifact[] }
@@ -187,12 +187,12 @@ export type WebProjectFilesListResult = {
 };
 export type WebCommandsListInput = { projectKey: string; query?: string; cursor?: string; limit?: number };
 export type WebCommandsListResult = { pinned: unknown[]; builtIn: unknown[]; custom: unknown[]; nextCursor?: string };
-export type WebExplicitModelSelection = { mode: "model"; provider: string; model: string; reasoning?: number; temperature?: number };
+export type WebExplicitModelSelection = { mode: "model"; provider: string; model: string; reasoning?: number; temperature?: number; speed?: number };
 export type WebSessionModelSelection = { mode: "auto" } | WebExplicitModelSelection;
 export type WebModelCatalogListInput = { projectKey: string; query?: string; provider?: string; includeAuto?: boolean };
 export type WebModelCatalogListResult = { items: unknown[]; router: { enabled: boolean; autoAvailable: boolean } };
 export type WebSessionModelInput = { projectKey: string; sessionKey: string };
-export type WebSessionModelResult = WebSessionModelInput & { saved?: WebSessionModelSelection; effective: { provider: string; model: string; source: "session" | "router" | "default"; reasoning?: number; temperature?: number } };
+export type WebSessionModelResult = WebSessionModelInput & { saved?: WebSessionModelSelection; effective: { provider: string; model: string; source: "session" | "router" | "default"; reasoning?: number; temperature?: number; speed?: number } };
 
 export type WebChannelAttachment = {
   type: "file" | "image" | "text" | "unknown";

--- a/tests/agent/loop/model-override-defaults.spec.ts
+++ b/tests/agent/loop/model-override-defaults.spec.ts
@@ -8,7 +8,7 @@ import type { CanonicalMessage, CanonicalModelRequest } from "../../../src/model
 import { createDefaultPermissionContext } from "../../../src/permission/index.js";
 import { ToolRegistry } from "../../../src/tool/index.js";
 
-test("provider and model overrides retain configured temperature and thinking defaults", async () => {
+test("provider and model overrides retain configured temperature, speed, and thinking defaults", async () => {
   const thinking = { enabled: true, mode: "high" as const };
   const config: AgentRuntimeConfig = {
     provider: "openai",
@@ -36,7 +36,7 @@ test("provider and model overrides retain configured temperature and thinking de
     sessionId: "session-1",
     turnId: "turn-1",
     messages,
-    modelOverride: { provider: "anthropic", model: "selected-model" },
+    modelOverride: { provider: "anthropic", model: "selected-model", speed: 0.7 },
   };
 
   const request = await (loop as unknown as {
@@ -50,5 +50,6 @@ test("provider and model overrides retain configured temperature and thinking de
   assert.equal(request.provider, "anthropic");
   assert.equal(request.model, "selected-model");
   assert.equal(request.temperature, 0.35);
+  assert.equal(request.speed, 0.7);
   assert.deepEqual(request.thinking, thinking);
 });

--- a/tests/gateway/dialog-model-catalog.test.ts
+++ b/tests/gateway/dialog-model-catalog.test.ts
@@ -21,6 +21,7 @@ model:
       protocol: openai
       url: https://example.test/v1
       apiKey: test-key
+      speedMapping: openai_service_tier
       models:
         default-model: {}
         no-thinking:

--- a/tests/gateway/dialog-model-catalog.test.ts
+++ b/tests/gateway/dialog-model-catalog.test.ts
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import {
+  listModelCatalog,
+  validateExplicitModelSelection,
+} from "../../src/gateway/dialog/modelCatalog.js";
+
+test("model catalog exposes default reasoning and opt-in speed capabilities", async (t) => {
+  const pilotHome = await mkdtemp(join(tmpdir(), "pilotdeck-model-catalog-"));
+  t.after(() => rm(pilotHome, { recursive: true, force: true }));
+  await writeFile(join(pilotHome, "pilotdeck.yaml"), `
+schemaVersion: 1
+agent:
+  model: custom/default-model
+model:
+  providers:
+    custom:
+      protocol: openai
+      url: https://example.test/v1
+      apiKey: test-key
+      models:
+        default-model: {}
+        no-thinking:
+          capabilities:
+            supportsThinking: false
+        speed-model:
+          capabilities:
+            supportsSpeed: true
+    google:
+      protocol: google
+      models:
+        speed-model:
+          capabilities:
+            supportsSpeed: true
+`);
+
+  const env = { ...process.env, PILOT_HOME: pilotHome, GEMINI_API_KEY: "test-key" };
+  const result = listModelCatalog({ projectKey: "/project" }, env);
+  const defaultModel = result.items.find((item) => item.model === "default-model");
+  const noThinking = result.items.find((item) => item.model === "no-thinking");
+  const speedModel = result.items.find((item) => item.model === "speed-model");
+  const googleSpeedModel = result.items.find((item) => item.provider === "google");
+
+  assert.deepEqual(defaultModel?.capabilities.reasoning?.values, [0, 0.2, 0.4, 0.6, 0.8, 0.9, 1]);
+  assert.equal(defaultModel?.capabilities.speed, undefined);
+  assert.equal(noThinking?.capabilities.reasoning, undefined);
+  assert.deepEqual(speedModel?.capabilities.speed, { type: "range", min: 0, max: 1, step: 0.1 });
+  assert.equal(googleSpeedModel?.capabilities.speed, undefined);
+
+  validateExplicitModelSelection("/project", {
+    mode: "model", provider: "custom", model: "speed-model", speed: 0,
+  }, env);
+  validateExplicitModelSelection("/project", {
+    mode: "model", provider: "custom", model: "speed-model", speed: 1,
+  }, env);
+  await assert.rejects(
+    Promise.resolve().then(() => validateExplicitModelSelection("/project", {
+      mode: "model", provider: "custom", model: "speed-model", speed: 1.1,
+    }, env)),
+    (error: unknown) => (error as { code?: string }).code === "UNSUPPORTED_MODEL_PARAMETER",
+  );
+  for (const speed of [Number.NaN, Number.POSITIVE_INFINITY]) {
+    await assert.rejects(
+      Promise.resolve().then(() => validateExplicitModelSelection("/project", {
+        mode: "model", provider: "custom", model: "speed-model", speed,
+      }, env)),
+      (error: unknown) => (error as { code?: string }).code === "UNSUPPORTED_MODEL_PARAMETER",
+    );
+  }
+  await assert.rejects(
+    Promise.resolve().then(() => validateExplicitModelSelection("/project", {
+      mode: "model", provider: "custom", model: "default-model", speed: 0.5,
+    }, env)),
+    (error: unknown) => (error as { code?: string }).code === "UNSUPPORTED_MODEL_PARAMETER",
+  );
+  await assert.rejects(
+    Promise.resolve().then(() => validateExplicitModelSelection("/project", {
+      mode: "model", provider: "google", model: "speed-model", speed: 0.5,
+    }, env)),
+    (error: unknown) => (error as { code?: string }).code === "UNSUPPORTED_MODEL_PARAMETER",
+  );
+});

--- a/tests/model/config/parseModelConfig.spec.ts
+++ b/tests/model/config/parseModelConfig.spec.ts
@@ -43,6 +43,56 @@ test("unknown custom models default to text-only input", () => {
   assert.deepEqual(config.providers.custom.models["text-model"].multimodal.input, ["text"]);
 });
 
+test("custom models default to thinking support and opt into speed explicitly", () => {
+  const defaulted = parseModelConfig({
+    providers: {
+      custom: {
+        protocol: "openai",
+        url: "https://example.test/v1",
+        apiKey: "test-key",
+        models: { "default-model": {} },
+      },
+    },
+  });
+  assert.equal(defaulted.providers.custom.models["default-model"].capabilities.supportsThinking, true);
+  assert.equal(defaulted.providers.custom.models["default-model"].capabilities.supportsSpeed, undefined);
+
+  const configured = parseModelConfig({
+    providers: {
+      custom: {
+        protocol: "openai",
+        url: "https://example.test/v1",
+        apiKey: "test-key",
+        models: {
+          "speed-model": { capabilities: { supportsThinking: false, supportsSpeed: true } },
+        },
+      },
+    },
+  });
+  assert.equal(configured.providers.custom.models["speed-model"].capabilities.supportsThinking, false);
+  assert.equal(configured.providers.custom.models["speed-model"].capabilities.supportsSpeed, true);
+});
+
+test("all protocol defaults enable thinking for undeclared models", () => {
+  for (const protocol of ["openai", "anthropic", "google"] as const) {
+    const config = parseModelConfig({
+      providers: {
+        [`custom-${protocol}`]: {
+          protocol,
+          url: "https://example.test/v1",
+          apiKey: "test-key",
+          models: { "undeclared-model": {} },
+        },
+      },
+    });
+    assert.equal(
+      config.providers[`custom-${protocol}`].models["undeclared-model"].capabilities.supportsThinking,
+      true,
+      protocol,
+    );
+  }
+});
+
 test("custom providers do not infer image input from a cross-provider model name", () => {
   const config = parseModelConfig({
     providers: {

--- a/tests/model/config/parseModelConfig.spec.ts
+++ b/tests/model/config/parseModelConfig.spec.ts
@@ -93,6 +93,36 @@ test("all protocol defaults enable thinking for undeclared models", () => {
   }
 });
 
+test("custom providers require an explicit protocol-compatible speed mapping", () => {
+  const config = parseModelConfig({
+    providers: {
+      custom: {
+        protocol: "openai",
+        url: "https://example.test/v1",
+        apiKey: "test-key",
+        speedMapping: "openai_service_tier",
+        models: { "speed-model": {} },
+      },
+    },
+  });
+  assert.equal(config.providers.custom.speedMapping, "openai_service_tier");
+
+  assert.throws(
+    () => parseModelConfig({
+      providers: {
+        custom: {
+          protocol: "openai",
+          url: "https://example.test/v1",
+          apiKey: "test-key",
+          speedMapping: "anthropic_speed",
+          models: { "speed-model": {} },
+        },
+      },
+    }),
+    (error: unknown) => (error as { code?: string }).code === "invalid_config_value",
+  );
+});
+
 test("custom providers do not infer image input from a cross-provider model name", () => {
   const config = parseModelConfig({
     providers: {

--- a/tests/model/request/speed.spec.ts
+++ b/tests/model/request/speed.spec.ts
@@ -13,19 +13,49 @@ import type {
 test("all provider request builders pass speed only when configured", () => {
   for (const protocol of ["openai", "openai-responses", "anthropic"] as const) {
     const withSpeed = buildModelRequest(request(protocol, 0.65), modelConfig(protocol)) as Record<string, unknown>;
-    assert.equal(withSpeed.speed, 0.65, `${protocol} should pass speed`);
+    if (protocol === "anthropic") {
+      assert.equal(withSpeed.speed, "fast", `${protocol} should map speed to its native value`);
+    } else {
+      assert.equal(withSpeed.service_tier, "priority", `${protocol} should map speed to service_tier`);
+      assert.equal(withSpeed.speed, undefined, `${protocol} should not send numeric speed`);
+    }
 
     const withoutSpeed = buildModelRequest(request(protocol), modelConfig(protocol)) as Record<string, unknown>;
     assert.equal(withoutSpeed.speed, undefined, `${protocol} should omit unset speed`);
+    assert.equal(withoutSpeed.service_tier, undefined, `${protocol} should omit unset service tier`);
   }
-  const googleBody = buildModelRequest(request("google", 0.65), modelConfig("google")) as Record<string, unknown>;
-  assert.equal(googleBody.speed, undefined, "google should not advertise an unsupported top-level speed field");
+  assert.throws(
+    () => buildModelRequest(request("google", 0.65), modelConfig("google")),
+    (error: unknown) => (error as { code?: string }).code === "unsupported_speed",
+  );
 });
 
-test("provider request builders omit speed for models without the capability", () => {
-  for (const protocol of ["openai", "openai-responses", "anthropic", "google"] as const) {
-    const body = buildModelRequest(request(protocol, 0.65), modelConfig(protocol, false)) as Record<string, unknown>;
-    assert.equal(body.speed, undefined, `${protocol} should filter unsupported speed`);
+test("native speed mappings preserve low and high normalized tiers", () => {
+  const openaiLow = buildModelRequest(request("openai", 0.49), modelConfig("openai")) as Record<string, unknown>;
+  const openaiHigh = buildModelRequest(request("openai", 0.5), modelConfig("openai")) as Record<string, unknown>;
+  const anthropicLow = buildModelRequest(request("anthropic", 0.49), modelConfig("anthropic")) as Record<string, unknown>;
+  const anthropicHigh = buildModelRequest(request("anthropic", 0.5), modelConfig("anthropic")) as Record<string, unknown>;
+  assert.equal(openaiLow.service_tier, "fast");
+  assert.equal(openaiHigh.service_tier, "priority");
+  assert.equal(anthropicLow.speed, "standard");
+  assert.equal(anthropicHigh.speed, "fast");
+});
+
+test("shared request validation rejects speed for models without the capability", () => {
+  for (const protocol of ["openai", "openai-responses", "anthropic"] as const) {
+    assert.throws(
+      () => buildModelRequest(request(protocol, 0.65), modelConfig(protocol, false)),
+      (error: unknown) => (error as { code?: string }).code === "unsupported_speed",
+    );
+  }
+});
+
+test("canonical request validation rejects invalid speed values before provider mapping", () => {
+  for (const speed of [-0.1, 2, Number.NaN, Number.POSITIVE_INFINITY]) {
+    assert.throws(
+      () => buildModelRequest(request("openai", speed), modelConfig("openai")),
+      (error: unknown) => (error as { code?: string }).code === "invalid_speed",
+    );
   }
 });
 
@@ -63,6 +93,7 @@ function modelConfig(protocol: ModelProtocol, supportsSpeed = true): ModelConfig
     url: "https://example.invalid/v1",
     apiKey: "test-key",
     headers: {},
+    speedMapping: protocol === "anthropic" ? "anthropic_speed" : protocol === "google" ? undefined : "openai_service_tier",
     models: { "test-model": model },
   };
   return { providers: { [protocol]: provider } };

--- a/tests/model/request/speed.spec.ts
+++ b/tests/model/request/speed.spec.ts
@@ -38,7 +38,7 @@ test("native speed mappings preserve low and high normalized tiers", () => {
   const anthropicHigh = buildModelRequest(request("anthropic", 0.5), modelConfig("anthropic")) as Record<string, unknown>;
   assert.equal(openaiLow.service_tier, undefined);
   assert.equal(openaiHigh.service_tier, "priority");
-  assert.equal(anthropicLow.speed, "standard");
+  assert.equal(anthropicLow.speed, undefined);
   assert.equal(anthropicHigh.speed, "fast");
 });
 
@@ -48,7 +48,7 @@ test("anthropic fast mode adds the required beta header and preserves existing b
   const headers = buildProviderHeaders(provider, { speed: "fast" }) as Record<string, string>;
   assert.equal(headers["anthropic-beta"], "prompt-caching-2024-07-31, fast-mode-2026-02-01");
 
-  const standardHeaders = buildProviderHeaders(provider, { speed: "standard" }) as Record<string, string>;
+  const standardHeaders = buildProviderHeaders(provider, {}) as Record<string, string>;
   assert.equal(standardHeaders["anthropic-beta"], "prompt-caching-2024-07-31");
 
   const duplicateHeaders = buildProviderHeaders({

--- a/tests/model/request/speed.spec.ts
+++ b/tests/model/request/speed.spec.ts
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildModelRequest } from "../../../src/model/index.js";
+import type {
+  CanonicalModelRequest,
+  ModelCapabilities,
+  ModelConfig,
+  ModelDefinition,
+  ModelProtocol,
+  ProviderConfig,
+} from "../../../src/model/index.js";
+
+test("all provider request builders pass speed only when configured", () => {
+  for (const protocol of ["openai", "openai-responses", "anthropic", "google"] as const) {
+    const withSpeed = buildModelRequest(request(protocol, 0.65), modelConfig(protocol)) as Record<string, unknown>;
+    assert.equal(withSpeed.speed, 0.65, `${protocol} should pass speed`);
+
+    const withoutSpeed = buildModelRequest(request(protocol), modelConfig(protocol)) as Record<string, unknown>;
+    assert.equal(withoutSpeed.speed, undefined, `${protocol} should omit unset speed`);
+  }
+});
+
+test("provider request builders omit speed for models without the capability", () => {
+  for (const protocol of ["openai", "openai-responses", "anthropic", "google"] as const) {
+    const body = buildModelRequest(request(protocol, 0.65), modelConfig(protocol, false)) as Record<string, unknown>;
+    assert.equal(body.speed, undefined, `${protocol} should filter unsupported speed`);
+  }
+});
+
+function request(provider: ModelProtocol, speed?: number): CanonicalModelRequest {
+  return {
+    provider,
+    model: "test-model",
+    messages: [{ role: "user", content: [{ type: "text", text: "hello" }] }],
+    stream: true,
+    ...(speed === undefined ? {} : { speed }),
+  };
+}
+
+function modelConfig(protocol: ModelProtocol, supportsSpeed = true): ModelConfig {
+  const capabilities: ModelCapabilities = {
+    supportsToolUse: true,
+    supportsStreaming: true,
+    supportsParallelToolCalls: true,
+    supportsThinking: true,
+    supportsSpeed,
+    supportsJsonSchema: true,
+    supportsSystemPrompt: true,
+    supportsPromptCache: false,
+    maxContextTokens: 128_000,
+    maxOutputTokens: 4_096,
+  };
+  const model: ModelDefinition = {
+    id: "test-model",
+    capabilities,
+    multimodal: { input: ["text"] },
+  };
+  const provider: ProviderConfig = {
+    id: protocol,
+    protocol,
+    url: "https://example.invalid/v1",
+    apiKey: "test-key",
+    headers: {},
+    models: { "test-model": model },
+  };
+  return { providers: { [protocol]: provider } };
+}

--- a/tests/model/request/speed.spec.ts
+++ b/tests/model/request/speed.spec.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { buildModelRequest } from "../../../src/model/index.js";
+import { buildProviderHeaders } from "../../../src/model/streaming/streamModel.js";
 import type {
   CanonicalModelRequest,
   ModelCapabilities,
@@ -35,10 +36,26 @@ test("native speed mappings preserve low and high normalized tiers", () => {
   const openaiHigh = buildModelRequest(request("openai", 0.5), modelConfig("openai")) as Record<string, unknown>;
   const anthropicLow = buildModelRequest(request("anthropic", 0.49), modelConfig("anthropic")) as Record<string, unknown>;
   const anthropicHigh = buildModelRequest(request("anthropic", 0.5), modelConfig("anthropic")) as Record<string, unknown>;
-  assert.equal(openaiLow.service_tier, "fast");
+  assert.equal(openaiLow.service_tier, undefined);
   assert.equal(openaiHigh.service_tier, "priority");
   assert.equal(anthropicLow.speed, "standard");
   assert.equal(anthropicHigh.speed, "fast");
+});
+
+test("anthropic fast mode adds the required beta header and preserves existing beta values", () => {
+  const provider = modelConfig("anthropic").providers.anthropic;
+  provider.headers = { "anthropic-beta": "prompt-caching-2024-07-31" };
+  const headers = buildProviderHeaders(provider, { speed: "fast" }) as Record<string, string>;
+  assert.equal(headers["anthropic-beta"], "prompt-caching-2024-07-31, fast-mode-2026-02-01");
+
+  const standardHeaders = buildProviderHeaders(provider, { speed: "standard" }) as Record<string, string>;
+  assert.equal(standardHeaders["anthropic-beta"], "prompt-caching-2024-07-31");
+
+  const duplicateHeaders = buildProviderHeaders({
+    ...provider,
+    headers: { "Anthropic-Beta": "fast-mode-2026-02-01" },
+  }, { speed: "fast" }) as Record<string, string>;
+  assert.equal(duplicateHeaders["Anthropic-Beta"], "fast-mode-2026-02-01");
 });
 
 test("shared request validation rejects speed for models without the capability", () => {

--- a/tests/model/request/speed.spec.ts
+++ b/tests/model/request/speed.spec.ts
@@ -11,13 +11,15 @@ import type {
 } from "../../../src/model/index.js";
 
 test("all provider request builders pass speed only when configured", () => {
-  for (const protocol of ["openai", "openai-responses", "anthropic", "google"] as const) {
+  for (const protocol of ["openai", "openai-responses", "anthropic"] as const) {
     const withSpeed = buildModelRequest(request(protocol, 0.65), modelConfig(protocol)) as Record<string, unknown>;
     assert.equal(withSpeed.speed, 0.65, `${protocol} should pass speed`);
 
     const withoutSpeed = buildModelRequest(request(protocol), modelConfig(protocol)) as Record<string, unknown>;
     assert.equal(withoutSpeed.speed, undefined, `${protocol} should omit unset speed`);
   }
+  const googleBody = buildModelRequest(request("google", 0.65), modelConfig("google")) as Record<string, unknown>;
+  assert.equal(googleBody.speed, undefined, "google should not advertise an unsupported top-level speed field");
 });
 
 test("provider request builders omit speed for models without the capability", () => {


### PR DESCRIPTION
## Summary

- Default undeclared model capabilities to `supportsThinking: true` while preserving explicit `false` overrides.
- Add opt-in `supportsSpeed` model capability and expose `speed` in model catalog/session/turn contracts.
- Validate `speed` in the normalized `0..1` range and propagate it through Gateway, Agent, transcript/Web types, and all provider request builders.
- Update dialog API/TRD documentation and add regression coverage.

## Verification

- `pnpm exec tsc --noEmit`
- `pnpm exec tsx --test tests/model/config/parseModelConfig.spec.ts tests/gateway/dialog-model-catalog.test.ts tests/model/request/speed.spec.ts tests/agent/loop/model-override-defaults.spec.ts` (13 passing)
- `git diff --check`

`pnpm build` was blocked by the local Node `v25.5.0`; this repository requires Node `>=22.13.0 <23`.