### PR TITLE
fix(im): serialize permission prompts across channels

### DIFF
--- a/docs/dialog-improvement-api.md
+++ b/docs/dialog-improvement-api.md
@@ -488,6 +488,8 @@ type SetSessionModelRequest = {
 5. 非法组合返回 `INVALID_PERMISSION_MODE`，且不得启动模型调用。
 
 权限确认继续通过 `permission_request` 事件和 `permission_decide` RPC 完成。
+文本 IM 渠道对同一会话内的多个权限请求按 FIFO 顺序逐条发送和确认；每次 `1/2/0` 只决策当前请求，完成后再发送下一条提示。
+下一条提示只有在渠道确认发送成功后才会解除队列锁；发送失败时保留提示和锁，避免用户尚未看到提示就决策后续请求。
 
 ## 8. 提交对话
 

--- a/docs/dialog-improvement-api.md
+++ b/docs/dialog-improvement-api.md
@@ -490,6 +490,7 @@ type SetSessionModelRequest = {
 权限确认继续通过 `permission_request` 事件和 `permission_decide` RPC 完成。
 文本 IM 渠道对同一会话内的多个权限请求按 FIFO 顺序逐条发送和确认；每次 `1/2/0` 只决策当前请求，完成后再发送下一条提示。
 下一条提示只有在渠道确认发送成功后才会解除队列锁；发送失败时保留提示和锁，避免用户尚未看到提示就决策后续请求。
+`permission_decide` 返回 `{ delivered: false }` 时，requestId 已未知或所属 turn 已结束；IM helper 丢弃该失效请求并为队列中的下一条请求建立提示，不重试同一个 requestId。确认消息投递期间到达的新权限请求仍按 FIFO 排队，且 turn 完成清理必须等待当前回答的投递确认。
 
 ## 8. 提交对话
 

--- a/docs/trd-dialog-improvement.md
+++ b/docs/trd-dialog-improvement.md
@@ -207,6 +207,7 @@ type UploadedAttachmentRef = {
 
 权限请求继续使用现有 `permission_request` / `permission_decide` 事件和 RPC。
 文本 IM 权限请求按 chat 维度 FIFO 串行处理；下一条提示发送成功前保持锁定，发送失败时保留待发送提示，不允许后续入站消息越过当前请求。
+`permission_decide` 返回 `delivered: false` 表示 request 已失效；渠道应丢弃该 request 并推进队列，不能重复提交同一个 requestId。确认消息和下一条权限提示均须在渠道确认发送完成后再释放锁；turn stream 的结束清理不得抢先清除正在投递的回答状态。
 
 ## 9. 模型目录与会话覆盖
 

--- a/docs/trd-dialog-improvement.md
+++ b/docs/trd-dialog-improvement.md
@@ -206,6 +206,7 @@ type UploadedAttachmentRef = {
 4. 生效模式写入 turn metadata；会话恢复不继承下一轮临时覆盖。
 
 权限请求继续使用现有 `permission_request` / `permission_decide` 事件和 RPC。
+文本 IM 权限请求按 chat 维度 FIFO 串行处理；下一条提示发送成功前保持锁定，发送失败时保留待发送提示，不允许后续入站消息越过当前请求。
 
 ## 9. 模型目录与会话覆盖
 

--- a/src/adapters/channel/bluebubbles/BlueBubblesChannel.ts
+++ b/src/adapters/channel/bluebubbles/BlueBubblesChannel.ts
@@ -163,12 +163,12 @@ export class BlueBubblesChannel implements ChannelAdapter {
             return;
           }
           if (!answer.canAdvance && !answer.retryPrompt) return;
-          const nextPrompt = this.permissions.takeNextPrompt(chatGuid);
+          const nextPrompt = this.permissions.takeNextPrompt(chatGuid, answer.answerToken);
           if (nextPrompt) {
-            const nextPromptRequestId = this.permissions.getPromptRequestId(chatGuid);
+            const nextPromptRequestId = this.permissions.getPromptRequestId(chatGuid, answer.answerToken);
 
             const delivered = await this.sendReply(chatGuid, nextPrompt);
-            this.permissions.confirmNextPrompt(chatGuid, delivered, nextPromptRequestId);
+            this.permissions.confirmNextPrompt(chatGuid, delivered, nextPromptRequestId, answer.answerToken);
           }
         }
       } catch (e) {
@@ -227,7 +227,7 @@ export class BlueBubblesChannel implements ChannelAdapter {
     }
 
     this.elicitation.clear(chatGuid);
-    this.permissions.clear(chatGuid);
+    this.permissions.clearAfterTurn(chatGuid);
 
     const finalText = replyText.trim();
     if (finalText) {

--- a/src/adapters/channel/bluebubbles/BlueBubblesChannel.ts
+++ b/src/adapters/channel/bluebubbles/BlueBubblesChannel.ts
@@ -152,10 +152,27 @@ export class BlueBubblesChannel implements ChannelAdapter {
     }
 
     if (this.permissions.hasPending(chatGuid) && this.gateway) {
+      let answerToken: number | undefined;
       try {
-        const confirmation = await this.permissions.answer(chatGuid, text, this.gateway);
-        if (confirmation) await this.sendReply(chatGuid, confirmation);
+        const answer = await this.permissions.answerWithState(chatGuid, text, this.gateway);
+        answerToken = answer?.answerToken;
+        if (answer?.text) {
+          const confirmationDelivered = await this.sendReply(chatGuid, answer.text);
+          if (!confirmationDelivered) {
+            this.permissions.releaseAnswer(chatGuid, answer.answerToken);
+            return;
+          }
+          if (!answer.canAdvance && !answer.retryPrompt) return;
+          const nextPrompt = this.permissions.takeNextPrompt(chatGuid);
+          if (nextPrompt) {
+            const nextPromptRequestId = this.permissions.getPromptRequestId(chatGuid);
+
+            const delivered = await this.sendReply(chatGuid, nextPrompt);
+            this.permissions.confirmNextPrompt(chatGuid, delivered, nextPromptRequestId);
+          }
+        }
       } catch (e) {
+        if (answerToken !== undefined) this.permissions.releaseAnswer(chatGuid, answerToken);
         this.logger?.error?.(`bluebubbles: permission answer error: ${e}`);
       }
       return;
@@ -198,7 +215,7 @@ export class BlueBubblesChannel implements ChannelAdapter {
         }
         if (event.type === "permission_request") {
           const questionText = this.permissions.capture(chatGuid, sessionKey, event);
-          if (questionText) await this.sendReply(chatGuid, questionText);
+          if (questionText) this.permissions.confirmInitialPrompt(chatGuid, await this.sendReply(chatGuid, questionText), event.requestId);
           continue;
         }
         const fragment = renderBlueBubblesEvent(event);
@@ -218,8 +235,8 @@ export class BlueBubblesChannel implements ChannelAdapter {
     }
   }
 
-  private async sendReply(chatGuid: string, text: string): Promise<void> {
-    if (!this.running) return;
+  private async sendReply(chatGuid: string, text: string): Promise<boolean> {
+    if (!this.running) return false;
     const url = new URL("/api/v1/message/text", this.serverUrl);
     const tempGuid = randomUUID();
     const body: Record<string, unknown> = {
@@ -242,9 +259,12 @@ export class BlueBubblesChannel implements ChannelAdapter {
         const raw: any = await res.json().catch(() => ({}));
         const err = raw?.message ?? raw?.error ?? res.statusText;
         this.logger?.error?.(`bluebubbles: send HTTP ${res.status}: ${err}`);
+        return false;
       }
+      return true;
     } catch (e) {
       this.logger?.error?.(`bluebubbles: send failed: ${e}`);
+      return false;
     }
   }
 }

--- a/src/adapters/channel/dingtalk/DingTalkChannel.ts
+++ b/src/adapters/channel/dingtalk/DingTalkChannel.ts
@@ -154,12 +154,12 @@ export class DingTalkChannel implements ChannelAdapter {
             return;
           }
           if (!answer.canAdvance && !answer.retryPrompt) return;
-          const nextPrompt = this.permissions.takeNextPrompt(chatId);
+          const nextPrompt = this.permissions.takeNextPrompt(chatId, answer.answerToken);
           if (nextPrompt) {
-            const nextPromptRequestId = this.permissions.getPromptRequestId(chatId);
+            const nextPromptRequestId = this.permissions.getPromptRequestId(chatId, answer.answerToken);
 
             const delivered = await this.sendReply(chatId, nextPrompt);
-            this.permissions.confirmNextPrompt(chatId, delivered, nextPromptRequestId);
+            this.permissions.confirmNextPrompt(chatId, delivered, nextPromptRequestId, answer.answerToken);
           }
         }
       } catch (e) {
@@ -244,7 +244,7 @@ export class DingTalkChannel implements ChannelAdapter {
     }
 
     this.elicitation.clear(chatId);
-    this.permissions.clear(chatId);
+    this.permissions.clearAfterTurn(chatId);
     const finalText = replyText.trim();
     if (finalText) {
       await this.sendReply(chatId, finalText);

--- a/src/adapters/channel/dingtalk/DingTalkChannel.ts
+++ b/src/adapters/channel/dingtalk/DingTalkChannel.ts
@@ -143,10 +143,27 @@ export class DingTalkChannel implements ChannelAdapter {
     }
 
     if (this.permissions.hasPending(chatId) && this.gateway) {
+      let answerToken: number | undefined;
       try {
-        const confirmation = await this.permissions.answer(chatId, text.trim(), this.gateway);
-        if (confirmation) await this.sendReply(chatId, confirmation);
+        const answer = await this.permissions.answerWithState(chatId, text.trim(), this.gateway);
+        answerToken = answer?.answerToken;
+        if (answer?.text) {
+          const confirmationDelivered = await this.sendReply(chatId, answer.text);
+          if (!confirmationDelivered) {
+            this.permissions.releaseAnswer(chatId, answer.answerToken);
+            return;
+          }
+          if (!answer.canAdvance && !answer.retryPrompt) return;
+          const nextPrompt = this.permissions.takeNextPrompt(chatId);
+          if (nextPrompt) {
+            const nextPromptRequestId = this.permissions.getPromptRequestId(chatId);
+
+            const delivered = await this.sendReply(chatId, nextPrompt);
+            this.permissions.confirmNextPrompt(chatId, delivered, nextPromptRequestId);
+          }
+        }
       } catch (e) {
+        if (answerToken !== undefined) this.permissions.releaseAnswer(chatId, answerToken);
         this.logger?.error?.(`dingtalk: permission answer error: ${e}`);
       }
       return;
@@ -215,7 +232,7 @@ export class DingTalkChannel implements ChannelAdapter {
         }
         if (event.type === "permission_request") {
           const questionText = this.permissions.capture(chatId, sessionKey, event);
-          if (questionText) await this.sendReply(chatId, questionText);
+          if (questionText) this.permissions.confirmInitialPrompt(chatId, await this.sendReply(chatId, questionText), event.requestId);
           continue;
         }
         const fragment = renderDingTalkEvent(event);

--- a/src/adapters/channel/discord/DiscordChannel.ts
+++ b/src/adapters/channel/discord/DiscordChannel.ts
@@ -137,12 +137,12 @@ export class DiscordChannel implements ChannelAdapter {
             return;
           }
           if (!answer.canAdvance && !answer.retryPrompt) return;
-          const nextPrompt = this.permissions.takeNextPrompt(chatId);
+          const nextPrompt = this.permissions.takeNextPrompt(chatId, answer.answerToken);
           if (nextPrompt) {
-            const nextPromptRequestId = this.permissions.getPromptRequestId(chatId);
+            const nextPromptRequestId = this.permissions.getPromptRequestId(chatId, answer.answerToken);
 
             const delivered = await this.sendReply(chatId, nextPrompt);
-            this.permissions.confirmNextPrompt(chatId, delivered, nextPromptRequestId);
+            this.permissions.confirmNextPrompt(chatId, delivered, nextPromptRequestId, answer.answerToken);
           }
         }
       } catch (e) {
@@ -203,7 +203,7 @@ export class DiscordChannel implements ChannelAdapter {
     }
 
     this.elicitation.clear(chatId);
-    this.permissions.clear(chatId);
+    this.permissions.clearAfterTurn(chatId);
     const finalText = replyText.trim();
     if (finalText) {
       await this.sendReply(chatId, finalText);

--- a/src/adapters/channel/discord/DiscordChannel.ts
+++ b/src/adapters/channel/discord/DiscordChannel.ts
@@ -126,10 +126,27 @@ export class DiscordChannel implements ChannelAdapter {
     }
 
     if (this.permissions.hasPending(chatId) && this.gateway) {
+      let answerToken: number | undefined;
       try {
-        const confirmation = await this.permissions.answer(chatId, text, this.gateway);
-        if (confirmation) await this.sendReply(chatId, confirmation);
+        const answer = await this.permissions.answerWithState(chatId, text, this.gateway);
+        answerToken = answer?.answerToken;
+        if (answer?.text) {
+          const confirmationDelivered = await this.sendReply(chatId, answer.text);
+          if (!confirmationDelivered) {
+            this.permissions.releaseAnswer(chatId, answer.answerToken);
+            return;
+          }
+          if (!answer.canAdvance && !answer.retryPrompt) return;
+          const nextPrompt = this.permissions.takeNextPrompt(chatId);
+          if (nextPrompt) {
+            const nextPromptRequestId = this.permissions.getPromptRequestId(chatId);
+
+            const delivered = await this.sendReply(chatId, nextPrompt);
+            this.permissions.confirmNextPrompt(chatId, delivered, nextPromptRequestId);
+          }
+        }
       } catch (e) {
+        if (answerToken !== undefined) this.permissions.releaseAnswer(chatId, answerToken);
         this.logger?.error?.(`discord: permission answer error: ${e}`);
       }
       return;
@@ -174,7 +191,7 @@ export class DiscordChannel implements ChannelAdapter {
         }
         if (event.type === "permission_request") {
           const questionText = this.permissions.capture(chatId, sessionKey, event);
-          if (questionText) await this.sendReply(chatId, questionText);
+          if (questionText) this.permissions.confirmInitialPrompt(chatId, await this.sendReply(chatId, questionText), event.requestId);
           continue;
         }
         const fragment = renderDiscordEvent(event);

--- a/src/adapters/channel/email/EmailChannel.ts
+++ b/src/adapters/channel/email/EmailChannel.ts
@@ -227,10 +227,27 @@ export class EmailChannel implements ChannelAdapter {
     }
 
     if (this.permissions.hasPending(chatId) && this.gateway) {
+      let answerToken: number | undefined;
       try {
-        const confirmation = await this.permissions.answer(chatId, text, this.gateway);
-        if (confirmation) await this.sendReply(chatId, confirmation);
+        const answer = await this.permissions.answerWithState(chatId, text, this.gateway);
+        answerToken = answer?.answerToken;
+        if (answer?.text) {
+          const confirmationDelivered = await this.sendReply(chatId, answer.text);
+          if (!confirmationDelivered) {
+            this.permissions.releaseAnswer(chatId, answer.answerToken);
+            return;
+          }
+          if (!answer.canAdvance && !answer.retryPrompt) return;
+          const nextPrompt = this.permissions.takeNextPrompt(chatId);
+          if (nextPrompt) {
+            const nextPromptRequestId = this.permissions.getPromptRequestId(chatId);
+
+            const delivered = await this.sendReply(chatId, nextPrompt);
+            this.permissions.confirmNextPrompt(chatId, delivered, nextPromptRequestId);
+          }
+        }
       } catch (e) {
+        if (answerToken !== undefined) this.permissions.releaseAnswer(chatId, answerToken);
         this.logger?.error?.(`email: permission answer error: ${e}`);
       }
       return;
@@ -273,7 +290,7 @@ export class EmailChannel implements ChannelAdapter {
         }
         if (event.type === "permission_request") {
           const questionText = this.permissions.capture(chatId, sessionKey, event);
-          if (questionText) await this.sendReply(chatId, questionText);
+          if (questionText) this.permissions.confirmInitialPrompt(chatId, await this.sendReply(chatId, questionText), event.requestId);
           continue;
         }
         const fragment = renderEmailEvent(event);

--- a/src/adapters/channel/email/EmailChannel.ts
+++ b/src/adapters/channel/email/EmailChannel.ts
@@ -238,12 +238,12 @@ export class EmailChannel implements ChannelAdapter {
             return;
           }
           if (!answer.canAdvance && !answer.retryPrompt) return;
-          const nextPrompt = this.permissions.takeNextPrompt(chatId);
+          const nextPrompt = this.permissions.takeNextPrompt(chatId, answer.answerToken);
           if (nextPrompt) {
-            const nextPromptRequestId = this.permissions.getPromptRequestId(chatId);
+            const nextPromptRequestId = this.permissions.getPromptRequestId(chatId, answer.answerToken);
 
             const delivered = await this.sendReply(chatId, nextPrompt);
-            this.permissions.confirmNextPrompt(chatId, delivered, nextPromptRequestId);
+            this.permissions.confirmNextPrompt(chatId, delivered, nextPromptRequestId, answer.answerToken);
           }
         }
       } catch (e) {
@@ -302,7 +302,7 @@ export class EmailChannel implements ChannelAdapter {
     }
 
     this.elicitation.clear(chatId);
-    this.permissions.clear(chatId);
+    this.permissions.clearAfterTurn(chatId);
 
     const finalText = replyText.trim();
     if (finalText) {

--- a/src/adapters/channel/feishu/FeishuChannel.ts
+++ b/src/adapters/channel/feishu/FeishuChannel.ts
@@ -78,6 +78,8 @@ export type FeishuChannelOptions = {
   connectionMode?: FeishuConnectionMode;
   /** "feishu" (open.feishu.cn) or "lark" (open.larksuite.com). */
   domainName?: "feishu" | "lark";
+  /** Optional per-channel permission mode forwarded to Gateway turns. */
+  permissionMode?: "default" | "bypassPermissions";
   mapper?: FeishuSessionMapper;
   /**
    * Optional override for outbound delivery (used in tests). When omitted the
@@ -142,6 +144,7 @@ export class FeishuChannel implements ChannelAdapter {
   private verifyToken?: string;
   private connectionMode: FeishuConnectionMode;
   private domainName: "feishu" | "lark";
+  private permissionMode?: "default" | "bypassPermissions";
 
   private gateway?: Gateway;
   private logger?: ChannelLogger;
@@ -152,6 +155,9 @@ export class FeishuChannel implements ChannelAdapter {
   private readonly activeChats = new Set<string>();
   private readonly chatState = new ImChatSessionState<QueuedFeishuTurn>({ maxPendingTurns: FEISHU_MAX_PENDING_TURNS_PER_CHAT });
   private readonly inboundBatches = new Map<string, FeishuInboundBatch>();
+  private readonly permissionAnsweringChats = new Set<string>();
+  private readonly permissionAnsweringTokens = new Map<string, number>();
+  private nextPermissionAnsweringToken = 1;
   private readonly elicitation = new ImElicitationHelper();
   private readonly permissions = new ImPermissionHelper();
   private readonly attachmentStore = new ImAttachmentStore({
@@ -173,6 +179,7 @@ export class FeishuChannel implements ChannelAdapter {
     this.verifyToken = options.verifyToken;
     this.connectionMode = options.connectionMode ?? "stream";
     this.domainName = options.domainName ?? "feishu";
+    this.permissionMode = options.permissionMode;
     this.onStateChange = options.onStateChange;
   }
 
@@ -186,6 +193,7 @@ export class FeishuChannel implements ChannelAdapter {
       this.appSecret = this.appSecret || cfg.appSecret || "";
       this.encryptKey = this.encryptKey ?? cfg.encryptKey;
       this.verifyToken = this.verifyToken ?? cfg.verifyToken;
+      this.permissionMode = this.permissionMode ?? cfg.permissionMode;
     }
 
     if (!this.explicitSend && (!this.appId || !this.appSecret)) {
@@ -343,10 +351,20 @@ export class FeishuChannel implements ChannelAdapter {
       });
       return true;
     }
-    if (this.permissions.hasPending(input.chatId)) {
-      void this.answerPendingPermission(input.chatId, input.text).catch((e: unknown) => {
-        this.logger?.error?.(`feishu: permission answer error: ${e}`);
-      });
+    if (this.permissions.hasPending(input.chatId) || this.permissionAnsweringChats.has(input.chatId)) {
+      if (this.permissionAnsweringChats.has(input.chatId)) return true;
+      const answeringToken = this.nextPermissionAnsweringToken++;
+      this.permissionAnsweringChats.add(input.chatId);
+      this.permissionAnsweringTokens.set(input.chatId, answeringToken);
+      void this.answerPendingPermission(input.chatId, input.text)
+        .catch((e: unknown) => {
+          this.logger?.error?.(`feishu: permission answer error: ${e}`);
+        })
+        .finally(() => {
+          if (this.permissionAnsweringTokens.get(input.chatId) !== answeringToken) return;
+          this.permissionAnsweringTokens.delete(input.chatId);
+          this.permissionAnsweringChats.delete(input.chatId);
+        });
       return true;
     }
     return false;
@@ -360,8 +378,29 @@ export class FeishuChannel implements ChannelAdapter {
 
   private async answerPendingPermission(chatId: string, text: string): Promise<void> {
     if (!this.gateway) return;
-    const confirmation = await this.permissions.answer(chatId, text, this.gateway);
-    if (confirmation) await this.send({ chatId, text: confirmation });
+    let answerToken: number | undefined;
+    try {
+      const answer = await this.permissions.answerWithState(chatId, text, this.gateway);
+      answerToken = answer?.answerToken;
+      if (answer?.text) {
+        const confirmationDelivered = await this.send({ chatId, text: answer.text });
+        if (!confirmationDelivered) {
+          this.permissions.releaseAnswer(chatId, answer.answerToken);
+          return;
+        }
+        if (!answer.canAdvance && !answer.retryPrompt) return;
+        const nextPrompt = this.permissions.takeNextPrompt(chatId);
+        if (nextPrompt) {
+          const nextPromptRequestId = this.permissions.getPromptRequestId(chatId);
+
+          const delivered = await this.send({ chatId, text: nextPrompt });
+          this.permissions.confirmNextPrompt(chatId, delivered, nextPromptRequestId);
+        }
+      }
+    } catch (error) {
+      if (answerToken !== undefined) this.permissions.releaseAnswer(chatId, answerToken);
+      throw error;
+    }
   }
 
   private async drainInboundBatch(chatId: string): Promise<void> {
@@ -445,7 +484,7 @@ export class FeishuChannel implements ChannelAdapter {
         gateway: this.gateway,
         chatId,
         channelKey: "feishu",
-        reply: (msg) => this.send({ chatId, text: msg }),
+        reply: (msg) => this.send({ chatId, text: msg }).then(() => undefined),
         bindProject: (projectKey) => { this.mapper.bindProject(chatId, projectKey); this.onStateChange?.(this.mapper.snapshot()); },
         getProject: () => this.mapper.getProject(chatId),
         resetSession: () => { this.mapper.resolve({ chatId, text: "/new" }); this.onStateChange?.(this.mapper.snapshot()); },
@@ -482,6 +521,8 @@ export class FeishuChannel implements ChannelAdapter {
   private resetChatInteractionState(chatId: string): void {
     this.chatState.resetForNewSession(chatId);
     this.elicitation.clear(chatId);
+    this.permissionAnsweringTokens.delete(chatId);
+    this.permissionAnsweringChats.delete(chatId);
     this.permissions.clear(chatId);
     const batch = this.inboundBatches.get(chatId);
     if (batch?.timer) clearTimeout(batch.timer);
@@ -539,6 +580,7 @@ export class FeishuChannel implements ChannelAdapter {
           message: turn.message,
           ...(turn.attachments.length > 0 ? { attachments: turn.attachments } : {}),
           allowPlanModeTools: false,
+          ...(this.permissionMode ? { mode: this.permissionMode, basePermissionMode: this.permissionMode } : {}),
           timeoutMs: turnTimeoutMs,
           ...(turn.projectKey ? { projectKey: turn.projectKey } : {}),
         })) {
@@ -556,7 +598,7 @@ export class FeishuChannel implements ChannelAdapter {
           if (event.type === "permission_request") {
             const questionText = this.permissions.capture(chatId, turn.sessionKey, event);
             await liveReply.pauseActivity();
-            if (questionText) await this.send({ chatId, text: questionText });
+            if (questionText) this.permissions.confirmInitialPrompt(chatId, await this.send({ chatId, text: questionText }), event.requestId);
             continue;
           }
           if (event.type === "error" && event.code === "agent_aborted") {
@@ -595,8 +637,10 @@ export class FeishuChannel implements ChannelAdapter {
         if (watchdog) clearTimeout(watchdog);
       }
 
-      this.elicitation.clear(chatId);
-      this.permissions.clear(chatId);
+      if (isCurrentTurn()) {
+        this.elicitation.clear(chatId);
+        this.permissions.clear(chatId);
+      }
       await liveReply.flushFinal();
     } finally {
       if (reactionId && turn.messageId) {
@@ -639,15 +683,15 @@ export class FeishuChannel implements ChannelAdapter {
     };
   }
 
-  private async send(message: FeishuOutboundMessage): Promise<void> {
-    await this.sendTextMessage(message);
+  private async send(message: FeishuOutboundMessage): Promise<boolean> {
+    return (await this.sendTextMessage(message)) !== false;
   }
 
   private async sendAttachment(chatId: string, attachment: Parameters<ImAttachmentDelivery["send"]>[0]): Promise<boolean> {
     return new ImAttachmentDelivery({
       maxBytes: FEISHU_MAX_ATTACHMENT_BYTES,
       logger: this.logger,
-      sendTextFallback: (text) => this.send({ chatId, text }),
+      sendTextFallback: (text) => this.send({ chatId, text }).then(() => undefined),
       sendPrepared: (prepared) => this.uploadAndSendFeishuAttachment(chatId, prepared),
     }).send(attachment);
   }

--- a/src/adapters/channel/feishu/FeishuChannel.ts
+++ b/src/adapters/channel/feishu/FeishuChannel.ts
@@ -389,12 +389,12 @@ export class FeishuChannel implements ChannelAdapter {
           return;
         }
         if (!answer.canAdvance && !answer.retryPrompt) return;
-        const nextPrompt = this.permissions.takeNextPrompt(chatId);
+        const nextPrompt = this.permissions.takeNextPrompt(chatId, answer.answerToken);
         if (nextPrompt) {
-          const nextPromptRequestId = this.permissions.getPromptRequestId(chatId);
+          const nextPromptRequestId = this.permissions.getPromptRequestId(chatId, answer.answerToken);
 
           const delivered = await this.send({ chatId, text: nextPrompt });
-          this.permissions.confirmNextPrompt(chatId, delivered, nextPromptRequestId);
+          this.permissions.confirmNextPrompt(chatId, delivered, nextPromptRequestId, answer.answerToken);
         }
       }
     } catch (error) {
@@ -639,7 +639,7 @@ export class FeishuChannel implements ChannelAdapter {
 
       if (isCurrentTurn()) {
         this.elicitation.clear(chatId);
-        this.permissions.clear(chatId);
+        this.permissions.clearAfterTurn(chatId);
       }
       await liveReply.flushFinal();
     } finally {

--- a/src/adapters/channel/feishu/FeishuChannel.ts
+++ b/src/adapters/channel/feishu/FeishuChannel.ts
@@ -816,8 +816,13 @@ export class FeishuChannel implements ChannelAdapter {
 
   private async sendTextMessage(message: FeishuOutboundMessage): Promise<string | undefined | false> {
     if (this.explicitSend) {
-      await this.explicitSend(message);
-      return undefined;
+      try {
+        await this.explicitSend(message);
+        return undefined;
+      } catch (error) {
+        this.logger?.error?.(`feishu: custom send failed: ${error}`);
+        return false;
+      }
     }
     return this.sendRawMessage(message.chatId, "text", { text: message.text });
   }

--- a/src/adapters/channel/homeassistant/HomeAssistantChannel.ts
+++ b/src/adapters/channel/homeassistant/HomeAssistantChannel.ts
@@ -17,6 +17,12 @@ try {
 }
 
 const DEFAULT_URL = "http://127.0.0.1:8123";
+const SERVICE_CALL_TIMEOUT_MS = 10_000;
+
+type PendingServiceCall = {
+  resolve: (delivered: boolean) => void;
+  timer: ReturnType<typeof setTimeout>;
+};
 
 export type HomeAssistantChannelOptions = {
   url?: string;
@@ -50,6 +56,7 @@ export class HomeAssistantChannel implements ChannelAdapter {
   private wsSessionReady = false;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private authSettle: ((ok: boolean) => void) | null = null;
+  private readonly pendingServiceCalls = new Map<number, PendingServiceCall>();
   private activeChats = new Set<string>();
   private readonly elicitation = new ImElicitationHelper();
   private readonly permissions = new ImPermissionHelper();
@@ -127,6 +134,7 @@ export class HomeAssistantChannel implements ChannelAdapter {
       };
       const onClose = () => {
         this.ws = null;
+        this.failPendingServiceCalls();
         this.authSettle?.(false);
         if (this.wsSessionReady && !this.closed) {
           this.reconnectTimer = setTimeout(() => this.openSocket(), 5000);
@@ -154,6 +162,7 @@ export class HomeAssistantChannel implements ChannelAdapter {
   }
 
   private async cleanupWs(): Promise<void> {
+    this.failPendingServiceCalls();
     if (this.ws) {
       try { this.ws.close(); } catch { /* best effort */ }
       this.ws = null;
@@ -171,6 +180,41 @@ export class HomeAssistantChannel implements ChannelAdapter {
     }
   }
 
+  private sendServiceCall(obj: Record<string, unknown>): Promise<boolean> {
+    const id = obj.id;
+    if (typeof id !== "number") return Promise.resolve(false);
+    return new Promise((resolve) => {
+      const timer = setTimeout(() => {
+        this.pendingServiceCalls.delete(id);
+        resolve(false);
+      }, SERVICE_CALL_TIMEOUT_MS);
+      this.pendingServiceCalls.set(id, { resolve, timer });
+      if (!this.sendJson(obj)) {
+        clearTimeout(timer);
+        this.pendingServiceCalls.delete(id);
+        resolve(false);
+      }
+    });
+  }
+
+  private failPendingServiceCalls(): void {
+    for (const [id, pending] of this.pendingServiceCalls) {
+      clearTimeout(pending.timer);
+      this.pendingServiceCalls.delete(id);
+      pending.resolve(false);
+    }
+  }
+
+  private handleServiceCallResult(msg: Record<string, unknown>): void {
+    const id = msg.id;
+    if (typeof id !== "number") return;
+    const pending = this.pendingServiceCalls.get(id);
+    if (!pending) return;
+    clearTimeout(pending.timer);
+    this.pendingServiceCalls.delete(id);
+    pending.resolve(msg.success === true);
+  }
+
   private nextId(): number {
     return this.idCounter++;
   }
@@ -184,6 +228,11 @@ export class HomeAssistantChannel implements ChannelAdapter {
     }
 
     const type = msg.type as string | undefined;
+
+    if (type === "result") {
+      this.handleServiceCallResult(msg);
+      return;
+    }
 
     if (type === "auth_required") {
       this.sendJson({ type: "auth", access_token: this.token });
@@ -336,7 +385,7 @@ export class HomeAssistantChannel implements ChannelAdapter {
       return false;
     }
     const title = this.notificationTitle ?? `Gateway · ${chatId}`;
-    return this.sendJson({
+    return this.sendServiceCall({
       id: this.nextId(),
       type: "call_service",
       domain: "persistent_notification",

--- a/src/adapters/channel/homeassistant/HomeAssistantChannel.ts
+++ b/src/adapters/channel/homeassistant/HomeAssistantChannel.ts
@@ -160,9 +160,15 @@ export class HomeAssistantChannel implements ChannelAdapter {
     }
   }
 
-  private sendJson(obj: Record<string, unknown>): void {
-    if (!this.ws || this.ws.readyState !== 1) return;
-    this.ws.send(JSON.stringify(obj));
+  private sendJson(obj: Record<string, unknown>): boolean {
+    if (!this.ws || this.ws.readyState !== 1) return false;
+    try {
+      this.ws.send(JSON.stringify(obj));
+      return true;
+    } catch (e) {
+      this.logger?.error?.(`homeassistant: send failed: ${e}`);
+      return false;
+    }
   }
 
   private nextId(): number {
@@ -330,7 +336,7 @@ export class HomeAssistantChannel implements ChannelAdapter {
       return false;
     }
     const title = this.notificationTitle ?? `Gateway · ${chatId}`;
-    this.sendJson({
+    return this.sendJson({
       id: this.nextId(),
       type: "call_service",
       domain: "persistent_notification",
@@ -341,6 +347,5 @@ export class HomeAssistantChannel implements ChannelAdapter {
         notification_id: `gw_${Date.now()}`,
       },
     });
-    return true;
   }
 }

--- a/src/adapters/channel/homeassistant/HomeAssistantChannel.ts
+++ b/src/adapters/channel/homeassistant/HomeAssistantChannel.ts
@@ -241,10 +241,27 @@ export class HomeAssistantChannel implements ChannelAdapter {
     }
 
     if (this.permissions.hasPending(chatId) && this.gateway) {
+      let answerToken: number | undefined;
       try {
-        const confirmation = await this.permissions.answer(chatId, text, this.gateway);
-        if (confirmation) await this.sendReply(chatId, confirmation);
+        const answer = await this.permissions.answerWithState(chatId, text, this.gateway);
+        answerToken = answer?.answerToken;
+        if (answer?.text) {
+          const confirmationDelivered = await this.sendReply(chatId, answer.text);
+          if (!confirmationDelivered) {
+            this.permissions.releaseAnswer(chatId, answer.answerToken);
+            return;
+          }
+          if (!answer.canAdvance && !answer.retryPrompt) return;
+          const nextPrompt = this.permissions.takeNextPrompt(chatId);
+          if (nextPrompt) {
+            const nextPromptRequestId = this.permissions.getPromptRequestId(chatId);
+
+            const delivered = await this.sendReply(chatId, nextPrompt);
+            this.permissions.confirmNextPrompt(chatId, delivered, nextPromptRequestId);
+          }
+        }
       } catch (e) {
+        if (answerToken !== undefined) this.permissions.releaseAnswer(chatId, answerToken);
         this.logger?.error?.(`homeassistant: permission answer error: ${e}`);
       }
       return;
@@ -287,7 +304,7 @@ export class HomeAssistantChannel implements ChannelAdapter {
         }
         if (event.type === "permission_request") {
           const questionText = this.permissions.capture(chatId, sessionKey, event);
-          if (questionText) await this.sendReply(chatId, questionText);
+          if (questionText) this.permissions.confirmInitialPrompt(chatId, await this.sendReply(chatId, questionText), event.requestId);
           continue;
         }
         const fragment = renderHomeAssistantEvent(event);

--- a/src/adapters/channel/homeassistant/HomeAssistantChannel.ts
+++ b/src/adapters/channel/homeassistant/HomeAssistantChannel.ts
@@ -307,12 +307,12 @@ export class HomeAssistantChannel implements ChannelAdapter {
             return;
           }
           if (!answer.canAdvance && !answer.retryPrompt) return;
-          const nextPrompt = this.permissions.takeNextPrompt(chatId);
+          const nextPrompt = this.permissions.takeNextPrompt(chatId, answer.answerToken);
           if (nextPrompt) {
-            const nextPromptRequestId = this.permissions.getPromptRequestId(chatId);
+            const nextPromptRequestId = this.permissions.getPromptRequestId(chatId, answer.answerToken);
 
             const delivered = await this.sendReply(chatId, nextPrompt);
-            this.permissions.confirmNextPrompt(chatId, delivered, nextPromptRequestId);
+            this.permissions.confirmNextPrompt(chatId, delivered, nextPromptRequestId, answer.answerToken);
           }
         }
       } catch (e) {
@@ -371,7 +371,7 @@ export class HomeAssistantChannel implements ChannelAdapter {
     }
 
     this.elicitation.clear(chatId);
-    this.permissions.clear(chatId);
+    this.permissions.clearAfterTurn(chatId);
 
     const finalText = replyText.trim();
     if (finalText) {

--- a/src/adapters/channel/matrix/MatrixChannel.ts
+++ b/src/adapters/channel/matrix/MatrixChannel.ts
@@ -144,10 +144,27 @@ export class MatrixChannel implements ChannelAdapter {
     }
 
     if (this.permissions.hasPending(roomId) && this.gateway) {
+      let answerToken: number | undefined;
       try {
-        const confirmation = await this.permissions.answer(roomId, text, this.gateway);
-        if (confirmation) await this.sendReply(roomId, confirmation);
+        const answer = await this.permissions.answerWithState(roomId, text, this.gateway);
+        answerToken = answer?.answerToken;
+        if (answer?.text) {
+          const confirmationDelivered = await this.sendReply(roomId, answer.text);
+          if (!confirmationDelivered) {
+            this.permissions.releaseAnswer(roomId, answer.answerToken);
+            return;
+          }
+          if (!answer.canAdvance && !answer.retryPrompt) return;
+          const nextPrompt = this.permissions.takeNextPrompt(roomId);
+          if (nextPrompt) {
+            const nextPromptRequestId = this.permissions.getPromptRequestId(roomId);
+
+            const delivered = await this.sendReply(roomId, nextPrompt);
+            this.permissions.confirmNextPrompt(roomId, delivered, nextPromptRequestId);
+          }
+        }
       } catch (e) {
+        if (answerToken !== undefined) this.permissions.releaseAnswer(roomId, answerToken);
         this.logger?.error?.(`matrix: permission answer error: ${e}`);
       }
       return;
@@ -190,7 +207,7 @@ export class MatrixChannel implements ChannelAdapter {
         }
         if (event.type === "permission_request") {
           const questionText = this.permissions.capture(roomId, sessionKey, event);
-          if (questionText) await this.sendReply(roomId, questionText);
+          if (questionText) this.permissions.confirmInitialPrompt(roomId, await this.sendReply(roomId, questionText), event.requestId);
           continue;
         }
         const fragment = renderMatrixEvent(event);

--- a/src/adapters/channel/matrix/MatrixChannel.ts
+++ b/src/adapters/channel/matrix/MatrixChannel.ts
@@ -155,12 +155,12 @@ export class MatrixChannel implements ChannelAdapter {
             return;
           }
           if (!answer.canAdvance && !answer.retryPrompt) return;
-          const nextPrompt = this.permissions.takeNextPrompt(roomId);
+          const nextPrompt = this.permissions.takeNextPrompt(roomId, answer.answerToken);
           if (nextPrompt) {
-            const nextPromptRequestId = this.permissions.getPromptRequestId(roomId);
+            const nextPromptRequestId = this.permissions.getPromptRequestId(roomId, answer.answerToken);
 
             const delivered = await this.sendReply(roomId, nextPrompt);
-            this.permissions.confirmNextPrompt(roomId, delivered, nextPromptRequestId);
+            this.permissions.confirmNextPrompt(roomId, delivered, nextPromptRequestId, answer.answerToken);
           }
         }
       } catch (e) {
@@ -219,7 +219,7 @@ export class MatrixChannel implements ChannelAdapter {
     }
 
     this.elicitation.clear(roomId);
-    this.permissions.clear(roomId);
+    this.permissions.clearAfterTurn(roomId);
 
     const finalText = replyText.trim();
     if (finalText) {

--- a/src/adapters/channel/mattermost/MattermostChannel.ts
+++ b/src/adapters/channel/mattermost/MattermostChannel.ts
@@ -173,10 +173,27 @@ export class MattermostChannel implements ChannelAdapter {
     }
 
     if (this.permissions.hasPending(chatId) && this.gateway) {
+      let answerToken: number | undefined;
       try {
-        const confirmation = await this.permissions.answer(chatId, text, this.gateway);
-        if (confirmation) await this.sendReply({ channelId, rootId }, confirmation);
+        const answer = await this.permissions.answerWithState(chatId, text, this.gateway);
+        answerToken = answer?.answerToken;
+        if (answer?.text) {
+          const confirmationDelivered = await this.sendReply({ channelId, rootId }, answer.text);
+          if (!confirmationDelivered) {
+            this.permissions.releaseAnswer(chatId, answer.answerToken);
+            return;
+          }
+          if (!answer.canAdvance && !answer.retryPrompt) return;
+          const nextPrompt = this.permissions.takeNextPrompt(chatId);
+          if (nextPrompt) {
+            const nextPromptRequestId = this.permissions.getPromptRequestId(chatId);
+
+            const delivered = await this.sendReply({ channelId, rootId }, nextPrompt);
+            this.permissions.confirmNextPrompt(chatId, delivered, nextPromptRequestId);
+          }
+        }
       } catch (e) {
+        if (answerToken !== undefined) this.permissions.releaseAnswer(chatId, answerToken);
         this.logger?.error?.(`mattermost: permission answer error: ${e}`);
       }
       return;
@@ -227,7 +244,7 @@ export class MattermostChannel implements ChannelAdapter {
         if (event.type === "permission_request") {
           const chatId = ctx.rootId ? `${ctx.channelId}:${ctx.rootId}` : ctx.channelId;
           const questionText = this.permissions.capture(chatId, sessionKey, event);
-          if (questionText) await this.sendReply(ctx, questionText);
+          if (questionText) this.permissions.confirmInitialPrompt(chatId, await this.sendReply(ctx, questionText), event.requestId);
           continue;
         }
         const fragment = renderMattermostEvent(event);
@@ -251,7 +268,8 @@ export class MattermostChannel implements ChannelAdapter {
   private async sendReply(
     ctx: { channelId: string; rootId?: string },
     text: string,
-  ): Promise<void> {
+  ): Promise<boolean> {
+    let delivered = true;
     const chunks = chunkText(text, MAX_MESSAGE_LENGTH);
     for (const chunk of chunks) {
       try {
@@ -262,8 +280,10 @@ export class MattermostChannel implements ChannelAdapter {
         });
       } catch (e) {
         this.logger?.error?.(`mattermost: post failed: ${e}`);
+        delivered = false;
       }
     }
+    return delivered;
   }
 
   private async rest(method: string, path: string, body?: Record<string, unknown>): Promise<unknown> {

--- a/src/adapters/channel/mattermost/MattermostChannel.ts
+++ b/src/adapters/channel/mattermost/MattermostChannel.ts
@@ -184,12 +184,12 @@ export class MattermostChannel implements ChannelAdapter {
             return;
           }
           if (!answer.canAdvance && !answer.retryPrompt) return;
-          const nextPrompt = this.permissions.takeNextPrompt(chatId);
+          const nextPrompt = this.permissions.takeNextPrompt(chatId, answer.answerToken);
           if (nextPrompt) {
-            const nextPromptRequestId = this.permissions.getPromptRequestId(chatId);
+            const nextPromptRequestId = this.permissions.getPromptRequestId(chatId, answer.answerToken);
 
             const delivered = await this.sendReply({ channelId, rootId }, nextPrompt);
-            this.permissions.confirmNextPrompt(chatId, delivered, nextPromptRequestId);
+            this.permissions.confirmNextPrompt(chatId, delivered, nextPromptRequestId, answer.answerToken);
           }
         }
       } catch (e) {
@@ -257,7 +257,7 @@ export class MattermostChannel implements ChannelAdapter {
 
     const chatId = ctx.rootId ? `${ctx.channelId}:${ctx.rootId}` : ctx.channelId;
     this.elicitation.clear(chatId);
-    this.permissions.clear(chatId);
+    this.permissions.clearAfterTurn(chatId);
 
     const finalText = replyText.trim();
     if (finalText) {

--- a/src/adapters/channel/protocol/ImPermissionHelper.ts
+++ b/src/adapters/channel/protocol/ImPermissionHelper.ts
@@ -102,6 +102,7 @@ export class ImPermissionHelper {
     this.initialPromptPending.delete(chatId);
     this.retryPromptPending.delete(chatId);
     this.answering.delete(chatId);
+    this.finishDeferredClear(chatId);
   }
 
   confirmNextPrompt(
@@ -149,19 +150,30 @@ export class ImPermissionHelper {
 
   /** Clear state after a completed turn, without racing an answer delivery. */
   clearAfterTurn(chatId: string): void {
-    if (this.answering.has(chatId) && !this.inFlight.has(chatId) && !this.initialPromptPending.has(chatId) && !this.promptDelivering.has(chatId)) {
-      const answerToken = this.answerTokens.get(chatId);
-      if (answerToken !== undefined) {
-        this.deferredClears.add(chatId);
-        return;
-      }
+    const initialPromptSending = this.initialPromptPending.has(chatId);
+    if (
+      this.inFlight.has(chatId)
+      || this.promptDelivering.has(chatId)
+      || this.retryPromptPending.has(chatId)
+      || (!initialPromptSending && this.answering.has(chatId))
+    ) {
+      this.deferredClears.add(chatId);
+      return;
     }
     this.clear(chatId);
   }
 
   private finishDeferredClear(chatId: string): void {
     if (!this.deferredClears.has(chatId)) return;
-    if (this.pending.get(chatId)?.length) return;
+    if (
+      this.pending.get(chatId)?.length
+      || this.answering.has(chatId)
+      || this.inFlight.has(chatId)
+      || this.promptDelivering.has(chatId)
+      || this.initialPromptPending.has(chatId)
+      || this.nextPrompts.has(chatId)
+      || this.retryPromptPending.has(chatId)
+    ) return;
     this.deferredClears.delete(chatId);
     this.clearNow(chatId);
   }

--- a/src/adapters/channel/protocol/ImPermissionHelper.ts
+++ b/src/adapters/channel/protocol/ImPermissionHelper.ts
@@ -153,7 +153,7 @@ export class ImPermissionHelper {
     else this.pending.set(chatId, entries);
     const deny = trimmed === "0";
     try {
-      await gateway.permissionDecide({
+      const decision = await gateway.permissionDecide({
         sessionKey: entry.sessionKey,
         requestId: entry.requestId,
         decision: deny ? "deny" : "allow",
@@ -161,6 +161,21 @@ export class ImPermissionHelper {
         ...(!deny ? { remember: trimmed === "2" } : {}),
       });
       if ((this.generations.get(chatId) ?? 0) !== generation) return undefined;
+      if (!decision.delivered) {
+        const currentEntries = this.pending.get(chatId) ?? entries;
+        this.pending.set(chatId, [entry, ...currentEntries]);
+        this.nextPrompts.set(chatId, {
+          text: formatPermissionPrompt(entry),
+          requestId: entry.requestId,
+        });
+        this.retryPromptPending.add(chatId);
+        return {
+          text: "权限请求未送达，正在重试。",
+          canAdvance: false,
+          retryPrompt: true,
+          answerToken,
+        };
+      }
       const remaining = this.pending.get(chatId) ?? entries;
       if (remaining.length > 0) {
         this.nextPrompts.set(chatId, {

--- a/src/adapters/channel/protocol/ImPermissionHelper.ts
+++ b/src/adapters/channel/protocol/ImPermissionHelper.ts
@@ -70,7 +70,10 @@ export class ImPermissionHelper {
     // queued prompt and clear the lock.
     if (this.promptDelivering.has(chatId) || this.initialPromptPending.has(chatId) || this.inFlight.has(chatId)) return undefined;
     const prompt = this.nextPrompts.get(chatId);
-    if (!prompt) return undefined;
+    if (!prompt) {
+      this.confirmAnswer(chatId);
+      return undefined;
+    }
     this.promptDelivering.add(chatId);
     return prompt.text;
   }
@@ -104,6 +107,7 @@ export class ImPermissionHelper {
     this.nextPrompts.delete(chatId);
     this.retryPromptPending.delete(chatId);
     this.answering.delete(chatId);
+    this.answerTokens.delete(chatId);
   }
 
   /** Release a completed answer when the adapter cannot deliver its reply. */
@@ -113,6 +117,18 @@ export class ImPermissionHelper {
     // the next inbound message decide the unseen request.
     this.promptDelivering.delete(chatId);
     if (this.nextPrompts.has(chatId)) this.retryPromptPending.add(chatId);
+    else this.confirmAnswer(chatId, answerToken);
+  }
+
+  /** Mark the confirmation message as delivered and release the final answer lock. */
+  confirmAnswer(chatId: string, answerToken?: number): void {
+    if (answerToken !== undefined && this.answerTokens.get(chatId) !== answerToken) return;
+    if (!this.answering.has(chatId) || this.inFlight.has(chatId) || this.initialPromptPending.has(chatId)) return;
+    if (this.promptDelivering.has(chatId) || this.nextPrompts.has(chatId)) return;
+    if ((this.pending.get(chatId)?.length ?? 0) > 0) return;
+    this.retryPromptPending.delete(chatId);
+    this.answering.delete(chatId);
+    this.answerTokens.delete(chatId);
   }
 
   async answer(chatId: string, text: string, gateway: Gateway): Promise<string | undefined> {
@@ -163,14 +179,19 @@ export class ImPermissionHelper {
       if ((this.generations.get(chatId) ?? 0) !== generation) return undefined;
       if (!decision.delivered) {
         const currentEntries = this.pending.get(chatId) ?? entries;
-        this.pending.set(chatId, [entry, ...currentEntries]);
-        this.nextPrompts.set(chatId, {
-          text: formatPermissionPrompt(entry),
-          requestId: entry.requestId,
-        });
-        this.retryPromptPending.add(chatId);
+        if (currentEntries.length > 0) {
+          this.pending.set(chatId, currentEntries);
+          this.nextPrompts.set(chatId, {
+            text: formatPermissionPrompt(currentEntries[0]!),
+            requestId: currentEntries[0]!.requestId,
+          });
+        } else {
+          this.pending.delete(chatId);
+          this.nextPrompts.delete(chatId);
+        }
+        this.retryPromptPending.delete(chatId);
         return {
-          text: "权限请求未送达，正在重试。",
+          text: "权限请求已失效，已跳过，继续处理。",
           canAdvance: false,
           retryPrompt: true,
           answerToken,
@@ -198,9 +219,6 @@ export class ImPermissionHelper {
     } finally {
       if ((this.generations.get(chatId) ?? 0) === generation) {
         this.inFlight.delete(chatId);
-        if ((this.pending.get(chatId)?.length ?? 0) === 0 && !this.nextPrompts.has(chatId)) {
-          this.answering.delete(chatId);
-        }
         this.generations.delete(chatId);
       } else if (!this.pending.has(chatId) && !this.inFlight.has(chatId) && !this.answering.has(chatId)) {
         this.generations.delete(chatId);

--- a/src/adapters/channel/protocol/ImPermissionHelper.ts
+++ b/src/adapters/channel/protocol/ImPermissionHelper.ts
@@ -31,6 +31,7 @@ export class ImPermissionHelper {
   private readonly inFlight = new Set<string>();
   private readonly generations = new Map<string, number>();
   private readonly answerTokens = new Map<string, number>();
+  private readonly deferredClears = new Map<string, number>();
   private nextAnswerToken = 1;
 
   capture(chatId: string, sessionKey: string, event: GatewayEvent & { type: "permission_request" }): string | undefined {
@@ -64,21 +65,28 @@ export class ImPermissionHelper {
     return this.answering.has(chatId);
   }
 
-  takeNextPrompt(chatId: string): string | undefined {
+  takeNextPrompt(chatId: string, answerToken?: number): string | undefined {
     // Status replies from answer() are non-advancing. Do not let an inbound
     // reply during initial delivery or an in-flight decision consume the
     // queued prompt and clear the lock.
+    if (answerToken !== undefined && this.answerTokens.get(chatId) !== answerToken) return undefined;
     if (this.promptDelivering.has(chatId) || this.initialPromptPending.has(chatId) || this.inFlight.has(chatId)) return undefined;
-    const prompt = this.nextPrompts.get(chatId);
+    let prompt = this.nextPrompts.get(chatId);
     if (!prompt) {
-      this.confirmAnswer(chatId);
-      return undefined;
+      const entry = this.pending.get(chatId)?.[0];
+      if (!entry) {
+        this.confirmAnswer(chatId, answerToken);
+        return undefined;
+      }
+      prompt = { text: formatPermissionPrompt(entry), requestId: entry.requestId };
+      this.nextPrompts.set(chatId, prompt);
     }
     this.promptDelivering.add(chatId);
     return prompt.text;
   }
 
-  getPromptRequestId(chatId: string): string | undefined {
+  getPromptRequestId(chatId: string, answerToken?: number): string | undefined {
+    if (answerToken !== undefined && this.answerTokens.get(chatId) !== answerToken) return undefined;
     return this.nextPrompts.get(chatId)?.requestId;
   }
 
@@ -96,7 +104,13 @@ export class ImPermissionHelper {
     this.answering.delete(chatId);
   }
 
-  confirmNextPrompt(chatId: string, delivered: boolean | void = true, expectedRequestId?: string): void {
+  confirmNextPrompt(
+    chatId: string,
+    delivered: boolean | void = true,
+    expectedRequestId?: string,
+    answerToken?: number,
+  ): void {
+    if (answerToken !== undefined && this.answerTokens.get(chatId) !== answerToken) return;
     if (!this.promptDelivering.has(chatId)) return;
     if (expectedRequestId !== undefined && this.nextPrompts.get(chatId)?.requestId !== expectedRequestId) return;
     this.promptDelivering.delete(chatId);
@@ -108,6 +122,7 @@ export class ImPermissionHelper {
     this.retryPromptPending.delete(chatId);
     this.answering.delete(chatId);
     this.answerTokens.delete(chatId);
+    this.finishDeferredClear(chatId, answerToken);
   }
 
   /** Release a completed answer when the adapter cannot deliver its reply. */
@@ -129,6 +144,26 @@ export class ImPermissionHelper {
     this.retryPromptPending.delete(chatId);
     this.answering.delete(chatId);
     this.answerTokens.delete(chatId);
+    this.finishDeferredClear(chatId, answerToken);
+  }
+
+  /** Clear state after a completed turn, without racing an answer delivery. */
+  clearAfterTurn(chatId: string): void {
+    if (this.answering.has(chatId) && !this.inFlight.has(chatId) && !this.initialPromptPending.has(chatId) && !this.promptDelivering.has(chatId)) {
+      const answerToken = this.answerTokens.get(chatId);
+      if (answerToken !== undefined) {
+        this.deferredClears.set(chatId, answerToken);
+        return;
+      }
+    }
+    this.clear(chatId);
+  }
+
+  private finishDeferredClear(chatId: string, answerToken?: number): void {
+    const deferredToken = this.deferredClears.get(chatId);
+    if (deferredToken === undefined || answerToken !== deferredToken) return;
+    this.deferredClears.delete(chatId);
+    this.clearNow(chatId);
   }
 
   async answer(chatId: string, text: string, gateway: Gateway): Promise<string | undefined> {
@@ -227,6 +262,11 @@ export class ImPermissionHelper {
   }
 
   clear(chatId: string): void {
+    this.deferredClears.delete(chatId);
+    this.clearNow(chatId);
+  }
+
+  private clearNow(chatId: string): void {
     if (this.inFlight.has(chatId)) {
       this.generations.set(chatId, (this.generations.get(chatId) ?? 0) + 1);
     } else {

--- a/src/adapters/channel/protocol/ImPermissionHelper.ts
+++ b/src/adapters/channel/protocol/ImPermissionHelper.ts
@@ -7,8 +7,31 @@ type PendingPermission = {
   payload: unknown;
 };
 
+type PendingPrompt = {
+  text: string;
+  requestId: string;
+};
+
+export type ImPermissionAnswerResult = {
+  text?: string;
+  /** True only for the invocation that completed a permission decision. */
+  canAdvance: boolean;
+  /** True when the caller should retry delivery of an already queued prompt. */
+  retryPrompt?: boolean;
+  answerToken?: number;
+};
+
 export class ImPermissionHelper {
   private readonly pending = new Map<string, PendingPermission[]>();
+  private readonly nextPrompts = new Map<string, PendingPrompt>();
+  private readonly promptDelivering = new Set<string>();
+  private readonly retryPromptPending = new Set<string>();
+  private readonly initialPromptPending = new Set<string>();
+  private readonly answering = new Set<string>();
+  private readonly inFlight = new Set<string>();
+  private readonly generations = new Map<string, number>();
+  private readonly answerTokens = new Map<string, number>();
+  private nextAnswerToken = 1;
 
   capture(chatId: string, sessionKey: string, event: GatewayEvent & { type: "permission_request" }): string | undefined {
     const entries = this.pending.get(chatId) ?? [];
@@ -20,25 +43,116 @@ export class ImPermissionHelper {
     });
     this.pending.set(chatId, entries);
 
-    return formatPermissionPrompt(entries);
+    if (entries.length !== 1 || this.answering.has(chatId)) return undefined;
+    const prompt = formatPermissionPrompt(entries[0]!);
+    this.answering.add(chatId);
+    this.nextPrompts.set(chatId, { text: prompt, requestId: entries[0]!.requestId });
+    this.initialPromptPending.add(chatId);
+    return prompt;
+  }
+
+  formatPending(chatId: string): string | undefined {
+    const entries = this.pending.get(chatId);
+    return entries && entries.length > 0 ? formatPermissionPrompt(entries[0]!) : undefined;
   }
 
   hasPending(chatId: string): boolean {
-    return (this.pending.get(chatId)?.length ?? 0) > 0;
+    return (this.pending.get(chatId)?.length ?? 0) > 0 || this.answering.has(chatId);
+  }
+
+  isAnswering(chatId: string): boolean {
+    return this.answering.has(chatId);
+  }
+
+  takeNextPrompt(chatId: string): string | undefined {
+    // Status replies from answer() are non-advancing. Do not let an inbound
+    // reply during initial delivery or an in-flight decision consume the
+    // queued prompt and clear the lock.
+    if (this.promptDelivering.has(chatId) || this.initialPromptPending.has(chatId) || this.inFlight.has(chatId)) return undefined;
+    const prompt = this.nextPrompts.get(chatId);
+    if (!prompt) return undefined;
+    this.promptDelivering.add(chatId);
+    return prompt.text;
+  }
+
+  getPromptRequestId(chatId: string): string | undefined {
+    return this.nextPrompts.get(chatId)?.requestId;
+  }
+
+  confirmInitialPrompt(chatId: string, delivered: boolean | void = true, expectedRequestId?: string): void {
+    if (!this.answering.has(chatId) || !this.nextPrompts.has(chatId)) return;
+    if (expectedRequestId !== undefined && this.nextPrompts.get(chatId)?.requestId !== expectedRequestId) return;
+    if (!delivered) {
+      this.initialPromptPending.delete(chatId);
+      this.retryPromptPending.add(chatId);
+      return;
+    }
+    this.nextPrompts.delete(chatId);
+    this.initialPromptPending.delete(chatId);
+    this.retryPromptPending.delete(chatId);
+    this.answering.delete(chatId);
+  }
+
+  confirmNextPrompt(chatId: string, delivered: boolean | void = true, expectedRequestId?: string): void {
+    if (!this.promptDelivering.has(chatId)) return;
+    if (expectedRequestId !== undefined && this.nextPrompts.get(chatId)?.requestId !== expectedRequestId) return;
+    this.promptDelivering.delete(chatId);
+    if (!delivered) {
+      this.retryPromptPending.add(chatId);
+      return;
+    }
+    this.nextPrompts.delete(chatId);
+    this.retryPromptPending.delete(chatId);
+    this.answering.delete(chatId);
+  }
+
+  /** Release a completed answer when the adapter cannot deliver its reply. */
+  releaseAnswer(chatId: string, answerToken?: number): void {
+    if (answerToken !== undefined && this.answerTokens.get(chatId) !== answerToken) return;
+    // Keep the queued prompt and lock intact so a failed delivery cannot let
+    // the next inbound message decide the unseen request.
+    this.promptDelivering.delete(chatId);
+    if (this.nextPrompts.has(chatId)) this.retryPromptPending.add(chatId);
   }
 
   async answer(chatId: string, text: string, gateway: Gateway): Promise<string | undefined> {
+    return (await this.answerWithState(chatId, text, gateway))?.text;
+  }
+
+  async answerWithState(chatId: string, text: string, gateway: Gateway): Promise<ImPermissionAnswerResult | undefined> {
+    if (this.answering.has(chatId)) {
+      // Keep ordinary messages inside the permission flow while the RPC or
+      // prompt delivery is pending. The structured result prevents adapters
+      // from treating these status messages as completed decisions.
+      if (this.inFlight.has(chatId)) return { text: "权限决定处理中，请稍候。", canAdvance: false };
+      if (this.initialPromptPending.has(chatId)) return { text: "权限提示发送中，请稍候。", canAdvance: false };
+      return this.retryPromptPending.has(chatId)
+        ? { text: "上一条权限提示发送失败，正在重试。", canAdvance: false, retryPrompt: true }
+        : undefined;
+    }
     const entries = this.pending.get(chatId);
     if (!entries || entries.length === 0) return undefined;
 
     const trimmed = text.trim();
     if (trimmed !== "0" && trimmed !== "1" && trimmed !== "2") {
-      return "请回复 1 允许一次，回复 2 允许本会话，回复 0 拒绝。";
+      return { text: "请回复 1 允许一次，回复 2 允许本会话，回复 0 拒绝。", canAdvance: false };
     }
 
-    this.pending.delete(chatId);
+    this.answering.add(chatId);
+    this.inFlight.add(chatId);
+    const answerToken = this.nextAnswerToken++;
+    this.answerTokens.set(chatId, answerToken);
+    const generation = (this.generations.get(chatId) ?? 0) + 1;
+    this.generations.set(chatId, generation);
+    const entry = entries.shift();
+    if (!entry) {
+      this.answering.delete(chatId);
+      return undefined;
+    }
+    if (entries.length === 0) this.pending.delete(chatId);
+    else this.pending.set(chatId, entries);
     const deny = trimmed === "0";
-    for (const entry of entries) {
+    try {
       await gateway.permissionDecide({
         sessionKey: entry.sessionKey,
         requestId: entry.requestId,
@@ -46,20 +160,53 @@ export class ImPermissionHelper {
         ...(deny ? { reason: "User denied permission from IM channel." } : {}),
         ...(!deny ? { remember: trimmed === "2" } : {}),
       });
+      if ((this.generations.get(chatId) ?? 0) !== generation) return undefined;
+      const remaining = this.pending.get(chatId) ?? entries;
+      if (remaining.length > 0) {
+        this.nextPrompts.set(chatId, {
+          text: formatPermissionPrompt(remaining[0]!),
+          requestId: remaining[0]!.requestId,
+        });
+      }
+      if (trimmed === "0") return { text: "已拒绝，继续处理。", canAdvance: true, answerToken };
+      if (trimmed === "2") return { text: "已允许本会话，继续执行。", canAdvance: true, answerToken };
+      return { text: "已允许一次，继续执行。", canAdvance: true, answerToken };
+    } catch (error) {
+      if ((this.generations.get(chatId) ?? 0) === generation) {
+        const currentEntries = this.pending.get(chatId) ?? entries;
+        this.pending.set(chatId, [entry, ...currentEntries]);
+        this.nextPrompts.delete(chatId);
+        this.retryPromptPending.delete(chatId);
+        this.answering.delete(chatId);
+      }
+      throw error;
+    } finally {
+      if ((this.generations.get(chatId) ?? 0) === generation) {
+        this.inFlight.delete(chatId);
+        if ((this.pending.get(chatId)?.length ?? 0) === 0 && !this.nextPrompts.has(chatId)) {
+          this.answering.delete(chatId);
+        }
+        this.generations.delete(chatId);
+      } else if (!this.pending.has(chatId) && !this.inFlight.has(chatId) && !this.answering.has(chatId)) {
+        this.generations.delete(chatId);
+      }
     }
-    const count = entries.length;
-    if (trimmed === "0") {
-      return count === 1 ? "已拒绝，继续处理。" : `已拒绝 ${count} 个待处理权限请求，继续处理。`;
-    }
-
-    if (trimmed === "2") {
-      return count === 1 ? "已允许本会话，继续执行。" : `已允许本会话的 ${count} 个待处理权限请求，继续执行。`;
-    }
-    return count === 1 ? "已允许一次，继续执行。" : `已允许 ${count} 个待处理权限请求一次，继续执行。`;
   }
 
   clear(chatId: string): void {
+    if (this.inFlight.has(chatId)) {
+      this.generations.set(chatId, (this.generations.get(chatId) ?? 0) + 1);
+    } else {
+      this.generations.delete(chatId);
+    }
     this.pending.delete(chatId);
+    this.nextPrompts.delete(chatId);
+    this.promptDelivering.delete(chatId);
+    this.retryPromptPending.delete(chatId);
+    this.initialPromptPending.delete(chatId);
+    this.inFlight.delete(chatId);
+    this.answerTokens.delete(chatId);
+    this.answering.delete(chatId);
   }
 }
 
@@ -76,32 +223,13 @@ function formatPayload(payload: unknown): string {
   return `${trimmed.slice(0, 800)}...`;
 }
 
-function formatPermissionPrompt(entries: PendingPermission[]): string {
-  if (entries.length === 1) {
-    const entry = entries[0]!;
-    return [
-      `工具 ${entry.toolName} 需要权限才能继续执行。`,
-      "",
-      "请求内容：",
-      formatPayload(entry.payload),
-      "",
-      "回复 1 允许一次，回复 2 允许本会话，回复 0 拒绝。",
-    ].join("\n");
-  }
-
-  const lines = [
-    `共有 ${entries.length} 个工具权限请求正在等待，以下请求都会被本次回复处理：`,
-  ];
-
-  entries.forEach((entry, index) => {
-    lines.push(
-      "",
-      `请求 ${index + 1}: 工具 ${entry.toolName}`,
-      "请求内容：",
-      formatPayload(entry.payload),
-    );
-  });
-
-  lines.push("", "回复 1 允许以上所有待处理请求一次，回复 2 允许本会话，回复 0 拒绝。");
-  return lines.join("\n");
+function formatPermissionPrompt(entry: PendingPermission): string {
+  return [
+    `工具 ${entry.toolName} 需要权限才能继续执行。`,
+    "",
+    "请求内容：",
+    formatPayload(entry.payload),
+    "",
+    "回复 1 允许一次，回复 2 允许本会话，回复 0 拒绝。",
+  ].join("\n");
 }

--- a/src/adapters/channel/protocol/ImPermissionHelper.ts
+++ b/src/adapters/channel/protocol/ImPermissionHelper.ts
@@ -31,7 +31,7 @@ export class ImPermissionHelper {
   private readonly inFlight = new Set<string>();
   private readonly generations = new Map<string, number>();
   private readonly answerTokens = new Map<string, number>();
-  private readonly deferredClears = new Map<string, number>();
+  private readonly deferredClears = new Set<string>();
   private nextAnswerToken = 1;
 
   capture(chatId: string, sessionKey: string, event: GatewayEvent & { type: "permission_request" }): string | undefined {
@@ -122,7 +122,7 @@ export class ImPermissionHelper {
     this.retryPromptPending.delete(chatId);
     this.answering.delete(chatId);
     this.answerTokens.delete(chatId);
-    this.finishDeferredClear(chatId, answerToken);
+    this.finishDeferredClear(chatId);
   }
 
   /** Release a completed answer when the adapter cannot deliver its reply. */
@@ -144,7 +144,7 @@ export class ImPermissionHelper {
     this.retryPromptPending.delete(chatId);
     this.answering.delete(chatId);
     this.answerTokens.delete(chatId);
-    this.finishDeferredClear(chatId, answerToken);
+    this.finishDeferredClear(chatId);
   }
 
   /** Clear state after a completed turn, without racing an answer delivery. */
@@ -152,16 +152,16 @@ export class ImPermissionHelper {
     if (this.answering.has(chatId) && !this.inFlight.has(chatId) && !this.initialPromptPending.has(chatId) && !this.promptDelivering.has(chatId)) {
       const answerToken = this.answerTokens.get(chatId);
       if (answerToken !== undefined) {
-        this.deferredClears.set(chatId, answerToken);
+        this.deferredClears.add(chatId);
         return;
       }
     }
     this.clear(chatId);
   }
 
-  private finishDeferredClear(chatId: string, answerToken?: number): void {
-    const deferredToken = this.deferredClears.get(chatId);
-    if (deferredToken === undefined || answerToken !== deferredToken) return;
+  private finishDeferredClear(chatId: string): void {
+    if (!this.deferredClears.has(chatId)) return;
+    if (this.pending.get(chatId)?.length) return;
     this.deferredClears.delete(chatId);
     this.clearNow(chatId);
   }

--- a/src/adapters/channel/qq/QQChannel.ts
+++ b/src/adapters/channel/qq/QQChannel.ts
@@ -139,10 +139,26 @@ export class QQChannel implements ChannelAdapter {
     }
 
     if (this.permissions.hasPending(chatKey) && this.gateway) {
+      let answerToken: number | undefined;
       try {
-        const confirmation = await this.permissions.answer(chatKey, text, this.gateway);
-        if (confirmation) await this.sendReply(groupOpenId, confirmation);
+        const answer = await this.permissions.answerWithState(chatKey, text, this.gateway);
+        answerToken = answer?.answerToken;
+        if (answer?.text) {
+          const confirmationDelivered = await this.sendReply(groupOpenId, answer.text);
+          if (!confirmationDelivered) {
+            this.permissions.releaseAnswer(chatKey, answer.answerToken);
+            return;
+          }
+          if (!answer.canAdvance && !answer.retryPrompt) return;
+          const nextPrompt = this.permissions.takeNextPrompt(chatKey);
+          if (nextPrompt) {
+            const nextPromptRequestId = this.permissions.getPromptRequestId(chatKey);
+            const delivered = await this.sendReply(groupOpenId, nextPrompt);
+            this.permissions.confirmNextPrompt(chatKey, delivered, nextPromptRequestId);
+          }
+        }
       } catch (e) {
+        if (answerToken !== undefined) this.permissions.releaseAnswer(chatKey, answerToken);
         this.logger?.error?.(`qq: permission answer error: ${e}`);
       }
       return;
@@ -193,10 +209,26 @@ export class QQChannel implements ChannelAdapter {
     }
 
     if (this.permissions.hasPending(chatKey) && this.gateway) {
+      let answerToken: number | undefined;
       try {
-        const confirmation = await this.permissions.answer(chatKey, rawText, this.gateway);
-        if (confirmation) await this.sendC2CReply(userOpenId, confirmation);
+        const answer = await this.permissions.answerWithState(chatKey, rawText, this.gateway);
+        answerToken = answer?.answerToken;
+        if (answer?.text) {
+          const confirmationDelivered = await this.sendC2CReply(userOpenId, answer.text);
+          if (!confirmationDelivered) {
+            this.permissions.releaseAnswer(chatKey, answer.answerToken);
+            return;
+          }
+          if (!answer.canAdvance && !answer.retryPrompt) return;
+          const nextPrompt = this.permissions.takeNextPrompt(chatKey);
+          if (nextPrompt) {
+            const nextPromptRequestId = this.permissions.getPromptRequestId(chatKey);
+            const delivered = await this.sendC2CReply(userOpenId, nextPrompt);
+            this.permissions.confirmNextPrompt(chatKey, delivered, nextPromptRequestId);
+          }
+        }
       } catch (e) {
+        if (answerToken !== undefined) this.permissions.releaseAnswer(chatKey, answerToken);
         this.logger?.error?.(`qq: permission answer error (c2c): ${e}`);
       }
       return;
@@ -239,7 +271,7 @@ export class QQChannel implements ChannelAdapter {
         }
         if (event.type === "permission_request") {
           const questionText = this.permissions.capture(chatKey, sessionKey, event);
-          if (questionText) await this.sendC2CReplyChunked(userOpenId, questionText, msgId);
+          if (questionText) this.permissions.confirmInitialPrompt(chatKey, await this.sendC2CReplyChunked(userOpenId, questionText, msgId), event.requestId);
           continue;
         }
         const fragment = renderQQEvent(event);
@@ -258,23 +290,26 @@ export class QQChannel implements ChannelAdapter {
     }
   }
 
-  private async sendC2CReply(userOpenId: string, text: string, msgId?: string, msgSeq?: number): Promise<void> {
-    if (!this.botGateway) return;
+  private async sendC2CReply(userOpenId: string, text: string, msgId?: string, msgSeq?: number): Promise<boolean> {
+    if (!this.botGateway) return false;
     try {
       await this.botGateway.sendC2CMessage(userOpenId, text, msgId, msgSeq);
+      return true;
     } catch (e) {
       this.logger?.error?.(`qq: sendC2CMessage failed: ${e}`);
+      return false;
     }
   }
 
-  private async sendC2CReplyChunked(userOpenId: string, text: string, msgId: string): Promise<void> {
+  private async sendC2CReplyChunked(userOpenId: string, text: string, msgId: string): Promise<boolean> {
     const chunks = this.splitText(text, this.maxMessageLength);
     for (let i = 0; i < chunks.length; i++) {
-      await this.sendC2CReply(userOpenId, chunks[i], msgId, i + 1);
+      if (!await this.sendC2CReply(userOpenId, chunks[i], msgId, i + 1)) return false;
       if (chunks.length > 1) {
         await this.sleep(500);
       }
     }
+    return true;
   }
 
   private extractText(raw: string): string | null {
@@ -311,7 +346,7 @@ export class QQChannel implements ChannelAdapter {
         }
         if (event.type === "permission_request") {
           const questionText = this.permissions.capture(chatKey, sessionKey, event);
-          if (questionText) await this.sendReplyChunked(groupOpenId, questionText, msgId);
+          if (questionText) this.permissions.confirmInitialPrompt(chatKey, await this.sendReplyChunked(groupOpenId, questionText, msgId), event.requestId);
           continue;
         }
         const fragment = renderQQEvent(event);
@@ -330,23 +365,26 @@ export class QQChannel implements ChannelAdapter {
     }
   }
 
-  private async sendReply(groupOpenId: string, text: string, msgId?: string, msgSeq?: number): Promise<void> {
-    if (!this.botGateway) return;
+  private async sendReply(groupOpenId: string, text: string, msgId?: string, msgSeq?: number): Promise<boolean> {
+    if (!this.botGateway) return false;
     try {
       await this.botGateway.sendGroupMessage(groupOpenId, text, msgId, msgSeq);
+      return true;
     } catch (e) {
       this.logger?.error?.(`qq: sendGroupMessage failed: ${e}`);
+      return false;
     }
   }
 
-  private async sendReplyChunked(groupOpenId: string, text: string, msgId: string): Promise<void> {
+  private async sendReplyChunked(groupOpenId: string, text: string, msgId: string): Promise<boolean> {
     const chunks = this.splitText(text, this.maxMessageLength);
     for (let i = 0; i < chunks.length; i++) {
-      await this.sendReply(groupOpenId, chunks[i], msgId, i + 1);
+      if (!await this.sendReply(groupOpenId, chunks[i], msgId, i + 1)) return false;
       if (chunks.length > 1) {
         await this.sleep(500);
       }
     }
+    return true;
   }
 
   private splitText(text: string, maxLen: number): string[] {

--- a/src/adapters/channel/qq/QQChannel.ts
+++ b/src/adapters/channel/qq/QQChannel.ts
@@ -150,11 +150,11 @@ export class QQChannel implements ChannelAdapter {
             return;
           }
           if (!answer.canAdvance && !answer.retryPrompt) return;
-          const nextPrompt = this.permissions.takeNextPrompt(chatKey);
+          const nextPrompt = this.permissions.takeNextPrompt(chatKey, answer.answerToken);
           if (nextPrompt) {
-            const nextPromptRequestId = this.permissions.getPromptRequestId(chatKey);
+            const nextPromptRequestId = this.permissions.getPromptRequestId(chatKey, answer.answerToken);
             const delivered = await this.sendReply(groupOpenId, nextPrompt);
-            this.permissions.confirmNextPrompt(chatKey, delivered, nextPromptRequestId);
+            this.permissions.confirmNextPrompt(chatKey, delivered, nextPromptRequestId, answer.answerToken);
           }
         }
       } catch (e) {
@@ -220,11 +220,11 @@ export class QQChannel implements ChannelAdapter {
             return;
           }
           if (!answer.canAdvance && !answer.retryPrompt) return;
-          const nextPrompt = this.permissions.takeNextPrompt(chatKey);
+          const nextPrompt = this.permissions.takeNextPrompt(chatKey, answer.answerToken);
           if (nextPrompt) {
-            const nextPromptRequestId = this.permissions.getPromptRequestId(chatKey);
+            const nextPromptRequestId = this.permissions.getPromptRequestId(chatKey, answer.answerToken);
             const delivered = await this.sendC2CReply(userOpenId, nextPrompt);
-            this.permissions.confirmNextPrompt(chatKey, delivered, nextPromptRequestId);
+            this.permissions.confirmNextPrompt(chatKey, delivered, nextPromptRequestId, answer.answerToken);
           }
         }
       } catch (e) {
@@ -283,7 +283,7 @@ export class QQChannel implements ChannelAdapter {
     }
 
     this.elicitation.clear(chatKey);
-    this.permissions.clear(chatKey);
+    this.permissions.clearAfterTurn(chatKey);
     const finalText = replyText.trim();
     if (finalText) {
       await this.sendC2CReplyChunked(userOpenId, finalText, msgId);
@@ -358,7 +358,7 @@ export class QQChannel implements ChannelAdapter {
     }
 
     this.elicitation.clear(chatKey);
-    this.permissions.clear(chatKey);
+    this.permissions.clearAfterTurn(chatKey);
     const finalText = replyText.trim();
     if (finalText) {
       await this.sendReplyChunked(groupOpenId, finalText, msgId);

--- a/src/adapters/channel/signal/SignalChannel.ts
+++ b/src/adapters/channel/signal/SignalChannel.ts
@@ -195,10 +195,27 @@ export class SignalChannel implements ChannelAdapter {
     }
 
     if (this.permissions.hasPending(sessionChatId) && this.gateway) {
+      let answerToken: number | undefined;
       try {
-        const confirmation = await this.permissions.answer(sessionChatId, text, this.gateway);
-        if (confirmation) await this.sendReply(sessionChatId, confirmation);
+        const answer = await this.permissions.answerWithState(sessionChatId, text, this.gateway);
+        answerToken = answer?.answerToken;
+        if (answer?.text) {
+          const confirmationDelivered = await this.sendReply(sessionChatId, answer.text);
+          if (!confirmationDelivered) {
+            this.permissions.releaseAnswer(sessionChatId, answer.answerToken);
+            return;
+          }
+          if (!answer.canAdvance && !answer.retryPrompt) return;
+          const nextPrompt = this.permissions.takeNextPrompt(sessionChatId);
+          if (nextPrompt) {
+            const nextPromptRequestId = this.permissions.getPromptRequestId(sessionChatId);
+
+            const delivered = await this.sendReply(sessionChatId, nextPrompt);
+            this.permissions.confirmNextPrompt(sessionChatId, delivered, nextPromptRequestId);
+          }
+        }
       } catch (e) {
+        if (answerToken !== undefined) this.permissions.releaseAnswer(sessionChatId, answerToken);
         this.logger?.error?.(`signal: permission answer error: ${e}`);
       }
       return;
@@ -241,7 +258,7 @@ export class SignalChannel implements ChannelAdapter {
         }
         if (event.type === "permission_request") {
           const questionText = this.permissions.capture(chatId, sessionKey, event);
-          if (questionText) await this.sendReply(chatId, questionText);
+          if (questionText) this.permissions.confirmInitialPrompt(chatId, await this.sendReply(chatId, questionText), event.requestId);
           continue;
         }
         const fragment = renderSignalEvent(event);

--- a/src/adapters/channel/signal/SignalChannel.ts
+++ b/src/adapters/channel/signal/SignalChannel.ts
@@ -206,12 +206,12 @@ export class SignalChannel implements ChannelAdapter {
             return;
           }
           if (!answer.canAdvance && !answer.retryPrompt) return;
-          const nextPrompt = this.permissions.takeNextPrompt(sessionChatId);
+          const nextPrompt = this.permissions.takeNextPrompt(sessionChatId, answer.answerToken);
           if (nextPrompt) {
-            const nextPromptRequestId = this.permissions.getPromptRequestId(sessionChatId);
+            const nextPromptRequestId = this.permissions.getPromptRequestId(sessionChatId, answer.answerToken);
 
             const delivered = await this.sendReply(sessionChatId, nextPrompt);
-            this.permissions.confirmNextPrompt(sessionChatId, delivered, nextPromptRequestId);
+            this.permissions.confirmNextPrompt(sessionChatId, delivered, nextPromptRequestId, answer.answerToken);
           }
         }
       } catch (e) {
@@ -270,7 +270,7 @@ export class SignalChannel implements ChannelAdapter {
     }
 
     this.elicitation.clear(chatId);
-    this.permissions.clear(chatId);
+    this.permissions.clearAfterTurn(chatId);
 
     const finalText = replyText.trim();
     if (finalText) {

--- a/src/adapters/channel/slack/SlackChannel.ts
+++ b/src/adapters/channel/slack/SlackChannel.ts
@@ -131,10 +131,27 @@ export class SlackChannel implements ChannelAdapter {
     }
 
     if (this.permissions.hasPending(chatId) && this.gateway) {
+      let answerToken: number | undefined;
       try {
-        const confirmation = await this.permissions.answer(chatId, text, this.gateway);
-        if (confirmation) await this.sendReply({ channelId, threadTs }, confirmation);
+        const answer = await this.permissions.answerWithState(chatId, text, this.gateway);
+        answerToken = answer?.answerToken;
+        if (answer?.text) {
+          const confirmationDelivered = await this.sendReply({ channelId, threadTs }, answer.text);
+          if (!confirmationDelivered) {
+            this.permissions.releaseAnswer(chatId, answer.answerToken);
+            return;
+          }
+          if (!answer.canAdvance && !answer.retryPrompt) return;
+          const nextPrompt = this.permissions.takeNextPrompt(chatId);
+          if (nextPrompt) {
+            const nextPromptRequestId = this.permissions.getPromptRequestId(chatId);
+
+            const delivered = await this.sendReply({ channelId, threadTs }, nextPrompt);
+            this.permissions.confirmNextPrompt(chatId, delivered, nextPromptRequestId);
+          }
+        }
       } catch (e) {
+        if (answerToken !== undefined) this.permissions.releaseAnswer(chatId, answerToken);
         this.logger?.error?.(`slack: permission answer error: ${e}`);
       }
       return;
@@ -184,7 +201,7 @@ export class SlackChannel implements ChannelAdapter {
         }
         if (event.type === "permission_request") {
           const questionText = this.permissions.capture(chatId, sessionKey, event);
-          if (questionText) await this.sendReply(ctx, questionText);
+          if (questionText) this.permissions.confirmInitialPrompt(chatId, await this.sendReply(ctx, questionText), event.requestId);
           continue;
         }
         const fragment = renderSlackEvent(event);
@@ -206,8 +223,9 @@ export class SlackChannel implements ChannelAdapter {
   private async sendReply(
     ctx: { channelId: string; threadTs?: string },
     text: string,
-  ): Promise<void> {
-    if (!this.app) return;
+  ): Promise<boolean> {
+    if (!this.app) return false;
+    let delivered = true;
     const formatted = formatSlackMrkdwn(text);
     const chunks = chunkText(formatted, MAX_MESSAGE_LENGTH);
     for (const chunk of chunks) {
@@ -220,8 +238,10 @@ export class SlackChannel implements ChannelAdapter {
         });
       } catch (e) {
         this.logger?.error?.(`slack: postMessage failed: ${e}`);
+        delivered = false;
       }
     }
+    return delivered;
   }
 }
 

--- a/src/adapters/channel/slack/SlackChannel.ts
+++ b/src/adapters/channel/slack/SlackChannel.ts
@@ -142,12 +142,12 @@ export class SlackChannel implements ChannelAdapter {
             return;
           }
           if (!answer.canAdvance && !answer.retryPrompt) return;
-          const nextPrompt = this.permissions.takeNextPrompt(chatId);
+          const nextPrompt = this.permissions.takeNextPrompt(chatId, answer.answerToken);
           if (nextPrompt) {
-            const nextPromptRequestId = this.permissions.getPromptRequestId(chatId);
+            const nextPromptRequestId = this.permissions.getPromptRequestId(chatId, answer.answerToken);
 
             const delivered = await this.sendReply({ channelId, threadTs }, nextPrompt);
-            this.permissions.confirmNextPrompt(chatId, delivered, nextPromptRequestId);
+            this.permissions.confirmNextPrompt(chatId, delivered, nextPromptRequestId, answer.answerToken);
           }
         }
       } catch (e) {
@@ -213,7 +213,7 @@ export class SlackChannel implements ChannelAdapter {
     }
 
     this.elicitation.clear(chatId);
-    this.permissions.clear(chatId);
+    this.permissions.clearAfterTurn(chatId);
     const finalText = replyText.trim();
     if (finalText) {
       await this.sendReply(ctx, finalText);

--- a/src/adapters/channel/sms/SmsChannel.ts
+++ b/src/adapters/channel/sms/SmsChannel.ts
@@ -215,10 +215,27 @@ export class SmsChannel implements ChannelAdapter {
     }
 
     if (this.permissions.hasPending(chatId) && this.gateway) {
+      let answerToken: number | undefined;
       try {
-        const confirmation = await this.permissions.answer(chatId, text, this.gateway);
-        if (confirmation) await this.sendReply(chatId, confirmation);
+        const answer = await this.permissions.answerWithState(chatId, text, this.gateway);
+        answerToken = answer?.answerToken;
+        if (answer?.text) {
+          const confirmationDelivered = await this.sendReply(chatId, answer.text);
+          if (!confirmationDelivered) {
+            this.permissions.releaseAnswer(chatId, answer.answerToken);
+            return;
+          }
+          if (!answer.canAdvance && !answer.retryPrompt) return;
+          const nextPrompt = this.permissions.takeNextPrompt(chatId);
+          if (nextPrompt) {
+            const nextPromptRequestId = this.permissions.getPromptRequestId(chatId);
+
+            const delivered = await this.sendReply(chatId, nextPrompt);
+            this.permissions.confirmNextPrompt(chatId, delivered, nextPromptRequestId);
+          }
+        }
       } catch (e) {
+        if (answerToken !== undefined) this.permissions.releaseAnswer(chatId, answerToken);
         this.logger?.error?.(`sms: permission answer error: ${e}`);
       }
       return;
@@ -261,7 +278,7 @@ export class SmsChannel implements ChannelAdapter {
         }
         if (event.type === "permission_request") {
           const questionText = this.permissions.capture(chatId, sessionKey, event);
-          if (questionText) await this.sendReply(chatId, questionText);
+          if (questionText) this.permissions.confirmInitialPrompt(chatId, await this.sendReply(chatId, questionText), event.requestId);
           continue;
         }
         const fragment = renderSmsEvent(event);

--- a/src/adapters/channel/sms/SmsChannel.ts
+++ b/src/adapters/channel/sms/SmsChannel.ts
@@ -226,12 +226,12 @@ export class SmsChannel implements ChannelAdapter {
             return;
           }
           if (!answer.canAdvance && !answer.retryPrompt) return;
-          const nextPrompt = this.permissions.takeNextPrompt(chatId);
+          const nextPrompt = this.permissions.takeNextPrompt(chatId, answer.answerToken);
           if (nextPrompt) {
-            const nextPromptRequestId = this.permissions.getPromptRequestId(chatId);
+            const nextPromptRequestId = this.permissions.getPromptRequestId(chatId, answer.answerToken);
 
             const delivered = await this.sendReply(chatId, nextPrompt);
-            this.permissions.confirmNextPrompt(chatId, delivered, nextPromptRequestId);
+            this.permissions.confirmNextPrompt(chatId, delivered, nextPromptRequestId, answer.answerToken);
           }
         }
       } catch (e) {
@@ -290,7 +290,7 @@ export class SmsChannel implements ChannelAdapter {
     }
 
     this.elicitation.clear(chatId);
-    this.permissions.clear(chatId);
+    this.permissions.clearAfterTurn(chatId);
 
     const finalText = replyText.trim();
     if (finalText) {

--- a/src/adapters/channel/telegram/TelegramChannel.ts
+++ b/src/adapters/channel/telegram/TelegramChannel.ts
@@ -121,12 +121,12 @@ export class TelegramChannel implements ChannelAdapter {
             return;
           }
           if (!answer.canAdvance && !answer.retryPrompt) return;
-          const nextPrompt = this.permissions.takeNextPrompt(chatId);
+          const nextPrompt = this.permissions.takeNextPrompt(chatId, answer.answerToken);
           if (nextPrompt) {
-            const nextPromptRequestId = this.permissions.getPromptRequestId(chatId);
+            const nextPromptRequestId = this.permissions.getPromptRequestId(chatId, answer.answerToken);
 
             const delivered = await this.sendReply(chatId, nextPrompt);
-            this.permissions.confirmNextPrompt(chatId, delivered, nextPromptRequestId);
+            this.permissions.confirmNextPrompt(chatId, delivered, nextPromptRequestId, answer.answerToken);
           }
         }
       } catch (e) {
@@ -187,7 +187,7 @@ export class TelegramChannel implements ChannelAdapter {
     }
 
     this.elicitation.clear(chatId);
-    this.permissions.clear(chatId);
+    this.permissions.clearAfterTurn(chatId);
     const finalText = replyText.trim();
     if (finalText) {
       await this.sendReply(chatId, finalText);

--- a/src/adapters/channel/telegram/TelegramChannel.ts
+++ b/src/adapters/channel/telegram/TelegramChannel.ts
@@ -110,10 +110,27 @@ export class TelegramChannel implements ChannelAdapter {
     }
 
     if (this.permissions.hasPending(chatId) && this.gateway) {
+      let answerToken: number | undefined;
       try {
-        const confirmation = await this.permissions.answer(chatId, msg.text, this.gateway);
-        if (confirmation) await this.sendReply(chatId, confirmation);
+        const answer = await this.permissions.answerWithState(chatId, msg.text, this.gateway);
+        answerToken = answer?.answerToken;
+        if (answer?.text) {
+          const confirmationDelivered = await this.sendReply(chatId, answer.text);
+          if (!confirmationDelivered) {
+            this.permissions.releaseAnswer(chatId, answer.answerToken);
+            return;
+          }
+          if (!answer.canAdvance && !answer.retryPrompt) return;
+          const nextPrompt = this.permissions.takeNextPrompt(chatId);
+          if (nextPrompt) {
+            const nextPromptRequestId = this.permissions.getPromptRequestId(chatId);
+
+            const delivered = await this.sendReply(chatId, nextPrompt);
+            this.permissions.confirmNextPrompt(chatId, delivered, nextPromptRequestId);
+          }
+        }
       } catch (e) {
+        if (answerToken !== undefined) this.permissions.releaseAnswer(chatId, answerToken);
         this.logger?.error?.(`telegram: permission answer error: ${e}`);
       }
       return;
@@ -158,7 +175,7 @@ export class TelegramChannel implements ChannelAdapter {
         }
         if (event.type === "permission_request") {
           const questionText = this.permissions.capture(chatId, sessionKey, event);
-          if (questionText) await this.sendReply(chatId, questionText);
+          if (questionText) this.permissions.confirmInitialPrompt(chatId, await this.sendReply(chatId, questionText), event.requestId);
           continue;
         }
         const fragment = renderTelegramEvent(event);

--- a/src/adapters/channel/wecom-callback/WeComCallbackChannel.ts
+++ b/src/adapters/channel/wecom-callback/WeComCallbackChannel.ts
@@ -235,12 +235,12 @@ export class WeComCallbackChannel implements ChannelAdapter {
             return;
           }
           if (!answer.canAdvance && !answer.retryPrompt) return;
-          const nextPrompt = this.permissions.takeNextPrompt(chatId);
+          const nextPrompt = this.permissions.takeNextPrompt(chatId, answer.answerToken);
           if (nextPrompt) {
-            const nextPromptRequestId = this.permissions.getPromptRequestId(chatId);
+            const nextPromptRequestId = this.permissions.getPromptRequestId(chatId, answer.answerToken);
 
             const delivered = await this.sendReply(chatId, nextPrompt);
-            this.permissions.confirmNextPrompt(chatId, delivered, nextPromptRequestId);
+            this.permissions.confirmNextPrompt(chatId, delivered, nextPromptRequestId, answer.answerToken);
           }
         }
       } catch (e) {
@@ -299,7 +299,7 @@ export class WeComCallbackChannel implements ChannelAdapter {
     }
 
     this.elicitation.clear(chatId);
-    this.permissions.clear(chatId);
+    this.permissions.clearAfterTurn(chatId);
 
     const finalText = replyText.trim();
     if (finalText) {

--- a/src/adapters/channel/wecom-callback/WeComCallbackChannel.ts
+++ b/src/adapters/channel/wecom-callback/WeComCallbackChannel.ts
@@ -224,10 +224,27 @@ export class WeComCallbackChannel implements ChannelAdapter {
     }
 
     if (this.permissions.hasPending(chatId) && this.gateway) {
+      let answerToken: number | undefined;
       try {
-        const confirmation = await this.permissions.answer(chatId, text, this.gateway);
-        if (confirmation) await this.sendReply(chatId, confirmation);
+        const answer = await this.permissions.answerWithState(chatId, text, this.gateway);
+        answerToken = answer?.answerToken;
+        if (answer?.text) {
+          const confirmationDelivered = await this.sendReply(chatId, answer.text);
+          if (!confirmationDelivered) {
+            this.permissions.releaseAnswer(chatId, answer.answerToken);
+            return;
+          }
+          if (!answer.canAdvance && !answer.retryPrompt) return;
+          const nextPrompt = this.permissions.takeNextPrompt(chatId);
+          if (nextPrompt) {
+            const nextPromptRequestId = this.permissions.getPromptRequestId(chatId);
+
+            const delivered = await this.sendReply(chatId, nextPrompt);
+            this.permissions.confirmNextPrompt(chatId, delivered, nextPromptRequestId);
+          }
+        }
       } catch (e) {
+        if (answerToken !== undefined) this.permissions.releaseAnswer(chatId, answerToken);
         this.logger?.error?.(`wecom_callback: permission answer error: ${e}`);
       }
       return;
@@ -270,7 +287,7 @@ export class WeComCallbackChannel implements ChannelAdapter {
         }
         if (event.type === "permission_request") {
           const questionText = this.permissions.capture(chatId, sessionKey, event);
-          if (questionText) await this.sendReply(chatId, questionText);
+          if (questionText) this.permissions.confirmInitialPrompt(chatId, await this.sendReply(chatId, questionText), event.requestId);
           continue;
         }
         const fragment = renderWeComCallbackEvent(event);

--- a/src/adapters/channel/wecom/WeComChannel.ts
+++ b/src/adapters/channel/wecom/WeComChannel.ts
@@ -529,7 +529,7 @@ export class WeComChannel implements ChannelAdapter {
       gateway: this.gateway,
       chatId,
       channelKey: "wecom",
-      reply: (msg) => this.sendReply(chatId, msg, { chatType, replyToMessageId: messageId }),
+      reply: (msg) => this.sendReply(chatId, msg, { chatType, replyToMessageId: messageId }).then(() => undefined),
       bindProject: (projectKey) => { this.mapper.bindProject(scopeInput, projectKey); this.onStateChange?.(this.mapper.snapshot()); },
       getProject: () => this.mapper.getProject(scopeInput),
       resetSession: () => { this.mapper.resolve({ ...scopeInput, text: "/new" }); this.onStateChange?.(this.mapper.snapshot()); },
@@ -602,10 +602,26 @@ export class WeComChannel implements ChannelAdapter {
     }
 
     if (this.permissions.hasPending(interactionKey) && this.gateway) {
+      let answerToken: number | undefined;
       try {
-        const confirmation = await this.permissions.answer(interactionKey, text, this.gateway);
-        if (confirmation) await this.sendReply(chatId, confirmation, { chatType, replyToMessageId: messageId });
+        const answer = await this.permissions.answerWithState(interactionKey, text, this.gateway);
+        answerToken = answer?.answerToken;
+        if (answer?.text) {
+          const confirmationDelivered = await this.sendReply(chatId, answer.text, { chatType, replyToMessageId: messageId });
+          if (!confirmationDelivered) {
+            this.permissions.releaseAnswer(interactionKey, answer.answerToken);
+            return;
+          }
+          if (!answer.canAdvance && !answer.retryPrompt) return;
+          const nextPrompt = this.permissions.takeNextPrompt(interactionKey);
+          if (nextPrompt) {
+            const nextPromptRequestId = this.permissions.getPromptRequestId(interactionKey);
+            const delivered = await this.sendReply(chatId, nextPrompt, { chatType, replyToMessageId: messageId });
+            this.permissions.confirmNextPrompt(interactionKey, delivered, nextPromptRequestId);
+          }
+        }
       } catch (e) {
+        if (answerToken !== undefined) this.permissions.releaseAnswer(interactionKey, answerToken);
         this.logger?.error?.(`wecom: permission answer error: ${e}`);
       }
       return;
@@ -911,10 +927,10 @@ export class WeComChannel implements ChannelAdapter {
         }
         if (event.type === "permission_request") {
           const questionText = this.permissions.capture(input.interactionKey, input.sessionKey, event);
-          if (questionText) await this.sendReply(input.chatId, questionText, {
+          if (questionText) { const delivered = await this.sendReply(input.chatId, questionText, {
             chatType: input.chatType,
             replyToMessageId: input.replyToMessageId,
-          });
+          }); this.permissions.confirmInitialPrompt(input.interactionKey, delivered, event.requestId); }
           continue;
         }
         await this.sendEventMedia(input.chatId, event, {
@@ -956,10 +972,10 @@ export class WeComChannel implements ChannelAdapter {
     chatId: string,
     text: string,
     context: { chatType?: "dm" | "group"; replyToMessageId?: string } = {},
-  ): Promise<void> {
+  ): Promise<boolean> {
     if (!this.ws || this.ws.readyState !== WS_OPEN) {
       this.logger?.warn?.(`wecom: not connected, cannot send to ${chatId}`);
-      return;
+      return false;
     }
 
     const slice = text.slice(0, MAX_MESSAGE_LENGTH);
@@ -974,15 +990,17 @@ export class WeComChannel implements ChannelAdapter {
 
       if (!response) {
         this.logger?.warn?.(`wecom: no reply request id for group chat ${chatId}, cannot send proactive message`);
-        return;
+        return false;
       }
-
       const err = this.responseError(response);
       if (err) {
         this.logger?.error?.(`wecom: sendReply error: ${err}`);
+        return false;
       }
+      return true;
     } catch (e) {
       this.logger?.error?.(`wecom: sendReply failed: ${e}`);
+      return false;
     }
   }
 
@@ -992,8 +1010,10 @@ export class WeComChannel implements ChannelAdapter {
     context: { chatType?: "dm" | "group"; replyToMessageId?: string },
   ): Promise<void> {
     if (event.type !== "tool_call_finished" || !event.images?.length) return;
+    const images = event.images;
+    if (images.length === 0) return;
 
-    for (const [index, image] of event.images.entries()) {
+    for (const [index, image] of images.entries()) {
       try {
         const data = Buffer.from(image.data, "base64");
         const prepared = this.prepareOutboundMediaBytes(

--- a/src/adapters/channel/wecom/WeComChannel.ts
+++ b/src/adapters/channel/wecom/WeComChannel.ts
@@ -613,11 +613,11 @@ export class WeComChannel implements ChannelAdapter {
             return;
           }
           if (!answer.canAdvance && !answer.retryPrompt) return;
-          const nextPrompt = this.permissions.takeNextPrompt(interactionKey);
+          const nextPrompt = this.permissions.takeNextPrompt(interactionKey, answer.answerToken);
           if (nextPrompt) {
-            const nextPromptRequestId = this.permissions.getPromptRequestId(interactionKey);
+            const nextPromptRequestId = this.permissions.getPromptRequestId(interactionKey, answer.answerToken);
             const delivered = await this.sendReply(chatId, nextPrompt, { chatType, replyToMessageId: messageId });
-            this.permissions.confirmNextPrompt(interactionKey, delivered, nextPromptRequestId);
+            this.permissions.confirmNextPrompt(interactionKey, delivered, nextPromptRequestId, answer.answerToken);
           }
         }
       } catch (e) {
@@ -946,7 +946,7 @@ export class WeComChannel implements ChannelAdapter {
     }
 
     this.elicitation.clear(input.interactionKey);
-    this.permissions.clear(input.interactionKey);
+    this.permissions.clearAfterTurn(input.interactionKey);
     const finalText = replyText.trim();
     if (!finalText) return;
 

--- a/src/adapters/channel/weixin/WeixinChannel.ts
+++ b/src/adapters/channel/weixin/WeixinChannel.ts
@@ -451,12 +451,12 @@ export class WeixinChannel implements ChannelAdapter {
             return;
           }
           if (!answer.canAdvance && !answer.retryPrompt) return;
-          const nextPrompt = this.permissions.takeNextPrompt(fromUser);
+          const nextPrompt = this.permissions.takeNextPrompt(fromUser, answer.answerToken);
           if (nextPrompt) {
-            const nextPromptRequestId = this.permissions.getPromptRequestId(fromUser);
+            const nextPromptRequestId = this.permissions.getPromptRequestId(fromUser, answer.answerToken);
             const delivered = await this.sendReply(fromUser, nextPrompt);
             if (!delivered) throw new Error("permission prompt delivery failed");
-            this.permissions.confirmNextPrompt(fromUser, true, nextPromptRequestId);
+            this.permissions.confirmNextPrompt(fromUser, true, nextPromptRequestId, answer.answerToken);
           }
           if (
             (trimmed === "1" || trimmed === "2")
@@ -771,7 +771,7 @@ export class WeixinChannel implements ChannelAdapter {
     if (isCurrentTurn()) {
       this.chatState.clearActiveRun(userId);
       this.elicitation.clear(userId);
-      this.permissions.clear(userId);
+      this.permissions.clearAfterTurn(userId);
       await liveReply.flushFinal();
     }
   }

--- a/src/adapters/channel/weixin/WeixinChannel.ts
+++ b/src/adapters/channel/weixin/WeixinChannel.ts
@@ -438,15 +438,36 @@ export class WeixinChannel implements ChannelAdapter {
       return;
     }
 
-    if (this.permissions.hasPending(fromUser) && this.gateway) {
+    if ((this.permissions.hasPending(fromUser) || this.permissions.isAnswering(fromUser)) && this.gateway) {
+      let answerToken: number | undefined;
       try {
         const trimmed = text.trim();
-        const confirmation = await this.permissions.answer(fromUser, text, this.gateway);
-        if (confirmation) await this.sendReply(fromUser, confirmation);
-        if (trimmed === "1" || trimmed === "2") {
-          await this.activeLiveReplies.get(fromUser)?.resumeActivity("tool", { immediate: false });
+        const answer = await this.permissions.answerWithState(fromUser, text, this.gateway);
+        answerToken = answer?.answerToken;
+        if (answer?.text) {
+          const confirmationDelivered = await this.sendReply(fromUser, answer.text);
+          if (!confirmationDelivered) {
+            this.permissions.releaseAnswer(fromUser, answer.answerToken);
+            return;
+          }
+          if (!answer.canAdvance && !answer.retryPrompt) return;
+          const nextPrompt = this.permissions.takeNextPrompt(fromUser);
+          if (nextPrompt) {
+            const nextPromptRequestId = this.permissions.getPromptRequestId(fromUser);
+            const delivered = await this.sendReply(fromUser, nextPrompt);
+            if (!delivered) throw new Error("permission prompt delivery failed");
+            this.permissions.confirmNextPrompt(fromUser, true, nextPromptRequestId);
+          }
+          if (
+            (trimmed === "1" || trimmed === "2")
+            && answer.text.startsWith("已允许")
+            && !this.permissions.hasPending(fromUser)
+          ) {
+            await this.activeLiveReplies.get(fromUser)?.resumeActivity("tool", { immediate: false });
+          }
         }
       } catch (e) {
+        if (answerToken !== undefined) this.permissions.releaseAnswer(fromUser, answerToken);
         this.logger?.error?.(`weixin: permission answer error: ${e}`);
       }
       return;
@@ -700,7 +721,7 @@ export class WeixinChannel implements ChannelAdapter {
         if (event.type === "permission_request") {
           const questionText = this.permissions.capture(userId, sessionKey, event);
           await liveReply.pauseActivity();
-          if (questionText) await this.sendReply(userId, questionText);
+          if (questionText) this.permissions.confirmInitialPrompt(userId, await this.sendReply(userId, questionText), event.requestId);
           continue;
         }
         if (event.type === "error" && event.code === "agent_aborted") {

--- a/src/adapters/channel/whatsapp/WhatsAppChannel.ts
+++ b/src/adapters/channel/whatsapp/WhatsAppChannel.ts
@@ -219,12 +219,12 @@ export class WhatsAppChannel implements ChannelAdapter {
             return;
           }
           if (!answer.canAdvance && !answer.retryPrompt) return;
-          const nextPrompt = this.permissions.takeNextPrompt(msg.chatId);
+          const nextPrompt = this.permissions.takeNextPrompt(msg.chatId, answer.answerToken);
           if (nextPrompt) {
-            const nextPromptRequestId = this.permissions.getPromptRequestId(msg.chatId);
+            const nextPromptRequestId = this.permissions.getPromptRequestId(msg.chatId, answer.answerToken);
 
             const delivered = await this.sendReply(msg.chatId, nextPrompt);
-            this.permissions.confirmNextPrompt(msg.chatId, delivered, nextPromptRequestId);
+            this.permissions.confirmNextPrompt(msg.chatId, delivered, nextPromptRequestId, answer.answerToken);
           }
         }
       } catch (e) {
@@ -283,7 +283,7 @@ export class WhatsAppChannel implements ChannelAdapter {
     }
 
     this.elicitation.clear(chatId);
-    this.permissions.clear(chatId);
+    this.permissions.clearAfterTurn(chatId);
     const finalText = replyText.trim();
     if (finalText) {
       await this.sendReply(chatId, finalText);

--- a/src/adapters/channel/whatsapp/WhatsAppChannel.ts
+++ b/src/adapters/channel/whatsapp/WhatsAppChannel.ts
@@ -208,10 +208,27 @@ export class WhatsAppChannel implements ChannelAdapter {
     }
 
     if (this.permissions.hasPending(msg.chatId) && this.gateway) {
+      let answerToken: number | undefined;
       try {
-        const confirmation = await this.permissions.answer(msg.chatId, msg.text, this.gateway);
-        if (confirmation) await this.sendReply(msg.chatId, confirmation);
+        const answer = await this.permissions.answerWithState(msg.chatId, msg.text, this.gateway);
+        answerToken = answer?.answerToken;
+        if (answer?.text) {
+          const confirmationDelivered = await this.sendReply(msg.chatId, answer.text);
+          if (!confirmationDelivered) {
+            this.permissions.releaseAnswer(msg.chatId, answer.answerToken);
+            return;
+          }
+          if (!answer.canAdvance && !answer.retryPrompt) return;
+          const nextPrompt = this.permissions.takeNextPrompt(msg.chatId);
+          if (nextPrompt) {
+            const nextPromptRequestId = this.permissions.getPromptRequestId(msg.chatId);
+
+            const delivered = await this.sendReply(msg.chatId, nextPrompt);
+            this.permissions.confirmNextPrompt(msg.chatId, delivered, nextPromptRequestId);
+          }
+        }
       } catch (e) {
+        if (answerToken !== undefined) this.permissions.releaseAnswer(msg.chatId, answerToken);
         this.logger?.error?.(`whatsapp: permission answer error: ${e}`);
       }
       return;
@@ -254,7 +271,7 @@ export class WhatsAppChannel implements ChannelAdapter {
         }
         if (event.type === "permission_request") {
           const questionText = this.permissions.capture(chatId, sessionKey, event);
-          if (questionText) await this.sendReply(chatId, questionText);
+          if (questionText) this.permissions.confirmInitialPrompt(chatId, await this.sendReply(chatId, questionText), event.requestId);
           continue;
         }
         const fragment = renderWhatsAppEvent(event);

--- a/src/cli/pilotdeck.ts
+++ b/src/cli/pilotdeck.ts
@@ -277,6 +277,7 @@ async function main(argv = process.argv.slice(2)): Promise<void> {
           verifyToken: fCfg.verifyToken,
           connectionMode: fCfg.connectionMode,
           domainName: fCfg.domainName,
+          permissionMode: fCfg.permissionMode,
           mapper: savedFeishu ? new FeishuSessionMapper(savedFeishu) : undefined,
           onStateChange: (state) => channelStatePersistence.save("feishu", state),
         });
@@ -342,6 +343,7 @@ async function main(argv = process.argv.slice(2)): Promise<void> {
           verifyToken: feishuCfg.verifyToken,
           connectionMode: feishuCfg.connectionMode,
           domainName: feishuCfg.domainName,
+          permissionMode: feishuCfg.permissionMode,
           mapper: savedFeishuState ? new FeishuSessionMapper(savedFeishuState) : undefined,
           onStateChange: (state) => channelStatePersistence.save("feishu", state),
         })

--- a/src/pilot/config/parseGatewayConfig.ts
+++ b/src/pilot/config/parseGatewayConfig.ts
@@ -124,6 +124,7 @@ function parseFeishu(raw: unknown): PilotAdaptersConfig["feishu"] {
   }
   const mode = stringField(raw, "connectionMode");
   const domain = stringField(raw, "domainName");
+  const permissionMode = stringField(raw, "permissionMode");
   return {
     enabled: booleanField(raw, "enabled", false),
     appId: stringField(raw, "appId"),
@@ -133,6 +134,7 @@ function parseFeishu(raw: unknown): PilotAdaptersConfig["feishu"] {
     defaultSessionLabel: stringField(raw, "defaultSessionLabel", "general") ?? "general",
     connectionMode: mode === "stream" || mode === "webhook" ? mode : undefined,
     domainName: domain === "feishu" || domain === "lark" ? domain : undefined,
+    permissionMode: permissionMode === "default" || permissionMode === "bypassPermissions" ? permissionMode : undefined,
   };
 }
 

--- a/src/pilot/config/types.ts
+++ b/src/pilot/config/types.ts
@@ -194,6 +194,7 @@ export type PilotAdaptersConfig = {
     defaultSessionLabel: string;
     connectionMode?: "stream" | "webhook";
     domainName?: "feishu" | "lark";
+    permissionMode?: "default" | "bypassPermissions";
   };
   weixin?: { enabled: boolean };
   qq?: {

--- a/tests/adapters/feishu-permission-reply.spec.ts
+++ b/tests/adapters/feishu-permission-reply.spec.ts
@@ -244,6 +244,17 @@ test("Feishu keeps the next permission locked when confirmation delivery fails",
   assert.match(sent.find((message) => message.text.includes("工具 write_file 需要权限"))?.text ?? "", /write_file/);
 });
 
+test("Feishu reports explicit sender failures as undelivered", async () => {
+  const channel = new FeishuChannel({
+    connectionMode: "webhook",
+    send: async () => {
+      throw new Error("send unavailable");
+    },
+  });
+
+  assert.equal(await (channel as any).send({ chatId: "oc_send_failure", text: "permission prompt" }), false);
+});
+
 function createMockResponse(): { statusCode?: number; body?: string; writeHead(statusCode: number): void; end(body: string): void } {
   return {
     writeHead(statusCode: number) {

--- a/tests/adapters/feishu-permission-reply.spec.ts
+++ b/tests/adapters/feishu-permission-reply.spec.ts
@@ -44,6 +44,8 @@ test("Feishu handles permission replies before the active chat drain finishes", 
     toolName: "read_file",
     payload: { file_path: "/tmp/a.txt" },
   });
+  (channel as any).permissions.confirmInitialPrompt(chatId);
+  await delay(10);
   (channel as any).inboundBatches.set(chatId, { messages: [], draining: true });
 
   const response = createMockResponse();
@@ -60,6 +62,186 @@ test("Feishu handles permission replies before the active chat drain finishes", 
   ]);
   assert.deepEqual(sent, [{ chatId, text: "已允许一次，继续执行。" }]);
   assert.deepEqual((channel as any).inboundBatches.get(chatId), { messages: [], draining: true });
+});
+
+test("Feishu sends permission prompts in FIFO order", async () => {
+  const chatId = "oc_batch";
+  const sent: Array<{ chatId: string; text: string }> = [];
+  const decisions: string[] = [];
+  let releaseTurn!: () => void;
+  const turnReleased = new Promise<void>((resolve) => { releaseTurn = resolve; });
+  const gateway = {
+    submitTurn: async function* () {
+      yield { type: "turn_started", runId: "run-batch" };
+      yield {
+        type: "permission_request",
+        requestId: "request-1",
+        toolName: "read_file",
+        payload: { file_path: "/tmp/a.txt" },
+      };
+      yield {
+        type: "permission_request",
+        requestId: "request-2",
+        toolName: "glob",
+        payload: { pattern: "**/*.pptx" },
+      };
+      await turnReleased;
+      yield { type: "turn_completed", usage: {}, finishReason: "completed" };
+    },
+    permissionDecide: async (input: { requestId: string }) => {
+      decisions.push(input.requestId);
+      if (decisions.length === 2) releaseTurn();
+      return { delivered: true };
+    },
+  } as unknown as Gateway;
+  const channel = new FeishuChannel({
+    connectionMode: "webhook",
+    send: async (message) => { sent.push(message); },
+  });
+  await channel.start({ gateway, logger: {} });
+
+  const response = createMockResponse();
+  await channel.handleWebhook(
+    {} as IncomingMessage,
+    response as unknown as ServerResponse,
+    JSON.stringify({ chatId, text: "run", eventId: "run-1" }),
+  );
+  await delay(50);
+
+  assert.equal(sent.length, 1);
+  assert.match(sent[0]?.text ?? "", /工具 read_file 需要权限/);
+
+  await channel.handleWebhook(
+    {} as IncomingMessage,
+    response as unknown as ServerResponse,
+    JSON.stringify({ chatId, text: "1", eventId: "reply-1" }),
+  );
+  await delay(50);
+  assert.deepEqual(decisions, ["request-1"]);
+  assert.equal(sent.length, 3);
+  assert.match(sent[2]?.text ?? "", /工具 glob 需要权限/);
+
+  await channel.handleWebhook(
+    {} as IncomingMessage,
+    response as unknown as ServerResponse,
+    JSON.stringify({ chatId, text: "1", eventId: "reply-2" }),
+  );
+  await delay(50);
+  assert.deepEqual(decisions, ["request-1", "request-2"]);
+});
+
+test("Feishu does not decide replies before the initial permission prompt is confirmed", async () => {
+  const chatId = "oc_duplicate_reply";
+  const sent: Array<{ chatId: string; text: string }> = [];
+  const decisions: string[] = [];
+  let releaseDecision!: () => void;
+  const decisionGate = new Promise<void>((resolve) => { releaseDecision = resolve; });
+  let resolvePermissionShown!: () => void;
+  const permissionShown = new Promise<void>((resolve) => { resolvePermissionShown = resolve; });
+  let turnCount = 0;
+  const gateway = {
+    submitTurn: async function* () {
+      turnCount += 1;
+      yield { type: "turn_started", runId: `run-${turnCount}` };
+      resolvePermissionShown();
+      yield {
+        type: "permission_request",
+        requestId: "request-duplicate",
+        toolName: "bash",
+        payload: { command: "ls -l /tmp" },
+      };
+      yield { type: "turn_completed", usage: {}, finishReason: "completed" };
+    },
+    permissionDecide: async (input: { requestId: string }) => {
+      decisions.push(input.requestId);
+      await decisionGate;
+      return { delivered: true };
+    },
+  } as unknown as Gateway;
+  const channel = new FeishuChannel({
+    connectionMode: "webhook",
+    send: async (message) => { sent.push(message); },
+  });
+  await channel.start({ gateway, logger: {} });
+
+  const response = createMockResponse();
+  await channel.handleWebhook(
+    {} as IncomingMessage,
+    response as unknown as ServerResponse,
+    JSON.stringify({ chatId, text: "run", eventId: "run-duplicate" }),
+  );
+  await withTimeout(permissionShown, 1_000);
+  while (!sent.some((message) => message.text.includes("工具 bash 需要权限"))) await delay(5);
+  (channel as any).permissions.confirmInitialPrompt(chatId);
+  await channel.handleWebhook(
+    {} as IncomingMessage,
+    response as unknown as ServerResponse,
+    JSON.stringify({ chatId, text: "1", eventId: "reply-duplicate-1" }),
+  );
+  await delay(20);
+  await channel.handleWebhook(
+    {} as IncomingMessage,
+    response as unknown as ServerResponse,
+    JSON.stringify({ chatId, text: "1", eventId: "reply-duplicate-2" }),
+  );
+  await delay(20);
+  await channel.handleWebhook(
+    {} as IncomingMessage,
+    response as unknown as ServerResponse,
+    JSON.stringify({ chatId, text: "1", eventId: "reply-duplicate-3" }),
+  );
+  await delay(50);
+
+  assert.deepEqual(decisions, []);
+  assert.ok(turnCount >= 1);
+  assert.equal(sent.filter((message) => message.text.includes("已允许一次")).length, 0);
+});
+
+test("Feishu keeps the next permission locked when confirmation delivery fails", async () => {
+  const chatId = "oc_send_failure";
+  const sent: Array<{ chatId: string; text: string }> = [];
+  const decisions: string[] = [];
+  let sendCount = 0;
+  const gateway = {
+    permissionDecide: async ({ requestId }: { requestId: string }) => {
+      decisions.push(requestId);
+      return { delivered: true };
+    },
+  } as unknown as Gateway;
+  const channel = new FeishuChannel({
+    connectionMode: "webhook",
+    send: async (message) => {
+      sendCount += 1;
+      if (sendCount === 1) throw new Error("send unavailable");
+      sent.push(message);
+    },
+  });
+  await channel.start({ gateway, logger: {} });
+
+  (channel as any).permissions.capture(chatId, "session-1", {
+    type: "permission_request", requestId: "request-1", toolName: "read_file", payload: {},
+  });
+  (channel as any).permissions.confirmInitialPrompt(chatId);
+  (channel as any).permissions.capture(chatId, "session-1", {
+    type: "permission_request", requestId: "request-2", toolName: "write_file", payload: {},
+  });
+
+  const response = createMockResponse();
+  await channel.handleWebhook(
+    {} as IncomingMessage,
+    response as unknown as ServerResponse,
+    JSON.stringify({ chatId, text: "1", eventId: "reply-send-failure-1" }),
+  );
+  await delay(20);
+  await channel.handleWebhook(
+    {} as IncomingMessage,
+    response as unknown as ServerResponse,
+    JSON.stringify({ chatId, text: "1", eventId: "reply-send-failure-2" }),
+  );
+  await delay(20);
+
+  assert.deepEqual(decisions, ["request-1"]);
+  assert.match(sent.find((message) => message.text.includes("工具 write_file 需要权限"))?.text ?? "", /write_file/);
 });
 
 function createMockResponse(): { statusCode?: number; body?: string; writeHead(statusCode: number): void; end(body: string): void } {
@@ -85,4 +267,8 @@ async function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T
   } finally {
     if (timer) clearTimeout(timer);
   }
+}
+
+async function delay(timeoutMs: number): Promise<void> {
+  await new Promise<void>((resolve) => setTimeout(resolve, timeoutMs));
 }

--- a/tests/adapters/im-permission-delivery.spec.ts
+++ b/tests/adapters/im-permission-delivery.spec.ts
@@ -1,0 +1,29 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { MattermostChannel } from "../../src/adapters/channel/mattermost/MattermostChannel.js";
+import { SlackChannel } from "../../src/adapters/channel/slack/SlackChannel.js";
+
+test("Mattermost reports failed permission prompt delivery", async () => {
+  const channel = new MattermostChannel();
+  (channel as any).rest = async () => {
+    throw new Error("post unavailable");
+  };
+
+  assert.equal(await (channel as any).sendReply({ channelId: "channel-1" }, "permission prompt"), false);
+});
+
+test("Slack reports failed permission prompt delivery", async () => {
+  const channel = new SlackChannel();
+  (channel as any).app = {
+    client: {
+      chat: {
+        postMessage: async () => {
+          throw new Error("post unavailable");
+        },
+      },
+    },
+  };
+
+  assert.equal(await (channel as any).sendReply({ channelId: "channel-1" }, "permission prompt"), false);
+});

--- a/tests/adapters/im-permission-delivery.spec.ts
+++ b/tests/adapters/im-permission-delivery.spec.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 
 import { MattermostChannel } from "../../src/adapters/channel/mattermost/MattermostChannel.js";
 import { SlackChannel } from "../../src/adapters/channel/slack/SlackChannel.js";
+import { HomeAssistantChannel } from "../../src/adapters/channel/homeassistant/HomeAssistantChannel.js";
 
 test("Mattermost reports failed permission prompt delivery", async () => {
   const channel = new MattermostChannel();
@@ -26,4 +27,16 @@ test("Slack reports failed permission prompt delivery", async () => {
   };
 
   assert.equal(await (channel as any).sendReply({ channelId: "channel-1" }, "permission prompt"), false);
+});
+
+test("Home Assistant reports failed permission prompt delivery", async () => {
+  const channel = new HomeAssistantChannel();
+  (channel as any).ws = {
+    readyState: 1,
+    send: () => {
+      throw new Error("socket closed");
+    },
+  };
+
+  assert.equal(await (channel as any).sendReply("conversation.chat", "permission prompt"), false);
 });

--- a/tests/adapters/im-permission-delivery.spec.ts
+++ b/tests/adapters/im-permission-delivery.spec.ts
@@ -40,3 +40,26 @@ test("Home Assistant reports failed permission prompt delivery", async () => {
 
   assert.equal(await (channel as any).sendReply("conversation.chat", "permission prompt"), false);
 });
+
+test("Home Assistant waits for the service result before confirming delivery", async () => {
+  const channel = new HomeAssistantChannel();
+  let sentId: number | undefined;
+  (channel as any).ws = {
+    readyState: 1,
+    send: (raw: string) => {
+      sentId = JSON.parse(raw).id;
+    },
+  };
+
+  const delivery = (channel as any).sendReply("conversation.chat", "permission prompt");
+  await Promise.resolve();
+  assert.ok(sentId !== undefined);
+  const result = (channel as any).onRawMessage(JSON.stringify({
+    type: "result",
+    id: sentId,
+    success: false,
+    error: { code: "service_not_found" },
+  }));
+  await result;
+  assert.equal(await delivery, false);
+});

--- a/tests/adapters/im-permission-helper.spec.ts
+++ b/tests/adapters/im-permission-helper.spec.ts
@@ -57,6 +57,7 @@ test("ImPermissionHelper resolves pending permission requests in FIFO order", as
     { sessionKey: "session-1", requestId: "request-1", decision: "allow", remember: false },
     { sessionKey: "session-1", requestId: "request-2", decision: "deny", reason: "User denied permission from IM channel." },
   ]);
+  assert.equal(helper.takeNextPrompt("chat-1"), undefined);
   assert.equal(helper.hasPending("chat-1"), false);
 });
 
@@ -382,13 +383,13 @@ test("ImPermissionHelper restores the current request when permissionDecide fail
   assert.match(helper.takeNextPrompt("chat-1") ?? "", /write_file/);
 });
 
-test("ImPermissionHelper restores the current request when permissionDecide is not delivered", async () => {
+test("ImPermissionHelper drops stale requests when permissionDecide is not delivered", async () => {
   const helper = new ImPermissionHelper();
   const decisions: string[] = [];
   const gateway = {
     permissionDecide: async ({ requestId }: { requestId: string }) => {
       decisions.push(requestId);
-      return { delivered: false };
+      return { delivered: requestId !== "request-1" };
     },
   } as unknown as Gateway;
 
@@ -403,13 +404,34 @@ test("ImPermissionHelper restores the current request when permissionDecide is n
   const result = await helper.answerWithState("chat-1", "1", gateway);
   assert.equal(result?.canAdvance, false);
   assert.equal(result?.retryPrompt, true);
-  assert.match(result?.text ?? "", /未送达|重试/);
+  assert.match(result?.text ?? "", /失效|跳过/);
   assert.equal(helper.isAnswering("chat-1"), true);
 
-  const retryPrompt = helper.takeNextPrompt("chat-1");
-  assert.match(retryPrompt ?? "", /read_file/);
-  assert.doesNotMatch(retryPrompt ?? "", /write_file/);
+  const nextPrompt = helper.takeNextPrompt("chat-1");
+  assert.match(nextPrompt ?? "", /write_file/);
+  assert.doesNotMatch(nextPrompt ?? "", /read_file/);
   assert.deepEqual(decisions, ["request-1"]);
+  helper.confirmNextPrompt("chat-1", true, "request-2");
+  assert.equal(await helper.answerWithState("chat-1", "1", gateway).then((next) => next?.canAdvance), true);
+  assert.deepEqual(decisions, ["request-1", "request-2"]);
+  assert.equal(helper.takeNextPrompt("chat-1"), undefined);
+});
+
+test("ImPermissionHelper keeps the final answer locked until delivery is confirmed", async () => {
+  const helper = new ImPermissionHelper();
+  const gateway = { permissionDecide: async () => ({ delivered: true }) } as unknown as Gateway;
+  helper.capture("chat-1", "session-1", {
+    type: "permission_request", requestId: "request-1", toolName: "read_file", payload: {},
+  });
+  helper.confirmInitialPrompt("chat-1");
+
+  const answer = await helper.answerWithState("chat-1", "1", gateway);
+  assert.equal(answer?.canAdvance, true);
+  assert.equal(helper.isAnswering("chat-1"), true);
+  assert.equal(await helper.answerWithState("chat-1", "1", gateway), undefined);
+
+  assert.equal(helper.takeNextPrompt("chat-1"), undefined);
+  assert.equal(helper.isAnswering("chat-1"), false);
 });
 
 test("ImPermissionHelper queues permission requests captured during a decision", async () => {
@@ -462,6 +484,7 @@ test("ImPermissionHelper keeps new state intact when an old answer finishes afte
   const newAnswer = helper.answer("chat-1", "1", gateway);
 
   assert.equal(await newAnswer, "已允许一次，继续执行。");
+  assert.equal(helper.takeNextPrompt("chat-1"), undefined);
   assert.equal(helper.hasPending("chat-1"), false);
   releaseOld();
   assert.equal(await oldAnswer, undefined);

--- a/tests/adapters/im-permission-helper.spec.ts
+++ b/tests/adapters/im-permission-helper.spec.ts
@@ -382,6 +382,36 @@ test("ImPermissionHelper restores the current request when permissionDecide fail
   assert.match(helper.takeNextPrompt("chat-1") ?? "", /write_file/);
 });
 
+test("ImPermissionHelper restores the current request when permissionDecide is not delivered", async () => {
+  const helper = new ImPermissionHelper();
+  const decisions: string[] = [];
+  const gateway = {
+    permissionDecide: async ({ requestId }: { requestId: string }) => {
+      decisions.push(requestId);
+      return { delivered: false };
+    },
+  } as unknown as Gateway;
+
+  helper.capture("chat-1", "session-1", {
+    type: "permission_request", requestId: "request-1", toolName: "read_file", payload: {},
+  });
+  helper.confirmInitialPrompt("chat-1");
+  helper.capture("chat-1", "session-1", {
+    type: "permission_request", requestId: "request-2", toolName: "write_file", payload: {},
+  });
+
+  const result = await helper.answerWithState("chat-1", "1", gateway);
+  assert.equal(result?.canAdvance, false);
+  assert.equal(result?.retryPrompt, true);
+  assert.match(result?.text ?? "", /未送达|重试/);
+  assert.equal(helper.isAnswering("chat-1"), true);
+
+  const retryPrompt = helper.takeNextPrompt("chat-1");
+  assert.match(retryPrompt ?? "", /read_file/);
+  assert.doesNotMatch(retryPrompt ?? "", /write_file/);
+  assert.deepEqual(decisions, ["request-1"]);
+});
+
 test("ImPermissionHelper queues permission requests captured during a decision", async () => {
   const helper = new ImPermissionHelper();
   let release!: () => void;

--- a/tests/adapters/im-permission-helper.spec.ts
+++ b/tests/adapters/im-permission-helper.spec.ts
@@ -536,6 +536,46 @@ test("ImPermissionHelper keeps queued requests when cleanup is deferred before n
   assert.equal(await helper.answerWithState("chat-1", "0", gateway).then((result) => result?.canAdvance), true);
 });
 
+test("ImPermissionHelper defers turn cleanup while permission decision is in flight", async () => {
+  const helper = new ImPermissionHelper();
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => { release = resolve; });
+  const gateway = {
+    permissionDecide: async () => {
+      await gate;
+      return { delivered: true };
+    },
+  } as unknown as Gateway;
+  helper.capture("chat-1", "session-1", {
+    type: "permission_request", requestId: "request-1", toolName: "read_file", payload: {},
+  });
+  helper.confirmInitialPrompt("chat-1");
+  const answer = helper.answerWithState("chat-1", "1", gateway);
+  helper.clearAfterTurn("chat-1");
+  release();
+
+  const result = await answer;
+  assert.equal(result?.canAdvance, true);
+  assert.equal(helper.isAnswering("chat-1"), true);
+  assert.equal(helper.takeNextPrompt("chat-1", result?.answerToken), undefined);
+  assert.equal(helper.isAnswering("chat-1"), false);
+});
+
+test("ImPermissionHelper preserves an initial prompt retry across turn cleanup", async () => {
+  const helper = new ImPermissionHelper();
+  const gateway = { permissionDecide: async () => ({ delivered: true }) } as unknown as Gateway;
+  helper.capture("chat-1", "session-1", {
+    type: "permission_request", requestId: "request-1", toolName: "read_file", payload: {},
+  });
+  helper.confirmInitialPrompt("chat-1", false);
+  helper.clearAfterTurn("chat-1");
+
+  assert.equal((await helper.answerWithState("chat-1", "1", gateway))?.retryPrompt, true);
+  assert.match(helper.takeNextPrompt("chat-1") ?? "", /read_file/);
+  helper.confirmNextPrompt("chat-1", true, "request-1");
+  assert.equal((await helper.answerWithState("chat-1", "1", gateway))?.canAdvance, true);
+});
+
 test("ImPermissionHelper keeps new state intact when an old answer finishes after clear", async () => {
   const helper = new ImPermissionHelper();
   let releaseOld!: () => void;

--- a/tests/adapters/im-permission-helper.spec.ts
+++ b/tests/adapters/im-permission-helper.spec.ts
@@ -517,6 +517,25 @@ test("ImPermissionHelper defers turn cleanup until the answer is delivered", asy
   assert.equal(helper.hasPending("chat-1"), false);
 });
 
+test("ImPermissionHelper keeps queued requests when cleanup is deferred before next prompt delivery", async () => {
+  const helper = new ImPermissionHelper();
+  const gateway = { permissionDecide: async () => ({ delivered: true }) } as unknown as Gateway;
+  helper.capture("chat-1", "session-1", {
+    type: "permission_request", requestId: "request-1", toolName: "read_file", payload: {},
+  });
+  helper.confirmInitialPrompt("chat-1");
+  helper.capture("chat-1", "session-1", {
+    type: "permission_request", requestId: "request-2", toolName: "write_file", payload: {},
+  });
+  const answer = await helper.answerWithState("chat-1", "1", gateway);
+  helper.clearAfterTurn("chat-1");
+
+  assert.match(helper.takeNextPrompt("chat-1", answer?.answerToken) ?? "", /write_file/);
+  helper.confirmNextPrompt("chat-1", true, "request-2", answer?.answerToken);
+  assert.equal(helper.hasPending("chat-1"), true);
+  assert.equal(await helper.answerWithState("chat-1", "0", gateway).then((result) => result?.canAdvance), true);
+});
+
 test("ImPermissionHelper keeps new state intact when an old answer finishes after clear", async () => {
   const helper = new ImPermissionHelper();
   let releaseOld!: () => void;

--- a/tests/adapters/im-permission-helper.spec.ts
+++ b/tests/adapters/im-permission-helper.spec.ts
@@ -4,7 +4,7 @@ import assert from "node:assert/strict";
 import { ImPermissionHelper } from "../../src/adapters/channel/protocol/ImPermissionHelper.js";
 import type { Gateway } from "../../src/gateway/index.js";
 
-test("ImPermissionHelper resolves all pending permission requests for a chat", async () => {
+test("ImPermissionHelper resolves pending permission requests in FIFO order", async () => {
   const helper = new ImPermissionHelper();
   const decisions: Array<{
     sessionKey: string;
@@ -36,22 +36,26 @@ test("ImPermissionHelper resolves all pending permission requests for a chat", a
     toolName: "read_file",
     payload: { file_path: "/tmp/b.txt" },
   });
+  helper.confirmInitialPrompt("chat-1");
 
   assert.match(first ?? "", /工具 read_file 需要权限/);
   assert.match(first ?? "", /\/tmp\/a\.txt/);
-  assert.match(second ?? "", /2 个工具权限请求|2 个工具权限/);
-  assert.match(second ?? "", /请求 1: 工具 read_file/);
-  assert.match(second ?? "", /\/tmp\/a\.txt/);
-  assert.match(second ?? "", /请求 2: 工具 read_file/);
-  assert.match(second ?? "", /\/tmp\/b\.txt/);
+  assert.equal(second, undefined);
   assert.equal(helper.hasPending("chat-1"), true);
 
   const confirmation = await helper.answer("chat-1", "1", gateway);
 
-  assert.equal(confirmation, "已允许 2 个待处理权限请求一次，继续执行。");
+  assert.equal(confirmation, "已允许一次，继续执行。");
   assert.deepEqual(decisions, [
     { sessionKey: "session-1", requestId: "request-1", decision: "allow", remember: false },
-    { sessionKey: "session-1", requestId: "request-2", decision: "allow", remember: false },
+  ]);
+  assert.equal(helper.hasPending("chat-1"), true);
+  assert.match(helper.takeNextPrompt("chat-1") ?? "", /\/tmp\/b\.txt/);
+  helper.confirmNextPrompt("chat-1");
+  assert.equal(await helper.answer("chat-1", "0", gateway), "已拒绝，继续处理。");
+  assert.deepEqual(decisions, [
+    { sessionKey: "session-1", requestId: "request-1", decision: "allow", remember: false },
+    { sessionKey: "session-1", requestId: "request-2", decision: "deny", reason: "User denied permission from IM channel." },
   ]);
   assert.equal(helper.hasPending("chat-1"), false);
 });
@@ -68,9 +72,370 @@ test("ImPermissionHelper keeps pending requests when the reply is invalid", asyn
     toolName: "read_file",
     payload: { file_path: "/tmp/a.txt" },
   });
+  helper.confirmInitialPrompt("chat-1");
 
   const confirmation = await helper.answer("chat-1", "maybe", gateway);
 
   assert.equal(confirmation, "请回复 1 允许一次，回复 2 允许本会话，回复 0 拒绝。");
   assert.equal(helper.hasPending("chat-1"), true);
+});
+
+test("ImPermissionHelper retries an undelivered initial prompt before accepting a reply", async () => {
+  const helper = new ImPermissionHelper();
+  const decisions: string[] = [];
+  const gateway = {
+    permissionDecide: async ({ requestId }: { requestId: string }) => {
+      decisions.push(requestId);
+      return { delivered: true };
+    },
+  } as unknown as Gateway;
+
+  const prompt = helper.capture("chat-1", "session-1", {
+    type: "permission_request", requestId: "request-1", toolName: "read_file", payload: {},
+  });
+  assert.match(prompt ?? "", /read_file/);
+  assert.equal(await helper.answer("chat-1", "1", gateway), "权限提示发送中，请稍候。");
+  helper.confirmInitialPrompt("chat-1", false);
+  assert.equal(await helper.answer("chat-1", "1", gateway), "上一条权限提示发送失败，正在重试。");
+  assert.match(helper.takeNextPrompt("chat-1") ?? "", /read_file/);
+  helper.confirmNextPrompt("chat-1", true);
+  assert.equal(await helper.answer("chat-1", "1", gateway), "已允许一次，继续执行。");
+  assert.deepEqual(decisions, ["request-1"]);
+});
+
+test("ImPermissionHelper does not advance on status replies during prompt delivery", async () => {
+  const helper = new ImPermissionHelper();
+  const gateway = { permissionDecide: async () => ({ delivered: true }) } as unknown as Gateway;
+  helper.capture("chat-1", "session-1", {
+    type: "permission_request", requestId: "request-1", toolName: "read_file", payload: {},
+  });
+
+  assert.equal(await helper.answer("chat-1", "1", gateway), "权限提示发送中，请稍候。");
+  assert.equal(helper.takeNextPrompt("chat-1"), undefined);
+  assert.equal(helper.isAnswering("chat-1"), true);
+});
+
+test("ImPermissionHelper ignores concurrent replies while a decision is in flight", async () => {
+  const helper = new ImPermissionHelper();
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => { release = resolve; });
+  const decisions: string[] = [];
+  const gateway = {
+    permissionDecide: async ({ requestId }: { requestId: string }) => {
+      decisions.push(requestId);
+      await gate;
+      return { delivered: true };
+    },
+  } as unknown as Gateway;
+  helper.capture("chat-1", "session-1", { type: "permission_request", requestId: "request-1", toolName: "read_file", payload: {} });
+  helper.capture("chat-1", "session-1", { type: "permission_request", requestId: "request-2", toolName: "write_file", payload: {} });
+  helper.confirmInitialPrompt("chat-1");
+  const first = helper.answer("chat-1", "1", gateway);
+  assert.equal(helper.hasPending("chat-1"), true);
+  assert.equal(await helper.answer("chat-1", "1", gateway), "权限决定处理中，请稍候。");
+  release();
+  assert.equal(await first, "已允许一次，继续执行。");
+  assert.deepEqual(decisions, ["request-1"]);
+  assert.equal(await helper.answer("chat-1", "1", gateway), undefined);
+  assert.match(helper.takeNextPrompt("chat-1") ?? "", /write_file/);
+  helper.confirmNextPrompt("chat-1");
+});
+
+test("ImPermissionHelper marks an in-flight status reply as non-advancing after completion", async () => {
+  const helper = new ImPermissionHelper();
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => { release = resolve; });
+  const gateway = {
+    permissionDecide: async () => {
+      await gate;
+      return { delivered: true };
+    },
+  } as unknown as Gateway;
+  helper.capture("chat-1", "session-1", {
+    type: "permission_request", requestId: "request-1", toolName: "read_file", payload: {},
+  });
+  helper.confirmInitialPrompt("chat-1");
+  helper.capture("chat-1", "session-1", {
+    type: "permission_request", requestId: "request-2", toolName: "write_file", payload: {},
+  });
+
+  const first = helper.answerWithState("chat-1", "1", gateway);
+  const duplicate = await helper.answerWithState("chat-1", "1", gateway);
+  assert.equal(duplicate?.canAdvance, false);
+  release();
+  assert.equal((await first)?.canAdvance, true);
+  assert.equal(duplicate?.text, "权限决定处理中，请稍候。");
+});
+
+test("ImPermissionHelper does not let a duplicate reply consume the answering lock", async () => {
+  const helper = new ImPermissionHelper();
+  const decisions: string[] = [];
+  const gateway = {
+    permissionDecide: async ({ requestId }: { requestId: string }) => {
+      decisions.push(requestId);
+      return { delivered: true };
+    },
+  } as unknown as Gateway;
+
+  helper.capture("chat-1", "session-1", {
+    type: "permission_request", requestId: "request-1", toolName: "read_file", payload: {},
+  });
+  helper.confirmInitialPrompt("chat-1");
+  helper.capture("chat-1", "session-1", {
+    type: "permission_request", requestId: "request-2", toolName: "write_file", payload: {},
+  });
+  helper.confirmInitialPrompt("chat-1");
+
+  assert.equal(await helper.answer("chat-1", "1", gateway), "已允许一次，继续执行。");
+  assert.equal(await helper.answer("chat-1", "1", gateway), undefined);
+  assert.equal(await helper.answer("chat-1", "1", gateway), undefined);
+  assert.deepEqual(decisions, ["request-1"]);
+
+  assert.match(helper.takeNextPrompt("chat-1") ?? "", /write_file/);
+  helper.confirmNextPrompt("chat-1");
+  assert.equal(await helper.answer("chat-1", "1", gateway), "已允许一次，继续执行。");
+  assert.deepEqual(decisions, ["request-1", "request-2"]);
+});
+
+test("ImPermissionHelper can recover when an adapter cannot deliver confirmation", async () => {
+  const helper = new ImPermissionHelper();
+  const gateway = { permissionDecide: async () => ({ delivered: true }) } as unknown as Gateway;
+  helper.capture("chat-1", "session-1", {
+    type: "permission_request", requestId: "request-1", toolName: "read_file", payload: {},
+  });
+  helper.confirmInitialPrompt("chat-1");
+  helper.capture("chat-1", "session-1", {
+    type: "permission_request", requestId: "request-2", toolName: "write_file", payload: {},
+  });
+
+  assert.equal(await helper.answer("chat-1", "1", gateway), "已允许一次，继续执行。");
+  assert.equal(helper.isAnswering("chat-1"), true);
+  helper.releaseAnswer("chat-1");
+  assert.equal(helper.isAnswering("chat-1"), true);
+  assert.equal(await helper.answer("chat-1", "1", gateway), "上一条权限提示发送失败，正在重试。");
+  assert.match(helper.takeNextPrompt("chat-1") ?? "", /write_file/);
+  helper.confirmNextPrompt("chat-1");
+  assert.equal(helper.isAnswering("chat-1"), false);
+  assert.equal(await helper.answer("chat-1", "1", gateway), "已允许一次，继续执行。");
+});
+
+test("ImPermissionHelper ignores stale prompt delivery callbacks after chat reuse", async () => {
+  const helper = new ImPermissionHelper();
+  const gateway = { permissionDecide: async () => ({ delivered: true }) } as unknown as Gateway;
+
+  const oldPrompt = helper.capture("chat-1", "session-1", {
+    type: "permission_request", requestId: "old", toolName: "read_file", payload: { path: "old" },
+  });
+  assert.ok(oldPrompt);
+  helper.clear("chat-1");
+
+  const newPrompt = helper.capture("chat-1", "session-2", {
+    type: "permission_request", requestId: "new", toolName: "write_file", payload: { path: "new" },
+  });
+  assert.ok(newPrompt);
+  helper.confirmInitialPrompt("chat-1", true, "old");
+  assert.equal(helper.isAnswering("chat-1"), true);
+  assert.equal(await helper.answer("chat-1", "1", gateway), "权限提示发送中，请稍候。");
+  helper.confirmInitialPrompt("chat-1", true, "new");
+  assert.equal(await helper.answer("chat-1", "1", gateway), "已允许一次，继续执行。");
+});
+
+test("ImPermissionHelper uses requestId when identical prompts are reused", async () => {
+  const helper = new ImPermissionHelper();
+  const gateway = { permissionDecide: async () => ({ delivered: true }) } as unknown as Gateway;
+  const oldPrompt = helper.capture("chat-1", "session-1", {
+    type: "permission_request", requestId: "old-request", toolName: "read_file", payload: { path: "/tmp/same" },
+  });
+  helper.clear("chat-1");
+  const newPrompt = helper.capture("chat-1", "session-2", {
+    type: "permission_request", requestId: "new-request", toolName: "read_file", payload: { path: "/tmp/same" },
+  });
+  assert.equal(oldPrompt, newPrompt);
+
+  helper.confirmInitialPrompt("chat-1", true, "old-request");
+  assert.equal(helper.isAnswering("chat-1"), true);
+  assert.equal(await helper.answer("chat-1", "1", gateway), "权限提示发送中，请稍候。");
+  helper.confirmInitialPrompt("chat-1", true, "new-request");
+  assert.equal(await helper.answer("chat-1", "1", gateway), "已允许一次，继续执行。");
+});
+
+test("ImPermissionHelper ignores stale next-prompt callbacks and answer releases", async () => {
+  const helper = new ImPermissionHelper();
+  const gateway = { permissionDecide: async () => ({ delivered: true }) } as unknown as Gateway;
+
+  const first = helper.capture("chat-1", "session-1", {
+    type: "permission_request", requestId: "first", toolName: "read_file", payload: {},
+  });
+  helper.confirmInitialPrompt("chat-1", true, "first");
+  helper.capture("chat-1", "session-1", {
+    type: "permission_request", requestId: "second", toolName: "write_file", payload: {},
+  });
+  const answer = await helper.answerWithState("chat-1", "1", gateway);
+  assert.equal(answer?.canAdvance, true);
+  const nextPrompt = helper.takeNextPrompt("chat-1");
+  assert.ok(nextPrompt);
+  helper.confirmNextPrompt("chat-1", true, "stale-request");
+  assert.equal(helper.isAnswering("chat-1"), true);
+  helper.clear("chat-1");
+
+  const replacement = helper.capture("chat-1", "session-2", {
+    type: "permission_request", requestId: "replacement", toolName: "exec", payload: {},
+  });
+  assert.ok(replacement);
+  helper.confirmNextPrompt("chat-1", true, "second");
+  helper.releaseAnswer("chat-1", answer?.answerToken);
+  assert.equal(await helper.answer("chat-1", "1", gateway), "权限提示发送中，请稍候。");
+  helper.confirmInitialPrompt("chat-1", true, "replacement");
+  assert.equal(await helper.answer("chat-1", "1", gateway), "已允许一次，继续执行。");
+});
+
+test("ImPermissionHelper does not let an old release unlock a replacement decision", async () => {
+  const helper = new ImPermissionHelper();
+  let releaseNew!: () => void;
+  const newGate = new Promise<void>((resolve) => { releaseNew = resolve; });
+  let calls = 0;
+  const gateway = {
+    permissionDecide: async () => {
+      calls += 1;
+      if (calls === 2) await newGate;
+      return { delivered: true };
+    },
+  } as unknown as Gateway;
+
+  const oldPrompt = helper.capture("chat-1", "session-1", {
+    type: "permission_request", requestId: "old", toolName: "read_file", payload: {},
+  });
+  helper.confirmInitialPrompt("chat-1", true, "old");
+  const oldAnswer = await helper.answerWithState("chat-1", "1", gateway);
+  helper.clear("chat-1");
+
+  const newPrompt = helper.capture("chat-1", "session-2", {
+    type: "permission_request", requestId: "new", toolName: "write_file", payload: {},
+  });
+  helper.confirmInitialPrompt("chat-1", true, "new");
+  const newAnswer = helper.answerWithState("chat-1", "1", gateway);
+  await new Promise((resolve) => setImmediate(resolve));
+  helper.releaseAnswer("chat-1", oldAnswer?.answerToken);
+  assert.equal(await helper.answerWithState("chat-1", "1", gateway).then((result) => result?.text), "权限决定处理中，请稍候。");
+  releaseNew();
+  assert.equal((await newAnswer)?.canAdvance, true);
+});
+
+test("ImPermissionHelper does not resurrect a prompt after clear", async () => {
+  const helper = new ImPermissionHelper();
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => { release = resolve; });
+  const gateway = {
+    permissionDecide: async () => {
+      await gate;
+      return { delivered: true };
+    },
+  } as unknown as Gateway;
+  helper.capture("chat-1", "old-session", {
+    type: "permission_request", requestId: "request-1", toolName: "read_file", payload: {},
+  });
+  helper.confirmInitialPrompt("chat-1");
+  const answer = helper.answer("chat-1", "1", gateway);
+  helper.clear("chat-1");
+  release();
+  assert.equal(await answer, undefined);
+  assert.equal(helper.takeNextPrompt("chat-1"), undefined);
+  assert.equal(helper.hasPending("chat-1"), false);
+  assert.equal((helper as any).generations.size, 0);
+});
+
+test("ImPermissionHelper releases generation state after a completed answer", async () => {
+  const helper = new ImPermissionHelper();
+  const gateway = { permissionDecide: async () => ({ delivered: true }) } as unknown as Gateway;
+  helper.capture("chat-1", "session-1", {
+    type: "permission_request", requestId: "request-1", toolName: "read_file", payload: {},
+  });
+  helper.confirmInitialPrompt("chat-1");
+  await helper.answer("chat-1", "1", gateway);
+  assert.equal((helper as any).generations.size, 0);
+});
+
+test("ImPermissionHelper restores the current request when permissionDecide fails", async () => {
+  const helper = new ImPermissionHelper();
+  let attempts = 0;
+  const gateway = {
+    permissionDecide: async () => {
+      attempts += 1;
+      if (attempts === 1) throw new Error("gateway unavailable");
+      return { delivered: true };
+    },
+  } as unknown as Gateway;
+
+  helper.capture("chat-1", "session-1", {
+    type: "permission_request", requestId: "request-1", toolName: "read_file", payload: {},
+  });
+  helper.confirmInitialPrompt("chat-1");
+  helper.capture("chat-1", "session-1", {
+    type: "permission_request", requestId: "request-2", toolName: "write_file", payload: {},
+  });
+
+  await assert.rejects(helper.answer("chat-1", "1", gateway), /gateway unavailable/);
+  assert.equal(helper.hasPending("chat-1"), true);
+  assert.equal(helper.isAnswering("chat-1"), false);
+  assert.equal(await helper.answer("chat-1", "1", gateway), "已允许一次，继续执行。");
+  assert.equal(attempts, 2);
+  assert.match(helper.takeNextPrompt("chat-1") ?? "", /write_file/);
+});
+
+test("ImPermissionHelper queues permission requests captured during a decision", async () => {
+  const helper = new ImPermissionHelper();
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => { release = resolve; });
+  const gateway = {
+    permissionDecide: async () => {
+      await gate;
+      return { delivered: true };
+    },
+  } as unknown as Gateway;
+
+  assert.match(helper.capture("chat-1", "session-1", {
+    type: "permission_request", requestId: "request-1", toolName: "read_file", payload: {},
+  }) ?? "", /read_file/);
+  helper.confirmInitialPrompt("chat-1");
+  const answer = helper.answer("chat-1", "1", gateway);
+  assert.equal(helper.capture("chat-1", "session-1", {
+    type: "permission_request", requestId: "request-2", toolName: "write_file", payload: {},
+  }), undefined);
+  release();
+  assert.equal(await answer, "已允许一次，继续执行。");
+  assert.match(helper.takeNextPrompt("chat-1") ?? "", /write_file/);
+});
+
+test("ImPermissionHelper keeps new state intact when an old answer finishes after clear", async () => {
+  const helper = new ImPermissionHelper();
+  let releaseOld!: () => void;
+  const oldGate = new Promise<void>((resolve) => { releaseOld = resolve; });
+  const decisions: string[] = [];
+  const gateway = {
+    permissionDecide: async ({ requestId }: { requestId: string }) => {
+      decisions.push(requestId);
+      if (requestId === "old-request") await oldGate;
+      return { delivered: true };
+    },
+  } as unknown as Gateway;
+
+  helper.capture("chat-1", "old-session", {
+    type: "permission_request", requestId: "old-request", toolName: "read_file", payload: {},
+  });
+  helper.confirmInitialPrompt("chat-1");
+  const oldAnswer = helper.answer("chat-1", "1", gateway);
+  helper.clear("chat-1");
+  helper.capture("chat-1", "new-session", {
+    type: "permission_request", requestId: "new-request", toolName: "write_file", payload: {},
+  });
+  helper.confirmInitialPrompt("chat-1");
+  const newAnswer = helper.answer("chat-1", "1", gateway);
+
+  assert.equal(await newAnswer, "已允许一次，继续执行。");
+  assert.equal(helper.hasPending("chat-1"), false);
+  releaseOld();
+  assert.equal(await oldAnswer, undefined);
+  assert.deepEqual(decisions, ["old-request", "new-request"]);
+  assert.equal(helper.isAnswering("chat-1"), false);
+  assert.equal((helper as any).generations.size, 0);
 });

--- a/tests/adapters/im-permission-helper.spec.ts
+++ b/tests/adapters/im-permission-helper.spec.ts
@@ -458,6 +458,65 @@ test("ImPermissionHelper queues permission requests captured during a decision",
   assert.match(helper.takeNextPrompt("chat-1") ?? "", /write_file/);
 });
 
+test("ImPermissionHelper queues a request captured after the final decision RPC", async () => {
+  const helper = new ImPermissionHelper();
+  const gateway = { permissionDecide: async () => ({ delivered: true }) } as unknown as Gateway;
+  helper.capture("chat-1", "session-1", {
+    type: "permission_request", requestId: "request-1", toolName: "read_file", payload: {},
+  });
+  helper.confirmInitialPrompt("chat-1");
+
+  const answer = await helper.answerWithState("chat-1", "1", gateway);
+  assert.ok(answer?.answerToken);
+  helper.capture("chat-1", "session-1", {
+    type: "permission_request", requestId: "request-2", toolName: "write_file", payload: {},
+  });
+
+  assert.match(helper.takeNextPrompt("chat-1", answer.answerToken) ?? "", /write_file/);
+  helper.confirmNextPrompt("chat-1", true, "request-2");
+  assert.equal(helper.isAnswering("chat-1"), false);
+});
+
+test("ImPermissionHelper rejects stale answer tokens when taking a replacement prompt", async () => {
+  const helper = new ImPermissionHelper();
+  const gateway = { permissionDecide: async () => ({ delivered: true }) } as unknown as Gateway;
+  helper.capture("chat-1", "session-1", {
+    type: "permission_request", requestId: "old", toolName: "read_file", payload: {},
+  });
+  helper.confirmInitialPrompt("chat-1");
+  const oldAnswer = await helper.answerWithState("chat-1", "1", gateway);
+  helper.clear("chat-1");
+
+  helper.capture("chat-1", "session-2", {
+    type: "permission_request", requestId: "new", toolName: "write_file", payload: {},
+  });
+  helper.confirmInitialPrompt("chat-1");
+  helper.capture("chat-1", "session-2", {
+    type: "permission_request", requestId: "new-next", toolName: "exec", payload: {},
+  });
+  const newAnswer = await helper.answerWithState("chat-1", "1", gateway);
+  assert.notEqual(oldAnswer?.answerToken, newAnswer?.answerToken);
+
+  assert.equal(helper.takeNextPrompt("chat-1", oldAnswer?.answerToken), undefined);
+  assert.match(helper.takeNextPrompt("chat-1", newAnswer?.answerToken) ?? "", /exec/);
+});
+
+test("ImPermissionHelper defers turn cleanup until the answer is delivered", async () => {
+  const helper = new ImPermissionHelper();
+  const gateway = { permissionDecide: async () => ({ delivered: true }) } as unknown as Gateway;
+  helper.capture("chat-1", "session-1", {
+    type: "permission_request", requestId: "request-1", toolName: "read_file", payload: {},
+  });
+  helper.confirmInitialPrompt("chat-1");
+  const answer = await helper.answerWithState("chat-1", "1", gateway);
+  helper.clearAfterTurn("chat-1");
+
+  assert.equal(helper.isAnswering("chat-1"), true);
+  helper.confirmAnswer("chat-1", answer?.answerToken);
+  assert.equal(helper.isAnswering("chat-1"), false);
+  assert.equal(helper.hasPending("chat-1"), false);
+});
+
 test("ImPermissionHelper keeps new state intact when an old answer finishes after clear", async () => {
   const helper = new ImPermissionHelper();
   let releaseOld!: () => void;

--- a/tests/pilot/config/parseGatewayConfig.spec.ts
+++ b/tests/pilot/config/parseGatewayConfig.spec.ts
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseAdaptersConfig } from "../../../src/pilot/config/parseGatewayConfig.js";
+import type { PilotConfigDiagnostic } from "../../../src/pilot/config/types.js";
+
+test("Feishu permission mode accepts only default and bypassPermissions", () => {
+  const diagnostics: PilotConfigDiagnostic[] = [];
+
+  assert.deepEqual(parseAdaptersConfig({
+    feishu: { enabled: true, permissionMode: "bypassPermissions" },
+  }, diagnostics)?.feishu?.permissionMode, "bypassPermissions");
+  assert.equal(parseAdaptersConfig({
+    feishu: { enabled: true, permissionMode: "plan" },
+  }, diagnostics)?.feishu?.permissionMode, undefined);
+  assert.deepEqual(diagnostics, []);
+});


### PR DESCRIPTION
## Summary

- Extract the IM permission FIFO/serialization fixes from PR #532.
- Handle one permission request per `requestId` across text IM channels.
- Preserve retry state on prompt delivery or permission RPC failures.
- Guard against duplicate replies, stale callbacks, and chat/session reuse.
- Keep Feishu permission mode configuration and IM contract documentation.

## Out of scope

This PR intentionally excludes `assistant_attachment`, Gateway terminal-error changes, media-reference persistence, and Web UI attachment/history changes.

## Tests

- `pnpm exec tsx --test tests/adapters/im-permission-helper.spec.ts tests/adapters/feishu-permission-reply.spec.ts tests/adapters/im-permission-delivery.spec.ts tests/pilot/config/parseGatewayConfig.spec.ts` (24 passed)
- `pnpm exec tsc --noEmit -p tsconfig.json` (passed)
- `git diff --check` (passed)

Environment: Node `v25.5.0`, pnpm `10.32.1`; repository requirement is Node `>=22.13.0 <23`.