### PR TITLE
feat(chat): add last-message editing and contextual message actions

### DIFF
--- a/scripts/tui-e2e-permission.tsx
+++ b/scripts/tui-e2e-permission.tsx
@@ -33,6 +33,10 @@ class MockGateway implements Gateway {
     throw new Error("replaceLastTurn is not used by this TUI test.");
   }
 
+  async finalizeLastTurnReplacement(): Promise<never> {
+    throw new Error("finalizeLastTurnReplacement is not used by this TUI test.");
+  }
+
   async *submitTurn(input: GatewaySubmitTurnInput): AsyncIterable<GatewayEvent> {
     this.aborted = false;
     yield { type: "turn_started", runId: "run-1" };

--- a/scripts/tui-e2e-permission.tsx
+++ b/scripts/tui-e2e-permission.tsx
@@ -29,6 +29,10 @@ class MockGateway implements Gateway {
   private pending = new Map<string, PendingPermission>();
   private aborted = false;
 
+  async replaceLastTurn(): Promise<never> {
+    throw new Error("replaceLastTurn is not used by this TUI test.");
+  }
+
   async *submitTurn(input: GatewaySubmitTurnInput): AsyncIterable<GatewayEvent> {
     this.aborted = false;
     yield { type: "turn_started", runId: "run-1" };

--- a/src/cli/createLocalGateway.ts
+++ b/src/cli/createLocalGateway.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { appendFileSync, existsSync, mkdirSync as mkdirSyncFs, renameSync } from "node:fs";
 import { dirname, resolve, join as joinPath } from "node:path";
 import { tmpdir } from "node:os";
@@ -173,6 +174,7 @@ export function createLocalGateway(options: CreateLocalGatewayOptions = {}): Cre
   const baseEnv = options.env ?? process.env;
   const projectRoot = resolve(options.projectRoot ?? process.cwd());
   const pilotHome = options.pilotHome ?? resolvePilotHome(baseEnv);
+  const replacementTransactionOwner = { instanceId: randomUUID(), pid: process.pid };
   const replacementRecovery = recoverPendingLastTurnReplacements(pilotHome);
   if (replacementRecovery.committed > 0 || replacementRecovery.rolledBack > 0) {
     // eslint-disable-next-line no-console
@@ -445,6 +447,7 @@ export function createLocalGateway(options: CreateLocalGatewayOptions = {}): Cre
         projectRoot: input.projectKey ? input.projectKey : fallbackProjectRoot,
         pilotHome,
         now,
+        transactionOwner: replacementTransactionOwner,
       }),
     finalizeLastTurnReplacement: (input) =>
       finalizeLastWebSessionTurnReplacement(input, {

--- a/src/cli/createLocalGateway.ts
+++ b/src/cli/createLocalGateway.ts
@@ -71,6 +71,7 @@ import { readWebSessionMessages, readSubagentWebMessages } from "../web/server/r
 import { forkWebSession } from "../web/server/forkSession.js";
 import {
   finalizeLastWebSessionTurnReplacement,
+  recoverPendingLastTurnReplacements,
   replaceLastWebSessionTurn,
 } from "../web/server/replaceLastTurn.js";
 import { describeWebProject, listWebProjects } from "../web/server/listProjects.js";
@@ -172,6 +173,21 @@ export function createLocalGateway(options: CreateLocalGatewayOptions = {}): Cre
   const baseEnv = options.env ?? process.env;
   const projectRoot = resolve(options.projectRoot ?? process.cwd());
   const pilotHome = options.pilotHome ?? resolvePilotHome(baseEnv);
+  const replacementRecovery = recoverPendingLastTurnReplacements(pilotHome);
+  if (replacementRecovery.committed > 0 || replacementRecovery.rolledBack > 0) {
+    // eslint-disable-next-line no-console
+    console.log(
+      `[pilotdeck] Recovered last-turn replacements: committed=${replacementRecovery.committed} ` +
+      `rolledBack=${replacementRecovery.rolledBack}.`,
+    );
+  }
+  for (const failure of replacementRecovery.failures) {
+    // Keep the backup/journal in place so a later startup can retry safely.
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[pilotdeck] Could not recover replacement transaction for ${failure.transcriptPath}: ${failure.message}`,
+    );
+  }
   const env = options.pilotHome ? { ...baseEnv, PILOT_HOME: pilotHome } : baseEnv;
   const builtinSkillsRoot = resolveBuiltinSkillsRoot(options.builtinSkillsRoot, env);
   const legacySkillMigration = migrateLegacyBundledSkillCopies({ pilotHome, builtinSkillsRoot });

--- a/src/cli/createLocalGateway.ts
+++ b/src/cli/createLocalGateway.ts
@@ -69,7 +69,10 @@ import { sanitizeSessionIdForPath } from "../session/storage/ProjectSessionStora
 import { createSessionTitleGenerator } from "../session/title/SessionTitleGenerator.js";
 import { readWebSessionMessages, readSubagentWebMessages } from "../web/server/readSessionMessages.js";
 import { forkWebSession } from "../web/server/forkSession.js";
-import { replaceLastWebSessionTurn } from "../web/server/replaceLastTurn.js";
+import {
+  finalizeLastWebSessionTurnReplacement,
+  replaceLastWebSessionTurn,
+} from "../web/server/replaceLastTurn.js";
 import { describeWebProject, listWebProjects } from "../web/server/listProjects.js";
 import { BackgroundTaskRuntime, type BackgroundTaskCompletionEvent } from "../task/runtime/BackgroundTaskRuntime.js";
 import { createBuiltinRegistry, createPlanFileManager, filterAvailableTools } from "../tool/index.js";
@@ -425,6 +428,13 @@ export function createLocalGateway(options: CreateLocalGatewayOptions = {}): Cre
       replaceLastWebSessionTurn(input, {
         projectRoot: input.projectKey ? input.projectKey : fallbackProjectRoot,
         pilotHome,
+        now,
+      }),
+    finalizeLastTurnReplacement: (input) =>
+      finalizeLastWebSessionTurnReplacement(input, {
+        projectRoot: input.projectKey ? input.projectKey : fallbackProjectRoot,
+        pilotHome,
+        now,
       }),
     async recordAgentStatusMessage(input) {
       const storage = createAgentProjectSessionStorage({

--- a/src/cli/createLocalGateway.ts
+++ b/src/cli/createLocalGateway.ts
@@ -69,6 +69,7 @@ import { sanitizeSessionIdForPath } from "../session/storage/ProjectSessionStora
 import { createSessionTitleGenerator } from "../session/title/SessionTitleGenerator.js";
 import { readWebSessionMessages, readSubagentWebMessages } from "../web/server/readSessionMessages.js";
 import { forkWebSession } from "../web/server/forkSession.js";
+import { replaceLastWebSessionTurn } from "../web/server/replaceLastTurn.js";
 import { describeWebProject, listWebProjects } from "../web/server/listProjects.js";
 import { BackgroundTaskRuntime, type BackgroundTaskCompletionEvent } from "../task/runtime/BackgroundTaskRuntime.js";
 import { createBuiltinRegistry, createPlanFileManager, filterAvailableTools } from "../tool/index.js";
@@ -419,6 +420,11 @@ export function createLocalGateway(options: CreateLocalGatewayOptions = {}): Cre
         projectRoot: input.projectKey ? input.projectKey : fallbackProjectRoot,
         pilotHome,
         now,
+      }),
+    replaceLastTurn: (input) =>
+      replaceLastWebSessionTurn(input, {
+        projectRoot: input.projectKey ? input.projectKey : fallbackProjectRoot,
+        pilotHome,
       }),
     async recordAgentStatusMessage(input) {
       const storage = createAgentProjectSessionStorage({

--- a/src/cli/pilotdeck.ts
+++ b/src/cli/pilotdeck.ts
@@ -782,6 +782,9 @@ function createFallbackGateway(): Gateway {
     replaceLastTurn: async () => {
       throw new Error("Message editing is unavailable while using the fallback gateway.");
     },
+    finalizeLastTurnReplacement: async () => {
+      throw new Error("Message editing is unavailable while using the fallback gateway.");
+    },
     describeServer: async () => ({ mode: "in_process" }),
     cronCreate: async () => {
       throw new Error("Cron runtime is not configured.");

--- a/src/cli/pilotdeck.ts
+++ b/src/cli/pilotdeck.ts
@@ -779,6 +779,9 @@ function createFallbackGateway(): Gateway {
     resumeSession: async (input) => input,
     newSession: async (input) => ({ sessionKey: `${input.channelKey}:project=${input.projectKey ?? process.cwd()}:s_local` }),
     closeSession: async () => undefined,
+    replaceLastTurn: async () => {
+      throw new Error("Message editing is unavailable while using the fallback gateway.");
+    },
     describeServer: async () => ({ mode: "in_process" }),
     cronCreate: async () => {
       throw new Error("Cron runtime is not configured.");

--- a/src/gateway/SessionRouter.ts
+++ b/src/gateway/SessionRouter.ts
@@ -101,6 +101,10 @@ export class SessionRouter {
     return this.inFlightTurns.has(sessionKey);
   }
 
+  activeTurnRunId(sessionKey: string): string | undefined {
+    return this.inFlightTurns.get(sessionKey);
+  }
+
   endTurn(sessionKey: string, runId?: string): void {
     const record = this.sessions.get(sessionKey);
     const inFlightRunId = this.inFlightTurns.get(sessionKey);

--- a/src/gateway/client/InProcessGateway.ts
+++ b/src/gateway/client/InProcessGateway.ts
@@ -108,6 +108,7 @@ import { listProjectFiles } from "../dialog/projectFiles.js";
 const PLAN_COMMAND_USAGE = "用法：/plan <任务>\n例如：/plan 设计一个新功能";
 const MAX_GATEWAY_TOOL_RESULT_PREVIEW_CHARS = 20_000;
 const MAX_GATEWAY_TOOL_DATA_STRING_CHARS = 4_000;
+const DEFAULT_REPLACEMENT_TRANSACTION_TIMEOUT_MS = 60_000;
 
 export type InProcessGatewayOptions = {
   /** Absolute command used by the model to install bundled FunASR assets. */
@@ -128,6 +129,8 @@ export type InProcessGatewayOptions = {
   finalizeLastTurnReplacement?: (
     input: WebFinalizeLastTurnReplacementInput,
   ) => Promise<WebFinalizeLastTurnReplacementResult>;
+  /** Roll back a prepared edit that never reaches durable input acceptance. */
+  replacementTransactionTimeoutMs?: number;
   recordAgentStatusMessage?: (input: GatewayRecordAgentStatusMessageInput) => Promise<{ recorded: boolean }>;
   /**
    * Web Phase 3 — pluggable project enumerator + describer.
@@ -217,11 +220,14 @@ type PendingTurnReplacement = {
   transactionId: string;
   replacementTurnId: string;
   projectKey?: string;
+  timeout?: ReturnType<typeof setTimeout>;
+  finalizing?: boolean;
 };
 
 export class InProcessGateway implements Gateway {
   private readonly now: () => Date;
   private readonly uuid: () => string;
+  private readonly replacementTransactionTimeoutMs: number;
   /**
    * B1 — registry of active per-session emit sinks. The gateway shares this
    * map with the per-session `GatewayElicitationChannel` so an `askUser`
@@ -230,7 +236,7 @@ export class InProcessGateway implements Gateway {
    */
   private readonly emitSinks = new Map<string, (event: GatewayEvent) => void>();
   private readonly activeTurnReplays = new Map<string, ActiveTurnReplay>();
-  private readonly replacementReservations = new Set<string>();
+  private readonly transcriptWriteReservations = new Set<string>();
   private readonly pendingTurnReplacements = new Map<string, PendingTurnReplacement>();
   /** B1 — pending askUser() promises keyed by sessionKey + requestId. */
   private readonly elicitationBus = new GatewayElicitationBus();
@@ -256,6 +262,10 @@ export class InProcessGateway implements Gateway {
   ) {
     this.now = options.now ?? (() => new Date());
     this.uuid = options.uuid ?? randomUUID;
+    this.replacementTransactionTimeoutMs = Math.max(
+      1,
+      options.replacementTransactionTimeoutMs ?? DEFAULT_REPLACEMENT_TRANSACTION_TIMEOUT_MS,
+    );
   }
 
   /**
@@ -358,14 +368,14 @@ export class InProcessGateway implements Gateway {
       }
     }
     const runId = input.runId ?? this.uuid();
-    if (this.replacementReservations.has(input.sessionKey)) {
+    if (this.transcriptWriteReservations.has(input.sessionKey)) {
       yield {
         type: "error",
         runId,
         code: "replace_turn_pending",
-        message: "This session is currently preparing an edited replacement turn.",
+        message: "This session transcript is currently being updated.",
         recoverable: true,
-        userHint: "Wait for the message edit to finish, then try again.",
+        userHint: "Wait for the session update to finish, then try again.",
       };
       return;
     }
@@ -804,12 +814,35 @@ export class InProcessGateway implements Gateway {
 
   async sessionModelSet(input: SessionModelSetInput): Promise<SessionModelResult> {
     if (!this.options.sessionModelSet) throw new DialogGatewayError("CAPABILITY_UNAVAILABLE", "session_model_set is unavailable.");
-    return this.options.sessionModelSet(input);
+    this.reserveTranscriptWrite(input.sessionKey, "change the session model");
+    try {
+      return await this.options.sessionModelSet(input);
+    } finally {
+      this.transcriptWriteReservations.delete(input.sessionKey);
+    }
   }
 
   async sessionModelClear(input: SessionModelInput): Promise<void> {
     if (!this.options.sessionModelClear) throw new DialogGatewayError("CAPABILITY_UNAVAILABLE", "session_model_clear is unavailable.");
-    await this.options.sessionModelClear(input);
+    this.reserveTranscriptWrite(input.sessionKey, "clear the session model");
+    try {
+      await this.options.sessionModelClear(input);
+    } finally {
+      this.transcriptWriteReservations.delete(input.sessionKey);
+    }
+  }
+
+  private reserveTranscriptWrite(sessionKey: string, operation: string): void {
+    if (
+      this.transcriptWriteReservations.has(sessionKey)
+      || this.pendingTurnReplacements.has(sessionKey)
+    ) {
+      throw new DialogGatewayError(
+        "SESSION_BUSY",
+        `Cannot ${operation} while another transcript update is pending.`,
+      );
+    }
+    this.transcriptWriteReservations.add(sessionKey);
   }
 
   private async resolveUploadedAttachments(input: GatewaySubmitTurnInput): Promise<ChannelAttachment[]> {
@@ -938,7 +971,7 @@ export class InProcessGateway implements Gateway {
       throw new DialogGatewayError("replace_invalid_input", "replacementTurnId is required.");
     }
     if (
-      this.replacementReservations.has(input.sessionKey)
+      this.transcriptWriteReservations.has(input.sessionKey)
       || this.pendingTurnReplacements.has(input.sessionKey)
     ) {
       throw new DialogGatewayError(
@@ -955,7 +988,12 @@ export class InProcessGateway implements Gateway {
         { activeRunId, expectedTurnId: input.expectedTurnId },
       );
     }
-    this.replacementReservations.add(input.sessionKey);
+    if (!this.options.finalizeLastTurnReplacement) {
+      throw new Error(
+        "finalize_last_turn_replacement is required when replace_last_turn is configured.",
+      );
+    }
+    this.transcriptWriteReservations.add(input.sessionKey);
     let result: WebReplaceLastTurnResult | undefined;
     try {
       // Reserve before awaiting the abort so a new turn cannot start between
@@ -975,12 +1013,13 @@ export class InProcessGateway implements Gateway {
         replacementTurnId: input.replacementTurnId,
         projectKey: input.projectKey,
       });
+      this.scheduleReplacementTimeout(input.sessionKey);
       // The cached AgentSession and transcript writer still reflect the old tail.
       // Evict them so the replacement submit resumes from the rewritten JSONL.
       await this.router.close(input.sessionKey);
       return result;
     } catch (error) {
-      this.pendingTurnReplacements.delete(input.sessionKey);
+      this.clearPendingTurnReplacement(input.sessionKey);
       if (result && this.options.finalizeLastTurnReplacement) {
         await this.options.finalizeLastTurnReplacement({
           sessionKey: input.sessionKey,
@@ -991,7 +1030,7 @@ export class InProcessGateway implements Gateway {
       }
       throw error;
     } finally {
-      this.replacementReservations.delete(input.sessionKey);
+      this.transcriptWriteReservations.delete(input.sessionKey);
     }
   }
 
@@ -1000,6 +1039,9 @@ export class InProcessGateway implements Gateway {
     if (!pending || pending.replacementTurnId !== runId || !this.options.finalizeLastTurnReplacement) {
       return;
     }
+    if (pending.finalizing) return;
+    pending.finalizing = true;
+    if (pending.timeout) clearTimeout(pending.timeout);
     try {
       await this.options.finalizeLastTurnReplacement({
         sessionKey,
@@ -1012,7 +1054,52 @@ export class InProcessGateway implements Gateway {
       // cleanup, but it must not block later turns in the live session.
       console.warn("[pilotdeck] failed to remove accepted replacement backup:", error);
     } finally {
-      this.pendingTurnReplacements.delete(sessionKey);
+      this.clearPendingTurnReplacement(sessionKey);
+    }
+  }
+
+  private scheduleReplacementTimeout(sessionKey: string): void {
+    const pending = this.pendingTurnReplacements.get(sessionKey);
+    if (!pending || pending.finalizing) return;
+    if (pending.timeout) clearTimeout(pending.timeout);
+    pending.timeout = setTimeout(() => {
+      void this.rollbackExpiredTurnReplacement(sessionKey, pending.transactionId);
+    }, this.replacementTransactionTimeoutMs);
+    pending.timeout.unref?.();
+  }
+
+  private clearPendingTurnReplacement(sessionKey: string): void {
+    const pending = this.pendingTurnReplacements.get(sessionKey);
+    if (pending?.timeout) clearTimeout(pending.timeout);
+    this.pendingTurnReplacements.delete(sessionKey);
+  }
+
+  private async rollbackExpiredTurnReplacement(
+    sessionKey: string,
+    transactionId: string,
+  ): Promise<void> {
+    const pending = this.pendingTurnReplacements.get(sessionKey);
+    if (!pending || pending.transactionId !== transactionId || pending.finalizing) return;
+    if (this.router.hasActiveTurn(sessionKey)) {
+      this.scheduleReplacementTimeout(sessionKey);
+      return;
+    }
+    if (!this.options.finalizeLastTurnReplacement) return;
+
+    pending.finalizing = true;
+    try {
+      await this.router.close(sessionKey);
+      await this.options.finalizeLastTurnReplacement({
+        sessionKey,
+        projectKey: pending.projectKey,
+        transactionId: pending.transactionId,
+        action: "rollback",
+      });
+      this.clearPendingTurnReplacement(sessionKey);
+    } catch (error) {
+      pending.finalizing = false;
+      console.warn("[pilotdeck] failed to roll back expired replacement transaction:", error);
+      this.scheduleReplacementTimeout(sessionKey);
     }
   }
 
@@ -1031,18 +1118,32 @@ export class InProcessGateway implements Gateway {
         "The replacement transaction is no longer pending.",
       );
     }
-    if (input.action === "rollback") {
-      if (this.router.hasActiveTurn(input.sessionKey)) {
-        throw new DialogGatewayError(
-          "replace_transaction_active",
-          "The replacement cannot be rolled back while its turn is active.",
-        );
-      }
-      await this.router.close(input.sessionKey);
+    if (pending.finalizing) {
+      throw new DialogGatewayError(
+        "replace_transaction_pending",
+        "The replacement transaction is already being finalized.",
+      );
     }
-    const result = await this.options.finalizeLastTurnReplacement(input);
-    this.pendingTurnReplacements.delete(input.sessionKey);
-    return result;
+    pending.finalizing = true;
+    if (pending.timeout) clearTimeout(pending.timeout);
+    try {
+      if (input.action === "rollback") {
+        if (this.router.hasActiveTurn(input.sessionKey)) {
+          throw new DialogGatewayError(
+            "replace_transaction_active",
+            "The replacement cannot be rolled back while its turn is active.",
+          );
+        }
+        await this.router.close(input.sessionKey);
+      }
+      const result = await this.options.finalizeLastTurnReplacement(input);
+      this.clearPendingTurnReplacement(input.sessionKey);
+      return result;
+    } catch (error) {
+      pending.finalizing = false;
+      this.scheduleReplacementTimeout(input.sessionKey);
+      throw error;
+    }
   }
 
   async listProjects(): Promise<WebListProjectsResult> {

--- a/src/gateway/client/InProcessGateway.ts
+++ b/src/gateway/client/InProcessGateway.ts
@@ -47,6 +47,8 @@ import type {
   WebReadSubagentMessagesResult,
   WebForkSessionInput,
   WebForkSessionResult,
+  WebReplaceLastTurnInput,
+  WebReplaceLastTurnResult,
   ProjectFilesListInput,
   ProjectFilesListResult,
   CommandsListInput,
@@ -120,6 +122,7 @@ export type InProcessGatewayOptions = {
   readSessionMessages?: (input: WebReadSessionMessagesInput) => Promise<WebReadSessionMessagesResult>;
   readSubagentMessages?: (input: WebReadSubagentMessagesInput) => Promise<WebReadSubagentMessagesResult>;
   forkSession?: (input: WebForkSessionInput) => Promise<WebForkSessionResult>;
+  replaceLastTurn?: (input: WebReplaceLastTurnInput) => Promise<WebReplaceLastTurnResult>;
   recordAgentStatusMessage?: (input: GatewayRecordAgentStatusMessageInput) => Promise<{ recorded: boolean }>;
   /**
    * Web Phase 3 — pluggable project enumerator + describer.
@@ -883,6 +886,22 @@ export class InProcessGateway implements Gateway {
       );
     }
     return this.options.forkSession(input);
+  }
+
+  async replaceLastTurn(input: WebReplaceLastTurnInput): Promise<WebReplaceLastTurnResult> {
+    if (!this.options.replaceLastTurn) {
+      throw new Error(
+        "replace_last_turn is not configured. Wire `replaceLastTurn` via createLocalGateway.",
+      );
+    }
+    // The transcript cannot be rewritten while its writer is still appending.
+    // abortTurn resolves only after the active turn has fully unwound.
+    await this.abortTurn({ sessionKey: input.sessionKey, reason: "message_replaced" });
+    const result = await this.options.replaceLastTurn(input);
+    // The cached AgentSession and transcript writer still reflect the old tail.
+    // Evict them so the replacement submit resumes from the rewritten JSONL.
+    await this.router.close(input.sessionKey);
+    return result;
   }
 
   async listProjects(): Promise<WebListProjectsResult> {

--- a/src/gateway/client/InProcessGateway.ts
+++ b/src/gateway/client/InProcessGateway.ts
@@ -221,7 +221,7 @@ type PendingTurnReplacement = {
   replacementTurnId: string;
   projectKey?: string;
   timeout?: ReturnType<typeof setTimeout>;
-  finalizing?: boolean;
+  phase: "prepared" | "submitting" | "finalizing";
 };
 
 export class InProcessGateway implements Gateway {
@@ -355,20 +355,23 @@ export class InProcessGateway implements Gateway {
     }
     input = plannedInput;
 
-    // Per-turn config refresh (defensive). The fs watcher path already
-    // catches most edits, but this guarantees a fresh apiKey/url is in
-    // effect for the very next turn even when watcher events are
-    // dropped or coalesced.
-    if (this.options.refreshConfigBeforeTurn) {
-      try {
-        await this.options.refreshConfigBeforeTurn();
-      } catch {
-        // Intentional: keep streaming on the previous snapshot rather
-        // than failing a turn over a transient yaml read error.
-      }
-    }
     const runId = input.runId ?? this.uuid();
+    const replacementClaim = this.claimPendingTurnReplacement(input.sessionKey, runId);
+    if (replacementClaim === "conflict") {
+      const message = "This session is waiting for its edited replacement turn to be accepted.";
+      yield {
+        type: "error",
+        runId,
+        code: "replace_turn_pending",
+        message,
+        recoverable: true,
+        userHint: "Wait for the edited message transaction to finish, then try again.",
+      };
+      return;
+    }
+
     if (this.transcriptWriteReservations.has(input.sessionKey)) {
+      this.releasePendingTurnReplacementClaim(input.sessionKey, runId);
       yield {
         type: "error",
         runId,
@@ -379,20 +382,8 @@ export class InProcessGateway implements Gateway {
       };
       return;
     }
-    const pendingReplacement = this.pendingTurnReplacements.get(input.sessionKey);
-    if (pendingReplacement && pendingReplacement.replacementTurnId !== runId) {
-      const message = "This session is waiting for its edited replacement turn to be accepted.";
-      yield {
-        type: "error",
-        runId,
-        code: "replace_turn_pending",
-        message,
-        recoverable: true,
-        userHint: "Wait for the edited message to be accepted, then try again.",
-      };
-      return;
-    }
     if (!this.router.beginTurn(input.sessionKey, runId)) {
+      this.releasePendingTurnReplacementClaim(input.sessionKey, runId);
       const message = `Session ${input.sessionKey} already has an active turn.`;
       const userHint = "Wait for the current turn to finish or stop it before sending another message.";
       yield {
@@ -460,6 +451,18 @@ export class InProcessGateway implements Gateway {
     // Background pump: agent events → queue.
     const pump = (async () => {
       try {
+        // Refresh only after beginTurn has reserved the session. Replacement
+        // submissions claim their transaction before this await, so an
+        // expiration callback cannot roll the transcript back underneath a
+        // submission that is already starting.
+        if (this.options.refreshConfigBeforeTurn) {
+          try {
+            await this.options.refreshConfigBeforeTurn();
+          } catch {
+            // Keep streaming on the previous snapshot rather than failing a
+            // turn over a transient yaml read error.
+          }
+        }
         const session = await this.router.getOrCreate({
           sessionKey: input.sessionKey,
           projectKey: input.projectKey,
@@ -711,6 +714,7 @@ export class InProcessGateway implements Gateway {
         this.turnCompletions.delete(input.sessionKey);
       }
       resolveTurnDone();
+      this.releasePendingTurnReplacementClaim(input.sessionKey, runId);
       this.options.afterTurnCompleted?.({
         sessionKey: input.sessionKey,
         projectKey: input.projectKey,
@@ -1012,6 +1016,7 @@ export class InProcessGateway implements Gateway {
         transactionId: result.transactionId,
         replacementTurnId: input.replacementTurnId,
         projectKey: input.projectKey,
+        phase: "prepared",
       });
       this.scheduleReplacementTimeout(input.sessionKey);
       // The cached AgentSession and transcript writer still reflect the old tail.
@@ -1036,11 +1041,15 @@ export class InProcessGateway implements Gateway {
 
   private async commitAcceptedTurnReplacement(sessionKey: string, runId: string): Promise<void> {
     const pending = this.pendingTurnReplacements.get(sessionKey);
-    if (!pending || pending.replacementTurnId !== runId || !this.options.finalizeLastTurnReplacement) {
+    if (
+      !pending
+      || pending.replacementTurnId !== runId
+      || pending.phase !== "submitting"
+      || !this.options.finalizeLastTurnReplacement
+    ) {
       return;
     }
-    if (pending.finalizing) return;
-    pending.finalizing = true;
+    pending.phase = "finalizing";
     if (pending.timeout) clearTimeout(pending.timeout);
     try {
       await this.options.finalizeLastTurnReplacement({
@@ -1058,9 +1067,33 @@ export class InProcessGateway implements Gateway {
     }
   }
 
+  private claimPendingTurnReplacement(
+    sessionKey: string,
+    runId: string,
+  ): "none" | "claimed" | "conflict" {
+    const pending = this.pendingTurnReplacements.get(sessionKey);
+    if (!pending) return "none";
+    if (pending.replacementTurnId !== runId || pending.phase !== "prepared") {
+      return "conflict";
+    }
+    pending.phase = "submitting";
+    if (pending.timeout) {
+      clearTimeout(pending.timeout);
+      pending.timeout = undefined;
+    }
+    return "claimed";
+  }
+
+  private releasePendingTurnReplacementClaim(sessionKey: string, runId: string): void {
+    const pending = this.pendingTurnReplacements.get(sessionKey);
+    if (!pending || pending.replacementTurnId !== runId || pending.phase !== "submitting") return;
+    pending.phase = "prepared";
+    this.scheduleReplacementTimeout(sessionKey);
+  }
+
   private scheduleReplacementTimeout(sessionKey: string): void {
     const pending = this.pendingTurnReplacements.get(sessionKey);
-    if (!pending || pending.finalizing) return;
+    if (!pending || pending.phase !== "prepared") return;
     if (pending.timeout) clearTimeout(pending.timeout);
     pending.timeout = setTimeout(() => {
       void this.rollbackExpiredTurnReplacement(sessionKey, pending.transactionId);
@@ -1079,14 +1112,14 @@ export class InProcessGateway implements Gateway {
     transactionId: string,
   ): Promise<void> {
     const pending = this.pendingTurnReplacements.get(sessionKey);
-    if (!pending || pending.transactionId !== transactionId || pending.finalizing) return;
+    if (!pending || pending.transactionId !== transactionId || pending.phase !== "prepared") return;
     if (this.router.hasActiveTurn(sessionKey)) {
       this.scheduleReplacementTimeout(sessionKey);
       return;
     }
     if (!this.options.finalizeLastTurnReplacement) return;
 
-    pending.finalizing = true;
+    pending.phase = "finalizing";
     try {
       await this.router.close(sessionKey);
       await this.options.finalizeLastTurnReplacement({
@@ -1097,7 +1130,7 @@ export class InProcessGateway implements Gateway {
       });
       this.clearPendingTurnReplacement(sessionKey);
     } catch (error) {
-      pending.finalizing = false;
+      pending.phase = "prepared";
       console.warn("[pilotdeck] failed to roll back expired replacement transaction:", error);
       this.scheduleReplacementTimeout(sessionKey);
     }
@@ -1118,13 +1151,13 @@ export class InProcessGateway implements Gateway {
         "The replacement transaction is no longer pending.",
       );
     }
-    if (pending.finalizing) {
+    if (pending.phase !== "prepared") {
       throw new DialogGatewayError(
         "replace_transaction_pending",
         "The replacement transaction is already being finalized.",
       );
     }
-    pending.finalizing = true;
+    pending.phase = "finalizing";
     if (pending.timeout) clearTimeout(pending.timeout);
     try {
       if (input.action === "rollback") {
@@ -1140,7 +1173,7 @@ export class InProcessGateway implements Gateway {
       this.clearPendingTurnReplacement(input.sessionKey);
       return result;
     } catch (error) {
-      pending.finalizing = false;
+      pending.phase = "prepared";
       this.scheduleReplacementTimeout(input.sessionKey);
       throw error;
     }

--- a/src/gateway/client/InProcessGateway.ts
+++ b/src/gateway/client/InProcessGateway.ts
@@ -49,6 +49,8 @@ import type {
   WebForkSessionResult,
   WebReplaceLastTurnInput,
   WebReplaceLastTurnResult,
+  WebFinalizeLastTurnReplacementInput,
+  WebFinalizeLastTurnReplacementResult,
   ProjectFilesListInput,
   ProjectFilesListResult,
   CommandsListInput,
@@ -123,6 +125,9 @@ export type InProcessGatewayOptions = {
   readSubagentMessages?: (input: WebReadSubagentMessagesInput) => Promise<WebReadSubagentMessagesResult>;
   forkSession?: (input: WebForkSessionInput) => Promise<WebForkSessionResult>;
   replaceLastTurn?: (input: WebReplaceLastTurnInput) => Promise<WebReplaceLastTurnResult>;
+  finalizeLastTurnReplacement?: (
+    input: WebFinalizeLastTurnReplacementInput,
+  ) => Promise<WebFinalizeLastTurnReplacementResult>;
   recordAgentStatusMessage?: (input: GatewayRecordAgentStatusMessageInput) => Promise<{ recorded: boolean }>;
   /**
    * Web Phase 3 — pluggable project enumerator + describer.
@@ -208,6 +213,12 @@ type ActiveTurnReplay = {
   truncated: boolean;
 };
 
+type PendingTurnReplacement = {
+  transactionId: string;
+  replacementTurnId: string;
+  projectKey?: string;
+};
+
 export class InProcessGateway implements Gateway {
   private readonly now: () => Date;
   private readonly uuid: () => string;
@@ -219,6 +230,8 @@ export class InProcessGateway implements Gateway {
    */
   private readonly emitSinks = new Map<string, (event: GatewayEvent) => void>();
   private readonly activeTurnReplays = new Map<string, ActiveTurnReplay>();
+  private readonly replacementReservations = new Set<string>();
+  private readonly pendingTurnReplacements = new Map<string, PendingTurnReplacement>();
   /** B1 — pending askUser() promises keyed by sessionKey + requestId. */
   private readonly elicitationBus = new GatewayElicitationBus();
   /**
@@ -345,6 +358,30 @@ export class InProcessGateway implements Gateway {
       }
     }
     const runId = input.runId ?? this.uuid();
+    if (this.replacementReservations.has(input.sessionKey)) {
+      yield {
+        type: "error",
+        runId,
+        code: "replace_turn_pending",
+        message: "This session is currently preparing an edited replacement turn.",
+        recoverable: true,
+        userHint: "Wait for the message edit to finish, then try again.",
+      };
+      return;
+    }
+    const pendingReplacement = this.pendingTurnReplacements.get(input.sessionKey);
+    if (pendingReplacement && pendingReplacement.replacementTurnId !== runId) {
+      const message = "This session is waiting for its edited replacement turn to be accepted.";
+      yield {
+        type: "error",
+        runId,
+        code: "replace_turn_pending",
+        message,
+        recoverable: true,
+        userHint: "Wait for the edited message to be accepted, then try again.",
+      };
+      return;
+    }
     if (!this.router.beginTurn(input.sessionKey, runId)) {
       const message = `Session ${input.sessionKey} already has an active turn.`;
       const userHint = "Wait for the current turn to finish or stop it before sending another message.";
@@ -558,6 +595,9 @@ export class InProcessGateway implements Gateway {
             executionKind: telemetryContext.executionKind,
             phase: telemetryContext.phase,
           });
+          if (event.type === "input_accepted") {
+            await this.commitAcceptedTurnReplacement(input.sessionKey, runId);
+          }
           if (event.type === "model_event" && event.event.type === "request_started"
             && lastEmittedModel !== `${event.event.provider}\0${event.event.model}`) {
             const selectionEvent: GatewayEvent = {
@@ -894,13 +934,114 @@ export class InProcessGateway implements Gateway {
         "replace_last_turn is not configured. Wire `replaceLastTurn` via createLocalGateway.",
       );
     }
-    // The transcript cannot be rewritten while its writer is still appending.
-    // abortTurn resolves only after the active turn has fully unwound.
-    await this.abortTurn({ sessionKey: input.sessionKey, reason: "message_replaced" });
-    const result = await this.options.replaceLastTurn(input);
-    // The cached AgentSession and transcript writer still reflect the old tail.
-    // Evict them so the replacement submit resumes from the rewritten JSONL.
-    await this.router.close(input.sessionKey);
+    if (typeof input.replacementTurnId !== "string" || !input.replacementTurnId.trim()) {
+      throw new DialogGatewayError("replace_invalid_input", "replacementTurnId is required.");
+    }
+    if (
+      this.replacementReservations.has(input.sessionKey)
+      || this.pendingTurnReplacements.has(input.sessionKey)
+    ) {
+      throw new DialogGatewayError(
+        "replace_turn_pending",
+        "A replacement transaction is already pending for this session.",
+      );
+    }
+
+    const activeRunId = this.router.activeTurnRunId(input.sessionKey);
+    if (activeRunId && activeRunId !== input.expectedTurnId) {
+      throw new DialogGatewayError(
+        "replace_turn_conflict",
+        "The selected message is no longer the active turn.",
+        { activeRunId, expectedTurnId: input.expectedTurnId },
+      );
+    }
+    this.replacementReservations.add(input.sessionKey);
+    let result: WebReplaceLastTurnResult | undefined;
+    try {
+      // Reserve before awaiting the abort so a new turn cannot start between
+      // the expected writer unwinding and the transcript rewrite beginning.
+      // Only abort the expected turn; a stale edit must never stop a newer run.
+      if (activeRunId) {
+        await this.abortTurn({
+          sessionKey: input.sessionKey,
+          runId: activeRunId,
+          reason: "message_replaced",
+        });
+      }
+
+      result = await this.options.replaceLastTurn(input);
+      this.pendingTurnReplacements.set(input.sessionKey, {
+        transactionId: result.transactionId,
+        replacementTurnId: input.replacementTurnId,
+        projectKey: input.projectKey,
+      });
+      // The cached AgentSession and transcript writer still reflect the old tail.
+      // Evict them so the replacement submit resumes from the rewritten JSONL.
+      await this.router.close(input.sessionKey);
+      return result;
+    } catch (error) {
+      this.pendingTurnReplacements.delete(input.sessionKey);
+      if (result && this.options.finalizeLastTurnReplacement) {
+        await this.options.finalizeLastTurnReplacement({
+          sessionKey: input.sessionKey,
+          projectKey: input.projectKey,
+          transactionId: result.transactionId,
+          action: "rollback",
+        }).catch(() => undefined);
+      }
+      throw error;
+    } finally {
+      this.replacementReservations.delete(input.sessionKey);
+    }
+  }
+
+  private async commitAcceptedTurnReplacement(sessionKey: string, runId: string): Promise<void> {
+    const pending = this.pendingTurnReplacements.get(sessionKey);
+    if (!pending || pending.replacementTurnId !== runId || !this.options.finalizeLastTurnReplacement) {
+      return;
+    }
+    try {
+      await this.options.finalizeLastTurnReplacement({
+        sessionKey,
+        projectKey: pending.projectKey,
+        transactionId: pending.transactionId,
+        action: "commit",
+      });
+    } catch (error) {
+      // accepted_input is already durable. A stale backup is safe to leave for
+      // cleanup, but it must not block later turns in the live session.
+      console.warn("[pilotdeck] failed to remove accepted replacement backup:", error);
+    } finally {
+      this.pendingTurnReplacements.delete(sessionKey);
+    }
+  }
+
+  async finalizeLastTurnReplacement(
+    input: WebFinalizeLastTurnReplacementInput,
+  ): Promise<WebFinalizeLastTurnReplacementResult> {
+    if (!this.options.finalizeLastTurnReplacement) {
+      throw new Error(
+        "finalize_last_turn_replacement is not configured. Wire `finalizeLastTurnReplacement` via createLocalGateway.",
+      );
+    }
+    const pending = this.pendingTurnReplacements.get(input.sessionKey);
+    if (!pending || pending.transactionId !== input.transactionId) {
+      throw new DialogGatewayError(
+        "replace_transaction_conflict",
+        "The replacement transaction is no longer pending.",
+      );
+    }
+    if (input.action === "rollback") {
+      if (this.router.hasActiveTurn(input.sessionKey)) {
+        throw new DialogGatewayError(
+          "replace_transaction_active",
+          "The replacement cannot be rolled back while its turn is active.",
+        );
+      }
+      await this.router.close(input.sessionKey);
+    }
+    const result = await this.options.finalizeLastTurnReplacement(input);
+    this.pendingTurnReplacements.delete(input.sessionKey);
     return result;
   }
 
@@ -1531,6 +1672,8 @@ function mapAgentEventForTurn(event: AgentEvent, runId: string): GatewayEvent[] 
   switch (event.type) {
     case "turn_started":
       return [{ type: "turn_started", runId }];
+    case "input_accepted":
+      return [{ type: "input_accepted", runId }];
     case "model_request_started":
       return [{ type: "model_request_started", model: event.model, provider: event.provider }];
     case "model_event":

--- a/src/gateway/client/RemoteGateway.ts
+++ b/src/gateway/client/RemoteGateway.ts
@@ -36,6 +36,8 @@ import type {
   WebForkSessionResult,
   WebReplaceLastTurnInput,
   WebReplaceLastTurnResult,
+  WebFinalizeLastTurnReplacementInput,
+  WebFinalizeLastTurnReplacementResult,
 } from "../protocol/types.js";
 import type {
   SkillAddressInput,
@@ -189,6 +191,15 @@ export class RemoteGateway implements Gateway {
 
   async replaceLastTurn(input: WebReplaceLastTurnInput): Promise<WebReplaceLastTurnResult> {
     return (await this.client.request("replace_last_turn", input)) as WebReplaceLastTurnResult;
+  }
+
+  async finalizeLastTurnReplacement(
+    input: WebFinalizeLastTurnReplacementInput,
+  ): Promise<WebFinalizeLastTurnReplacementResult> {
+    return (await this.client.request(
+      "finalize_last_turn_replacement",
+      input,
+    )) as WebFinalizeLastTurnReplacementResult;
   }
 
   async listProjects(): Promise<WebListProjectsResult> {

--- a/src/gateway/client/RemoteGateway.ts
+++ b/src/gateway/client/RemoteGateway.ts
@@ -34,6 +34,8 @@ import type {
   WebReadSubagentMessagesResult,
   WebForkSessionInput,
   WebForkSessionResult,
+  WebReplaceLastTurnInput,
+  WebReplaceLastTurnResult,
 } from "../protocol/types.js";
 import type {
   SkillAddressInput,
@@ -183,6 +185,10 @@ export class RemoteGateway implements Gateway {
 
   async forkSession(input: WebForkSessionInput): Promise<WebForkSessionResult> {
     return (await this.client.request("fork_session", input)) as WebForkSessionResult;
+  }
+
+  async replaceLastTurn(input: WebReplaceLastTurnInput): Promise<WebReplaceLastTurnResult> {
+    return (await this.client.request("replace_last_turn", input)) as WebReplaceLastTurnResult;
   }
 
   async listProjects(): Promise<WebListProjectsResult> {

--- a/src/gateway/protocol/frames.ts
+++ b/src/gateway/protocol/frames.ts
@@ -46,6 +46,7 @@ export type WsGatewayMethod =
   | "read_subagent_messages"
   | "fork_session"
   | "replace_last_turn"
+  | "finalize_last_turn_replacement"
   | "list_projects"
   | "describe_project"
   | "reload_config"

--- a/src/gateway/protocol/frames.ts
+++ b/src/gateway/protocol/frames.ts
@@ -45,6 +45,7 @@ export type WsGatewayMethod =
   | "read_session_messages"
   | "read_subagent_messages"
   | "fork_session"
+  | "replace_last_turn"
   | "list_projects"
   | "describe_project"
   | "reload_config"

--- a/src/gateway/protocol/types.ts
+++ b/src/gateway/protocol/types.ts
@@ -33,6 +33,8 @@ import type {
   WebForkSessionResult as WebUiForkSessionResult,
   WebReplaceLastTurnInput as WebUiReplaceLastTurnInput,
   WebReplaceLastTurnResult as WebUiReplaceLastTurnResult,
+  WebFinalizeLastTurnReplacementInput as WebUiFinalizeLastTurnReplacementInput,
+  WebFinalizeLastTurnReplacementResult as WebUiFinalizeLastTurnReplacementResult,
 } from "../../web/client/protocol.js";
 import type {
   SkillCreateInput,
@@ -144,6 +146,7 @@ type GatewayTurnScopedEventMetadata = {
 
 export type GatewayEvent = GatewayTurnScopedEventMetadata & (
   | { type: "turn_started"; runId: string }
+  | { type: "input_accepted"; runId: string }
   | { type: "model_request_started"; model?: string; provider?: string }
   | {
       type: "model_selection_changed";
@@ -308,6 +311,8 @@ export type WebForkSessionInput = WebUiForkSessionInput;
 export type WebForkSessionResult = WebUiForkSessionResult;
 export type WebReplaceLastTurnInput = WebUiReplaceLastTurnInput;
 export type WebReplaceLastTurnResult = WebUiReplaceLastTurnResult;
+export type WebFinalizeLastTurnReplacementInput = WebUiFinalizeLastTurnReplacementInput;
+export type WebFinalizeLastTurnReplacementResult = WebUiFinalizeLastTurnReplacementResult;
 export type WebProjectSummary = WebUiProjectSummary;
 export type WebListProjectsResult = WebUiListProjectsResult;
 export type WebDescribeProjectInput = { projectKey: string };
@@ -581,6 +586,10 @@ export interface Gateway {
   forkSession(input: WebForkSessionInput): Promise<WebForkSessionResult>;
   /** Abort any active run and atomically remove the latest turn from the transcript. */
   replaceLastTurn(input: WebReplaceLastTurnInput): Promise<WebReplaceLastTurnResult>;
+  /** Commit a durable replacement input or restore the transcript when submission failed. */
+  finalizeLastTurnReplacement(
+    input: WebFinalizeLastTurnReplacementInput,
+  ): Promise<WebFinalizeLastTurnReplacementResult>;
   /**
    * Read a subagent's sidechain transcript and return its messages in WebMessage format.
    */

--- a/src/gateway/protocol/types.ts
+++ b/src/gateway/protocol/types.ts
@@ -31,6 +31,8 @@ import type {
   WebReadSubagentMessagesResult as WebUiReadSubagentMessagesResult,
   WebForkSessionInput as WebUiForkSessionInput,
   WebForkSessionResult as WebUiForkSessionResult,
+  WebReplaceLastTurnInput as WebUiReplaceLastTurnInput,
+  WebReplaceLastTurnResult as WebUiReplaceLastTurnResult,
 } from "../../web/client/protocol.js";
 import type {
   SkillCreateInput,
@@ -304,6 +306,8 @@ export type WebReadSubagentMessagesInput = WebUiReadSubagentMessagesInput;
 export type WebReadSubagentMessagesResult = WebUiReadSubagentMessagesResult;
 export type WebForkSessionInput = WebUiForkSessionInput;
 export type WebForkSessionResult = WebUiForkSessionResult;
+export type WebReplaceLastTurnInput = WebUiReplaceLastTurnInput;
+export type WebReplaceLastTurnResult = WebUiReplaceLastTurnResult;
 export type WebProjectSummary = WebUiProjectSummary;
 export type WebListProjectsResult = WebUiListProjectsResult;
 export type WebDescribeProjectInput = { projectKey: string };
@@ -575,6 +579,8 @@ export interface Gateway {
    * Fork a session transcript at a prior user turn into a new session file.
    */
   forkSession(input: WebForkSessionInput): Promise<WebForkSessionResult>;
+  /** Abort any active run and atomically remove the latest turn from the transcript. */
+  replaceLastTurn(input: WebReplaceLastTurnInput): Promise<WebReplaceLastTurnResult>;
   /**
    * Read a subagent's sidechain transcript and return its messages in WebMessage format.
    */

--- a/src/gateway/server/GatewayWsConnection.ts
+++ b/src/gateway/server/GatewayWsConnection.ts
@@ -249,6 +249,8 @@ export class GatewayWsConnection {
         return this.options.gateway.forkSession(frame.params as never);
       case "replace_last_turn":
         return this.options.gateway.replaceLastTurn(frame.params as never);
+      case "finalize_last_turn_replacement":
+        return this.options.gateway.finalizeLastTurnReplacement(frame.params as never);
       case "list_projects":
         return this.options.gateway.listProjects();
       case "describe_project":

--- a/src/gateway/server/GatewayWsConnection.ts
+++ b/src/gateway/server/GatewayWsConnection.ts
@@ -247,6 +247,8 @@ export class GatewayWsConnection {
         return this.options.gateway.readSubagentMessages(frame.params as never);
       case "fork_session":
         return this.options.gateway.forkSession(frame.params as never);
+      case "replace_last_turn":
+        return this.options.gateway.replaceLastTurn(frame.params as never);
       case "list_projects":
         return this.options.gateway.listProjects();
       case "describe_project":

--- a/src/web/client/GatewayBrowserClient.ts
+++ b/src/web/client/GatewayBrowserClient.ts
@@ -203,6 +203,17 @@ export class GatewayBrowserClient {
     );
   }
 
+  replaceLastTurn(input: import("./protocol.js").WebReplaceLastTurnInput) {
+    return this.request<import("./protocol.js").WebReplaceLastTurnResult>("replace_last_turn", input);
+  }
+
+  finalizeLastTurnReplacement(input: import("./protocol.js").WebFinalizeLastTurnReplacementInput) {
+    return this.request<import("./protocol.js").WebFinalizeLastTurnReplacementResult>(
+      "finalize_last_turn_replacement",
+      input,
+    );
+  }
+
   permissionDecide(input: import("./protocol.js").WebPermissionDecision) {
     return this.request<{ delivered: boolean }>("permission_decide", input);
   }

--- a/src/web/client/protocol.ts
+++ b/src/web/client/protocol.ts
@@ -46,6 +46,7 @@ type WebGatewayEventMetadata = {
 
 export type WebGatewayEvent = WebGatewayEventMetadata & (
   | { type: "turn_started"; runId: string }
+  | { type: "input_accepted"; runId: string }
   | { type: "model_selection_changed"; provider: string; model: string; source: "turn" | "session" | "router" | "default"; reasoning?: number; temperature?: number; speed?: number }
   | { type: "assistant_text_delta"; text: string }
   | { type: "assistant_thinking_delta"; text: string }
@@ -146,6 +147,7 @@ export type WebGatewayMethod =
   | "read_subagent_messages"
   | "fork_session"
   | "replace_last_turn"
+  | "finalize_last_turn_replacement"
   | "rename_session"
   | "delete_session"
   | "list_projects"
@@ -342,12 +344,29 @@ export type WebReplaceLastTurnInput = {
   projectKey?: string;
   /** Guards against replacing a turn that is no longer the transcript tail. */
   expectedTurnId: string;
+  /** The new turn that is allowed to consume this replacement transaction. */
+  replacementTurnId: string;
 };
 
 export type WebReplaceLastTurnResult = {
   sessionKey: string;
   replacedTurnId: string;
   removedEntryCount: number;
+  /** Opaque token used to commit or roll back the transcript rewrite. */
+  transactionId: string;
+};
+
+export type WebFinalizeLastTurnReplacementInput = {
+  sessionKey: string;
+  projectKey?: string;
+  transactionId: string;
+  action: "commit" | "rollback";
+};
+
+export type WebFinalizeLastTurnReplacementResult = {
+  sessionKey: string;
+  transactionId: string;
+  action: "commit" | "rollback";
 };
 
 export type WebActiveTurnSnapshotInput = {

--- a/src/web/client/protocol.ts
+++ b/src/web/client/protocol.ts
@@ -145,6 +145,7 @@ export type WebGatewayMethod =
   | "read_session_messages"
   | "read_subagent_messages"
   | "fork_session"
+  | "replace_last_turn"
   | "rename_session"
   | "delete_session"
   | "list_projects"
@@ -176,6 +177,7 @@ export type WebSubmitTurnInput = {
   allowPlanModeTools?: boolean;
   canPrompt?: boolean;
   runId?: string;
+  syntheticMessages?: Array<{ text: string; purpose?: string }>;
 };
 
 export type WebMatchRange = { field: string; start: number; end: number };
@@ -333,6 +335,19 @@ export type WebForkSessionResult = {
   carriedMessageCount: number;
   runMode?: WebAgentRunMode;
   mode?: WebGatewayMode;
+};
+
+export type WebReplaceLastTurnInput = {
+  sessionKey: string;
+  projectKey?: string;
+  /** Guards against replacing a turn that is no longer the transcript tail. */
+  expectedTurnId: string;
+};
+
+export type WebReplaceLastTurnResult = {
+  sessionKey: string;
+  replacedTurnId: string;
+  removedEntryCount: number;
 };
 
 export type WebActiveTurnSnapshotInput = {

--- a/src/web/server/replaceLastTurn.ts
+++ b/src/web/server/replaceLastTurn.ts
@@ -1,7 +1,15 @@
 /** Atomically remove the latest user turn from a normal web-session transcript. */
 
 import { randomUUID } from "node:crypto";
-import { chmod, readFile, rename, rm, writeFile } from "node:fs/promises";
+import {
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { readFile, rename, rm, writeFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { getPilotProjectChatDir } from "../../pilot/index.js";
 import { mergeMetadata } from "../../session/metadata/SessionMetadataStore.js";
@@ -26,6 +34,21 @@ export type ReplaceLastWebSessionTurnOptions = {
   now?: () => Date;
 };
 
+type ReplacementJournal = {
+  version: 1;
+  transactionId: string;
+  sessionKey: string;
+  replacementTurnId: string;
+  preparedAt: string;
+};
+
+export type RecoverLastTurnReplacementsResult = {
+  committed: number;
+  rolledBack: number;
+  cleaned: number;
+  failures: Array<{ transcriptPath: string; message: string }>;
+};
+
 export class ReplaceLastTurnError extends Error {
   constructor(readonly code: string, message: string) {
     super(message);
@@ -48,7 +71,7 @@ function replacementPaths(
   projectKey: string,
   pilotHome: string,
   transactionId?: string,
-): { transcriptPath: string; safeId: string; backupPath?: string } {
+): { transcriptPath: string; safeId: string; backupPath?: string; journalPath?: string } {
   const chatDir = getPilotProjectChatDir(projectKey, pilotHome);
   const safeId = sanitizeSessionIdForPath(sessionKey);
   const transcriptPath = resolve(chatDir, `${safeId}.jsonl`);
@@ -56,7 +79,10 @@ function replacementPaths(
     transcriptPath,
     safeId,
     ...(transactionId
-      ? { backupPath: resolve(chatDir, `.${safeId}.${transactionId}.replace.bak`) }
+      ? {
+          backupPath: resolve(chatDir, `.${safeId}.${transactionId}.replace.bak`),
+          journalPath: resolve(chatDir, `.${safeId}.${transactionId}.replace.json`),
+        }
       : {}),
   };
 }
@@ -69,6 +95,15 @@ function latestMetadataSnapshot(entries: AgentTranscriptEntry[]): SessionMetadat
   ), {});
 }
 
+function removeGeneratedTitleFromPrefix(entries: AgentTranscriptEntry[]): AgentTranscriptEntry[] {
+  return entries.map((entry) => {
+    if (entry.type !== "session_metadata" || entry.metadata.aiTitle === undefined) return entry;
+    const metadata = { ...entry.metadata };
+    delete metadata.aiTitle;
+    return { ...entry, metadata };
+  });
+}
+
 function createPreservedMetadataEntry(
   entries: AgentTranscriptEntry[],
   preserved: AgentTranscriptEntry[],
@@ -78,6 +113,10 @@ function createPreservedMetadataEntry(
   delete metadata.lastPrompt;
   if (!preserved.some((entry) => entry.type === "accepted_input")) {
     delete metadata.firstPrompt;
+    // The generated title describes the original first prompt. A corrected
+    // first prompt must be allowed to generate a fresh aiTitle, while a title
+    // explicitly chosen by the user remains intact.
+    delete metadata.aiTitle;
   }
 
   const hasMetadata = Object.entries(metadata).some(([key, value]) => (
@@ -109,6 +148,196 @@ function validateTransactionId(transactionId: string): void {
   if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(transactionId)) {
     throw new ReplaceLastTurnError("replace_invalid_transaction", "The replacement transaction is invalid.");
   }
+}
+
+function isTransactionId(transactionId: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(transactionId);
+}
+
+function readReplacementJournalSync(
+  journalPath: string,
+  transactionId: string,
+): ReplacementJournal | undefined {
+  try {
+    const parsed = JSON.parse(readFileSync(journalPath, "utf8")) as Partial<ReplacementJournal>;
+    if (
+      parsed.version !== 1
+      || parsed.transactionId !== transactionId
+      || typeof parsed.sessionKey !== "string"
+      || !parsed.sessionKey.trim()
+      || typeof parsed.replacementTurnId !== "string"
+      || !parsed.replacementTurnId.trim()
+      || typeof parsed.preparedAt !== "string"
+    ) {
+      return undefined;
+    }
+    return parsed as ReplacementJournal;
+  } catch {
+    return undefined;
+  }
+}
+
+function acceptedTurnIds(body: string): Set<string> {
+  const turnIds = new Set<string>();
+  for (const line of body.split(/\r?\n/)) {
+    if (!line.includes('"type":"accepted_input"') || !line.includes('"turnId"')) continue;
+    try {
+      const entry = JSON.parse(line) as { type?: unknown; turnId?: unknown };
+      if (entry.type === "accepted_input" && typeof entry.turnId === "string") {
+        turnIds.add(entry.turnId);
+      }
+    } catch {
+      // Malformed lines do not provide durable commit evidence.
+    }
+  }
+  return turnIds;
+}
+
+function readAcceptedTurnIdsSync(transcriptPath: string): Set<string> {
+  try {
+    return acceptedTurnIds(readFileSync(transcriptPath, "utf8"));
+  } catch {
+    // A missing transcript is restored from the newest available backup.
+    return new Set();
+  }
+}
+
+type ReplacementArtifact = {
+  safeId: string;
+  transactionId: string;
+  backupPath: string;
+  journalPath: string;
+};
+
+/**
+ * Recover replacement transactions left behind by a process crash.
+ *
+ * A durable accepted_input for the replacement turn means the transaction
+ * committed and only stale artifacts need cleanup. Otherwise the newest
+ * backup is restored atomically. This runs before a local Gateway starts, so
+ * no transcript writer can race the recovery pass.
+ */
+export function recoverPendingLastTurnReplacements(
+  pilotHome: string,
+): RecoverLastTurnReplacementsResult {
+  const result: RecoverLastTurnReplacementsResult = {
+    committed: 0,
+    rolledBack: 0,
+    cleaned: 0,
+    failures: [],
+  };
+  const groups = new Map<string, { transcriptPath: string; artifacts: ReplacementArtifact[] }>();
+  const projectsDir = resolve(pilotHome, "projects");
+  let projectDirNames: string[];
+  try {
+    projectDirNames = readdirSync(projectsDir, { withFileTypes: true, encoding: "utf8" })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name);
+  } catch {
+    return result;
+  }
+
+  for (const projectDirName of projectDirNames) {
+    const chatDir = resolve(projectsDir, projectDirName, "chats");
+    let names: string[];
+    try {
+      names = readdirSync(chatDir);
+    } catch {
+      continue;
+    }
+    for (const name of names) {
+      const match = /^\.(.+)\.([0-9a-f-]{36})\.replace\.(?:bak|json)$/i.exec(name);
+      if (!match || !isTransactionId(match[2])) continue;
+      const [, safeId, transactionId] = match;
+      const key = resolve(chatDir, safeId);
+      const group = groups.get(key) ?? {
+        transcriptPath: resolve(chatDir, `${safeId}.jsonl`),
+        artifacts: [],
+      };
+      if (!group.artifacts.some((artifact) => artifact.transactionId === transactionId)) {
+        group.artifacts.push({
+          safeId,
+          transactionId,
+          backupPath: resolve(chatDir, `.${safeId}.${transactionId}.replace.bak`),
+          journalPath: resolve(chatDir, `.${safeId}.${transactionId}.replace.json`),
+        });
+      }
+      groups.set(key, group);
+    }
+  }
+
+  for (const group of groups.values()) {
+    try {
+      const currentAcceptedTurnIds = readAcceptedTurnIdsSync(group.transcriptPath);
+      const committed = group.artifacts.some((artifact) => {
+        const journal = readReplacementJournalSync(artifact.journalPath, artifact.transactionId);
+        if (journal) return currentAcceptedTurnIds.has(journal.replacementTurnId);
+
+        // Backups created by the first transactional release did not have a
+        // journal. If the current transcript contains a turn absent from the
+        // backup, input acceptance already advanced the session and restoring
+        // the legacy backup would undo a committed edit.
+        try {
+          const originalTurnIds = acceptedTurnIds(readFileSync(artifact.backupPath, "utf8"));
+          return [...currentAcceptedTurnIds].some((turnId) => !originalTurnIds.has(turnId));
+        } catch {
+          return false;
+        }
+      });
+      if (committed) {
+        for (const artifact of group.artifacts) {
+          rmSync(artifact.backupPath, { force: true });
+          rmSync(artifact.journalPath, { force: true });
+        }
+        result.committed += 1;
+        result.cleaned += group.artifacts.length;
+        continue;
+      }
+
+      const restorable = group.artifacts
+        .map((artifact) => {
+          try {
+            return { artifact, mtimeMs: statSync(artifact.backupPath).mtimeMs };
+          } catch {
+            return undefined;
+          }
+        })
+        .filter((candidate): candidate is { artifact: ReplacementArtifact; mtimeMs: number } => Boolean(candidate))
+        .sort((left, right) => right.mtimeMs - left.mtimeMs)[0];
+      if (!restorable) {
+        for (const artifact of group.artifacts) {
+          rmSync(artifact.journalPath, { force: true });
+        }
+        result.cleaned += group.artifacts.length;
+        continue;
+      }
+
+      const originalBody = readFileSync(restorable.artifact.backupPath, "utf8");
+      const temporaryPath = resolve(
+        dirname(group.transcriptPath),
+        `.${restorable.artifact.safeId}.${randomUUID()}.recovery.tmp`,
+      );
+      try {
+        writeFileSync(temporaryPath, originalBody, { encoding: "utf8", mode: 0o600 });
+        renameSync(temporaryPath, group.transcriptPath);
+      } finally {
+        rmSync(temporaryPath, { force: true });
+      }
+      for (const artifact of group.artifacts) {
+        rmSync(artifact.backupPath, { force: true });
+        rmSync(artifact.journalPath, { force: true });
+      }
+      result.rolledBack += 1;
+      result.cleaned += group.artifacts.length;
+    } catch (error) {
+      result.failures.push({
+        transcriptPath: group.transcriptPath,
+        message: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  return result;
 }
 
 export async function replaceLastWebSessionTurn(
@@ -155,7 +384,11 @@ export async function replaceLastWebSessionTurn(
     );
   }
 
-  const preserved = entries.slice(0, latestInputIndex);
+  const originalPrefix = entries.slice(0, latestInputIndex);
+  const replacingFirstInput = !originalPrefix.some((entry) => entry.type === "accepted_input");
+  const preserved = replacingFirstInput
+    ? removeGeneratedTitleFromPrefix(originalPrefix)
+    : originalPrefix;
   const metadataEntry = createPreservedMetadataEntry(
     entries,
     preserved,
@@ -165,22 +398,34 @@ export async function replaceLastWebSessionTurn(
   const body = rewrittenEntries.map((entry) => `${JSON.stringify(entry)}\n`).join("");
   const originalBody = await readFile(transcriptPath, "utf8");
   const transactionId = randomUUID();
-  const { backupPath } = replacementPaths(
+  const { backupPath, journalPath } = replacementPaths(
     input.sessionKey,
     effectiveProjectRoot,
     options.pilotHome,
     transactionId,
   );
-  if (!backupPath) throw new Error("Replacement backup path was not created.");
+  if (!backupPath || !journalPath) throw new Error("Replacement transaction paths were not created.");
   const temporaryPath = resolve(dirname(transcriptPath), `.${safeId}.${randomUUID()}.replace.tmp`);
   try {
     await writeFile(backupPath, originalBody, { encoding: "utf8", mode: 0o600, flag: "wx" });
+    const journal: ReplacementJournal = {
+      version: 1,
+      transactionId,
+      sessionKey: input.sessionKey,
+      replacementTurnId: input.replacementTurnId,
+      preparedAt: (options.now?.() ?? new Date()).toISOString(),
+    };
+    await writeFile(journalPath, `${JSON.stringify(journal)}\n`, {
+      encoding: "utf8",
+      mode: 0o600,
+      flag: "wx",
+    });
     await writeFile(temporaryPath, body, { encoding: "utf8", mode: 0o600 });
     await rename(temporaryPath, transcriptPath);
-    await chmod(transcriptPath, 0o600);
   } catch (error) {
     await rm(temporaryPath, { force: true }).catch(() => undefined);
     await rm(backupPath, { force: true }).catch(() => undefined);
+    await rm(journalPath, { force: true }).catch(() => undefined);
     throw error;
   }
 
@@ -213,16 +458,17 @@ export async function finalizeLastWebSessionTurnReplacement(
   }
 
   const effectiveProjectRoot = input.projectKey ?? options.projectRoot;
-  const { transcriptPath, safeId, backupPath } = replacementPaths(
+  const { transcriptPath, safeId, backupPath, journalPath } = replacementPaths(
     input.sessionKey,
     effectiveProjectRoot,
     options.pilotHome,
     input.transactionId,
   );
-  if (!backupPath) throw new Error("Replacement backup path was not created.");
+  if (!backupPath || !journalPath) throw new Error("Replacement transaction paths were not created.");
 
   if (input.action === "commit") {
     await rm(backupPath, { force: true });
+    await rm(journalPath, { force: true });
   } else {
     let originalBody: string;
     try {
@@ -237,8 +483,8 @@ export async function finalizeLastWebSessionTurnReplacement(
     try {
       await writeFile(temporaryPath, originalBody, { encoding: "utf8", mode: 0o600 });
       await rename(temporaryPath, transcriptPath);
-      await chmod(transcriptPath, 0o600);
       await rm(backupPath, { force: true });
+      await rm(journalPath, { force: true });
     } catch (error) {
       await rm(temporaryPath, { force: true }).catch(() => undefined);
       throw error;

--- a/src/web/server/replaceLastTurn.ts
+++ b/src/web/server/replaceLastTurn.ts
@@ -1,13 +1,21 @@
 /** Atomically remove the latest user turn from a normal web-session transcript. */
 
 import { randomUUID } from "node:crypto";
-import { chmod, rename, rm, writeFile } from "node:fs/promises";
+import { chmod, readFile, rename, rm, writeFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { getPilotProjectChatDir } from "../../pilot/index.js";
+import { mergeMetadata } from "../../session/metadata/SessionMetadataStore.js";
 import { sanitizeSessionIdForPath } from "../../session/storage/ProjectSessionStorage.js";
 import { readTranscript } from "../../session/transcript/TranscriptReader.js";
-import type { AgentAcceptedInputTranscriptEntry } from "../../session/transcript/TranscriptEntry.js";
 import type {
+  AgentAcceptedInputTranscriptEntry,
+  AgentSessionMetadataTranscriptEntry,
+  AgentTranscriptEntry,
+  SessionMetadataValue,
+} from "../../session/transcript/TranscriptEntry.js";
+import type {
+  WebFinalizeLastTurnReplacementInput,
+  WebFinalizeLastTurnReplacementResult,
   WebReplaceLastTurnInput,
   WebReplaceLastTurnResult,
 } from "../client/protocol.js";
@@ -15,6 +23,7 @@ import type {
 export type ReplaceLastWebSessionTurnOptions = {
   projectRoot: string;
   pilotHome: string;
+  now?: () => Date;
 };
 
 export class ReplaceLastTurnError extends Error {
@@ -26,29 +35,106 @@ export class ReplaceLastTurnError extends Error {
 
 function findLatestAcceptedInput(
   entries: Awaited<ReturnType<typeof readTranscript>>["entries"],
-): AgentAcceptedInputTranscriptEntry | undefined {
+): { entry: AgentAcceptedInputTranscriptEntry; index: number } | undefined {
   for (let index = entries.length - 1; index >= 0; index -= 1) {
     const entry = entries[index];
-    if (entry.type === "accepted_input") return entry;
+    if (entry.type === "accepted_input") return { entry, index };
   }
   return undefined;
+}
+
+function replacementPaths(
+  sessionKey: string,
+  projectKey: string,
+  pilotHome: string,
+  transactionId?: string,
+): { transcriptPath: string; safeId: string; backupPath?: string } {
+  const chatDir = getPilotProjectChatDir(projectKey, pilotHome);
+  const safeId = sanitizeSessionIdForPath(sessionKey);
+  const transcriptPath = resolve(chatDir, `${safeId}.jsonl`);
+  return {
+    transcriptPath,
+    safeId,
+    ...(transactionId
+      ? { backupPath: resolve(chatDir, `.${safeId}.${transactionId}.replace.bak`) }
+      : {}),
+  };
+}
+
+function latestMetadataSnapshot(entries: AgentTranscriptEntry[]): SessionMetadataValue {
+  return entries.reduce<SessionMetadataValue>((metadata, entry) => (
+    entry.type === "session_metadata"
+      ? mergeMetadata(metadata, entry.metadata)
+      : metadata
+  ), {});
+}
+
+function createPreservedMetadataEntry(
+  entries: AgentTranscriptEntry[],
+  preserved: AgentTranscriptEntry[],
+  now: Date,
+): AgentSessionMetadataTranscriptEntry | undefined {
+  const metadata = latestMetadataSnapshot(entries);
+  delete metadata.lastPrompt;
+  if (!preserved.some((entry) => entry.type === "accepted_input")) {
+    delete metadata.firstPrompt;
+  }
+
+  const hasMetadata = Object.entries(metadata).some(([key, value]) => (
+    key !== "isSnapshot" && key !== "updatedAt" && value !== undefined
+  ));
+  if (!hasMetadata) return undefined;
+
+  const sequence = preserved.reduce((highest, entry) => Math.max(highest, entry.sequence), 0) + 1;
+  const parentEntryId = [...preserved]
+    .reverse()
+    .find((entry) => typeof entry.entryId === "string" && entry.entryId)?.entryId ?? null;
+  return {
+    type: "session_metadata",
+    sessionId: entries[0]?.sessionId ?? "",
+    turnId: "metadata-replace",
+    sequence,
+    createdAt: now.toISOString(),
+    entryId: randomUUID(),
+    parentEntryId,
+    metadata: {
+      ...metadata,
+      isSnapshot: true,
+      updatedAt: now.toISOString(),
+    },
+  };
+}
+
+function validateTransactionId(transactionId: string): void {
+  if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(transactionId)) {
+    throw new ReplaceLastTurnError("replace_invalid_transaction", "The replacement transaction is invalid.");
+  }
 }
 
 export async function replaceLastWebSessionTurn(
   input: WebReplaceLastTurnInput,
   options: ReplaceLastWebSessionTurnOptions,
 ): Promise<WebReplaceLastTurnResult> {
-  if (!input.sessionKey?.trim() || !input.expectedTurnId?.trim()) {
+  if (
+    typeof input.sessionKey !== "string"
+    || !input.sessionKey.trim()
+    || typeof input.expectedTurnId !== "string"
+    || !input.expectedTurnId.trim()
+    || typeof input.replacementTurnId !== "string"
+    || !input.replacementTurnId.trim()
+  ) {
     throw new ReplaceLastTurnError(
       "replace_invalid_input",
-      "sessionKey and expectedTurnId are required.",
+      "sessionKey, expectedTurnId, and replacementTurnId are required.",
     );
   }
 
   const effectiveProjectRoot = input.projectKey ?? options.projectRoot;
-  const chatDir = getPilotProjectChatDir(effectiveProjectRoot, options.pilotHome);
-  const safeId = sanitizeSessionIdForPath(input.sessionKey);
-  const transcriptPath = resolve(chatDir, `${safeId}.jsonl`);
+  const { transcriptPath, safeId } = replacementPaths(
+    input.sessionKey,
+    effectiveProjectRoot,
+    options.pilotHome,
+  );
   const { entries, diagnostics } = await readTranscript(transcriptPath);
   if (diagnostics.some((diagnostic) => diagnostic.severity === "error")) {
     throw new ReplaceLastTurnError(
@@ -57,10 +143,11 @@ export async function replaceLastWebSessionTurn(
     );
   }
 
-  const latestInput = findLatestAcceptedInput(entries);
-  if (!latestInput) {
+  const latest = findLatestAcceptedInput(entries);
+  if (!latest) {
     throw new ReplaceLastTurnError("replace_empty_transcript", "No user turn is available to replace.");
   }
+  const { entry: latestInput, index: latestInputIndex } = latest;
   if (latestInput.turnId !== input.expectedTurnId) {
     throw new ReplaceLastTurnError(
       "replace_turn_conflict",
@@ -68,21 +155,99 @@ export async function replaceLastWebSessionTurn(
     );
   }
 
-  const preserved = entries.filter((entry) => entry.sequence < latestInput.sequence);
-  const body = preserved.map((entry) => `${JSON.stringify(entry)}\n`).join("");
+  const preserved = entries.slice(0, latestInputIndex);
+  const metadataEntry = createPreservedMetadataEntry(
+    entries,
+    preserved,
+    options.now?.() ?? new Date(),
+  );
+  const rewrittenEntries = metadataEntry ? [...preserved, metadataEntry] : preserved;
+  const body = rewrittenEntries.map((entry) => `${JSON.stringify(entry)}\n`).join("");
+  const originalBody = await readFile(transcriptPath, "utf8");
+  const transactionId = randomUUID();
+  const { backupPath } = replacementPaths(
+    input.sessionKey,
+    effectiveProjectRoot,
+    options.pilotHome,
+    transactionId,
+  );
+  if (!backupPath) throw new Error("Replacement backup path was not created.");
   const temporaryPath = resolve(dirname(transcriptPath), `.${safeId}.${randomUUID()}.replace.tmp`);
   try {
+    await writeFile(backupPath, originalBody, { encoding: "utf8", mode: 0o600, flag: "wx" });
     await writeFile(temporaryPath, body, { encoding: "utf8", mode: 0o600 });
     await rename(temporaryPath, transcriptPath);
     await chmod(transcriptPath, 0o600);
   } catch (error) {
     await rm(temporaryPath, { force: true }).catch(() => undefined);
+    await rm(backupPath, { force: true }).catch(() => undefined);
     throw error;
   }
 
   return {
     sessionKey: input.sessionKey,
     replacedTurnId: latestInput.turnId,
-    removedEntryCount: entries.length - preserved.length,
+    removedEntryCount: entries.length - latestInputIndex,
+    transactionId,
+  };
+}
+
+export async function finalizeLastWebSessionTurnReplacement(
+  input: WebFinalizeLastTurnReplacementInput,
+  options: ReplaceLastWebSessionTurnOptions,
+): Promise<WebFinalizeLastTurnReplacementResult> {
+  if (
+    typeof input.sessionKey !== "string"
+    || !input.sessionKey.trim()
+    || typeof input.transactionId !== "string"
+    || !input.transactionId.trim()
+  ) {
+    throw new ReplaceLastTurnError(
+      "replace_invalid_transaction",
+      "sessionKey and transactionId are required.",
+    );
+  }
+  validateTransactionId(input.transactionId);
+  if (input.action !== "commit" && input.action !== "rollback") {
+    throw new ReplaceLastTurnError("replace_invalid_action", "Replacement action must be commit or rollback.");
+  }
+
+  const effectiveProjectRoot = input.projectKey ?? options.projectRoot;
+  const { transcriptPath, safeId, backupPath } = replacementPaths(
+    input.sessionKey,
+    effectiveProjectRoot,
+    options.pilotHome,
+    input.transactionId,
+  );
+  if (!backupPath) throw new Error("Replacement backup path was not created.");
+
+  if (input.action === "commit") {
+    await rm(backupPath, { force: true });
+  } else {
+    let originalBody: string;
+    try {
+      originalBody = await readFile(backupPath, "utf8");
+    } catch (error) {
+      throw new ReplaceLastTurnError(
+        "replace_transaction_missing",
+        `The replacement transaction could not be restored: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+    const temporaryPath = resolve(dirname(transcriptPath), `.${safeId}.${randomUUID()}.rollback.tmp`);
+    try {
+      await writeFile(temporaryPath, originalBody, { encoding: "utf8", mode: 0o600 });
+      await rename(temporaryPath, transcriptPath);
+      await chmod(transcriptPath, 0o600);
+      await rm(backupPath, { force: true });
+    } catch (error) {
+      await rm(temporaryPath, { force: true }).catch(() => undefined);
+      throw error;
+    }
+  }
+
+  return {
+    sessionKey: input.sessionKey,
+    transactionId: input.transactionId,
+    action: input.action,
   };
 }

--- a/src/web/server/replaceLastTurn.ts
+++ b/src/web/server/replaceLastTurn.ts
@@ -32,21 +32,35 @@ export type ReplaceLastWebSessionTurnOptions = {
   projectRoot: string;
   pilotHome: string;
   now?: () => Date;
+  /** Identifies the live Gateway process that owns a prepared transaction. */
+  transactionOwner?: ReplacementTransactionOwner;
+};
+
+export type ReplacementTransactionOwner = {
+  instanceId: string;
+  pid: number;
 };
 
 type ReplacementJournal = {
-  version: 1;
+  version: 1 | 2;
   transactionId: string;
   sessionKey: string;
   replacementTurnId: string;
   preparedAt: string;
+  owner?: ReplacementTransactionOwner;
 };
 
 export type RecoverLastTurnReplacementsResult = {
   committed: number;
   rolledBack: number;
   cleaned: number;
+  skipped: number;
   failures: Array<{ transcriptPath: string; message: string }>;
+};
+
+export type RecoverLastTurnReplacementsOptions = {
+  /** @internal Injectable process probe for deterministic recovery tests. */
+  isProcessAlive?: (pid: number) => boolean;
 };
 
 export class ReplaceLastTurnError extends Error {
@@ -161,13 +175,26 @@ function readReplacementJournalSync(
   try {
     const parsed = JSON.parse(readFileSync(journalPath, "utf8")) as Partial<ReplacementJournal>;
     if (
-      parsed.version !== 1
+      (parsed.version !== 1 && parsed.version !== 2)
       || parsed.transactionId !== transactionId
       || typeof parsed.sessionKey !== "string"
       || !parsed.sessionKey.trim()
       || typeof parsed.replacementTurnId !== "string"
       || !parsed.replacementTurnId.trim()
       || typeof parsed.preparedAt !== "string"
+    ) {
+      return undefined;
+    }
+    if (
+      parsed.version === 2
+      && (
+        typeof parsed.owner !== "object"
+        || parsed.owner === null
+        || typeof parsed.owner.instanceId !== "string"
+        || !parsed.owner.instanceId.trim()
+        || !Number.isSafeInteger(parsed.owner.pid)
+        || parsed.owner.pid <= 0
+      )
     ) {
       return undefined;
     }
@@ -209,6 +236,52 @@ type ReplacementArtifact = {
   journalPath: string;
 };
 
+type ReplacementArtifactState = {
+  artifact: ReplacementArtifact;
+  journal?: ReplacementJournal;
+  order: number;
+  hasBackup: boolean;
+};
+
+function artifactMtimeMs(path: string): number | undefined {
+  try {
+    return statSync(path).mtimeMs;
+  } catch {
+    return undefined;
+  }
+}
+
+function replacementArtifactState(artifact: ReplacementArtifact): ReplacementArtifactState {
+  const journal = readReplacementJournalSync(artifact.journalPath, artifact.transactionId);
+  const preparedAt = journal ? Date.parse(journal.preparedAt) : Number.NaN;
+  const backupMtime = artifactMtimeMs(artifact.backupPath);
+  const journalMtime = artifactMtimeMs(artifact.journalPath);
+  return {
+    artifact,
+    journal,
+    order: Math.max(
+      Number.isFinite(preparedAt) ? preparedAt : 0,
+      backupMtime ?? 0,
+      journalMtime ?? 0,
+    ),
+    hasBackup: backupMtime !== undefined,
+  };
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (
+      typeof error === "object"
+      && error !== null
+      && "code" in error
+      && error.code === "EPERM"
+    );
+  }
+}
+
 /**
  * Recover replacement transactions left behind by a process crash.
  *
@@ -219,13 +292,16 @@ type ReplacementArtifact = {
  */
 export function recoverPendingLastTurnReplacements(
   pilotHome: string,
+  options: RecoverLastTurnReplacementsOptions = {},
 ): RecoverLastTurnReplacementsResult {
   const result: RecoverLastTurnReplacementsResult = {
     committed: 0,
     rolledBack: 0,
     cleaned: 0,
+    skipped: 0,
     failures: [],
   };
+  const processIsAlive = options.isProcessAlive ?? isProcessAlive;
   const groups = new Map<string, { transcriptPath: string; artifacts: ReplacementArtifact[] }>();
   const projectsDir = resolve(pilotHome, "projects");
   let projectDirNames: string[];
@@ -268,22 +344,38 @@ export function recoverPendingLastTurnReplacements(
 
   for (const group of groups.values()) {
     try {
-      const currentAcceptedTurnIds = readAcceptedTurnIdsSync(group.transcriptPath);
-      const committed = group.artifacts.some((artifact) => {
-        const journal = readReplacementJournalSync(artifact.journalPath, artifact.transactionId);
-        if (journal) return currentAcceptedTurnIds.has(journal.replacementTurnId);
+      // Only the newest transaction can describe the current transcript tail.
+      // Older artifacts may be leftovers from a committed replacement whose
+      // cleanup failed, so they must never decide the fate of a newer edit.
+      const states = group.artifacts
+        .map(replacementArtifactState)
+        .sort((left, right) => right.order - left.order);
+      const latest = states[0];
+      if (!latest) continue;
 
+      // Another local Gateway can share PILOT_HOME (for example server + TUI).
+      // A live owner's transaction is still in flight and is not crash debris.
+      const owner = latest.journal?.owner;
+      if (owner && processIsAlive(owner.pid)) {
+        result.skipped += 1;
+        continue;
+      }
+
+      const currentAcceptedTurnIds = readAcceptedTurnIdsSync(group.transcriptPath);
+      let committed: boolean;
+      if (latest.journal) {
+        committed = currentAcceptedTurnIds.has(latest.journal.replacementTurnId);
+      } else {
         // Backups created by the first transactional release did not have a
         // journal. If the current transcript contains a turn absent from the
-        // backup, input acceptance already advanced the session and restoring
-        // the legacy backup would undo a committed edit.
+        // newest backup, input acceptance advanced that legacy transaction.
         try {
-          const originalTurnIds = acceptedTurnIds(readFileSync(artifact.backupPath, "utf8"));
-          return [...currentAcceptedTurnIds].some((turnId) => !originalTurnIds.has(turnId));
+          const originalTurnIds = acceptedTurnIds(readFileSync(latest.artifact.backupPath, "utf8"));
+          committed = [...currentAcceptedTurnIds].some((turnId) => !originalTurnIds.has(turnId));
         } catch {
-          return false;
+          committed = false;
         }
-      });
+      }
       if (committed) {
         for (const artifact of group.artifacts) {
           rmSync(artifact.backupPath, { force: true });
@@ -294,28 +386,16 @@ export function recoverPendingLastTurnReplacements(
         continue;
       }
 
-      const restorable = group.artifacts
-        .map((artifact) => {
-          try {
-            return { artifact, mtimeMs: statSync(artifact.backupPath).mtimeMs };
-          } catch {
-            return undefined;
-          }
-        })
-        .filter((candidate): candidate is { artifact: ReplacementArtifact; mtimeMs: number } => Boolean(candidate))
-        .sort((left, right) => right.mtimeMs - left.mtimeMs)[0];
-      if (!restorable) {
-        for (const artifact of group.artifacts) {
-          rmSync(artifact.journalPath, { force: true });
-        }
-        result.cleaned += group.artifacts.length;
-        continue;
+      if (!latest.hasBackup) {
+        throw new Error(
+          `Newest replacement transaction ${latest.artifact.transactionId} has no backup to restore.`,
+        );
       }
 
-      const originalBody = readFileSync(restorable.artifact.backupPath, "utf8");
+      const originalBody = readFileSync(latest.artifact.backupPath, "utf8");
       const temporaryPath = resolve(
         dirname(group.transcriptPath),
-        `.${restorable.artifact.safeId}.${randomUUID()}.recovery.tmp`,
+        `.${latest.artifact.safeId}.${randomUUID()}.recovery.tmp`,
       );
       try {
         writeFileSync(temporaryPath, originalBody, { encoding: "utf8", mode: 0o600 });
@@ -407,19 +487,23 @@ export async function replaceLastWebSessionTurn(
   if (!backupPath || !journalPath) throw new Error("Replacement transaction paths were not created.");
   const temporaryPath = resolve(dirname(transcriptPath), `.${safeId}.${randomUUID()}.replace.tmp`);
   try {
-    await writeFile(backupPath, originalBody, { encoding: "utf8", mode: 0o600, flag: "wx" });
     const journal: ReplacementJournal = {
-      version: 1,
+      version: options.transactionOwner ? 2 : 1,
       transactionId,
       sessionKey: input.sessionKey,
       replacementTurnId: input.replacementTurnId,
       preparedAt: (options.now?.() ?? new Date()).toISOString(),
+      ...(options.transactionOwner ? { owner: options.transactionOwner } : {}),
     };
+    // Publish owner metadata before the backup or transcript becomes visible.
+    // A second Gateway scanning the shared PILOT_HOME will therefore skip this
+    // transaction throughout its entire preparation window.
     await writeFile(journalPath, `${JSON.stringify(journal)}\n`, {
       encoding: "utf8",
       mode: 0o600,
       flag: "wx",
     });
+    await writeFile(backupPath, originalBody, { encoding: "utf8", mode: 0o600, flag: "wx" });
     await writeFile(temporaryPath, body, { encoding: "utf8", mode: 0o600 });
     await rename(temporaryPath, transcriptPath);
   } catch (error) {

--- a/src/web/server/replaceLastTurn.ts
+++ b/src/web/server/replaceLastTurn.ts
@@ -1,0 +1,88 @@
+/** Atomically remove the latest user turn from a normal web-session transcript. */
+
+import { randomUUID } from "node:crypto";
+import { chmod, rename, rm, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { getPilotProjectChatDir } from "../../pilot/index.js";
+import { sanitizeSessionIdForPath } from "../../session/storage/ProjectSessionStorage.js";
+import { readTranscript } from "../../session/transcript/TranscriptReader.js";
+import type { AgentAcceptedInputTranscriptEntry } from "../../session/transcript/TranscriptEntry.js";
+import type {
+  WebReplaceLastTurnInput,
+  WebReplaceLastTurnResult,
+} from "../client/protocol.js";
+
+export type ReplaceLastWebSessionTurnOptions = {
+  projectRoot: string;
+  pilotHome: string;
+};
+
+export class ReplaceLastTurnError extends Error {
+  constructor(readonly code: string, message: string) {
+    super(message);
+    this.name = "ReplaceLastTurnError";
+  }
+}
+
+function findLatestAcceptedInput(
+  entries: Awaited<ReturnType<typeof readTranscript>>["entries"],
+): AgentAcceptedInputTranscriptEntry | undefined {
+  for (let index = entries.length - 1; index >= 0; index -= 1) {
+    const entry = entries[index];
+    if (entry.type === "accepted_input") return entry;
+  }
+  return undefined;
+}
+
+export async function replaceLastWebSessionTurn(
+  input: WebReplaceLastTurnInput,
+  options: ReplaceLastWebSessionTurnOptions,
+): Promise<WebReplaceLastTurnResult> {
+  if (!input.sessionKey?.trim() || !input.expectedTurnId?.trim()) {
+    throw new ReplaceLastTurnError(
+      "replace_invalid_input",
+      "sessionKey and expectedTurnId are required.",
+    );
+  }
+
+  const effectiveProjectRoot = input.projectKey ?? options.projectRoot;
+  const chatDir = getPilotProjectChatDir(effectiveProjectRoot, options.pilotHome);
+  const safeId = sanitizeSessionIdForPath(input.sessionKey);
+  const transcriptPath = resolve(chatDir, `${safeId}.jsonl`);
+  const { entries, diagnostics } = await readTranscript(transcriptPath);
+  if (diagnostics.some((diagnostic) => diagnostic.severity === "error")) {
+    throw new ReplaceLastTurnError(
+      "replace_invalid_transcript",
+      "The conversation transcript could not be safely rewritten.",
+    );
+  }
+
+  const latestInput = findLatestAcceptedInput(entries);
+  if (!latestInput) {
+    throw new ReplaceLastTurnError("replace_empty_transcript", "No user turn is available to replace.");
+  }
+  if (latestInput.turnId !== input.expectedTurnId) {
+    throw new ReplaceLastTurnError(
+      "replace_turn_conflict",
+      "The selected message is no longer the latest user turn.",
+    );
+  }
+
+  const preserved = entries.filter((entry) => entry.sequence < latestInput.sequence);
+  const body = preserved.map((entry) => `${JSON.stringify(entry)}\n`).join("");
+  const temporaryPath = resolve(dirname(transcriptPath), `.${safeId}.${randomUUID()}.replace.tmp`);
+  try {
+    await writeFile(temporaryPath, body, { encoding: "utf8", mode: 0o600 });
+    await rename(temporaryPath, transcriptPath);
+    await chmod(transcriptPath, 0o600);
+  } catch (error) {
+    await rm(temporaryPath, { force: true }).catch(() => undefined);
+    throw error;
+  }
+
+  return {
+    sessionKey: input.sessionKey,
+    replacedTurnId: latestInput.turnId,
+    removedEntryCount: entries.length - preserved.length,
+  };
+}

--- a/tests/gateway/map-agent-event-runid.spec.ts
+++ b/tests/gateway/map-agent-event-runid.spec.ts
@@ -7,6 +7,14 @@ import { mapAgentEvent } from "../../src/gateway/client/InProcessGateway.js";
 test("mapAgentEvent propagates runId to streaming lifecycle boundaries", () => {
   const runId = "run-1";
 
+  const accepted = mapAgentEvent({
+    type: "input_accepted",
+    sessionId: "session-1",
+    turnId: "turn-1",
+    messages: [],
+  }, runId);
+  assert.deepEqual(accepted, [{ type: "input_accepted", runId }]);
+
   const toolStarted = mapAgentEvent({
     type: "tool_calls_detected",
     sessionId: "session-1",

--- a/tests/web/replace-last-turn.spec.ts
+++ b/tests/web/replace-last-turn.spec.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, readdir, rm, stat, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -11,6 +11,7 @@ import { SessionRouter } from "../../src/gateway/SessionRouter.js";
 import type { AgentSession, AgentSubmitOptions } from "../../src/agent/index.js";
 import {
   finalizeLastWebSessionTurnReplacement,
+  recoverPendingLastTurnReplacements,
   ReplaceLastTurnError,
   replaceLastWebSessionTurn,
 } from "../../src/web/server/replaceLastTurn.js";
@@ -146,6 +147,161 @@ test("gateway commits the replacement transaction before emitting input_accepted
   assert.deepEqual(calls, ["commit"]);
 });
 
+test("gateway rolls back an abandoned replacement after its acceptance timeout", async () => {
+  let resolveRollback!: () => void;
+  const rolledBack = new Promise<void>((resolve) => { resolveRollback = resolve; });
+  const router = {
+    activeTurnRunId: () => undefined,
+    hasActiveTurn: () => false,
+    close: async () => undefined,
+  } as unknown as SessionRouter;
+  const gateway = new InProcessGateway(router, {
+    replacementTransactionTimeoutMs: 5,
+    replaceLastTurn: async (input) => ({
+      sessionKey: input.sessionKey,
+      replacedTurnId: input.expectedTurnId,
+      removedEntryCount: 2,
+      transactionId: "33333333-3333-4333-8333-333333333333",
+    }),
+    finalizeLastTurnReplacement: async (input) => {
+      if (input.action === "rollback") resolveRollback();
+      return input;
+    },
+  });
+
+  await gateway.replaceLastTurn({
+    sessionKey: "web:s_timeout",
+    expectedTurnId: "turn-old",
+    replacementTurnId: "turn-replacement",
+  });
+  await Promise.race([
+    rolledBack,
+    new Promise<never>((_resolve, reject) => {
+      setTimeout(() => reject(new Error("replacement timeout did not roll back")), 1_000);
+    }),
+  ]);
+});
+
+test("gateway blocks model metadata writes while a replacement is pending", async () => {
+  let modelWrites = 0;
+  const router = {
+    activeTurnRunId: () => undefined,
+    hasActiveTurn: () => false,
+    close: async () => undefined,
+  } as unknown as SessionRouter;
+  const gateway = new InProcessGateway(router, {
+    replaceLastTurn: async (input) => ({
+      sessionKey: input.sessionKey,
+      replacedTurnId: input.expectedTurnId,
+      removedEntryCount: 2,
+      transactionId: "44444444-4444-4444-8444-444444444444",
+    }),
+    finalizeLastTurnReplacement: async (input) => input,
+    sessionModelSet: async (input) => {
+      modelWrites += 1;
+      return {
+        sessionKey: input.sessionKey,
+        projectKey: input.projectKey,
+        saved: input.selection,
+        effective: { provider: "openai", model: "gpt-test", source: "session" },
+      };
+    },
+    sessionModelClear: async () => { modelWrites += 1; },
+  });
+
+  const replacement = await gateway.replaceLastTurn({
+    sessionKey: "web:s_model_lock",
+    projectKey: "/tmp/project",
+    expectedTurnId: "turn-old",
+    replacementTurnId: "turn-replacement",
+  });
+  const isBusy = (error: unknown) => (
+    typeof error === "object"
+    && error !== null
+    && "code" in error
+    && error.code === "SESSION_BUSY"
+  );
+  await assert.rejects(
+    gateway.sessionModelSet({
+      sessionKey: "web:s_model_lock",
+      projectKey: "/tmp/project",
+      selection: { mode: "model", provider: "openai", model: "gpt-test" },
+    }),
+    isBusy,
+  );
+  await assert.rejects(
+    gateway.sessionModelClear({ sessionKey: "web:s_model_lock", projectKey: "/tmp/project" }),
+    isBusy,
+  );
+  assert.equal(modelWrites, 0);
+
+  await gateway.finalizeLastTurnReplacement({
+    sessionKey: "web:s_model_lock",
+    projectKey: "/tmp/project",
+    transactionId: replacement.transactionId,
+    action: "rollback",
+  });
+});
+
+test("gateway cannot start replacement while a model metadata write holds the transcript lock", async () => {
+  let releaseModelWrite!: () => void;
+  let markModelWriteStarted!: () => void;
+  const modelWriteStarted = new Promise<void>((resolve) => { markModelWriteStarted = resolve; });
+  const modelWriteRelease = new Promise<void>((resolve) => { releaseModelWrite = resolve; });
+  let replacements = 0;
+  const router = {
+    activeTurnRunId: () => undefined,
+    hasActiveTurn: () => false,
+    close: async () => undefined,
+  } as unknown as SessionRouter;
+  const gateway = new InProcessGateway(router, {
+    replaceLastTurn: async (input) => {
+      replacements += 1;
+      return {
+        sessionKey: input.sessionKey,
+        replacedTurnId: input.expectedTurnId,
+        removedEntryCount: 2,
+        transactionId: "55555555-5555-4555-8555-555555555555",
+      };
+    },
+    finalizeLastTurnReplacement: async (input) => input,
+    sessionModelSet: async (input) => {
+      markModelWriteStarted();
+      await modelWriteRelease;
+      return {
+        sessionKey: input.sessionKey,
+        projectKey: input.projectKey,
+        saved: input.selection,
+        effective: { provider: "openai", model: "gpt-test", source: "session" },
+      };
+    },
+  });
+
+  const modelWrite = gateway.sessionModelSet({
+    sessionKey: "web:s_model_first",
+    projectKey: "/tmp/project",
+    selection: { mode: "model", provider: "openai", model: "gpt-test" },
+  });
+  await modelWriteStarted;
+  await assert.rejects(
+    gateway.replaceLastTurn({
+      sessionKey: "web:s_model_first",
+      projectKey: "/tmp/project",
+      expectedTurnId: "turn-old",
+      replacementTurnId: "turn-replacement",
+    }),
+    (error: unknown) => (
+      typeof error === "object"
+      && error !== null
+      && "code" in error
+      && error.code === "replace_turn_pending"
+    ),
+  );
+  assert.equal(replacements, 0);
+  releaseModelWrite();
+  await modelWrite;
+});
+
 test("replaceLastWebSessionTurn removes only the latest turn and leaves workspace files untouched", async () => {
   const projectRoot = await mkdtemp(join(tmpdir(), "pilotdeck-replace-turn-project-"));
   const pilotHome = await mkdtemp(join(tmpdir(), "pilotdeck-replace-turn-home-"));
@@ -185,6 +341,9 @@ test("replaceLastWebSessionTurn removes only the latest turn and leaves workspac
     assert.equal(result.replacedTurnId, "turn-2");
     assert.equal(result.removedEntryCount, 2);
     assert.deepEqual(new Set(transcript.entries.map((entry) => entry.turnId)), new Set(["turn-1"]));
+    if (process.platform !== "win32") {
+      assert.equal((await stat(storage.transcriptPath)).mode & 0o777, 0o600);
+    }
     assert.equal(await readFile(workspaceFile, "utf8"), "keep current workspace state");
   } finally {
     await rm(projectRoot, { recursive: true, force: true });
@@ -198,6 +357,10 @@ test("replaceLastWebSessionTurn preserves session metadata written after the edi
   try {
     const sessionKey = "web:s_replace_metadata";
     const storage = createAgentProjectSessionStorage({ projectRoot, pilotHome, sessionId: sessionKey });
+    await storage.transcript.recordSessionMetadata(sessionKey, "early-title", {
+      aiTitle: "Obsolete generated title from before input",
+      updatedAt: "2026-08-25T09:59:00.000Z",
+    });
     await storage.transcript.recordAcceptedInput(sessionKey, "turn-1", [{
       role: "user",
       content: [{ type: "text", text: "mistyped request" }],
@@ -208,6 +371,7 @@ test("replaceLastWebSessionTurn preserves session metadata written after the edi
     });
     await storage.transcript.recordSessionMetadata(sessionKey, "model-selection", {
       title: "Keep this title",
+      aiTitle: "Obsolete generated title",
       firstPrompt: "mistyped request",
       lastPrompt: "mistyped request",
       modelSelection: { mode: "model", provider: "openai", model: "gpt-test" },
@@ -225,9 +389,10 @@ test("replaceLastWebSessionTurn preserves session metadata written after the edi
     );
 
     const transcript = await readTranscript(storage.transcriptPath);
-    const metadataEntry = transcript.entries.find((entry) => entry.type === "session_metadata");
+    const metadataEntry = transcript.entries.filter((entry) => entry.type === "session_metadata").at(-1);
     assert.ok(metadataEntry && metadataEntry.type === "session_metadata");
     assert.equal(metadataEntry.metadata.title, "Keep this title");
+    assert.equal(metadataEntry.metadata.aiTitle, undefined);
     assert.deepEqual(metadataEntry.metadata.modelSelection, {
       mode: "model",
       provider: "openai",
@@ -278,6 +443,97 @@ test("failed replacement submission can restore the original transcript exactly"
     );
 
     assert.equal(await readFile(storage.transcriptPath, "utf8"), original);
+  } finally {
+    await rm(projectRoot, { recursive: true, force: true });
+    await rm(pilotHome, { recursive: true, force: true });
+  }
+});
+
+test("startup recovery restores a prepared replacement that was never accepted", async () => {
+  const projectRoot = await mkdtemp(join(tmpdir(), "pilotdeck-replace-recovery-project-"));
+  const pilotHome = await mkdtemp(join(tmpdir(), "pilotdeck-replace-recovery-home-"));
+  try {
+    const sessionKey = "web:s_replace_recovery";
+    const storage = createAgentProjectSessionStorage({ projectRoot, pilotHome, sessionId: sessionKey });
+    await storage.transcript.recordAcceptedInput(sessionKey, "turn-1", [{
+      role: "user",
+      content: [{ type: "text", text: "original request" }],
+    }]);
+    await storage.transcript.recordDurableMessage(sessionKey, "turn-1", {
+      role: "assistant",
+      content: [{ type: "text", text: "original answer" }],
+    });
+    const original = await readFile(storage.transcriptPath, "utf8");
+
+    await replaceLastWebSessionTurn(
+      {
+        sessionKey,
+        projectKey: projectRoot,
+        expectedTurnId: "turn-1",
+        replacementTurnId: "turn-2",
+      },
+      { projectRoot, pilotHome },
+    );
+
+    const recovery = recoverPendingLastTurnReplacements(pilotHome);
+    assert.equal(recovery.rolledBack, 1);
+    assert.equal(recovery.committed, 0);
+    assert.deepEqual(recovery.failures, []);
+    assert.equal(await readFile(storage.transcriptPath, "utf8"), original);
+  } finally {
+    await rm(projectRoot, { recursive: true, force: true });
+    await rm(pilotHome, { recursive: true, force: true });
+  }
+});
+
+test("startup recovery recognizes a durable legacy replacement without its journal", async () => {
+  const projectRoot = await mkdtemp(join(tmpdir(), "pilotdeck-replace-commit-recovery-project-"));
+  const pilotHome = await mkdtemp(join(tmpdir(), "pilotdeck-replace-commit-recovery-home-"));
+  try {
+    const sessionKey = "web:s_replace_commit_recovery";
+    const storage = createAgentProjectSessionStorage({ projectRoot, pilotHome, sessionId: sessionKey });
+    await storage.transcript.recordAcceptedInput(sessionKey, "turn-1", [{
+      role: "user",
+      content: [{ type: "text", text: "original request" }],
+    }]);
+
+    await replaceLastWebSessionTurn(
+      {
+        sessionKey,
+        projectKey: projectRoot,
+        expectedTurnId: "turn-1",
+        replacementTurnId: "turn-2",
+      },
+      { projectRoot, pilotHome },
+    );
+    const prepared = await readTranscript(storage.transcriptPath);
+    const latest = prepared.entries.at(-1);
+    storage.transcript.restoreState(
+      prepared.entries.reduce((highest, entry) => Math.max(highest, entry.sequence), 0),
+      latest?.entryId ?? null,
+    );
+    await storage.transcript.recordAcceptedInput(sessionKey, "turn-2", [{
+      role: "user",
+      content: [{ type: "text", text: "corrected request" }],
+    }]);
+    const legacyJournal = (await readdir(storage.chatDir))
+      .find((name) => name.endsWith(".replace.json"));
+    assert.ok(legacyJournal);
+    await rm(join(storage.chatDir, legacyJournal));
+
+    const recovery = recoverPendingLastTurnReplacements(pilotHome);
+    assert.equal(recovery.committed, 1);
+    assert.equal(recovery.rolledBack, 0);
+    assert.deepEqual(recovery.failures, []);
+    const recovered = await readTranscript(storage.transcriptPath);
+    assert.equal(
+      recovered.entries.some((entry) => entry.type === "accepted_input" && entry.turnId === "turn-2"),
+      true,
+    );
+    assert.equal(
+      recovered.entries.some((entry) => entry.type === "accepted_input" && entry.turnId === "turn-1"),
+      false,
+    );
   } finally {
     await rm(projectRoot, { recursive: true, force: true });
     await rm(pilotHome, { recursive: true, force: true });

--- a/tests/web/replace-last-turn.spec.ts
+++ b/tests/web/replace-last-turn.spec.ts
@@ -7,8 +7,10 @@ import { tmpdir } from "node:os";
 import { createAgentProjectSessionStorage } from "../../src/session/storage/ProjectSessionStorage.js";
 import { readTranscript } from "../../src/session/transcript/TranscriptReader.js";
 import { InProcessGateway } from "../../src/gateway/client/InProcessGateway.js";
-import type { SessionRouter } from "../../src/gateway/SessionRouter.js";
+import { SessionRouter } from "../../src/gateway/SessionRouter.js";
+import type { AgentSession, AgentSubmitOptions } from "../../src/agent/index.js";
 import {
+  finalizeLastWebSessionTurnReplacement,
   ReplaceLastTurnError,
   replaceLastWebSessionTurn,
 } from "../../src/web/server/replaceLastTurn.js";
@@ -18,6 +20,7 @@ test("gateway waits for abort, rewrites, then evicts the cached session", async 
   const router = {
     abort: async () => { calls.push("abort"); },
     close: async () => { calls.push("close"); },
+    activeTurnRunId: () => "turn-old",
   } as unknown as SessionRouter;
   const gateway = new InProcessGateway(router, {
     replaceLastTurn: async (input) => {
@@ -26,17 +29,121 @@ test("gateway waits for abort, rewrites, then evicts the cached session", async 
         sessionKey: input.sessionKey,
         replacedTurnId: input.expectedTurnId,
         removedEntryCount: 3,
+        transactionId: "11111111-1111-4111-8111-111111111111",
       };
     },
+    finalizeLastTurnReplacement: async (input) => input,
   });
 
   const result = await gateway.replaceLastTurn({
     sessionKey: "web:s_order",
     expectedTurnId: "turn-old",
+    replacementTurnId: "turn-new",
   });
 
   assert.deepEqual(calls, ["abort", "rewrite", "close"]);
   assert.equal(result.removedEntryCount, 3);
+});
+
+test("gateway rejects a stale replacement without aborting a newer active turn", async () => {
+  const calls: string[] = [];
+  const router = {
+    abort: async () => { calls.push("abort"); },
+    close: async () => { calls.push("close"); },
+    activeTurnRunId: () => "turn-newer",
+  } as unknown as SessionRouter;
+  const gateway = new InProcessGateway(router, {
+    replaceLastTurn: async () => {
+      calls.push("rewrite");
+      throw new Error("must not rewrite");
+    },
+    finalizeLastTurnReplacement: async (input) => input,
+  });
+
+  await assert.rejects(
+    gateway.replaceLastTurn({
+      sessionKey: "web:s_stale_active",
+      expectedTurnId: "turn-old",
+      replacementTurnId: "turn-replacement",
+    }),
+    (error: unknown) => (
+      typeof error === "object"
+      && error !== null
+      && "code" in error
+      && error.code === "replace_turn_conflict"
+    ),
+  );
+  assert.deepEqual(calls, []);
+});
+
+test("gateway commits the replacement transaction before emitting input_accepted", async () => {
+  const calls: string[] = [];
+  const fakeSession = {
+    async *submit(_input: unknown, options: AgentSubmitOptions = {}) {
+      const turnId = options.turnId ?? "turn-replacement";
+      yield { type: "turn_started", sessionId: "web:s_accept", turnId } as const;
+      yield {
+        type: "input_accepted",
+        sessionId: "web:s_accept",
+        turnId,
+        messages: [{ role: "user", content: [{ type: "text", text: "corrected" }] }],
+      } as const;
+      yield {
+        type: "turn_completed",
+        sessionId: "web:s_accept",
+        turnId,
+        result: {
+          type: "success",
+          sessionId: "web:s_accept",
+          turnId,
+          stopReason: "completed",
+          usage: {},
+          permissionDenials: [],
+          turns: 1,
+          startedAt: "2026-08-25T10:00:00.000Z",
+          completedAt: "2026-08-25T10:00:01.000Z",
+        },
+      } as const;
+    },
+    abort() {},
+  } as unknown as AgentSession;
+  const router = new SessionRouter({
+    idleSweepIntervalMs: 0,
+    createSession: () => fakeSession,
+  });
+  const gateway = new InProcessGateway(router, {
+    replaceLastTurn: async (input) => ({
+      sessionKey: input.sessionKey,
+      replacedTurnId: input.expectedTurnId,
+      removedEntryCount: 2,
+      transactionId: "22222222-2222-4222-8222-222222222222",
+    }),
+    finalizeLastTurnReplacement: async (input) => {
+      calls.push(input.action);
+      return input;
+    },
+  });
+
+  await gateway.replaceLastTurn({
+    sessionKey: "web:s_accept",
+    expectedTurnId: "turn-old",
+    replacementTurnId: "turn-replacement",
+  });
+  const events = [];
+  for await (const event of gateway.submitTurn({
+    sessionKey: "web:s_accept",
+    channelKey: "web",
+    message: "corrected",
+    runId: "turn-replacement",
+  })) {
+    events.push(event.type);
+    if (event.type === "input_accepted") {
+      assert.deepEqual(calls, ["commit"]);
+    }
+  }
+
+  assert.ok(events.includes("input_accepted"));
+  assert.deepEqual(calls, ["commit"]);
 });
 
 test("replaceLastWebSessionTurn removes only the latest turn and leaves workspace files untouched", async () => {
@@ -65,7 +172,12 @@ test("replaceLastWebSessionTurn removes only the latest turn and leaves workspac
     const workspaceFile = join(projectRoot, "already-changed.txt");
     await writeFile(workspaceFile, "keep current workspace state", "utf8");
     const result = await replaceLastWebSessionTurn(
-      { sessionKey, projectKey: projectRoot, expectedTurnId: "turn-2" },
+      {
+        sessionKey,
+        projectKey: projectRoot,
+        expectedTurnId: "turn-2",
+        replacementTurnId: "turn-3",
+      },
       { projectRoot, pilotHome },
     );
 
@@ -74,6 +186,98 @@ test("replaceLastWebSessionTurn removes only the latest turn and leaves workspac
     assert.equal(result.removedEntryCount, 2);
     assert.deepEqual(new Set(transcript.entries.map((entry) => entry.turnId)), new Set(["turn-1"]));
     assert.equal(await readFile(workspaceFile, "utf8"), "keep current workspace state");
+  } finally {
+    await rm(projectRoot, { recursive: true, force: true });
+    await rm(pilotHome, { recursive: true, force: true });
+  }
+});
+
+test("replaceLastWebSessionTurn preserves session metadata written after the edited turn", async () => {
+  const projectRoot = await mkdtemp(join(tmpdir(), "pilotdeck-replace-metadata-project-"));
+  const pilotHome = await mkdtemp(join(tmpdir(), "pilotdeck-replace-metadata-home-"));
+  try {
+    const sessionKey = "web:s_replace_metadata";
+    const storage = createAgentProjectSessionStorage({ projectRoot, pilotHome, sessionId: sessionKey });
+    await storage.transcript.recordAcceptedInput(sessionKey, "turn-1", [{
+      role: "user",
+      content: [{ type: "text", text: "mistyped request" }],
+    }]);
+    await storage.transcript.recordDurableMessage(sessionKey, "turn-1", {
+      role: "assistant",
+      content: [{ type: "text", text: "obsolete answer" }],
+    });
+    await storage.transcript.recordSessionMetadata(sessionKey, "model-selection", {
+      title: "Keep this title",
+      firstPrompt: "mistyped request",
+      lastPrompt: "mistyped request",
+      modelSelection: { mode: "model", provider: "openai", model: "gpt-test" },
+      updatedAt: "2026-08-25T10:00:00.000Z",
+    });
+
+    await replaceLastWebSessionTurn(
+      {
+        sessionKey,
+        projectKey: projectRoot,
+        expectedTurnId: "turn-1",
+        replacementTurnId: "turn-2",
+      },
+      { projectRoot, pilotHome, now: () => new Date("2026-08-25T11:00:00.000Z") },
+    );
+
+    const transcript = await readTranscript(storage.transcriptPath);
+    const metadataEntry = transcript.entries.find((entry) => entry.type === "session_metadata");
+    assert.ok(metadataEntry && metadataEntry.type === "session_metadata");
+    assert.equal(metadataEntry.metadata.title, "Keep this title");
+    assert.deepEqual(metadataEntry.metadata.modelSelection, {
+      mode: "model",
+      provider: "openai",
+      model: "gpt-test",
+    });
+    assert.equal(metadataEntry.metadata.firstPrompt, undefined);
+    assert.equal(metadataEntry.metadata.lastPrompt, undefined);
+    assert.equal(metadataEntry.metadata.isSnapshot, true);
+  } finally {
+    await rm(projectRoot, { recursive: true, force: true });
+    await rm(pilotHome, { recursive: true, force: true });
+  }
+});
+
+test("failed replacement submission can restore the original transcript exactly", async () => {
+  const projectRoot = await mkdtemp(join(tmpdir(), "pilotdeck-replace-rollback-project-"));
+  const pilotHome = await mkdtemp(join(tmpdir(), "pilotdeck-replace-rollback-home-"));
+  try {
+    const sessionKey = "web:s_replace_rollback";
+    const storage = createAgentProjectSessionStorage({ projectRoot, pilotHome, sessionId: sessionKey });
+    await storage.transcript.recordAcceptedInput(sessionKey, "turn-1", [{
+      role: "user",
+      content: [{ type: "text", text: "original request" }],
+    }]);
+    await storage.transcript.recordDurableMessage(sessionKey, "turn-1", {
+      role: "assistant",
+      content: [{ type: "text", text: "original answer" }],
+    });
+    const original = await readFile(storage.transcriptPath, "utf8");
+
+    const replacement = await replaceLastWebSessionTurn(
+      {
+        sessionKey,
+        projectKey: projectRoot,
+        expectedTurnId: "turn-1",
+        replacementTurnId: "turn-2",
+      },
+      { projectRoot, pilotHome },
+    );
+    await finalizeLastWebSessionTurnReplacement(
+      {
+        sessionKey,
+        projectKey: projectRoot,
+        transactionId: replacement.transactionId,
+        action: "rollback",
+      },
+      { projectRoot, pilotHome },
+    );
+
+    assert.equal(await readFile(storage.transcriptPath, "utf8"), original);
   } finally {
     await rm(projectRoot, { recursive: true, force: true });
     await rm(pilotHome, { recursive: true, force: true });
@@ -94,7 +298,12 @@ test("replaceLastWebSessionTurn rejects a stale target without changing the tran
 
     await assert.rejects(
       replaceLastWebSessionTurn(
-        { sessionKey, projectKey: projectRoot, expectedTurnId: "stale-turn" },
+        {
+          sessionKey,
+          projectKey: projectRoot,
+          expectedTurnId: "stale-turn",
+          replacementTurnId: "replacement-turn",
+        },
         { projectRoot, pilotHome },
       ),
       (error: unknown) => (

--- a/tests/web/replace-last-turn.spec.ts
+++ b/tests/web/replace-last-turn.spec.ts
@@ -147,6 +147,77 @@ test("gateway commits the replacement transaction before emitting input_accepted
   assert.deepEqual(calls, ["commit"]);
 });
 
+test("gateway claims a replacement before an asynchronous turn-start refresh", async () => {
+  const calls: string[] = [];
+  const fakeSession = {
+    async *submit(_input: unknown, options: AgentSubmitOptions = {}) {
+      const turnId = options.turnId ?? "turn-replacement";
+      yield { type: "turn_started", sessionId: "web:s_claim", turnId } as const;
+      yield {
+        type: "input_accepted",
+        sessionId: "web:s_claim",
+        turnId,
+        messages: [{ role: "user", content: [{ type: "text", text: "corrected" }] }],
+      } as const;
+      yield {
+        type: "turn_completed",
+        sessionId: "web:s_claim",
+        turnId,
+        result: {
+          type: "success",
+          sessionId: "web:s_claim",
+          turnId,
+          stopReason: "completed",
+          usage: {},
+          permissionDenials: [],
+          turns: 1,
+          startedAt: "2026-08-25T10:00:00.000Z",
+          completedAt: "2026-08-25T10:00:01.000Z",
+        },
+      } as const;
+    },
+    abort() {},
+  } as unknown as AgentSession;
+  const router = new SessionRouter({
+    idleSweepIntervalMs: 0,
+    createSession: () => fakeSession,
+  });
+  const gateway = new InProcessGateway(router, {
+    replacementTransactionTimeoutMs: 5,
+    refreshConfigBeforeTurn: async () => {
+      await new Promise<void>((resolve) => setTimeout(resolve, 30));
+    },
+    replaceLastTurn: async (input) => ({
+      sessionKey: input.sessionKey,
+      replacedTurnId: input.expectedTurnId,
+      removedEntryCount: 2,
+      transactionId: "66666666-6666-4666-8666-666666666666",
+    }),
+    finalizeLastTurnReplacement: async (input) => {
+      calls.push(input.action);
+      return input;
+    },
+  });
+
+  await gateway.replaceLastTurn({
+    sessionKey: "web:s_claim",
+    expectedTurnId: "turn-old",
+    replacementTurnId: "turn-replacement",
+  });
+  const events = [];
+  for await (const event of gateway.submitTurn({
+    sessionKey: "web:s_claim",
+    channelKey: "web",
+    message: "corrected",
+    runId: "turn-replacement",
+  })) {
+    events.push(event.type);
+  }
+
+  assert.ok(events.includes("input_accepted"));
+  assert.deepEqual(calls, ["commit"]);
+});
+
 test("gateway rolls back an abandoned replacement after its acceptance timeout", async () => {
   let resolveRollback!: () => void;
   const rolledBack = new Promise<void>((resolve) => { resolveRollback = resolve; });
@@ -534,6 +605,121 @@ test("startup recovery recognizes a durable legacy replacement without its journ
       recovered.entries.some((entry) => entry.type === "accepted_input" && entry.turnId === "turn-1"),
       false,
     );
+  } finally {
+    await rm(projectRoot, { recursive: true, force: true });
+    await rm(pilotHome, { recursive: true, force: true });
+  }
+});
+
+test("startup recovery decides from the newest replacement transaction only", async () => {
+  const projectRoot = await mkdtemp(join(tmpdir(), "pilotdeck-replace-newest-project-"));
+  const pilotHome = await mkdtemp(join(tmpdir(), "pilotdeck-replace-newest-home-"));
+  try {
+    const sessionKey = "web:s_replace_newest";
+    const storage = createAgentProjectSessionStorage({ projectRoot, pilotHome, sessionId: sessionKey });
+    await storage.transcript.recordAcceptedInput(sessionKey, "turn-1", [{
+      role: "user",
+      content: [{ type: "text", text: "first request" }],
+    }]);
+
+    await replaceLastWebSessionTurn(
+      {
+        sessionKey,
+        projectKey: projectRoot,
+        expectedTurnId: "turn-1",
+        replacementTurnId: "turn-2",
+      },
+      {
+        projectRoot,
+        pilotHome,
+        now: () => new Date("2026-08-25T10:00:00.000Z"),
+      },
+    );
+    let prepared = await readTranscript(storage.transcriptPath);
+    storage.transcript.restoreState(
+      prepared.entries.reduce((highest, entry) => Math.max(highest, entry.sequence), 0),
+      prepared.entries.at(-1)?.entryId ?? null,
+    );
+    await storage.transcript.recordAcceptedInput(sessionKey, "turn-2", [{
+      role: "user",
+      content: [{ type: "text", text: "committed corrected request" }],
+    }]);
+    await storage.transcript.recordAcceptedInput(sessionKey, "turn-3", [{
+      role: "user",
+      content: [{ type: "text", text: "newest original request" }],
+    }]);
+
+    // Leave transaction 1's artifacts behind as if commit cleanup failed,
+    // then prepare a second edit that has not yet been accepted.
+    await replaceLastWebSessionTurn(
+      {
+        sessionKey,
+        projectKey: projectRoot,
+        expectedTurnId: "turn-3",
+        replacementTurnId: "turn-4",
+      },
+      {
+        projectRoot,
+        pilotHome,
+        now: () => new Date("2026-08-25T10:01:00.000Z"),
+      },
+    );
+
+    const recovery = recoverPendingLastTurnReplacements(pilotHome);
+    assert.equal(recovery.rolledBack, 1);
+    assert.equal(recovery.committed, 0);
+    assert.deepEqual(recovery.failures, []);
+    prepared = await readTranscript(storage.transcriptPath);
+    const accepted = prepared.entries
+      .filter((entry) => entry.type === "accepted_input")
+      .map((entry) => entry.turnId);
+    assert.deepEqual(accepted, ["turn-2", "turn-3"]);
+    assert.equal(accepted.includes("turn-4"), false);
+  } finally {
+    await rm(projectRoot, { recursive: true, force: true });
+    await rm(pilotHome, { recursive: true, force: true });
+  }
+});
+
+test("startup recovery skips a replacement owned by a live Gateway process", async () => {
+  const projectRoot = await mkdtemp(join(tmpdir(), "pilotdeck-replace-owner-project-"));
+  const pilotHome = await mkdtemp(join(tmpdir(), "pilotdeck-replace-owner-home-"));
+  try {
+    const sessionKey = "web:s_replace_owner";
+    const storage = createAgentProjectSessionStorage({ projectRoot, pilotHome, sessionId: sessionKey });
+    await storage.transcript.recordAcceptedInput(sessionKey, "turn-1", [{
+      role: "user",
+      content: [{ type: "text", text: "original request" }],
+    }]);
+
+    await replaceLastWebSessionTurn(
+      {
+        sessionKey,
+        projectKey: projectRoot,
+        expectedTurnId: "turn-1",
+        replacementTurnId: "turn-2",
+      },
+      {
+        projectRoot,
+        pilotHome,
+        transactionOwner: { instanceId: "gateway-owner", pid: process.pid },
+      },
+    );
+
+    const whileOwned = recoverPendingLastTurnReplacements(pilotHome);
+    assert.equal(whileOwned.skipped, 1);
+    assert.equal(whileOwned.rolledBack, 0);
+    let transcript = await readTranscript(storage.transcriptPath);
+    assert.equal(transcript.entries.some((entry) => entry.turnId === "turn-1"), false);
+
+    const afterOwnerExit = recoverPendingLastTurnReplacements(pilotHome, {
+      isProcessAlive: () => false,
+    });
+    assert.equal(afterOwnerExit.skipped, 0);
+    assert.equal(afterOwnerExit.rolledBack, 1);
+    assert.deepEqual(afterOwnerExit.failures, []);
+    transcript = await readTranscript(storage.transcriptPath);
+    assert.equal(transcript.entries.some((entry) => entry.turnId === "turn-1"), true);
   } finally {
     await rm(projectRoot, { recursive: true, force: true });
     await rm(pilotHome, { recursive: true, force: true });

--- a/tests/web/replace-last-turn.spec.ts
+++ b/tests/web/replace-last-turn.spec.ts
@@ -1,0 +1,109 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { createAgentProjectSessionStorage } from "../../src/session/storage/ProjectSessionStorage.js";
+import { readTranscript } from "../../src/session/transcript/TranscriptReader.js";
+import { InProcessGateway } from "../../src/gateway/client/InProcessGateway.js";
+import type { SessionRouter } from "../../src/gateway/SessionRouter.js";
+import {
+  ReplaceLastTurnError,
+  replaceLastWebSessionTurn,
+} from "../../src/web/server/replaceLastTurn.js";
+
+test("gateway waits for abort, rewrites, then evicts the cached session", async () => {
+  const calls: string[] = [];
+  const router = {
+    abort: async () => { calls.push("abort"); },
+    close: async () => { calls.push("close"); },
+  } as unknown as SessionRouter;
+  const gateway = new InProcessGateway(router, {
+    replaceLastTurn: async (input) => {
+      calls.push("rewrite");
+      return {
+        sessionKey: input.sessionKey,
+        replacedTurnId: input.expectedTurnId,
+        removedEntryCount: 3,
+      };
+    },
+  });
+
+  const result = await gateway.replaceLastTurn({
+    sessionKey: "web:s_order",
+    expectedTurnId: "turn-old",
+  });
+
+  assert.deepEqual(calls, ["abort", "rewrite", "close"]);
+  assert.equal(result.removedEntryCount, 3);
+});
+
+test("replaceLastWebSessionTurn removes only the latest turn and leaves workspace files untouched", async () => {
+  const projectRoot = await mkdtemp(join(tmpdir(), "pilotdeck-replace-turn-project-"));
+  const pilotHome = await mkdtemp(join(tmpdir(), "pilotdeck-replace-turn-home-"));
+  try {
+    const sessionKey = "web:s_replace_tail";
+    const storage = createAgentProjectSessionStorage({ projectRoot, pilotHome, sessionId: sessionKey });
+    await storage.transcript.recordAcceptedInput(sessionKey, "turn-1", [{
+      role: "user",
+      content: [{ type: "text", text: "first request" }],
+    }]);
+    await storage.transcript.recordDurableMessage(sessionKey, "turn-1", {
+      role: "assistant",
+      content: [{ type: "text", text: "first answer" }],
+    });
+    await storage.transcript.recordAcceptedInput(sessionKey, "turn-2", [{
+      role: "user",
+      content: [{ type: "text", text: "mistyped request" }],
+    }]);
+    await storage.transcript.recordDurableMessage(sessionKey, "turn-2", {
+      role: "assistant",
+      content: [{ type: "text", text: "obsolete answer" }],
+    });
+
+    const workspaceFile = join(projectRoot, "already-changed.txt");
+    await writeFile(workspaceFile, "keep current workspace state", "utf8");
+    const result = await replaceLastWebSessionTurn(
+      { sessionKey, projectKey: projectRoot, expectedTurnId: "turn-2" },
+      { projectRoot, pilotHome },
+    );
+
+    const transcript = await readTranscript(storage.transcriptPath);
+    assert.equal(result.replacedTurnId, "turn-2");
+    assert.equal(result.removedEntryCount, 2);
+    assert.deepEqual(new Set(transcript.entries.map((entry) => entry.turnId)), new Set(["turn-1"]));
+    assert.equal(await readFile(workspaceFile, "utf8"), "keep current workspace state");
+  } finally {
+    await rm(projectRoot, { recursive: true, force: true });
+    await rm(pilotHome, { recursive: true, force: true });
+  }
+});
+
+test("replaceLastWebSessionTurn rejects a stale target without changing the transcript", async () => {
+  const projectRoot = await mkdtemp(join(tmpdir(), "pilotdeck-replace-conflict-project-"));
+  const pilotHome = await mkdtemp(join(tmpdir(), "pilotdeck-replace-conflict-home-"));
+  try {
+    const sessionKey = "web:s_replace_conflict";
+    const storage = createAgentProjectSessionStorage({ projectRoot, pilotHome, sessionId: sessionKey });
+    await storage.transcript.recordAcceptedInput(sessionKey, "current-turn", [{
+      role: "user",
+      content: [{ type: "text", text: "current request" }],
+    }]);
+    const before = await readFile(storage.transcriptPath, "utf8");
+
+    await assert.rejects(
+      replaceLastWebSessionTurn(
+        { sessionKey, projectKey: projectRoot, expectedTurnId: "stale-turn" },
+        { projectRoot, pilotHome },
+      ),
+      (error: unknown) => (
+        error instanceof ReplaceLastTurnError && error.code === "replace_turn_conflict"
+      ),
+    );
+    assert.equal(await readFile(storage.transcriptPath, "utf8"), before);
+  } finally {
+    await rm(projectRoot, { recursive: true, force: true });
+    await rm(pilotHome, { recursive: true, force: true });
+  }
+});

--- a/ui/server/index.js
+++ b/ui/server/index.js
@@ -62,6 +62,7 @@ import { getOpenUrlSpawnCommand } from './utils/processSpawn.js';
 import { getProjects, getProjectCronJobsOverview, getSessions, renameProject, deleteSession, deleteProject, addProjectManually, extractProjectDirectory, clearProjectDirectoryCache, searchConversations } from './projects.js';
 import {
     runChatViaGateway,
+    replaceLastTurnViaGateway,
     abortViaGateway,
     decidePermissionViaGateway,
     grantSessionPermissionViaGateway,
@@ -2506,6 +2507,51 @@ function handleChatConnection(ws, request) {
                 }
                 const providerHint = data.options?.providerHint || data.type.replace('-command', '');
                 await runChatViaGateway(data.command, data.options, streamWriter, providerHint);
+            } else if (data.type === 'regenerate-last-message') {
+                const sessionId = normalizeSessionId(data.sessionId || data.options?.sessionId);
+                const requestId = typeof data.requestId === 'string' ? data.requestId : null;
+                const expectedTurnId = typeof data.expectedTurnId === 'string'
+                    ? data.expectedTurnId.trim()
+                    : '';
+                const provider = data.options?.providerHint || 'pilotdeck';
+                try {
+                    if (!sessionId || !expectedTurnId) {
+                        throw new Error('The last message could not be identified for editing.');
+                    }
+                    sessionWatchRegistry.watch(sessionId, ws);
+                    const result = await replaceLastTurnViaGateway(
+                        sessionId,
+                        expectedTurnId,
+                        data.options || {},
+                    );
+                    const replacementRunId = data.options?.runId;
+                    streamWriter.send({
+                        type: 'session-turn-replaced',
+                        requestId,
+                        sessionId,
+                        replacedTurnId: result.replacedTurnId,
+                        replacementRunId,
+                        provider,
+                        content: data.options?.userVisibleInput ?? data.command ?? '',
+                        images: data.options?.images || [],
+                        attachments: data.options?.attachments || [],
+                    });
+                    writer.send({
+                        type: 'regenerate-last-message-result',
+                        requestId,
+                        sessionId,
+                        success: true,
+                    });
+                    await runChatViaGateway(data.command, data.options, streamWriter, provider);
+                } catch (error) {
+                    writer.send({
+                        type: 'regenerate-last-message-result',
+                        requestId,
+                        sessionId,
+                        success: false,
+                        error: error instanceof Error ? error.message : String(error),
+                    });
+                }
             } else if (data.type === 'abort-session') {
                 console.log('[DEBUG] Abort session request:', data.sessionId);
                 const provider = data.provider || 'pilotdeck';

--- a/ui/server/index.js
+++ b/ui/server/index.js
@@ -56,6 +56,7 @@ import fetch from 'node-fetch';
 import mime from 'mime-types';
 import JSZip from 'jszip';
 import { readPermissionSettings } from './services/permissionSettings.js';
+import { regenerateLastMessageTransaction } from './services/regenerateLastMessage.js';
 import { getDefaultPtyShell } from './utils/defaultShell.js';
 import { getOpenUrlSpawnCommand } from './utils/processSpawn.js';
 
@@ -63,6 +64,7 @@ import { getProjects, getProjectCronJobsOverview, getSessions, renameProject, de
 import {
     runChatViaGateway,
     replaceLastTurnViaGateway,
+    finalizeLastTurnReplacementViaGateway,
     abortViaGateway,
     decidePermissionViaGateway,
     grantSessionPermissionViaGateway,
@@ -2514,44 +2516,21 @@ function handleChatConnection(ws, request) {
                     ? data.expectedTurnId.trim()
                     : '';
                 const provider = data.options?.providerHint || 'pilotdeck';
-                try {
-                    if (!sessionId || !expectedTurnId) {
-                        throw new Error('The last message could not be identified for editing.');
-                    }
+                if (sessionId) {
                     sessionWatchRegistry.watch(sessionId, ws);
-                    const result = await replaceLastTurnViaGateway(
-                        sessionId,
-                        expectedTurnId,
-                        data.options || {},
-                    );
-                    const replacementRunId = data.options?.runId;
-                    streamWriter.send({
-                        type: 'session-turn-replaced',
-                        requestId,
-                        sessionId,
-                        replacedTurnId: result.replacedTurnId,
-                        replacementRunId,
-                        provider,
-                        content: data.options?.userVisibleInput ?? data.command ?? '',
-                        images: data.options?.images || [],
-                        attachments: data.options?.attachments || [],
-                    });
-                    writer.send({
-                        type: 'regenerate-last-message-result',
-                        requestId,
-                        sessionId,
-                        success: true,
-                    });
-                    await runChatViaGateway(data.command, data.options, streamWriter, provider);
-                } catch (error) {
-                    writer.send({
-                        type: 'regenerate-last-message-result',
-                        requestId,
-                        sessionId,
-                        success: false,
-                        error: error instanceof Error ? error.message : String(error),
-                    });
                 }
+                await regenerateLastMessageTransaction({
+                    data,
+                    sessionId,
+                    requestId,
+                    expectedTurnId,
+                    provider,
+                    writer,
+                    streamWriter,
+                    replaceLastTurn: replaceLastTurnViaGateway,
+                    finalizeLastTurnReplacement: finalizeLastTurnReplacementViaGateway,
+                    runChat: runChatViaGateway,
+                });
             } else if (data.type === 'abort-session') {
                 console.log('[DEBUG] Abort session request:', data.sessionId);
                 const provider = data.provider || 'pilotdeck';

--- a/ui/server/pilotdeck-bridge.js
+++ b/ui/server/pilotdeck-bridge.js
@@ -480,6 +480,8 @@ function resolvePermissionMode(options) {
 export function gatewayEventToFrames(event, sessionId, provider) {
     const base = { sessionId, provider, ...(event.runId ? { runId: event.runId } : {}) };
     switch (event.type) {
+        case 'input_accepted':
+            return [];
         case 'turn_started':
             return [
                 createNormalizedMessage({
@@ -1107,12 +1109,14 @@ function sendBridgeStatusEvent(writer, statusEvent, sessionKey, provider) {
  * @param {object} options Legacy options blob from the WS frame.
  * @param {{send: (msg: object) => void}} writer Existing writer.
  * @param {string} provider Provider hint (kept for legacy frame branding).
+ * @param {{onInputAccepted?: (input: {sessionKey: string, runId: string}) => void | Promise<void>}} hooks
  */
 export async function runChatViaGateway(
     command,
     options = {},
     writer,
     provider = 'pilotdeck',
+    hooks = {},
 ) {
     const projectKey = options.projectPath || options.cwd || GENERAL_HOME;
     const channelKey = 'web';
@@ -1154,6 +1158,9 @@ export async function runChatViaGateway(
     console.log(`[pilotdeck-bridge] submitTurn runMode=${runMode} mode=${resolvedMode} (options.permissionMode=${options?.permissionMode}, options.mode=${options?.mode})`);
 
     let gw = null;
+    let inputAccepted = false;
+    let sawTurnCompleted = false;
+    let sawGatewayError = false;
     try {
         gw = await ensureGateway();
 
@@ -1208,9 +1215,15 @@ export async function runChatViaGateway(
             ...(Array.isArray(options?.syntheticMessages) ? { syntheticMessages: options.syntheticMessages } : {}),
         });
 
-        let sawTurnCompleted = false;
-        let sawGatewayError = false;
         for await (const event of stream) {
+            if (event && event.type === 'input_accepted') {
+                inputAccepted = true;
+                try {
+                    await hooks.onInputAccepted?.({ sessionKey, runId });
+                } catch (error) {
+                    console.error('[pilotdeck-bridge] input accepted callback failed:', error);
+                }
+            }
             if (isVisibleFailureAgentStatus(event)) {
                 state.hasVisibleFailureStatus = true;
             }
@@ -1337,6 +1350,7 @@ export async function runChatViaGateway(
     } finally {
         clearActiveRunIfCurrent(state, runId);
     }
+    return { sessionKey, runId, inputAccepted, sawTurnCompleted, sawGatewayError };
 }
 
 export function resolveTurnRunId(value) {
@@ -1397,12 +1411,41 @@ export async function replaceLastTurnViaGateway(sessionId, expectedTurnId, optio
         sessionKey,
         projectKey,
         expectedTurnId,
+        replacementTurnId: options.runId,
     });
     const state = sessionState.get(sessionKey);
     if (state) {
         state.active = false;
         state.runId = undefined;
         state.hasVisibleFailureStatus = false;
+    }
+    return result;
+}
+
+export async function finalizeLastTurnReplacementViaGateway(
+    sessionId,
+    transactionId,
+    action,
+    options = {},
+) {
+    const gw = await ensureGateway();
+    const sessionKey = isPilotDeckSessionKey(sessionId) ? sessionId : null;
+    if (!sessionKey) throw new Error('A normal PilotDeck session is required to finalize a message edit.');
+
+    const projectKey = options.projectPath || options.cwd || GENERAL_HOME;
+    const result = await gw.finalizeLastTurnReplacement({
+        sessionKey,
+        projectKey,
+        transactionId,
+        action,
+    });
+    if (action === 'rollback') {
+        const state = sessionState.get(sessionKey);
+        if (state) {
+            state.active = false;
+            state.runId = undefined;
+            state.hasVisibleFailureStatus = false;
+        }
     }
     return result;
 }

--- a/ui/server/pilotdeck-bridge.js
+++ b/ui/server/pilotdeck-bridge.js
@@ -1205,6 +1205,7 @@ export async function runChatViaGateway(
             ...(basePermissionMode ? { basePermissionMode } : {}),
             ...(attachments.length > 0 ? { attachments } : {}),
             ...(options.workspaceCwd ? { workspaceCwd: options.workspaceCwd } : {}),
+            ...(Array.isArray(options?.syntheticMessages) ? { syntheticMessages: options.syntheticMessages } : {}),
         });
 
         let sawTurnCompleted = false;
@@ -1379,6 +1380,31 @@ export async function abortViaGateway(sessionId, _provider = 'pilotdeck') {
         console.warn('[pilotdeck-bridge] abortTurn failed:', error);
         return false;
     }
+}
+
+/**
+ * Stop the active run (if any), remove the latest transcript turn, and evict
+ * the cached gateway session. The caller can then submit the edited prompt to
+ * the same session key without racing the old transcript writer.
+ */
+export async function replaceLastTurnViaGateway(sessionId, expectedTurnId, options = {}) {
+    const gw = await ensureGateway();
+    const sessionKey = isPilotDeckSessionKey(sessionId) ? sessionId : null;
+    if (!sessionKey) throw new Error('A normal PilotDeck session is required to edit a message.');
+
+    const projectKey = options.projectPath || options.cwd || GENERAL_HOME;
+    const result = await gw.replaceLastTurn({
+        sessionKey,
+        projectKey,
+        expectedTurnId,
+    });
+    const state = sessionState.get(sessionKey);
+    if (state) {
+        state.active = false;
+        state.runId = undefined;
+        state.hasVisibleFailureStatus = false;
+    }
+    return result;
 }
 
 export async function decidePermissionViaGateway(requestId, decision, options = {}) {

--- a/ui/server/services/regenerateLastMessage.js
+++ b/ui/server/services/regenerateLastMessage.js
@@ -1,0 +1,118 @@
+/**
+ * Replace the latest transcript turn and acknowledge success only after the
+ * edited accepted_input is durable. Frames emitted before that point stay
+ * buffered; a pre-acceptance failure restores the original transcript.
+ */
+export async function regenerateLastMessageTransaction({
+    data,
+    sessionId,
+    requestId,
+    expectedTurnId,
+    provider,
+    writer,
+    streamWriter,
+    replaceLastTurn,
+    finalizeLastTurnReplacement,
+    runChat,
+}) {
+    let replacementResult = null;
+    let replacementInputAccepted = false;
+    let replacementRolledBack = false;
+    const bufferedFrames = [];
+    let releaseBufferedFrames = false;
+    const replacementStreamWriter = {
+        send: (frame) => {
+            if (releaseBufferedFrames) {
+                streamWriter.send(frame);
+            } else {
+                bufferedFrames.push(frame);
+            }
+        },
+    };
+
+    try {
+        if (!sessionId || !expectedTurnId) {
+            throw new Error('The last message could not be identified for editing.');
+        }
+        const replacementRunId = typeof data.options?.runId === 'string'
+            ? data.options.runId.trim()
+            : '';
+        if (!replacementRunId) {
+            throw new Error('The edited message could not be assigned a replacement turn.');
+        }
+        replacementResult = await replaceLastTurn(
+            sessionId,
+            expectedTurnId,
+            data.options || {},
+        );
+        const acknowledgeAcceptedInput = () => {
+            if (replacementInputAccepted) return;
+            // The gateway commits the replacement backup before it emits
+            // input_accepted, so this acknowledgement is durable.
+            replacementInputAccepted = true;
+            streamWriter.send({
+                type: 'session-turn-replaced',
+                requestId,
+                sessionId,
+                replacedTurnId: replacementResult.replacedTurnId,
+                replacementRunId,
+                provider,
+                content: data.options?.userVisibleInput ?? data.command ?? '',
+                images: data.options?.images || [],
+                attachments: data.options?.attachments || [],
+            });
+            writer.send({
+                type: 'regenerate-last-message-result',
+                requestId,
+                sessionId,
+                success: true,
+            });
+            releaseBufferedFrames = true;
+            for (const frame of bufferedFrames.splice(0)) {
+                streamWriter.send(frame);
+            }
+        };
+        const runResult = await runChat(
+            data.command,
+            data.options,
+            replacementStreamWriter,
+            provider,
+            { onInputAccepted: acknowledgeAcceptedInput },
+        );
+        if (runResult?.inputAccepted) {
+            acknowledgeAcceptedInput();
+            return { success: true, inputAccepted: true };
+        }
+
+        await finalizeLastTurnReplacement(
+            sessionId,
+            replacementResult.transactionId,
+            'rollback',
+            data.options || {},
+        );
+        replacementRolledBack = true;
+        throw new Error('The edited message was not persisted, so the original turn was restored.');
+    } catch (error) {
+        if (replacementResult && !replacementInputAccepted && !replacementRolledBack) {
+            try {
+                await finalizeLastTurnReplacement(
+                    sessionId,
+                    replacementResult.transactionId,
+                    'rollback',
+                    data.options || {},
+                );
+                replacementRolledBack = true;
+            } catch (rollbackError) {
+                console.error('[regenerate-last-message] failed to restore original turn:', rollbackError);
+            }
+        }
+        writer.send({
+            type: 'regenerate-last-message-result',
+            requestId,
+            sessionId,
+            success: false,
+            error: error instanceof Error ? error.message : String(error),
+        });
+        return { success: false, inputAccepted: false, rolledBack: replacementRolledBack };
+    }
+}

--- a/ui/server/services/regenerateLastMessage.test.js
+++ b/ui/server/services/regenerateLastMessage.test.js
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { regenerateLastMessageTransaction } from './regenerateLastMessage.js';
+
+function requestData() {
+    return {
+        command: 'corrected request',
+        options: {
+            runId: 'turn-replacement',
+            userVisibleInput: 'corrected request',
+        },
+    };
+}
+
+describe('regenerateLastMessageTransaction', () => {
+    it('reports success and releases buffered frames only after input_accepted', async () => {
+        const resultFrames = [];
+        const streamFrames = [];
+        const finalize = vi.fn();
+
+        const result = await regenerateLastMessageTransaction({
+            data: requestData(),
+            sessionId: 'web:s_test',
+            requestId: 'request-1',
+            expectedTurnId: 'turn-old',
+            provider: 'pilotdeck',
+            writer: { send: (frame) => resultFrames.push(frame) },
+            streamWriter: { send: (frame) => streamFrames.push(frame) },
+            replaceLastTurn: vi.fn(async () => ({
+                replacedTurnId: 'turn-old',
+                transactionId: 'transaction-1',
+            })),
+            finalizeLastTurnReplacement: finalize,
+            runChat: vi.fn(async (_command, _options, replacementWriter, _provider, hooks) => {
+                replacementWriter.send({ type: 'status-before-acceptance' });
+                expect(streamFrames).toEqual([]);
+                await hooks.onInputAccepted();
+                replacementWriter.send({ type: 'assistant-after-acceptance' });
+                return { inputAccepted: true };
+            }),
+        });
+
+        expect(result).toEqual({ success: true, inputAccepted: true });
+        expect(finalize).not.toHaveBeenCalled();
+        expect(resultFrames).toEqual([expect.objectContaining({
+            type: 'regenerate-last-message-result',
+            success: true,
+        })]);
+        expect(streamFrames.map((frame) => frame.type)).toEqual([
+            'session-turn-replaced',
+            'status-before-acceptance',
+            'assistant-after-acceptance',
+        ]);
+    });
+
+    it('rolls back and suppresses buffered turn frames when input is not accepted', async () => {
+        const resultFrames = [];
+        const streamFrames = [];
+        const finalize = vi.fn(async () => undefined);
+
+        const result = await regenerateLastMessageTransaction({
+            data: requestData(),
+            sessionId: 'web:s_test',
+            requestId: 'request-2',
+            expectedTurnId: 'turn-old',
+            provider: 'pilotdeck',
+            writer: { send: (frame) => resultFrames.push(frame) },
+            streamWriter: { send: (frame) => streamFrames.push(frame) },
+            replaceLastTurn: vi.fn(async () => ({
+                replacedTurnId: 'turn-old',
+                transactionId: 'transaction-2',
+            })),
+            finalizeLastTurnReplacement: finalize,
+            runChat: vi.fn(async (_command, _options, replacementWriter) => {
+                replacementWriter.send({ type: 'gateway-preflight-error' });
+                return { inputAccepted: false };
+            }),
+        });
+
+        expect(result).toEqual({ success: false, inputAccepted: false, rolledBack: true });
+        expect(finalize).toHaveBeenCalledOnce();
+        expect(finalize).toHaveBeenCalledWith(
+            'web:s_test',
+            'transaction-2',
+            'rollback',
+            requestData().options,
+        );
+        expect(streamFrames).toEqual([]);
+        expect(resultFrames).toEqual([expect.objectContaining({
+            type: 'regenerate-last-message-result',
+            success: false,
+            error: expect.stringContaining('original turn was restored'),
+        })]);
+    });
+});

--- a/ui/src/components/chat-v2/ChatInterfaceV2.tsx
+++ b/ui/src/components/chat-v2/ChatInterfaceV2.tsx
@@ -13,9 +13,24 @@ import { useChatProviderState } from '../chat/hooks/useChatProviderState';
 import { useChatSessionState } from '../chat/hooks/useChatSessionState';
 import { useChatRealtimeHandlers } from '../chat/hooks/useChatRealtimeHandlers';
 import { useChatComposerState } from '../chat/hooks/useChatComposerState';
-import { getThinkingModeAvailability } from '../chat/constants/thinkingModeAvailability';
+import {
+  getEffectiveThinkingMode,
+  getThinkingModeAvailability,
+} from '../chat/constants/thinkingModeAvailability';
+import { thinkingModeToConfig } from '../chat/constants/thinkingModes';
 import { useSessionStore } from '../../stores/useSessionStore';
-import { getDraftInputStorageKey, safeLocalStorage } from '../chat/utils/chatStorage';
+import { getDraftInputStorageKey, getPilotDeckSettings, safeLocalStorage } from '../chat/utils/chatStorage';
+import { buildAttachmentPathNote } from '../chat/utils/attachmentNotes';
+import {
+  createUserTurnRunId,
+  getNotificationSessionSummary,
+  regenerateLastSessionCommand,
+} from '../chat/utils/sessionLauncher';
+import {
+  formatContentReferencePromptBlock,
+  normalizeContentReference,
+  type ContentReference,
+} from '../../types/contentReference';
 import { useSessionWatch } from '../../hooks/useSessionWatch';
 import MessagesPaneV2 from './MessagesPaneV2';
 import ComposerV2 from './ComposerV2';
@@ -25,6 +40,12 @@ type PendingViewSession = {
   sessionId: string | null;
   startedAt: number;
 };
+
+const EDIT_RECONCILIATION_HINT = [
+  'The user replaced their immediately previous request with this edited request.',
+  'The conversation transcript no longer contains the replaced turn, but its tool actions may already have changed the current workspace.',
+  'Treat the current workspace as the source of truth: inspect existing changes, do not assume earlier work is correct, and reconcile or revise it to satisfy the edited request.',
+].join(' ');
 
 // V2 chat wrapper. Reuses all business-logic hooks from legacy
 // `ChatInterface` so streaming, file-mentions, slash commands, permissions,
@@ -81,6 +102,11 @@ function ChatInterfaceV2({
   const [isAbortPending, setIsAbortPending] = useState(false);
   const [runMode, setRunMode] = useState<ChatRunMode>('agent');
   const [isForkPending, setIsForkPending] = useState(false);
+  const regenerateRequestsRef = useRef(new Map<string, {
+    resolve: () => void;
+    reject: (error: Error) => void;
+    timeoutId: number;
+  }>());
   const { addToast } = useToast();
 
   const resetStreamingState = useCallback(() => {
@@ -361,7 +387,7 @@ function ChatInterfaceV2({
 
   const handleFork = useCallback(async (message: ChatMessage, _carriedPreview: number) => {
     if (isForkPending || isLoading || sessionIsReadOnly) return;
-    const sessionId = currentSessionId || selectedSession?.id;
+    const sessionId = selectedSession?.id || currentSessionId;
     const fromEntryId = message.entryId;
     if (!sessionId || !fromEntryId || !selectedProject) {
       addToast('error', t('fork.missingTarget', { defaultValue: 'Cannot fork this message.' }));
@@ -441,6 +467,98 @@ function ChatInterfaceV2({
     setInput,
     t,
     textareaRef,
+  ]);
+
+  useEffect(() => {
+    if (!subscribe) return undefined;
+    const unsubscribe = subscribe((message: any) => {
+      if (message?.type !== 'regenerate-last-message-result') return;
+      const requestId = typeof message.requestId === 'string' ? message.requestId : '';
+      const pending = regenerateRequestsRef.current.get(requestId);
+      if (!pending) return;
+      regenerateRequestsRef.current.delete(requestId);
+      window.clearTimeout(pending.timeoutId);
+      if (message.success) pending.resolve();
+      else pending.reject(new Error(message.error || t('edit.failed', { defaultValue: 'Could not edit this message.' })));
+    });
+    return () => unsubscribe();
+  }, [subscribe, t]);
+
+  useEffect(() => () => {
+    for (const pending of regenerateRequestsRef.current.values()) {
+      window.clearTimeout(pending.timeoutId);
+      pending.reject(new Error(t('edit.cancelled', { defaultValue: 'Message edit was cancelled.' })));
+    }
+    regenerateRequestsRef.current.clear();
+  }, [t]);
+
+  const handleRegenerate = useCallback(async (message: ChatMessage, editedText: string) => {
+    const sessionId = selectedSession?.id || currentSessionId;
+    const expectedTurnId = String(message.turnId || message.runId || '').trim();
+    if (!sessionId || !expectedTurnId || !selectedProject || sessionIsReadOnly) {
+      throw new Error(t('edit.missingTarget', { defaultValue: 'The last message can no longer be edited.' }));
+    }
+
+    const attachments = Array.isArray(message.attachments) ? message.attachments : [];
+    const references = attachments
+      .map((attachment) => normalizeContentReference(attachment.contentReference ?? attachment))
+      .filter((reference): reference is ContentReference => Boolean(reference));
+    const regularFiles = attachments
+      .filter((attachment) => !attachment.kind || attachment.kind === 'file')
+      .flatMap((attachment) => {
+        const path = attachment.path || attachment.filePath;
+        return path ? [{ name: attachment.name, path }] : [];
+      });
+    const command = `${editedText}${buildAttachmentPathNote(regularFiles)}${formatContentReferencePromptBlock(references)}`;
+    const requestId = createUserTurnRunId();
+    const runId = createUserTurnRunId();
+    const result = new Promise<void>((resolve, reject) => {
+      const timeoutId = window.setTimeout(() => {
+        regenerateRequestsRef.current.delete(requestId);
+        reject(new Error(t('edit.timeout', { defaultValue: 'Editing timed out. Please try again.' })));
+      }, 120_000);
+      regenerateRequestsRef.current.set(requestId, { resolve, reject, timeoutId });
+    });
+
+    const effectiveThinkingMode = getEffectiveThinkingMode(thinkingMode, thinkingModeAvailability);
+    regenerateLastSessionCommand({
+      sendMessage,
+      selectedProject,
+      requestId,
+      sessionId,
+      expectedTurnId,
+      command,
+      runId,
+      userVisibleInput: editedText,
+      toolsSettings: getPilotDeckSettings(),
+      runMode,
+      permissionMode: effectivePermissionMode,
+      basePermissionMode: permissionMode,
+      model,
+      thinking: thinkingModeToConfig(effectiveThinkingMode),
+      sessionSummary: getNotificationSessionSummary(selectedSession, editedText),
+      images: Array.isArray(message.images) ? message.images : [],
+      attachments,
+      syntheticMessages: [{
+        text: EDIT_RECONCILIATION_HINT,
+        purpose: 'edited_turn_workspace_reconciliation',
+      }],
+    });
+
+    return result;
+  }, [
+    currentSessionId,
+    effectivePermissionMode,
+    model,
+    permissionMode,
+    runMode,
+    selectedProject,
+    selectedSession,
+    sendMessage,
+    sessionIsReadOnly,
+    t,
+    thinkingMode,
+    thinkingModeAvailability,
   ]);
 
   useEffect(() => {
@@ -657,6 +775,7 @@ function ChatInterfaceV2({
         planModeActive={effectivePermissionMode === 'plan'}
         sessionStore={sessionStore}
         onFork={sessionIsReadOnly ? undefined : handleFork}
+        onRegenerate={sessionIsReadOnly ? undefined : handleRegenerate}
         forkDisabled={isForkPending}
       />
       {composerSlot}

--- a/ui/src/components/chat-v2/MessageRowV2.tsx
+++ b/ui/src/components/chat-v2/MessageRowV2.tsx
@@ -1,8 +1,9 @@
-import { memo, useMemo, useRef, useState, type ReactNode } from 'react';
+import { memo, useEffect, useMemo, useRef, useState, type KeyboardEvent, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { TFunction } from 'i18next';
-import { AlertTriangle, Check, ChevronRight, Copy, GitBranch, Loader2 } from 'lucide-react';
+import { AlertTriangle, Check, ChevronRight, Copy, GitBranch, Loader2, Pencil } from 'lucide-react';
 import { copyTextToClipboard } from '../../utils/clipboard';
+import { isImeEnterEvent } from '../../utils/ime.js';
 import { cn } from '../../lib/utils.js';
 import type { Project, SessionProvider } from '../../types/app';
 import {
@@ -33,6 +34,28 @@ import DocumentReferenceChip from './DocumentReferenceChip';
 import { AgentFileArtifactGroup, UserAttachmentCards } from './MessageFileCards';
 
 type DiffLine = { type: string; content: string; lineNum: number };
+
+function formatMessageTime(timestamp: ChatMessage['timestamp']): {
+  dateTime: string;
+  label: string;
+  title: string;
+} | null {
+  const date = timestamp instanceof Date ? timestamp : new Date(timestamp);
+  if (Number.isNaN(date.getTime())) return null;
+
+  return {
+    dateTime: date.toISOString(),
+    label: new Intl.DateTimeFormat(undefined, {
+      hour: '2-digit',
+      minute: '2-digit',
+      hourCycle: 'h23',
+    }).format(date),
+    title: new Intl.DateTimeFormat(undefined, {
+      dateStyle: 'medium',
+      timeStyle: 'short',
+    }).format(date),
+  };
+}
 
 function attachmentToDocumentReference(attachment: ChatAttachment): ContentReference | null {
   const structured = normalizeContentReference(attachment.contentReference);
@@ -86,6 +109,8 @@ type MessageRowV2Props = {
   forkCarriedMessageCount?: number;
   forkDisabled?: boolean;
   showAssistantActions?: boolean;
+  canEdit?: boolean;
+  onRegenerate?: (message: ChatMessage, editedText: string) => Promise<void>;
 };
 
 // Fall back to the heavy legacy renderer for anything that isn't a vanilla
@@ -130,6 +155,8 @@ function MessageRowV2({
   forkCarriedMessageCount = 0,
   forkDisabled = false,
   showAssistantActions,
+  canEdit = false,
+  onRegenerate,
 }: MessageRowV2Props) {
   const { t } = useTranslation('chat');
   const delegate = useMemo(() => shouldDelegate(message), [message]);
@@ -182,6 +209,17 @@ function MessageRowV2({
     [messageAttachments],
   );
   const [userImageLightbox, setUserImageLightbox] = useState<number | null>(null);
+  const [isEditing, setIsEditing] = useState(false);
+  const [editDraft, setEditDraft] = useState('');
+  const [editError, setEditError] = useState<string | null>(null);
+  const [isEditSubmitting, setIsEditSubmitting] = useState(false);
+  const editTextareaRef = useRef<HTMLTextAreaElement | null>(null);
+  useEffect(() => {
+    if (!isEditing || !editTextareaRef.current) return;
+    const textarea = editTextareaRef.current;
+    textarea.style.height = '0px';
+    textarea.style.height = `${Math.min(Math.max(textarea.scrollHeight, 84), 360)}px`;
+  }, [editDraft, isEditing]);
   const hasForkUnsupportedContent =
     Boolean(message.forkUnsupportedContent) ||
     messageImages.length > 0 ||
@@ -288,29 +326,46 @@ function MessageRowV2({
 
   // User: right-aligned grey bubble.
   if (isUser) {
+    const messageTime = formatMessageTime(message.timestamp);
     const lightboxImages: LightboxImage[] = messageImages.map((image) => ({
       data: image.data,
       name: image.name,
       mimeType: image.mimeType,
     }));
+    const submitEdit = async () => {
+      const editedText = editDraft.trim();
+      if (!onRegenerate || !editedText || isEditSubmitting) return;
+      setIsEditSubmitting(true);
+      setEditError(null);
+      try {
+        await onRegenerate(message, editedText);
+        setIsEditing(false);
+      } catch (error) {
+        setEditError(error instanceof Error ? error.message : String(error));
+      } finally {
+        setIsEditSubmitting(false);
+      }
+    };
+    const handleEditKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
+      if (isImeEnterEvent(event)) return;
+
+      if (event.key === 'Escape' && !isEditSubmitting) {
+        event.preventDefault();
+        setIsEditing(false);
+        setEditError(null);
+        return;
+      }
+      if (event.key === 'Enter' && !event.shiftKey) {
+        event.preventDefault();
+        void submitEdit();
+      }
+    };
     return withProcessRows(
-      <div className="group/user-msg flex w-full items-end justify-end gap-1.5">
-        {onFork ? (
-          <ForkMessageButton
-            carriedMessageCount={forkCarriedMessageCount}
-            disabled={forkDisabled || isSessionRunning || !message.entryId || hasForkUnsupportedContent}
-            disabledReason={hasForkUnsupportedContent
-              ? String(message.forkUnsupportedReason || t('fork.unsupportedAttachments', {
-                  defaultValue: 'Forking messages with attachments or media is not supported yet',
-                }))
-              : undefined}
-            onFork={() => {
-              if (message.entryId && !hasForkUnsupportedContent) onFork(message, forkCarriedMessageCount);
-            }}
-            t={t}
-          />
-        ) : null}
-        <div className="min-w-0 max-w-[78%] overflow-hidden rounded-[22px] bg-neutral-100 px-4 py-2.5 text-[14px] leading-relaxed text-neutral-900 dark:bg-neutral-800 dark:text-neutral-100">
+      <div className="group/user-msg flex w-full flex-col items-end">
+        <div className={cn(
+          'min-w-0 max-w-[78%] overflow-hidden rounded-[22px] bg-neutral-100 px-4 py-2.5 text-[14px] leading-relaxed text-neutral-900 dark:bg-neutral-800 dark:text-neutral-100',
+          isEditing && 'w-full',
+        )}>
           {message.isStreaming && !formattedContent ? (
             <span className="inline-block h-4 w-2 animate-pulse bg-neutral-400 dark:bg-neutral-500" />
           ) : (
@@ -359,13 +414,97 @@ function MessageRowV2({
                   ))}
                 </div>
               ) : null}
-              {formattedContent ? (
+              {isEditing ? (
+                <div className="mt-1">
+                  <textarea
+                    ref={editTextareaRef}
+                    value={editDraft}
+                    onChange={(event) => setEditDraft(event.target.value)}
+                    onKeyDown={handleEditKeyDown}
+                    disabled={isEditSubmitting}
+                    autoFocus
+                    aria-label={t('edit.message', { defaultValue: 'Edit message' })}
+                    className="block min-h-[84px] w-full resize-none bg-transparent text-[14px] leading-relaxed outline-none placeholder:text-neutral-400 disabled:opacity-60 dark:text-neutral-100"
+                  />
+                  {editError ? <p className="mt-1 text-xs text-red-500">{editError}</p> : null}
+                  <div className="mt-2 flex justify-end gap-2">
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setIsEditing(false);
+                        setEditError(null);
+                      }}
+                      disabled={isEditSubmitting}
+                      className="rounded-xl border border-neutral-200 bg-white px-3 py-1.5 text-sm font-medium text-neutral-800 transition-colors hover:bg-neutral-50 disabled:opacity-50 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100 dark:hover:bg-neutral-800"
+                    >
+                      {t('edit.cancel', { defaultValue: 'Cancel' })}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => void submitEdit()}
+                      disabled={!editDraft.trim() || isEditSubmitting}
+                      className="inline-flex items-center gap-1.5 rounded-xl bg-neutral-900 px-3 py-1.5 text-sm font-medium text-white transition-colors hover:bg-neutral-700 disabled:cursor-not-allowed disabled:opacity-40 dark:bg-neutral-100 dark:text-neutral-900 dark:hover:bg-white"
+                    >
+                      {isEditSubmitting ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : null}
+                      {t('edit.send', { defaultValue: 'Send' })}
+                    </button>
+                  </div>
+                </div>
+              ) : formattedContent ? (
                 <Markdown className="prose prose-sm prose-neutral min-w-0 max-w-none break-words [overflow-wrap:anywhere] dark:prose-invert prose-p:my-1 prose-ol:my-1 prose-ul:my-1 prose-li:my-0" projectName={selectedProject?.name}
           onFileOpen={onFileOpen}>{formattedContent}</Markdown>
               ) : null}
             </>
           )}
         </div>
+        {!isEditing ? (
+          <div
+            data-testid="user-message-actions"
+            className="pointer-events-none mt-1 flex h-6 items-center justify-end gap-1 pr-1 opacity-0 transition-opacity duration-150 group-hover/user-msg:pointer-events-auto group-hover/user-msg:opacity-100 group-focus-within/user-msg:pointer-events-auto group-focus-within/user-msg:opacity-100"
+          >
+            {messageTime ? (
+              <time
+                dateTime={messageTime.dateTime}
+                title={messageTime.title}
+                className="mr-1 text-xs tabular-nums text-neutral-400 dark:text-neutral-500"
+              >
+                {messageTime.label}
+              </time>
+            ) : null}
+            <CopyMarkdownButton content={String(message.content ?? '')} t={t} />
+            {canEdit && onRegenerate ? (
+              <button
+                type="button"
+                onClick={() => {
+                  setEditDraft(String(message.content ?? ''));
+                  setEditError(null);
+                  setIsEditing(true);
+                }}
+                className="rounded p-1 text-neutral-400 transition-colors hover:text-neutral-600 dark:text-neutral-500 dark:hover:text-neutral-300"
+                aria-label={t('edit.message', { defaultValue: 'Edit message' })}
+                title={t('edit.message', { defaultValue: 'Edit message' })}
+              >
+                <Pencil className="h-3.5 w-3.5" strokeWidth={2} />
+              </button>
+            ) : null}
+            {onFork ? (
+              <ForkMessageButton
+                carriedMessageCount={forkCarriedMessageCount}
+                disabled={forkDisabled || isSessionRunning || !message.entryId || hasForkUnsupportedContent}
+                disabledReason={hasForkUnsupportedContent
+                  ? String(message.forkUnsupportedReason || t('fork.unsupportedAttachments', {
+                      defaultValue: 'Forking messages with attachments or media is not supported yet',
+                    }))
+                  : undefined}
+                onFork={() => {
+                  if (message.entryId && !hasForkUnsupportedContent) onFork(message, forkCarriedMessageCount);
+                }}
+                t={t}
+                variant="action-row"
+              />
+            ) : null}
+          </div>
+        ) : null}
         {userImageLightbox !== null && lightboxImages.length > 0 ? (
           <ImageLightbox
             images={lightboxImages}
@@ -481,7 +620,7 @@ function MessageRowV2({
               variant="action-row"
             />
           ) : null}
-          {showAssistantCopyButton ? <CopyMarkdownButton content={formattedContent} /> : null}
+          {showAssistantCopyButton ? <CopyMarkdownButton content={formattedContent} t={t} /> : null}
         </div>
       ) : null}
     </div>
@@ -494,7 +633,7 @@ function MessageRowV2({
   return withProcessRows(assistantBody);
 }
 
-function CopyMarkdownButton({ content }: { content: string }) {
+function CopyMarkdownButton({ content, t }: { content: string; t: TFunction }) {
   const [copied, setCopied] = useState(false);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -511,8 +650,8 @@ function CopyMarkdownButton({ content }: { content: string }) {
       type="button"
       onClick={handleClick}
       className="rounded p-1 text-neutral-400 transition-colors hover:text-neutral-600 dark:text-neutral-500 dark:hover:text-neutral-300"
-      aria-label={copied ? 'Copied' : 'Copy'}
-      title={copied ? 'Copied' : 'Copy'}
+      aria-label={copied ? t('copyMessage.copied', { defaultValue: 'Copied' }) : t('copyMessage.copy', { defaultValue: 'Copy message' })}
+      title={copied ? t('copyMessage.copied', { defaultValue: 'Copied' }) : t('copyMessage.copy', { defaultValue: 'Copy message' })}
     >
       {copied ? <Check className="h-3.5 w-3.5" strokeWidth={2} /> : <Copy className="h-3.5 w-3.5" strokeWidth={2} />}
     </button>

--- a/ui/src/components/chat-v2/MessageRowV2.tsx
+++ b/ui/src/components/chat-v2/MessageRowV2.tsx
@@ -593,7 +593,7 @@ function MessageRowV2({
     forkDisabled || isSessionRunning || message.isStreaming || !message.entryId,
   );
   const assistantBody = (hasAssistantProse || showStreamingCursor || assistantArtifacts.length > 0) ? (
-    <div className="min-w-0 text-[14px] leading-relaxed text-neutral-900 dark:text-neutral-100">
+    <div className="group/assistant-msg min-w-0 text-[14px] leading-relaxed text-neutral-900 dark:text-neutral-100">
       {showStreamingCursor ? (
         <span className="inline-block h-4 w-2 animate-pulse bg-neutral-400 dark:bg-neutral-500" />
       ) : (
@@ -608,7 +608,11 @@ function MessageRowV2({
         />
       ) : null}
       {shouldRenderAssistantActions ? (
-        <div className="mt-1.5 flex justify-end gap-1">
+        <div
+          data-testid="assistant-message-actions"
+          className="pointer-events-none mt-1.5 flex h-6 items-center justify-start gap-1 opacity-0 transition-opacity duration-150 group-hover/assistant-msg:pointer-events-auto group-hover/assistant-msg:opacity-100 group-focus-within/assistant-msg:pointer-events-auto group-focus-within/assistant-msg:opacity-100"
+        >
+          {showAssistantCopyButton ? <CopyMarkdownButton content={formattedContent} t={t} /> : null}
           {canRenderAssistantForkButton ? (
             <ForkMessageButton
               carriedMessageCount={forkCarriedMessageCount}
@@ -620,7 +624,6 @@ function MessageRowV2({
               variant="action-row"
             />
           ) : null}
-          {showAssistantCopyButton ? <CopyMarkdownButton content={formattedContent} t={t} /> : null}
         </div>
       ) : null}
     </div>

--- a/ui/src/components/chat-v2/MessageRowV2.tsx
+++ b/ui/src/components/chat-v2/MessageRowV2.tsx
@@ -586,9 +586,14 @@ function MessageRowV2({
   const hasAssistantProse = contentDisplayText.trim().length > 0;
   const showStreamingCursor = Boolean(message.isStreaming && !contentDisplayText);
   const resolvedShowAssistantActions = showAssistantActions ?? true;
+  const assistantMessageTime = resolvedShowAssistantActions
+    ? formatMessageTime(message.timestamp)
+    : null;
   const showAssistantCopyButton = resolvedShowAssistantActions && hasAssistantProse;
   const canRenderAssistantForkButton = Boolean(resolvedShowAssistantActions && onFork && hasAssistantProse);
-  const shouldRenderAssistantActions = showAssistantCopyButton || canRenderAssistantForkButton;
+  const shouldRenderAssistantActions = Boolean(
+    assistantMessageTime || showAssistantCopyButton || canRenderAssistantForkButton,
+  );
   const assistantForkDisabled = Boolean(
     forkDisabled || isSessionRunning || message.isStreaming || !message.entryId,
   );
@@ -612,6 +617,15 @@ function MessageRowV2({
           data-testid="assistant-message-actions"
           className="pointer-events-none mt-1.5 flex h-6 items-center justify-start gap-1 opacity-0 transition-opacity duration-150 group-hover/assistant-msg:pointer-events-auto group-hover/assistant-msg:opacity-100 group-focus-within/assistant-msg:pointer-events-auto group-focus-within/assistant-msg:opacity-100"
         >
+          {assistantMessageTime ? (
+            <time
+              dateTime={assistantMessageTime.dateTime}
+              title={assistantMessageTime.title}
+              className="mr-1 text-xs tabular-nums text-neutral-400 dark:text-neutral-500"
+            >
+              {assistantMessageTime.label}
+            </time>
+          ) : null}
           {showAssistantCopyButton ? <CopyMarkdownButton content={formattedContent} t={t} /> : null}
           {canRenderAssistantForkButton ? (
             <ForkMessageButton

--- a/ui/src/components/chat-v2/MessageRowV2.userActions.test.tsx
+++ b/ui/src/components/chat-v2/MessageRowV2.userActions.test.tsx
@@ -130,3 +130,40 @@ describe('MessageRowV2 user actions', () => {
     await waitFor(() => expect(onRegenerate).toHaveBeenCalledWith(message, 'First line\nSecond line'));
   });
 });
+
+describe('MessageRowV2 assistant actions', () => {
+  it('keeps copy and branch hidden at the bottom left until the response is hovered or focused', () => {
+    const message: ChatMessage = {
+      id: 'assistant-1',
+      entryId: 'assistant-entry-1',
+      turnId: 'turn-1',
+      type: 'assistant',
+      content: 'Generated response',
+      timestamp: '2026-08-25T12:00:01.000Z',
+    };
+
+    render(
+      <MessageRowV2
+        message={message}
+        prevMessage={null}
+        provider="pilotdeck"
+        selectedProject={null}
+        createDiff={() => []}
+        onFork={vi.fn()}
+      />,
+    );
+
+    const actionRow = screen.getByTestId('assistant-message-actions');
+    expect(actionRow.className).toContain('justify-start');
+    expect(actionRow.className).toContain('pointer-events-none');
+    expect(actionRow.className).toContain('opacity-0');
+    expect(actionRow.className).toContain('group-hover/assistant-msg:pointer-events-auto');
+    expect(actionRow.className).toContain('group-hover/assistant-msg:opacity-100');
+    expect(actionRow.className).toContain('group-focus-within/assistant-msg:opacity-100');
+    expect(Array.from(actionRow.querySelectorAll('button')).map((button) => button.getAttribute('aria-label')))
+      .toEqual([
+        'Copy message',
+        'Fork from here · carries 0 messages',
+      ]);
+  });
+});

--- a/ui/src/components/chat-v2/MessageRowV2.userActions.test.tsx
+++ b/ui/src/components/chat-v2/MessageRowV2.userActions.test.tsx
@@ -1,0 +1,132 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { ChatMessage } from '../chat/types/types';
+import MessageRowV2 from './MessageRowV2';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { defaultValue?: string }) => options?.defaultValue || key,
+  }),
+}));
+
+afterEach(cleanup);
+
+function renderUserMessage(
+  message: ChatMessage,
+  options: {
+    canEdit?: boolean;
+    onRegenerate?: (message: ChatMessage, text: string) => Promise<void>;
+    onFork?: (message: ChatMessage, carried: number) => void;
+  } = {},
+) {
+  return render(
+    <MessageRowV2
+      message={message}
+      prevMessage={null}
+      provider="pilotdeck"
+      selectedProject={null}
+      createDiff={() => []}
+      canEdit={options.canEdit}
+      onRegenerate={options.onRegenerate}
+      onFork={options.onFork}
+    />,
+  );
+}
+
+describe('MessageRowV2 user actions', () => {
+  it('keeps the action row hidden until hover or focus and orders time, copy, edit, then branch', () => {
+    const message: ChatMessage = {
+      id: 'user-1',
+      entryId: 'entry-1',
+      turnId: 'turn-1',
+      type: 'user',
+      content: 'Original request',
+      timestamp: '2026-08-25T12:00:00.000Z',
+    };
+    const onRegenerate = vi.fn(async () => undefined);
+    const { rerender } = renderUserMessage(message, {
+      canEdit: true,
+      onRegenerate,
+      onFork: vi.fn(),
+    });
+
+    expect(screen.getByRole('button', { name: 'Copy message' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /Fork from here/ })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Edit message' })).toBeTruthy();
+    const actionRow = screen.getByTestId('user-message-actions');
+    expect(actionRow.className).toContain('pointer-events-none');
+    expect(actionRow.className).toContain('opacity-0');
+    expect(actionRow.className).toContain('group-hover/user-msg:pointer-events-auto');
+    expect(actionRow.className).toContain('group-hover/user-msg:opacity-100');
+    expect(actionRow.className).toContain('group-focus-within/user-msg:opacity-100');
+    expect(actionRow.querySelector('time')?.getAttribute('datetime')).toBe(message.timestamp);
+    expect(Array.from(actionRow.querySelectorAll('button')).map((button) => button.getAttribute('aria-label')))
+      .toEqual([
+        'Copy message',
+        'Edit message',
+        'Fork from here · carries 0 messages',
+      ]);
+
+    rerender(
+      <MessageRowV2
+        message={message}
+        prevMessage={null}
+        provider="pilotdeck"
+        selectedProject={null}
+        createDiff={() => []}
+        canEdit={false}
+        onRegenerate={onRegenerate}
+      />,
+    );
+    expect(screen.queryByRole('button', { name: 'Edit message' })).toBeNull();
+    expect(screen.getByRole('button', { name: 'Copy message' })).toBeTruthy();
+  });
+
+  it('edits only the text while preserving the original message payload for regeneration', async () => {
+    const message: ChatMessage = {
+      id: 'user-with-file',
+      entryId: 'entry-with-file',
+      turnId: 'turn-with-file',
+      type: 'user',
+      content: 'Typo in requset',
+      timestamp: '2026-08-25T12:00:00.000Z',
+      attachments: [{ name: 'brief.pdf', path: '/workspace/brief.pdf' }],
+    };
+    const onRegenerate = vi.fn(async () => undefined);
+    renderUserMessage(message, { canEdit: true, onRegenerate });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit message' }));
+    const editor = screen.getByRole('textbox', { name: 'Edit message' });
+    expect((editor as HTMLTextAreaElement).value).toBe('Typo in requset');
+    fireEvent.change(editor, { target: { value: 'Typo in request' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }));
+
+    await waitFor(() => expect(onRegenerate).toHaveBeenCalledWith(message, 'Typo in request'));
+  });
+
+  it('submits with Enter, keeps Shift+Enter for a newline, and ignores IME confirmation Enter', async () => {
+    const message: ChatMessage = {
+      id: 'user-keyboard-edit',
+      entryId: 'entry-keyboard-edit',
+      turnId: 'turn-keyboard-edit',
+      type: 'user',
+      content: 'First line',
+      timestamp: '2026-08-25T12:00:00.000Z',
+    };
+    const onRegenerate = vi.fn(async () => undefined);
+    renderUserMessage(message, { canEdit: true, onRegenerate });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit message' }));
+    const editor = screen.getByRole('textbox', { name: 'Edit message' });
+
+    fireEvent.keyDown(editor, { key: 'Enter', keyCode: 229 });
+    fireEvent.keyDown(editor, { key: 'Enter', shiftKey: true });
+    expect(onRegenerate).not.toHaveBeenCalled();
+
+    fireEvent.change(editor, { target: { value: 'First line\nSecond line' } });
+    fireEvent.keyDown(editor, { key: 'Enter' });
+
+    await waitFor(() => expect(onRegenerate).toHaveBeenCalledWith(message, 'First line\nSecond line'));
+  });
+});

--- a/ui/src/components/chat-v2/MessageRowV2.userActions.test.tsx
+++ b/ui/src/components/chat-v2/MessageRowV2.userActions.test.tsx
@@ -132,7 +132,7 @@ describe('MessageRowV2 user actions', () => {
 });
 
 describe('MessageRowV2 assistant actions', () => {
-  it('keeps copy and branch hidden at the bottom left until the response is hovered or focused', () => {
+  it('keeps time, copy, and branch hidden at the bottom left until the response is hovered or focused', () => {
     const message: ChatMessage = {
       id: 'assistant-1',
       entryId: 'assistant-entry-1',
@@ -160,6 +160,9 @@ describe('MessageRowV2 assistant actions', () => {
     expect(actionRow.className).toContain('group-hover/assistant-msg:pointer-events-auto');
     expect(actionRow.className).toContain('group-hover/assistant-msg:opacity-100');
     expect(actionRow.className).toContain('group-focus-within/assistant-msg:opacity-100');
+    expect(actionRow.querySelector('time')?.getAttribute('datetime')).toBe(message.timestamp);
+    expect(Array.from(actionRow.children).map((element) => element.tagName.toLowerCase()))
+      .toEqual(['time', 'button', 'button']);
     expect(Array.from(actionRow.querySelectorAll('button')).map((button) => button.getAttribute('aria-label')))
       .toEqual([
         'Copy message',

--- a/ui/src/components/chat-v2/MessagesPaneV2.render.test.tsx
+++ b/ui/src/components/chat-v2/MessagesPaneV2.render.test.tsx
@@ -96,6 +96,7 @@ function createPaneElement({
   planModeActive = false,
   showThinking = true,
   inlineThinking = false,
+  onRegenerate,
 }: {
   messages: ChatMessage[];
   activityMessages?: ChatMessage[];
@@ -106,6 +107,7 @@ function createPaneElement({
   planModeActive?: boolean;
   showThinking?: boolean;
   inlineThinking?: boolean;
+  onRegenerate?: (message: ChatMessage, editedText: string) => Promise<void>;
 }) {
   const scrollContainerRef = React.createRef<HTMLDivElement>();
 
@@ -139,6 +141,7 @@ function createPaneElement({
         planModeActive={planModeActive}
         showThinking={showThinking}
         inlineThinking={inlineThinking}
+        onRegenerate={onRegenerate}
       />
     </FindShortcutProvider>
   );
@@ -154,6 +157,7 @@ function renderPane(options: {
   planModeActive?: boolean;
   showThinking?: boolean;
   inlineThinking?: boolean;
+  onRegenerate?: (message: ChatMessage, editedText: string) => Promise<void>;
 }) {
   return render(createPaneElement(options));
 }
@@ -194,6 +198,25 @@ function SessionPaneHarness({
 }
 
 describe('MessagesPaneV2 render behavior', () => {
+  it('offers editing only on the latest user message', () => {
+    const now = new Date().toISOString();
+    renderPane({
+      messages: [
+        { id: 'user-old', turnId: 'turn-old', type: 'user', content: 'Old request', timestamp: now },
+        { id: 'assistant-old', turnId: 'turn-old', type: 'assistant', content: 'Old answer', timestamp: now },
+        { id: 'user-latest', turnId: 'turn-latest', type: 'user', content: 'Latest request', timestamp: now },
+        { id: 'assistant-latest', turnId: 'turn-latest', type: 'assistant', content: 'Latest answer', timestamp: now },
+      ],
+      onRegenerate: vi.fn(async () => undefined),
+    });
+
+    expect(screen.getAllByRole('button', { name: 'Edit message' })).toHaveLength(1);
+    const latestMessageRow = screen.getByText('Latest request').closest('.chat-message');
+    expect(latestMessageRow?.querySelector('[aria-label="Edit message"]')).not.toBeNull();
+    const oldMessageRow = screen.getByText('Old request').closest('.chat-message');
+    expect(oldMessageRow?.querySelector('[aria-label="Edit message"]')).toBeNull();
+  });
+
   it('shows a waiting state before the model produces content', () => {
     const now = new Date().toISOString();
     renderPane({

--- a/ui/src/components/chat-v2/MessagesPaneV2.tsx
+++ b/ui/src/components/chat-v2/MessagesPaneV2.tsx
@@ -78,6 +78,7 @@ type MessagesPaneV2Props = {
   planModeActive?: boolean;
   sessionStore?: SessionStore;
   onFork?: (message: ChatMessage, carriedMessageCount: number) => void;
+  onRegenerate?: (message: ChatMessage, editedText: string) => Promise<void>;
   forkDisabled?: boolean;
   forkParentSessionTitle?: string | null;
 };
@@ -357,6 +358,7 @@ function MessagesPaneV2({
   planModeActive = false,
   sessionStore,
   onFork,
+  onRegenerate,
   forkDisabled = false,
   forkParentSessionTitle = null,
 }: MessagesPaneV2Props) {
@@ -556,6 +558,12 @@ function MessagesPaneV2({
     })),
     [getMessageKey, messageWindowScope, renderableMessageItems],
   );
+  const lastUserMessageItemKey = useMemo(() => {
+    for (let index = keyedMessageItems.length - 1; index >= 0; index -= 1) {
+      if (keyedMessageItems[index].message.type === 'user') return keyedMessageItems[index].itemKey;
+    }
+    return null;
+  }, [keyedMessageItems]);
   const measuredItemHeights = useMemo(() => {
     void heightVersion;
     return keyedMessageItems.map((item) => measuredHeightsRef.current.get(item.itemKey) ?? item.estimatedHeight);
@@ -1035,6 +1043,12 @@ function MessagesPaneV2({
             forkCarriedMessageCount={forkCarriedMessageCount}
             forkDisabled={forkDisabled}
             showAssistantActions={showAssistantActions}
+            canEdit={Boolean(
+              onRegenerate
+              && !sessionIsReadOnly
+              && item.itemKey === lastUserMessageItemKey
+            )}
+            onRegenerate={onRegenerate}
           />
           {rendersLiveHeaderAfterItem ? (
             <LiveProcessHeader
@@ -1078,7 +1092,10 @@ function MessagesPaneV2({
     liveProcessStartedAtMs,
     onFileOpen,
     onFork,
+    onRegenerate,
     forkDisabled,
+    lastUserMessageItemKey,
+    sessionIsReadOnly,
     onGrantSessionToolPermission,
     onShowSettings,
     provider,

--- a/ui/src/components/chat/hooks/useChatRealtimeHandlers.ts
+++ b/ui/src/components/chat/hooks/useChatRealtimeHandlers.ts
@@ -451,6 +451,56 @@ export function useChatRealtimeHandlers({
           return;
         }
 
+        case 'session-turn-replaced': {
+          const replacedSessionId = resolveSessionId(msg);
+          const replacedTurnId = typeof msg.replacedTurnId === 'string'
+            ? msg.replacedTurnId.trim()
+            : '';
+          const replacementRunId = typeof msg.replacementRunId === 'string'
+            ? msg.replacementRunId.trim()
+            : '';
+          if (!replacedSessionId || !replacedTurnId || !replacementRunId) return;
+
+          clearAccumulators();
+          sessionStore.setActiveSession(replacedSessionId);
+          sessionStore.replaceLastTurn?.(
+            replacedSessionId,
+            replacedTurnId,
+            {
+              id: `local_${replacementRunId}`,
+              sessionId: replacedSessionId,
+              timestamp: new Date().toISOString(),
+              provider,
+              kind: 'text',
+              role: 'user',
+              content: typeof msg.content === 'string' ? msg.content : '',
+              images: Array.isArray(msg.images)
+                ? msg.images.flatMap((image) => {
+                    if (typeof image === 'string') return image ? [image] : [];
+                    return image && typeof image.data === 'string' ? [image.data] : [];
+                  })
+                : [],
+              attachments: Array.isArray(msg.attachments) ? msg.attachments : [],
+              runId: replacementRunId,
+              turnId: replacementRunId,
+            },
+          );
+          setPendingPermissionRequests((previous) => (
+            previous.filter((request) => request.sessionId !== replacedSessionId)
+          ));
+          if (isSessionForActiveView(replacedSessionId, activeViewSessionId)) {
+            updateActiveRunId(replacementRunId);
+            setSessionRuntimeState('running');
+            setIsLoading(true);
+            setCanAbortSession(true);
+            setIsAborting(false);
+            setClaudeStatus(null);
+            setPilotDeckStatus(null);
+          }
+          onSessionProcessing?.(replacedSessionId);
+          return;
+        }
+
         case 'session-status': {
           const statusSessionId = msg.sessionId;
           if (!statusSessionId) return;

--- a/ui/src/components/chat/utils/sessionLauncher.spec.ts
+++ b/ui/src/components/chat/utils/sessionLauncher.spec.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { Project } from '../../../types/app';
-import { createUserTurnRunId, startSessionCommand } from './sessionLauncher';
+import { createUserTurnRunId, regenerateLastSessionCommand, startSessionCommand } from './sessionLauncher';
 
 describe('sessionLauncher turn identity', () => {
   afterEach(() => {
@@ -45,5 +45,39 @@ describe('sessionLauncher turn identity', () => {
         runId: 'run-user-1',
       }),
     }));
+  });
+
+  it('sends an atomic same-session replacement request with preserved payload', () => {
+    const sendMessage = vi.fn();
+
+    regenerateLastSessionCommand({
+      sendMessage,
+      selectedProject: { name: 'PilotDeck', path: '/workspace/PilotDeck' } as Project,
+      requestId: 'replace-request-1',
+      sessionId: 'web:session-1',
+      expectedTurnId: 'old-turn',
+      command: 'Corrected request',
+      userVisibleInput: 'Corrected request',
+      runId: 'new-turn',
+      images: [{ data: 'data:image/png;base64,abc', name: 'image.png' }],
+      attachments: [{ name: 'brief.pdf', path: '/workspace/brief.pdf' }],
+      syntheticMessages: [{ text: 'Inspect the current workspace.', purpose: 'edit' }],
+    });
+
+    expect(sendMessage).toHaveBeenCalledWith({
+      type: 'regenerate-last-message',
+      requestId: 'replace-request-1',
+      sessionId: 'web:session-1',
+      expectedTurnId: 'old-turn',
+      command: 'Corrected request',
+      options: expect.objectContaining({
+        sessionId: 'web:session-1',
+        runId: 'new-turn',
+        userVisibleInput: 'Corrected request',
+        images: [{ data: 'data:image/png;base64,abc', name: 'image.png' }],
+        attachments: [{ name: 'brief.pdf', path: '/workspace/brief.pdf' }],
+        syntheticMessages: [{ text: 'Inspect the current workspace.', purpose: 'edit' }],
+      }),
+    });
   });
 });

--- a/ui/src/components/chat/utils/sessionLauncher.ts
+++ b/ui/src/components/chat/utils/sessionLauncher.ts
@@ -25,6 +25,16 @@ type StartSessionOptions = {
   forceStart?: boolean;
 };
 
+type RegenerateLastSessionOptions = Omit<
+  StartSessionOptions,
+  'temporarySessionId' | 'alwaysOnPlanId' | 'alwaysOnExecutionToken' | 'forceStart'
+> & {
+  requestId: string;
+  sessionId: string;
+  expectedTurnId: string;
+  syntheticMessages?: Array<{ text: string; purpose?: string }>;
+};
+
 const VALID_PERMISSION_MODES = new Set<PermissionMode>([
   'default',
   'bypassPermissions',
@@ -150,4 +160,58 @@ export function startSessionCommand({
   });
 
   return sessionToActivate;
+}
+
+export function regenerateLastSessionCommand({
+  sendMessage,
+  selectedProject,
+  command,
+  requestId,
+  sessionId,
+  expectedTurnId,
+  runId,
+  userVisibleInput,
+  permissionMode = 'default',
+  basePermissionMode,
+  runMode,
+  model,
+  thinking,
+  sessionSummary,
+  toolsSettings = getPilotDeckSettings(),
+  images,
+  attachments,
+  workspaceCwd,
+  syntheticMessages,
+}: RegenerateLastSessionOptions): void {
+  const resolvedProjectPath = getSelectedProjectPath(selectedProject);
+  sendMessage({
+    type: 'regenerate-last-message',
+    requestId,
+    sessionId,
+    expectedTurnId,
+    command,
+    options: {
+      sessionId,
+      resume: true,
+      projectPath: resolvedProjectPath,
+      cwd: resolvedProjectPath,
+      ...(runId ? { runId } : {}),
+      toolsSettings,
+      ...(runMode ? { runMode } : {}),
+      permissionMode,
+      ...(basePermissionMode ? { basePermissionMode } : {}),
+      ...(model ? { model } : {}),
+      ...(thinking ? { thinking } : {}),
+      sessionSummary,
+      ...(typeof userVisibleInput === 'string' && userVisibleInput.trim()
+        ? { userVisibleInput: userVisibleInput.trim() }
+        : {}),
+      ...(Array.isArray(images) && images.length > 0 ? { images } : {}),
+      ...(Array.isArray(attachments) && attachments.length > 0 ? { attachments } : {}),
+      ...(workspaceCwd ? { workspaceCwd } : {}),
+      ...(Array.isArray(syntheticMessages) && syntheticMessages.length > 0
+        ? { syntheticMessages }
+        : {}),
+    },
+  });
 }

--- a/ui/src/i18n/locales/en/chat.json
+++ b/ui/src/i18n/locales/en/chat.json
@@ -15,6 +15,15 @@
     "copyAsMarkdown": "Copy as markdown",
     "copyAsText": "Copy as text"
   },
+  "edit": {
+    "message": "Edit message",
+    "cancel": "Cancel",
+    "send": "Send",
+    "failed": "Could not edit this message.",
+    "cancelled": "Message edit was cancelled.",
+    "missingTarget": "The last message can no longer be edited.",
+    "timeout": "Editing timed out. Please try again."
+  },
   "messageTypes": {
     "user": "U",
     "error": "Error",

--- a/ui/src/i18n/locales/zh-CN/chat.json
+++ b/ui/src/i18n/locales/zh-CN/chat.json
@@ -15,6 +15,15 @@
     "copyAsMarkdown": "复制为 Markdown",
     "copyAsText": "复制为纯文本"
   },
+  "edit": {
+    "message": "修改消息",
+    "cancel": "取消",
+    "send": "发送",
+    "failed": "无法修改这条消息。",
+    "cancelled": "已取消修改消息。",
+    "missingTarget": "最后一条消息已无法修改。",
+    "timeout": "修改请求超时，请重试。"
+  },
   "messageTypes": {
     "user": "U",
     "error": "错误",

--- a/ui/src/stores/useSessionStore.requests.spec.tsx
+++ b/ui/src/stores/useSessionStore.requests.spec.tsx
@@ -104,6 +104,45 @@ describe('useSessionStore last-turn replacement', () => {
       turnId: 'turn-3',
     });
   });
+
+  it('keeps the previous response when a discarded-turn status row is ordered early', () => {
+    const { result } = renderHook(() => useSessionStore());
+    const slot = result.current.getSlot('session-1');
+    slot.serverMessages = [
+      userMessage('first-user', 'First request', '2026-08-04T00:00:00.000Z', { turnId: 'turn-1' }),
+      {
+        ...serverMessage('early-status', 'Working'),
+        kind: 'status',
+        turnId: 'turn-2',
+      },
+      { ...serverMessage('first-thinking', 'First reasoning'), kind: 'thinking', turnId: 'turn-1' },
+      { ...serverMessage('first-answer', 'First answer'), turnId: 'turn-1' },
+      userMessage('old-user', 'Old request', '2026-08-04T00:01:00.000Z', { turnId: 'turn-2' }),
+      { ...serverMessage('old-answer', 'Old answer'), turnId: 'turn-2' },
+    ];
+
+    act(() => {
+      result.current.replaceLastTurn('session-1', 'turn-2', {
+        ...userMessage('local-new-turn', 'Corrected request', '2026-08-04T00:02:00.000Z'),
+        runId: 'turn-3',
+        turnId: 'turn-3',
+      });
+    });
+
+    const updated = result.current.getSessionSlot('session-1');
+    expect(updated?.serverMessages.map((message) => message.id)).toEqual([
+      'first-user',
+      'first-thinking',
+      'first-answer',
+    ]);
+    expect(updated?.realtimeMessages.map((message) => message.id)).toEqual(['local-new-turn']);
+    expect(updated?.merged.map((message) => message.id)).toEqual([
+      'first-user',
+      'first-thinking',
+      'first-answer',
+      'local-new-turn',
+    ]);
+  });
 });
 
 describe('useSessionStore server request ordering', () => {

--- a/ui/src/stores/useSessionStore.requests.spec.tsx
+++ b/ui/src/stores/useSessionStore.requests.spec.tsx
@@ -62,6 +62,50 @@ function userMessage(
   };
 }
 
+describe('useSessionStore last-turn replacement', () => {
+  afterEach(cleanup);
+
+  it('drops the discarded tail and inserts the edited user message', () => {
+    const { result } = renderHook(() => useSessionStore());
+    const slot = result.current.getSlot('session-1');
+    slot.serverMessages = [
+      userMessage('first-user', 'First request', '2026-08-04T00:00:00.000Z', { turnId: 'turn-1' }),
+      serverMessage('first-answer', 'First answer'),
+      userMessage('old-user', 'Old request', '2026-08-04T00:01:00.000Z', { turnId: 'turn-2' }),
+      { ...serverMessage('old-answer', 'Old answer'), turnId: 'turn-2' },
+    ];
+    slot.serverMessages[1] = { ...slot.serverMessages[1], turnId: 'turn-1' };
+    slot.realtimeMessages = [{
+      ...serverMessage('old-tool', 'tool output'),
+      kind: 'tool_result',
+      turnId: 'turn-2',
+    }];
+    slot.activityMessages = [{
+      ...serverMessage('old-activity', 'working'),
+      kind: 'agent_activity',
+      parentRunId: 'turn-2',
+    }];
+
+    act(() => {
+      result.current.replaceLastTurn('session-1', 'turn-2', {
+        ...userMessage('local-new-turn', 'Corrected request', '2026-08-04T00:02:00.000Z'),
+        runId: 'turn-3',
+        turnId: 'turn-3',
+      });
+    });
+
+    const updated = result.current.getSessionSlot('session-1');
+    expect(updated?.serverMessages.map((message) => message.id)).toEqual(['first-user', 'first-answer']);
+    expect(updated?.realtimeMessages.map((message) => message.id)).toEqual(['local-new-turn']);
+    expect(updated?.activityMessages).toEqual([]);
+    expect(updated?.merged.at(-1)).toMatchObject({
+      role: 'user',
+      content: 'Corrected request',
+      turnId: 'turn-3',
+    });
+  });
+});
+
 describe('useSessionStore server request ordering', () => {
   beforeEach(() => {
     mocks.authenticatedFetch.mockReset();

--- a/ui/src/stores/useSessionStore.ts
+++ b/ui/src/stores/useSessionStore.ts
@@ -1438,14 +1438,21 @@ export function useSessionStore() {
     replacement: NormalizedMessage,
   ) => {
     const slot = getSlot(sessionId);
+    const belongsToReplacedTurn = (message: NormalizedMessage) => (
+      getMessageTurnId(message) === replacedTurnId
+      || message.parentRunId === replacedTurnId
+    );
     const truncateAtTurn = (messages: NormalizedMessage[]) => {
-      const index = messages.findIndex((message) => getMessageTurnId(message) === replacedTurnId);
-      return index >= 0
-        ? messages.slice(0, index)
-        : messages.filter((message) => (
-            getMessageTurnId(message) !== replacedTurnId
-            && message.parentRunId !== replacedTurnId
-          ));
+      // Status rows can be inserted before earlier turns because their sequence
+      // numbers are turn-local. Only the discarded user message is a safe tail
+      // boundary; remove any misplaced rows from that turn in the retained prefix.
+      const index = messages.findIndex((message) => (
+        message.kind === 'text'
+        && message.role === 'user'
+        && getMessageTurnId(message) === replacedTurnId
+      ));
+      const prefix = index >= 0 ? messages.slice(0, index) : messages;
+      return prefix.filter((message) => !belongsToReplacedTurn(message));
     };
 
     const previousServerMessageCount = slot.serverMessages.length;
@@ -1454,10 +1461,7 @@ export function useSessionStore() {
       ...truncateAtTurn(slot.realtimeMessages),
       captureOptimisticUserServerTail(replacement, slot.serverMessages, false),
     ];
-    slot.activityMessages = slot.activityMessages.filter((message) => (
-      getMessageTurnId(message) !== replacedTurnId
-      && message.parentRunId !== replacedTurnId
-    ));
+    slot.activityMessages = slot.activityMessages.filter((message) => !belongsToReplacedTurn(message));
     const removedServerMessageCount = previousServerMessageCount - slot.serverMessages.length;
     slot.total = Math.max(
       slot.serverMessages.length + 1,

--- a/ui/src/stores/useSessionStore.ts
+++ b/ui/src/stores/useSessionStore.ts
@@ -1427,6 +1427,52 @@ export function useSessionStore() {
     }
   }, [getSlot, notify]);
 
+  /**
+   * Replace the transcript tail in-place after the gateway atomically removes
+   * the latest turn. Because editing is limited to the last user message, all
+   * rendered rows at and after that turn belong to the discarded turn.
+   */
+  const replaceLastTurn = useCallback((
+    sessionId: string,
+    replacedTurnId: string,
+    replacement: NormalizedMessage,
+  ) => {
+    const slot = getSlot(sessionId);
+    const truncateAtTurn = (messages: NormalizedMessage[]) => {
+      const index = messages.findIndex((message) => getMessageTurnId(message) === replacedTurnId);
+      return index >= 0
+        ? messages.slice(0, index)
+        : messages.filter((message) => (
+            getMessageTurnId(message) !== replacedTurnId
+            && message.parentRunId !== replacedTurnId
+          ));
+    };
+
+    const previousServerMessageCount = slot.serverMessages.length;
+    slot.serverMessages = truncateAtTurn(slot.serverMessages);
+    slot.realtimeMessages = [
+      ...truncateAtTurn(slot.realtimeMessages),
+      captureOptimisticUserServerTail(replacement, slot.serverMessages, false),
+    ];
+    slot.activityMessages = slot.activityMessages.filter((message) => (
+      getMessageTurnId(message) !== replacedTurnId
+      && message.parentRunId !== replacedTurnId
+    ));
+    const removedServerMessageCount = previousServerMessageCount - slot.serverMessages.length;
+    slot.total = Math.max(
+      slot.serverMessages.length + 1,
+      slot.total - removedServerMessageCount + 1,
+    );
+    slot.offset = Math.max(
+      slot.serverMessages.length + 1,
+      slot.offset - removedServerMessageCount + 1,
+    );
+    slot.status = 'streaming';
+    slot.lastError = null;
+    recomputeMergedIfNeeded(slot);
+    notify(sessionId);
+  }, [getSlot, notify]);
+
   const upsertActivity = useCallback((sessionId: string, msg: NormalizedMessage) => {
     const slot = getSlot(sessionId);
     const key = msg.activityId || msg.id;
@@ -1975,6 +2021,7 @@ export function useSessionStore() {
     fetchFromServer,
     fetchMore,
     appendRealtime,
+    replaceLastTurn,
     upsertActivity,
     setActivities,
     cancelRunningActivities,
@@ -2001,7 +2048,7 @@ export function useSessionStore() {
     finalizeSubagentDetailThinking,
   }), [
     getSlot, has, fetchFromServer, fetchMore,
-    appendRealtime, upsertActivity, setActivities, cancelRunningActivities, appendRealtimeBatch, refreshFromServer,
+    appendRealtime, replaceLastTurn, upsertActivity, setActivities, cancelRunningActivities, appendRealtimeBatch, refreshFromServer,
     setActiveSession, setStatus, isStale, updateStreaming, finalizeStreaming,
     updateStreamingThinking, finalizeStreamingThinking,
     clearRealtime, clearAssistantRealtime, getMessages, getActivityMessages, getSubagentDetailMessages, getSessionSlot,


### PR DESCRIPTION
## Summary

This PR improves the chat experience with contextual message actions and last-message editing.

- Add copy actions for user and assistant messages.
- Allow the latest user message to be edited and regenerated in the same session.
- Add a Gateway operation that atomically replaces the latest user turn before regeneration.
- Move message actions below their content and show them only on hover or keyboard focus.
- Display local message timestamps alongside the actions.
- Preserve previous responses while the edited message is regenerating.

## Message actions

User messages use the following right-aligned action order:

`time → copy → edit → fork`

Assistant messages use the following left-aligned action order:

`time → copy → fork`

The action rows are hidden by default and become visible when the corresponding message is hovered or focused.

## Editing and regeneration

- Only the latest user message can be edited.
- Pressing Enter submits the edited message.
- Shift+Enter inserts a newline.
- IME confirmation events do not accidentally submit the editor.
- Attachments, images, and content references from the original message are preserved.
- Regeneration replaces the latest conversation turn instead of creating a branch.
- The transcript is rewritten atomically before the edited prompt is submitted again.
- Existing workspace file changes are intentionally left untouched.

## Session consistency

The frontend now locates the actual discarded user message when replacing the latest turn. This prevents an earlier response from temporarily disappearing when turn-local status messages are received out of transcript order.

## Testing

- Added Gateway tests for latest-turn replacement and stale-target handling.
- Added UI tests for copy, edit, keyboard submission, timestamps, action ordering, and hover/focus visibility.
- Added a regression test ensuring previous responses remain visible during regeneration.
- Relevant UI tests: 51 passed.
- Gateway replacement tests: 3 passed.
- UI production build completed successfully.