### PR TITLE
fix(mcp): keep wire-name server segment unambiguous for parsing

### DIFF
--- a/src/mcp/runtime/wireName.ts
+++ b/src/mcp/runtime/wireName.ts
@@ -10,7 +10,7 @@
  */
 
 export function buildMcpToolWireName(serverId: string, toolName: string): string {
-  return `mcp__${normalizeSegment(serverId)}__${normalizeSegment(toolName)}`;
+  return `mcp__${normalizeServerSegment(serverId)}__${normalizeSegment(toolName)}`;
 }
 
 export function parseMcpToolWireName(
@@ -28,4 +28,15 @@ export function parseMcpToolWireName(
 
 function normalizeSegment(value: string): string {
   return value.replace(/[^A-Za-z0-9_-]/g, "_");
+}
+
+/**
+ * `parseMcpToolWireName` splits at the first `__` after the prefix, so the
+ * server segment must never contain `__` or end in `_` — otherwise the
+ * separator becomes ambiguous and the wire name parses to a different
+ * server/tool pair. Collapse underscore runs and trim edge underscores,
+ * mirroring `normalizeMcpName` in tool/builtin/mcpTool.ts.
+ */
+function normalizeServerSegment(value: string): string {
+  return normalizeSegment(value).replace(/_{2,}/g, "_").replace(/^_+|_+$/g, "");
 }

--- a/tests/mcp/wire-name.spec.ts
+++ b/tests/mcp/wire-name.spec.ts
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildMcpToolWireName,
+  parseMcpToolWireName,
+} from "../../src/mcp/runtime/wireName.js";
+
+function roundTrip(serverId: string, toolName: string) {
+  return parseMcpToolWireName(buildMcpToolWireName(serverId, toolName));
+}
+
+test("plain server and tool names round-trip", () => {
+  assert.deepEqual(roundTrip("filesystem", "read_file"), {
+    serverId: "filesystem",
+    toolName: "read_file",
+  });
+});
+
+test("server IDs with double underscores build an unambiguous wire name", () => {
+  const wireName = buildMcpToolWireName("0__A", "a");
+  assert.equal(wireName, "mcp__0_A__a");
+  assert.deepEqual(parseMcpToolWireName(wireName), {
+    serverId: "0_A",
+    toolName: "a",
+  });
+});
+
+test("server IDs ending in an underscore keep the separator unambiguous", () => {
+  const wireName = buildMcpToolWireName("srv_", "tool");
+  assert.equal(wireName, "mcp__srv__tool");
+  assert.deepEqual(parseMcpToolWireName(wireName), {
+    serverId: "srv",
+    toolName: "tool",
+  });
+});
+
+test("sanitized characters cannot form a bogus separator", () => {
+  // "a..b" would previously normalize to "a__b" and split as server "a".
+  const wireName = buildMcpToolWireName("a..b", "tool");
+  assert.equal(wireName, "mcp__a_b__tool");
+  assert.deepEqual(parseMcpToolWireName(wireName), {
+    serverId: "a_b",
+    toolName: "tool",
+  });
+});
+
+test("tool names may contain double underscores", () => {
+  assert.deepEqual(roundTrip("srv", "a__b"), {
+    serverId: "srv",
+    toolName: "a__b",
+  });
+});
+
+test("single underscores inside a server ID are preserved", () => {
+  assert.deepEqual(roundTrip("my_server", "tool"), {
+    serverId: "my_server",
+    toolName: "tool",
+  });
+});


### PR DESCRIPTION
## What

`buildMcpToolWireName` now normalizes the server segment so it can never contain `__` or edge underscores: underscore runs are collapsed and leading/trailing underscores trimmed, mirroring `normalizeMcpName` in `src/tool/builtin/mcpTool.ts`. Tool names keep `__` as before, since parsing splits at the first separator only.

## Why

`parseMcpToolWireName` splits at the first `__` after the `mcp__` prefix, but the builder accepted server IDs containing `__` — directly, via sanitization (`a..b` → `a__b`), or ending in `_`. Such wire names parsed back to a different server/tool pair. Reproduced on `main`:

```ts
buildMcpToolWireName("0__A", "a")      // => "mcp__0__A__a"
parseMcpToolWireName("mcp__0__A__a")   // => { serverId: "0", toolName: "A__a" }
```

With this change every built wire name parses back to a stable server/tool identity, and wire names for ordinary server IDs (including single underscores) are unchanged.

## How verified

- Added `tests/mcp/wire-name.spec.ts` (6 cases: plain round-trip, `__` in server ID, trailing underscore, sanitization-induced `__`, `__` in tool name preserved, single underscore preserved) — all pass via `tsx --test`.
- Existing `tests/mcp/client/McpClient.spec.ts` (3 cases) still passes.
- `tsc --noEmit -p tsconfig.json` passes.

Fixes #424
