### PR TITLE
feat: use bash-preferred command shell

### DIFF
--- a/docs/trd/41-background-task.zh.md
+++ b/docs/trd/41-background-task.zh.md
@@ -1,0 +1,27 @@
+# Background Task TRD
+
+状态：评审中　维护者：Runtime 团队　目标读者：后端、CLI 和测试维护者
+
+## 代码边界
+
+本 TRD 定义 `src/task/runtime/BackgroundTaskRuntime.ts` 与 `src/task/storage/TaskOutputStore.ts` 的后台进程任务边界。它不定义 AgentLoop 的前台工具调用，也不替代 Gateway 的 turn 生命周期。
+
+## 核心契约
+
+- `start` 必须创建唯一 task ID、记录 session/agent 归属并立即返回可查询状态。
+- `list/get/output/wait/stop` 必须对未知 task 返回明确的空结果或错误，不得伪造完成。
+- 任务达到并发上限时必须拒绝新任务；子进程退出只能产生一次 completion。
+- 输出读取按 offset 单调推进，环形缓冲淘汰必须显式返回 `truncated`，磁盘 spill 失败不得使 runtime 崩溃。
+- 本地命令通过共享 shell resolver 启动：Unix 优先 `/bin/bash`，缺失时回退 `/bin/sh`；Windows 优先 Git Bash，缺失时依次回退 `cmd.exe`、PowerShell 7 (`pwsh.exe`)，不使用 Windows PowerShell 5。可用 `PILOTDECK_SHELL_PATH` 显式指定 shell；Windows 非标准 Git Bash 路径可用 `PILOTDECK_GIT_BASH_PATH`。
+
+## 流程与恢复
+
+正常流程为 `created -> running -> completed|failed`。`stop` 先发 graceful signal，超过 grace period 后强制终止并进入 `cancelled`。等待支持 timeout 和 AbortSignal，二者都必须释放监听器。进程重启后的持久化恢复属于延期能力，不得把内存 registry 写成可恢复。
+
+## 测试与证据
+
+源码映射：`src/task/runtime/BackgroundTaskRuntime.ts`、`src/task/storage/TaskOutputStore.ts`、`src/task/protocol/types.ts`。测试映射：`tests/task/background-task-runtime.spec.ts`、`tests/task/task-output-store.spec.ts`、`tests/tool/session-tools-display.spec.ts`。runtime/store 的确定性行覆盖已纳入 `pnpm test:coverage`；测试使用 fake child、受控 stream 和临时 spill 目录，真实 shell 归 `DEFER_EXTERNAL`。CI 归属：根 Node deterministic gate。
+
+## 验收与变更
+
+验收覆盖并发上限、输出截断、spill、完成回调、stop、wait abort 和重复 stop。证据状态：`CURRENT_ONLY`，当前模块行覆盖率门槛已通过；timeout escalation、mutation proof 和 built artifact smoke 仍待补齐。

