### PR TITLE
fix(router): prefer exact tier match over word-prefix fallback in parseTier

### DIFF
--- a/src/router/tokenSaver/parseTier.ts
+++ b/src/router/tokenSaver/parseTier.ts
@@ -10,7 +10,14 @@ export function parseTier(judgeOutput: string, knownTiers: string[]): string | u
     if (found) return found;
   }
 
-  for (const tier of knownTiers) {
+  const exact = knownTiers.find(t => t.toLowerCase() === cleaned.toLowerCase());
+  if (exact) return exact;
+
+  // Longest tiers first: `-` is a word boundary, so a shorter tier that is a
+  // word-prefix of a hyphenated tier (e.g. "fast" vs "fast-pro") would
+  // otherwise match inside the longer name.
+  const byLength = [...knownTiers].sort((a, b) => b.length - a.length);
+  for (const tier of byLength) {
     const pattern = new RegExp(`\\b${escapeRegex(tier)}\\b`, "i");
     if (pattern.test(cleaned)) {
       return tier;

--- a/tests/router/parseTier.spec.ts
+++ b/tests/router/parseTier.spec.ts
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseTier } from "../../src/router/tokenSaver/parseTier.js";
+
+test("prefers an exact tier over a word-prefix of a hyphenated tier", () => {
+  assert.equal(parseTier("a-a", ["a", "a-a"]), "a-a");
+  assert.equal(parseTier("fast-pro", ["fast", "fast-pro"]), "fast-pro");
+});
+
+test("keeps exact matching case-insensitive", () => {
+  assert.equal(parseTier("Fast-Pro", ["fast", "fast-pro"]), "fast-pro");
+});
+
+test("tagged output still resolves the longer tier", () => {
+  assert.equal(parseTier("<tier>a-a</tier>", ["a", "a-a"]), "a-a");
+});
+
+test("fallback text matching picks the longest tier mentioned", () => {
+  assert.equal(parseTier("please use a-a", ["a", "a-a"]), "a-a");
+});
+
+test("fallback text matching still resolves a plain tier mention", () => {
+  assert.equal(parseTier("the answer is fast", ["fast", "fast-pro"]), "fast");
+});
+
+test("returns undefined when no tier matches", () => {
+  assert.equal(parseTier("no such tier", ["fast", "fast-pro"]), undefined);
+});


### PR DESCRIPTION
## What

`parseTier` now checks whether the cleaned judge output exactly equals a known tier (case-insensitively) before falling back to word-boundary matching, and the fallback iterates tiers longest-first.

## Why

The fallback loop iterated `knownTiers` in configuration order with a `\b<tier>\b` regex. Since `-` is a word boundary, a tier that is a word-prefix of a hyphenated tier matched first: with tiers `fast` and `fast-pro`, a bare judge output of `fast-pro` was parsed as `fast`. Reproduced on `main`:

```ts
parseTier("fast-pro", ["fast", "fast-pro"]) // => "fast", expected "fast-pro"
```

## How verified

- Added `tests/router/parseTier.spec.ts` (6 cases: exact match over prefix, case-insensitive exact match, tagged output, free-text longest match, plain fallback mention, no-match returns undefined) — all pass via `tsx --test`.
- Existing `tests/router/tokenSaver.spec.ts` (7 cases) still passes.
- `tsc --noEmit -p tsconfig.json` passes.

Fixes #428