--- a/src/runtime/commandShell.ts
+++ b/src/runtime/commandShell.ts
@@ -7,6 +7,7 @@ export type CommandShell = {
   shell: string;
   args: (command: string) => string[];
   kind: CommandShellKind;
+  windowsVerbatimArguments: boolean;
 };
 
 export type CommandShellResolverOptions = {
@@ -104,12 +105,22 @@ function bashShell(shell: string): CommandShell {
 
 function shellWithArgs(shell: string, kind: CommandShellKind): CommandShell {
   if (kind === "cmd") {
-    return { shell, kind, args: (command) => ["/d", "/s", "/c", command] };
+    return {
+      shell,
+      kind,
+      args: (command) => ["/d", "/s", "/c", command],
+      windowsVerbatimArguments: true,
+    };
   }
   if (kind === "pwsh") {
-    return { shell, kind, args: (command) => ["-NoLogo", "-NoProfile", "-Command", command] };
+    return {
+      shell,
+      kind,
+      args: (command) => ["-NoLogo", "-NoProfile", "-Command", command],
+      windowsVerbatimArguments: false,
+    };
   }
-  return { shell, kind, args: (command) => ["-c", command] };
+  return { shell, kind, args: (command) => ["-c", command], windowsVerbatimArguments: false };
 }
 
 function findOnPath(

--- a/src/runtime/commandShell.ts
+++ b/src/runtime/commandShell.ts
@@ -1,0 +1,142 @@
+import { existsSync as defaultExistsSync } from "node:fs";
+import { delimiter, join, win32 } from "node:path";
+
+export type CommandShellKind = "bash" | "sh" | "cmd" | "pwsh" | "custom";
+
+export type CommandShell = {
+  shell: string;
+  args: (command: string) => string[];
+  kind: CommandShellKind;
+};
+
+export type CommandShellResolverOptions = {
+  platform?: string;
+  env?: NodeJS.ProcessEnv;
+  existsSync?: (path: string) => boolean;
+  commandAvailable?: (command: string) => boolean;
+};
+
+const DEFAULT_GIT_BASH_PATHS = [
+  "C:\\Program Files\\Git\\bin\\bash.exe",
+  "C:\\Program Files\\Git\\usr\\bin\\bash.exe",
+  "C:\\Program Files (x86)\\Git\\bin\\bash.exe",
+  "C:\\Program Files (x86)\\Git\\usr\\bin\\bash.exe",
+];
+
+const POSIX_BASH_NAMES = new Set(["bash", "bash.exe"]);
+const POSIX_SH_NAMES = new Set(["sh", "sh.exe", "dash", "dash.exe", "ksh", "ksh.exe", "mksh", "mksh.exe"]);
+
+/** Resolve the shell used for agent-authored foreground and background commands. */
+export function resolveDefaultCommandShell(options: CommandShellResolverOptions = {}): CommandShell {
+  const platform = options.platform ?? process.platform;
+  const env = options.env ?? process.env;
+  const existsSync = options.existsSync ?? defaultExistsSync;
+  const commandAvailable = options.commandAvailable
+    ?? ((command: string) => defaultCommandAvailable(command, platform, env, existsSync));
+
+  const configured = env.PILOTDECK_SHELL_PATH;
+  if (configured) {
+    if (!commandAvailable(configured)) {
+      throw new Error(`Configured PilotDeck shell was not found: ${configured}`);
+    }
+    return shellFromPath(configured);
+  }
+
+  if (platform !== "win32") {
+    if (existsSync("/bin/bash")) return bashShell("/bin/bash");
+    const bash = findOnPath("bash", env, platform, existsSync);
+    if (bash) return bashShell(bash);
+    return shellWithArgs("/bin/sh", "sh");
+  }
+
+  const gitBash = resolveWindowsGitBash(env, existsSync);
+  if (gitBash) return bashShell(gitBash);
+
+  const cmd = env.ComSpec || "cmd.exe";
+  if (commandAvailable(cmd)) return shellWithArgs(cmd, "cmd");
+  if (commandAvailable("pwsh.exe")) return shellWithArgs("pwsh.exe", "pwsh");
+
+  throw new Error("No supported PilotDeck command shell found. Install Git Bash, cmd.exe, or PowerShell 7 (pwsh.exe).");
+}
+
+export function resolveWindowsGitBash(
+  env: NodeJS.ProcessEnv = process.env,
+  existsSync: (path: string) => boolean = defaultExistsSync,
+): string | undefined {
+  const candidates = [
+    env.PILOTDECK_GIT_BASH_PATH,
+    env.GIT_BASH_PATH,
+    ...(env.ProgramFiles ? [
+      `${env.ProgramFiles}\\Git\\bin\\bash.exe`,
+      `${env.ProgramFiles}\\Git\\usr\\bin\\bash.exe`,
+    ] : []),
+    ...(env["ProgramFiles(x86)"] ? [
+      `${env["ProgramFiles(x86)"]}\\Git\\bin\\bash.exe`,
+      `${env["ProgramFiles(x86)"]}\\Git\\usr\\bin\\bash.exe`,
+    ] : []),
+    ...(env.LOCALAPPDATA ? [`${env.LOCALAPPDATA}\\Programs\\Git\\bin\\bash.exe`] : []),
+    ...DEFAULT_GIT_BASH_PATHS,
+  ].filter((candidate): candidate is string => Boolean(candidate));
+
+  const seen = new Set<string>();
+  for (const candidate of candidates) {
+    const key = candidate.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    if (existsSync(candidate)) return candidate;
+  }
+
+  return undefined;
+}
+
+function shellFromPath(shell: string): CommandShell {
+  const name = shell.split(/[\\/]/u).at(-1)?.toLowerCase() ?? shell.toLowerCase();
+  if (POSIX_BASH_NAMES.has(name)) return bashShell(shell);
+  if (POSIX_SH_NAMES.has(name)) return shellWithArgs(shell, "sh");
+  if (name === "cmd" || name === "cmd.exe") return shellWithArgs(shell, "cmd");
+  if (name === "pwsh" || name === "pwsh.exe") return shellWithArgs(shell, "pwsh");
+  return shellWithArgs(shell, "custom");
+}
+
+function bashShell(shell: string): CommandShell {
+  return shellWithArgs(shell, "bash");
+}
+
+function shellWithArgs(shell: string, kind: CommandShellKind): CommandShell {
+  if (kind === "cmd") {
+    return { shell, kind, args: (command) => ["/d", "/s", "/c", command] };
+  }
+  if (kind === "pwsh") {
+    return { shell, kind, args: (command) => ["-NoLogo", "-NoProfile", "-Command", command] };
+  }
+  return { shell, kind, args: (command) => ["-c", command] };
+}
+
+function findOnPath(
+  command: string,
+  env: NodeJS.ProcessEnv,
+  platform: string,
+  existsSync: (path: string) => boolean,
+): string | undefined {
+  const pathKey = Object.keys(env).find((key) => key.toLowerCase() === "path");
+  const pathValue = pathKey ? env[pathKey] : undefined;
+  if (!pathValue) return undefined;
+  for (const entry of pathValue.split(platform === "win32" ? ";" : delimiter).filter(Boolean)) {
+    const candidate = platform === "win32" ? win32.join(entry, command) : join(entry, command);
+    if (existsSync(candidate)) return candidate;
+  }
+  return undefined;
+}
+
+function defaultCommandAvailable(
+  command: string,
+  platform: string,
+  env: NodeJS.ProcessEnv,
+  existsSync: (path: string) => boolean,
+): boolean {
+  if (command.includes("/") || command.includes("\\")) return existsSync(command);
+  if (platform === "win32" && command.toLowerCase() === "cmd.exe" && !Object.keys(env).some((key) => key.toLowerCase() === "path")) {
+    return true;
+  }
+  return Boolean(findOnPath(command, env, platform, existsSync));
+}

--- a/src/runtime/commandShell.ts
+++ b/src/runtime/commandShell.ts
@@ -108,7 +108,7 @@ function shellWithArgs(shell: string, kind: CommandShellKind): CommandShell {
     return {
       shell,
       kind,
-      args: (command) => ["/d", "/s", "/c", command],
+      args: (command) => ["/d", "/s", "/c", `"${command}"`],
       windowsVerbatimArguments: true,
     };
   }

--- a/src/task/runtime/BackgroundTaskRuntime.ts
+++ b/src/task/runtime/BackgroundTaskRuntime.ts
@@ -227,6 +227,7 @@ export class BackgroundTaskRuntime {
         env: spec.env,
         stdio: ["ignore", "pipe", "pipe"],
         detached: true,
+        windowsVerbatimArguments: shell.windowsVerbatimArguments,
       });
       child.unref();
     } catch (err) {

--- a/src/task/runtime/BackgroundTaskRuntime.ts
+++ b/src/task/runtime/BackgroundTaskRuntime.ts
@@ -4,8 +4,8 @@
  * LocalShellTask behaviour (T1-T11).
  *
  * Process model:
- *   - `start(spec)` spawns a *detached* child via `spawn(command, { shell:
- *     true, detached: true })` and immediately calls `child.unref()` so the
+ *   - `start(spec)` spawns a *detached* child through the shared
+ *     Bash-preferred command-shell resolver and immediately calls `child.unref()` so the
  *     PilotDeck process can exit without waiting for the child. (T11)
  *   - stdout / stderr are piped into a `TaskOutputStore` (1 MB ring buffer
  *     + optional disk spill). The runtime never blocks on the stream — the
@@ -24,6 +24,7 @@
 import { type ChildProcess, spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { TaskOutputStore } from "../storage/TaskOutputStore.js";
+import { resolveDefaultCommandShell } from "../../runtime/commandShell.js";
 import type {
   PilotDeckBackgroundBashTask,
   PilotDeckBackgroundTaskStatus,
@@ -220,10 +221,10 @@ export class BackgroundTaskRuntime {
 
     let child: ChildProcess;
     try {
-      child = this.options.spawn(spec.command, {
+      const shell = resolveDefaultCommandShell({ env: spec.env });
+      child = this.options.spawn(shell.shell, shell.args(spec.command), {
         cwd: spec.cwd,
         env: spec.env,
-        shell: true,
         stdio: ["ignore", "pipe", "pipe"],
         detached: true,
       });

--- a/src/tool/builtin/bash.ts
+++ b/src/tool/builtin/bash.ts
@@ -40,7 +40,8 @@ export type BashOutput = {
 const BASH_TOOL_DESCRIPTION = `Run a shell command in the PilotDeck workspace.
 
 Usage:
-- The \`command\` parameter is passed to the system shell (\`cmd.exe\` on Windows, \`/bin/sh\` on macOS/Linux).
+- The \`command\` parameter is passed to PilotDeck's resolved command shell (Bash preferred; Unix falls back to \`/bin/sh\`, Windows falls back to \`cmd.exe\` and then PowerShell 7).
+- Set \`PILOTDECK_SHELL_PATH\` to explicitly select a shell executable; on Windows, \`PILOTDECK_GIT_BASH_PATH\` can select a non-standard Git Bash installation.
 - The shell runs in the current workspace directory and inherits the tool runtime environment.
 - Use \`timeout\` to override the command timeout in milliseconds. When omitted, the default is 30000ms. Values above 600000ms are rejected; lower the foreground timeout to 600000 or less, or use task_create followed by task_wait for background work that should finish.
 - Use \`description\` to provide a short, clear label for logs and audits. Prefer 3-10 words that say what the command does.
@@ -87,7 +88,7 @@ export function createBashTool(options?: CreateBashToolOptions): PilotDeckToolDe
       properties: {
         command: {
           type: "string",
-          description: "The shell command to execute (passed to the system shell).",
+          description: "The shell command to execute (passed to PilotDeck's resolved command shell).",
         },
         timeout: {
           type: "integer",

--- a/src/tool/builtin/bash/commandRunner.ts
+++ b/src/tool/builtin/bash/commandRunner.ts
@@ -1,5 +1,6 @@
 import { spawn } from "node:child_process";
 import { TextDecoder } from "node:util";
+import { resolveDefaultCommandShell } from "../../../runtime/commandShell.js";
 
 export type PilotDeckCommandOptions = {
   cwd: string;
@@ -33,10 +34,10 @@ export class NodeShellCommandRunner implements PilotDeckCommandRunner {
     const startedAt = Date.now();
     return new Promise((resolve, reject) => {
       const isWindows = process.platform === "win32";
-      const child = this.spawnShell(command, {
+      const shell = resolveDefaultCommandShell({ env: options.env });
+      const child = this.spawnShell(shell.shell, shell.args(command), {
         cwd: options.cwd,
         env: options.env,
-        shell: true,
         detached: !isWindows,
         windowsHide: isWindows,
         stdio: ["ignore", "pipe", "pipe"],

--- a/src/tool/builtin/bash/commandRunner.ts
+++ b/src/tool/builtin/bash/commandRunner.ts
@@ -40,6 +40,7 @@ export class NodeShellCommandRunner implements PilotDeckCommandRunner {
         env: options.env,
         detached: !isWindows,
         windowsHide: isWindows,
+        windowsVerbatimArguments: shell.windowsVerbatimArguments,
         stdio: ["ignore", "pipe", "pipe"],
       });
 

--- a/tests/task/background-task-runtime.spec.ts
+++ b/tests/task/background-task-runtime.spec.ts
@@ -58,6 +58,7 @@ test("BackgroundTaskRuntime tracks output and emits one completion", async () =>
   assert.equal(invocation?.options.cwd, "/tmp");
   assert.equal(invocation?.options.env, env);
   assert.equal(invocation?.options.detached, true);
+  assert.equal(invocation?.options.windowsVerbatimArguments, expectedShell.windowsVerbatimArguments);
 
   child.stdout.write("hello\n");
   child.stderr.write("warning\n");

--- a/tests/task/background-task-runtime.spec.ts
+++ b/tests/task/background-task-runtime.spec.ts
@@ -1,0 +1,155 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { PassThrough } from "node:stream";
+import { EventEmitter } from "node:events";
+import { BackgroundTaskRuntime } from "../../src/task/runtime/BackgroundTaskRuntime.js";
+import { resolveDefaultCommandShell } from "../../src/runtime/commandShell.js";
+
+class FakeChild extends EventEmitter {
+  readonly stdout = new PassThrough();
+  readonly stderr = new PassThrough();
+  readonly pid = 4242;
+  readonly kills: Array<string | undefined> = [];
+  unrefCalled = false;
+
+  constructor(private readonly autoExitOnKill = false) {
+    super();
+  }
+
+  unref(): void {
+    this.unrefCalled = true;
+  }
+
+  kill(signal?: string): boolean {
+    this.kills.push(signal);
+    if (this.autoExitOnKill) {
+      queueMicrotask(() => this.finish(null, signal ?? "SIGTERM"));
+    }
+    return true;
+  }
+
+  finish(code: number | null = 0, signal: string | null = null): void {
+    this.emit("exit", code, signal);
+  }
+}
+
+test("BackgroundTaskRuntime tracks output and emits one completion", async () => {
+  const child = new FakeChild();
+  let invocation: { command: string; args: string[]; options: Record<string, unknown> } | undefined;
+  const env = { ...process.env, PILOTDECK_TEST_SHELL: "background" };
+  const completions: unknown[] = [];
+  const runtime = new BackgroundTaskRuntime({
+    spawn: ((command: string, args: string[], options: Record<string, unknown>) => {
+      invocation = { command, args, options };
+      return child;
+    }) as never,
+    now: () => new Date("2026-08-23T00:00:00.000Z"),
+    onCompletion: (event) => completions.push(event),
+  });
+
+  const task = await runtime.start({ command: "echo ok", cwd: "/tmp", env, sessionId: "s1", agentId: "a1" });
+  assert.equal(task.status, "running");
+  assert.equal(task.pid, 4242);
+  assert.equal(child.unrefCalled, true);
+  const expectedShell = resolveDefaultCommandShell({ env });
+  assert.equal(invocation?.command, expectedShell.shell);
+  assert.deepEqual(invocation?.args, expectedShell.args("echo ok"));
+  assert.equal(invocation?.options.shell, undefined);
+  assert.equal(invocation?.options.cwd, "/tmp");
+  assert.equal(invocation?.options.env, env);
+  assert.equal(invocation?.options.detached, true);
+
+  child.stdout.write("hello\n");
+  child.stderr.write("warning\n");
+  assert.equal(runtime.getOutput(task.taskId, 0).content, "hello\nwarning\n");
+
+  child.finish(0);
+  await runtime.waitFor(task.taskId);
+  assert.equal(runtime.get(task.taskId)?.status, "completed");
+  assert.equal(completions.length, 1);
+  assert.match(String((completions[0] as { outputPreview: string }).outputPreview), /warning/);
+});
+
+test("BackgroundTaskRuntime marks non-zero exit as failed and filters list", async () => {
+  const child = new FakeChild();
+  const runtime = new BackgroundTaskRuntime({ spawn: (() => child) as never });
+  const task = await runtime.start({ command: "false", cwd: "/tmp", agentId: "agent-a", kind: "watch" as never });
+  child.finish(2);
+  await runtime.waitFor(task.taskId);
+
+  assert.equal(runtime.list({ status: "failed" }).length, 1);
+  assert.equal(runtime.list({ status: "running" }).length, 0);
+  assert.equal(runtime.list({ agentId: "other" }).length, 0);
+});
+
+test("BackgroundTaskRuntime handles spawn errors without throwing or losing completion", async () => {
+  const completions: unknown[] = [];
+  const runtime = new BackgroundTaskRuntime({
+    spawn: (() => { throw new Error("spawn unavailable"); }) as never,
+    onCompletion: (event) => completions.push(event),
+  });
+
+  const task = await runtime.start({ command: "missing", cwd: "/tmp" });
+  assert.equal(task.status, "failed");
+  assert.equal(runtime.getOutput(task.taskId, 0).content, "spawn error: spawn unavailable\n");
+  assert.equal(completions.length, 1);
+});
+
+test("BackgroundTaskRuntime supports abort waits and idempotent stop", async () => {
+  const child = new FakeChild();
+  const runtime = new BackgroundTaskRuntime({ spawn: (() => child) as never });
+  const task = await runtime.start({ command: "sleep", cwd: "/tmp" });
+  const controller = new AbortController();
+  controller.abort();
+  const waited = await runtime.wait(task.taskId, { abortSignal: controller.signal });
+  assert.equal(waited?.outcome, "aborted");
+
+  child.finish(null, "SIGTERM");
+  await runtime.stop(task.taskId);
+  await runtime.stop(task.taskId);
+  assert.equal(runtime.get(task.taskId)?.status, "cancelled");
+  assert.deepEqual(child.kills, []);
+});
+
+test("BackgroundTaskRuntime enforces the task limit and stops by agent", async () => {
+  const children = [new FakeChild(), new FakeChild()];
+  let index = 0;
+  const runtime = new BackgroundTaskRuntime({ maxTasks: 1, spawn: (() => children[index++]) as never });
+  const first = await runtime.start({ command: "one", cwd: "/tmp", agentId: "a1" });
+  await assert.rejects(() => runtime.start({ command: "two", cwd: "/tmp" }), /max tasks/);
+
+  const stopPromise = runtime.killForAgent("a1");
+  assert.deepEqual(children[0].kills, ["SIGTERM"]);
+  children[0].finish(null, "SIGTERM");
+  await stopPromise;
+  assert.equal(first.status, "cancelled");
+});
+
+test("BackgroundTaskRuntime covers timeout, abort, unknown task and kill-all cleanup", async () => {
+  const first = new FakeChild(true);
+  const second = new FakeChild(true);
+  let index = 0;
+  const runtime = new BackgroundTaskRuntime({
+    spawn: (() => [first, second][index++]) as never,
+    onCompletion: () => { throw new Error("notification sink failed"); },
+    completionPreviewBytes: 0,
+  });
+  const task = await runtime.start({ command: "one", cwd: "/tmp", agentId: "a" });
+  assert.equal(await runtime.wait("missing"), undefined);
+  await assert.rejects(() => runtime.waitFor("missing"), /Unknown taskId/);
+  assert.throws(() => runtime.getOutput("missing", 0), /Unknown taskId/);
+  const timeout = await runtime.wait(task.taskId, { timeoutMs: 1 });
+  assert.equal(timeout?.outcome, "timeout");
+  await runtime.stop(task.taskId);
+
+  const next = await runtime.start({ command: "two", cwd: "/tmp", agentId: "b" });
+  const controller = new AbortController();
+  const pending = runtime.wait(next.taskId, { abortSignal: controller.signal });
+  controller.abort();
+  const aborted = await pending;
+  assert.ok(aborted);
+  assert.equal(aborted.outcome, "aborted");
+  await runtime.killAll();
+  assert.equal(runtime.get(next.taskId)?.status, "cancelled");
+  await assert.rejects(() => runtime.stop("missing"), /Unknown taskId/);
+});

--- a/tests/tool/bash-command-runner.spec.ts
+++ b/tests/tool/bash-command-runner.spec.ts
@@ -1,0 +1,38 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+import { NodeShellCommandRunner } from "../../src/tool/builtin/bash/commandRunner.js";
+import { resolveDefaultCommandShell } from "../../src/runtime/commandShell.js";
+
+class FakeChild extends EventEmitter {
+  readonly stdout = new PassThrough();
+  readonly stderr = new PassThrough();
+  readonly pid = 4242;
+}
+
+test("foreground bash runner invokes the resolved shell explicitly", async () => {
+  const child = new FakeChild();
+  let invocation: { command: string; args: string[]; options: Record<string, unknown> } | undefined;
+  const env = { ...process.env, PILOTDECK_TEST_SHELL: "runner" };
+  const runner = new NodeShellCommandRunner(((command: string, args: string[], options: Record<string, unknown>) => {
+    invocation = { command, args, options };
+    return child;
+  }) as never);
+
+  const resultPromise = runner.run("printf ok", { cwd: "/tmp", env, timeoutMs: 1000 });
+  child.stdout.end("ok");
+  child.stderr.end();
+  child.emit("close", 0);
+  const result = await resultPromise;
+  const expected = resolveDefaultCommandShell({ env });
+
+  assert.equal(invocation?.command, expected.shell);
+  assert.deepEqual(invocation?.args, expected.args("printf ok"));
+  assert.equal(invocation?.options.shell, undefined);
+  assert.equal(invocation?.options.cwd, "/tmp");
+  assert.equal(invocation?.options.env, env);
+  assert.equal(invocation?.options.detached, process.platform !== "win32");
+  assert.equal(result.exitCode, 0);
+  assert.equal(result.stdout, "ok");
+});

--- a/tests/tool/bash-command-runner.spec.ts
+++ b/tests/tool/bash-command-runner.spec.ts
@@ -33,6 +33,7 @@ test("foreground bash runner invokes the resolved shell explicitly", async () =>
   assert.equal(invocation?.options.cwd, "/tmp");
   assert.equal(invocation?.options.env, env);
   assert.equal(invocation?.options.detached, process.platform !== "win32");
+  assert.equal(invocation?.options.windowsVerbatimArguments, expected.windowsVerbatimArguments);
   assert.equal(result.exitCode, 0);
   assert.equal(result.stdout, "ok");
 });

--- a/tests/tool/command-shell.spec.ts
+++ b/tests/tool/command-shell.spec.ts
@@ -11,6 +11,7 @@ test("command shell prefers /bin/bash on Unix", () => {
 
   assert.equal(shell.shell, "/bin/bash");
   assert.equal(shell.kind, "bash");
+  assert.equal(shell.windowsVerbatimArguments, false);
   assert.deepEqual(shell.args("printf ok"), ["-c", "printf ok"]);
 });
 
@@ -60,6 +61,7 @@ test("command shell falls back to cmd then PowerShell 7 on Windows", () => {
   });
   assert.equal(cmd.shell, "cmd.exe");
   assert.equal(cmd.kind, "cmd");
+  assert.equal(cmd.windowsVerbatimArguments, true);
   assert.deepEqual(cmd.args("echo ok"), ["/d", "/s", "/c", "echo ok"]);
 
   const pwsh = resolveDefaultCommandShell({
@@ -70,6 +72,7 @@ test("command shell falls back to cmd then PowerShell 7 on Windows", () => {
   });
   assert.equal(pwsh.shell, "pwsh.exe");
   assert.equal(pwsh.kind, "pwsh");
+  assert.equal(pwsh.windowsVerbatimArguments, false);
   assert.deepEqual(pwsh.args("Write-Output ok"), ["-NoLogo", "-NoProfile", "-Command", "Write-Output ok"]);
 });
 

--- a/tests/tool/command-shell.spec.ts
+++ b/tests/tool/command-shell.spec.ts
@@ -1,5 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
 import { resolveDefaultCommandShell } from "../../src/runtime/commandShell.js";
 
 test("command shell prefers /bin/bash on Unix", () => {
@@ -62,7 +63,7 @@ test("command shell falls back to cmd then PowerShell 7 on Windows", () => {
   assert.equal(cmd.shell, "cmd.exe");
   assert.equal(cmd.kind, "cmd");
   assert.equal(cmd.windowsVerbatimArguments, true);
-  assert.deepEqual(cmd.args("echo ok"), ["/d", "/s", "/c", "echo ok"]);
+  assert.deepEqual(cmd.args("echo ok"), ["/d", "/s", "/c", '"echo ok"']);
 
   const pwsh = resolveDefaultCommandShell({
     platform: "win32",
@@ -94,4 +95,31 @@ test("command shell supports an explicit generic shell path", () => {
   assert.equal(shell.shell, "/opt/custom-shell");
   assert.equal(shell.kind, "custom");
   assert.deepEqual(shell.args("echo ok"), ["-c", "echo ok"]);
+});
+
+test("cmd shell executes a quoted executable path on Windows", { skip: process.platform !== "win32" }, async () => {
+  const commandShellPath = process.env.ComSpec ?? "cmd.exe";
+  const env = { ...process.env, PILOTDECK_SHELL_PATH: commandShellPath };
+  const shell = resolveDefaultCommandShell({
+    platform: "win32",
+    env,
+    commandAvailable: () => true,
+  });
+  const command = `"${process.execPath}" -e "process.stdout.write('pilotdeck-cmd-smoke')"`;
+  const child = spawn(shell.shell, shell.args(command), {
+    env,
+    windowsHide: true,
+    windowsVerbatimArguments: shell.windowsVerbatimArguments,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let stdout = "";
+  child.stdout?.setEncoding("utf8");
+  child.stdout?.on("data", (chunk: string) => { stdout += chunk; });
+  const exitCode = await new Promise<number>((resolve, reject) => {
+    child.on("error", reject);
+    child.on("close", (code) => resolve(code ?? -1));
+  });
+
+  assert.equal(exitCode, 0);
+  assert.equal(stdout, "pilotdeck-cmd-smoke");
 });

--- a/tests/tool/command-shell.spec.ts
+++ b/tests/tool/command-shell.spec.ts
@@ -1,0 +1,94 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { resolveDefaultCommandShell } from "../../src/runtime/commandShell.js";
+
+test("command shell prefers /bin/bash on Unix", () => {
+  const shell = resolveDefaultCommandShell({
+    platform: "linux",
+    env: { PATH: "/custom/bin" },
+    existsSync: (path) => path === "/bin/bash",
+  });
+
+  assert.equal(shell.shell, "/bin/bash");
+  assert.equal(shell.kind, "bash");
+  assert.deepEqual(shell.args("printf ok"), ["-c", "printf ok"]);
+});
+
+test("command shell uses PATH bash before falling back to sh", () => {
+  const pathBash = resolveDefaultCommandShell({
+    platform: "linux",
+    env: { PATH: "/custom/bin" },
+    existsSync: (path) => path === "/custom/bin/bash",
+  });
+  assert.equal(pathBash.shell, "/custom/bin/bash");
+
+  const fallback = resolveDefaultCommandShell({
+    platform: "linux",
+    env: { PATH: "/custom/bin" },
+    existsSync: () => false,
+  });
+  assert.equal(fallback.shell, "/bin/sh");
+  assert.equal(fallback.kind, "sh");
+});
+
+test("command shell prefers configured and standard Git Bash on Windows", () => {
+  const configured = resolveDefaultCommandShell({
+    platform: "win32",
+    env: { PILOTDECK_GIT_BASH_PATH: "D:\\Git\\bin\\bash.exe" },
+    existsSync: (path) => path === "D:\\Git\\bin\\bash.exe",
+    commandAvailable: () => true,
+  });
+  assert.equal(configured.shell, "D:\\Git\\bin\\bash.exe");
+  assert.equal(configured.kind, "bash");
+  assert.deepEqual(configured.args("echo ok"), ["-c", "echo ok"]);
+
+  const standard = resolveDefaultCommandShell({
+    platform: "win32",
+    env: { ProgramFiles: "C:\\Program Files" },
+    existsSync: (path) => path === "C:\\Program Files\\Git\\bin\\bash.exe",
+    commandAvailable: () => true,
+  });
+  assert.equal(standard.shell, "C:\\Program Files\\Git\\bin\\bash.exe");
+});
+
+test("command shell falls back to cmd then PowerShell 7 on Windows", () => {
+  const cmd = resolveDefaultCommandShell({
+    platform: "win32",
+    env: { PATH: "C:\\Windows\\System32" },
+    existsSync: () => false,
+    commandAvailable: (command) => command === "cmd.exe",
+  });
+  assert.equal(cmd.shell, "cmd.exe");
+  assert.equal(cmd.kind, "cmd");
+  assert.deepEqual(cmd.args("echo ok"), ["/d", "/s", "/c", "echo ok"]);
+
+  const pwsh = resolveDefaultCommandShell({
+    platform: "win32",
+    env: { PATH: "C:\\Program Files\\PowerShell\\7" },
+    existsSync: () => false,
+    commandAvailable: (command) => command === "pwsh.exe",
+  });
+  assert.equal(pwsh.shell, "pwsh.exe");
+  assert.equal(pwsh.kind, "pwsh");
+  assert.deepEqual(pwsh.args("Write-Output ok"), ["-NoLogo", "-NoProfile", "-Command", "Write-Output ok"]);
+});
+
+test("command shell never falls back to Windows PowerShell 5", () => {
+  assert.throws(() => resolveDefaultCommandShell({
+    platform: "win32",
+    env: { PATH: "C:\\Windows\\System32" },
+    existsSync: () => false,
+    commandAvailable: () => false,
+  }), /No supported PilotDeck command shell/);
+});
+
+test("command shell supports an explicit generic shell path", () => {
+  const shell = resolveDefaultCommandShell({
+    platform: "linux",
+    env: { PILOTDECK_SHELL_PATH: "/opt/custom-shell" },
+    commandAvailable: (command) => command === "/opt/custom-shell",
+  });
+  assert.equal(shell.shell, "/opt/custom-shell");
+  assert.equal(shell.kind, "custom");
+  assert.deepEqual(shell.args("echo ok"), ["-c", "echo ok"]);
+});


### PR DESCRIPTION
## Summary
- add a shared cross-platform command shell resolver for foreground bash and background tasks
- prefer Bash, with Unix `/bin/sh` and Windows `cmd.exe` -> PowerShell 7 fallbacks
- support `PILOTDECK_SHELL_PATH` and `PILOTDECK_GIT_BASH_PATH`; never select Windows PowerShell 5
- invoke shells with explicit executable arguments and preserve process lifecycle options
- add resolver, foreground runner, and background runtime coverage

## Validation
- `node --test --import tsx tests/tool/command-shell.spec.ts tests/tool/bash-command-runner.spec.ts tests/task/background-task-runtime.spec.ts` (13 passed)
- `pnpm run check:docs` (passed on the current checkout)
- `git diff --check` (passed)

Full `pnpm test:unit` / `pnpm check` are environment-blocked here because the checkout is running Node `v25.5.0`, while PilotDeck requires Node `>=22.13.0 <23`.
