### PR TITLE
fix(attachments): preserve upload names in history

### DIFF
--- a/src/cli/createLocalGateway.ts
+++ b/src/cli/createLocalGateway.ts
@@ -439,6 +439,7 @@ export function createLocalGateway(options: CreateLocalGatewayOptions = {}): Cre
           mimeType: attachment.mimeType,
           bytes: attachment.bytes,
           metadata: {
+            channelKey: "web",
             uploadId,
             attachmentId: attachment.attachmentId,
             relativePath: attachment.relativePath,

--- a/src/context/attachments/AttachmentResolver.ts
+++ b/src/context/attachments/AttachmentResolver.ts
@@ -145,7 +145,10 @@ export class AttachmentResolver {
         diagnostics: [
           {
             code: "attachment_unsupported",
-            severity: "warning",
+            // Office and archive formats are expected to be available only as
+            // registered paths. They need a document tool or conversion, but
+            // are not an upload failure that belongs in the user's message.
+            severity: BINARY_CONTAINER_EXTENSIONS.has(ext) ? "info" : "warning",
             message: unsupportedFileMessage(absolute, ext),
           },
         ],

--- a/src/gateway/client/InProcessGateway.ts
+++ b/src/gateway/client/InProcessGateway.ts
@@ -2479,7 +2479,9 @@ function buildAttachmentPathNote(
   }
 
   if (lines.length === 0) return undefined;
-  const guidance = hasDiagnostics || attachments.some(isAudioAttachment)
+  const guidance = hasDiagnostics
+    || attachments.some(isAudioAttachment)
+    || attachments.some((attachment) => !isReadFileInspectableAttachment(attachment))
     ? attachmentDiagnosticsGuidance(attachments, allowedReadFiles, projectRoot, installCommand)
     : "These are path references for reuse. If an image/PDF is already visible in this turn, do not call read_file just to view it.";
   return {
@@ -2524,7 +2526,9 @@ function isReadFileInspectableAttachment(attachment: ChannelAttachment): boolean
   if (mimeType === "application/json" || mimeType.endsWith("+json")) return true;
 
   const pathOrName = attachment.path || attachment.name || "";
-  const extension = extname(pathOrName).toLowerCase();
+  // Upload staging paths can be opaque IDs for legacy attachments. Prefer the
+  // original name so Office files still receive conversion guidance.
+  const extension = extname(attachment.name ?? "").toLowerCase() || extname(pathOrName).toLowerCase();
   if (extension === ".pdf" || extension === ".ipynb") return true;
   if (READ_FILE_BINARY_ATTACHMENT_EXTENSIONS.has(extension)) return false;
   return true;

--- a/tests/context/attachment-resolver.spec.ts
+++ b/tests/context/attachment-resolver.spec.ts
@@ -6,7 +6,7 @@ import { tmpdir } from "node:os";
 
 import { AttachmentResolver } from "../../src/context/attachments/AttachmentResolver.js";
 
-test("Office attachments are reported unsupported before size checks", async () => {
+test("Office attachments are registered as non-inline information before size checks", async () => {
   const root = await mkdtemp(join(tmpdir(), "pilotdeck-attachment-resolver-"));
   try {
     const filePath = join(root, "sample.docx");
@@ -17,7 +17,7 @@ test("Office attachments are reported unsupported before size checks", async () 
     assert.equal(result.blocks.length, 0);
     assert.equal(result.diagnostics.length, 1);
     assert.equal(result.diagnostics[0]?.code, "attachment_unsupported");
-    assert.equal(result.diagnostics[0]?.severity, "warning");
+    assert.equal(result.diagnostics[0]?.severity, "info");
     assert.match(result.diagnostics[0]?.message ?? "", /read_file cannot inspect this format directly/);
   } finally {
     await rm(root, { recursive: true, force: true });

--- a/tests/gateway/attachment-guidance.spec.ts
+++ b/tests/gateway/attachment-guidance.spec.ts
@@ -42,7 +42,7 @@ test("registered plain-text attachments with non-whitelisted names are described
   }
 });
 
-test("registered Office attachments are still described as not directly inspectable", async () => {
+test("registered Office attachments receive conversion guidance without raw diagnostics", async () => {
   const root = await mkdtemp(join(tmpdir(), "pilotdeck-attachment-guidance-"));
   try {
     const docxPath = join(root, "sample.docx");
@@ -70,6 +70,42 @@ test("registered Office attachments are still described as not directly inspecta
     const text = inputText(capturedInput);
     assert.match(text, /sample\.docx/);
     assert.match(text, /not directly inspectable with read_file/);
+    assert.doesNotMatch(text, /\[Attachment diagnostics\]/);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("registered PDF attachments retain their original name in the history path note", async () => {
+  const root = await mkdtemp(join(tmpdir(), "pilotdeck-attachment-guidance-"));
+  try {
+    const pdfPath = join(root, "file-0-opaque-upload-id.pdf");
+    await writeFile(pdfPath, Buffer.from("%PDF-1.7"));
+
+    let capturedInput: AgentInput | undefined;
+    const gateway = createGateway((input) => {
+      capturedInput = input;
+    });
+
+    for await (const _event of gateway.submitTurn({
+      sessionKey: "session-1",
+      channelKey: "web",
+      message: "分析附件",
+      attachments: [{
+        type: "file",
+        path: pdfPath,
+        name: "心理学科百年材料.pdf",
+        mimeType: "application/pdf",
+        metadata: { channelKey: "web" },
+      }],
+    })) {
+      // Drain the stream so the fake session runs to completion.
+    }
+
+    const text = inputText(capturedInput);
+    assert.match(text, /\[Registered attachment files in this session:\]/);
+    assert.match(text, /心理学科百年材料\.pdf/);
+    assert.match(text, new RegExp(pdfPath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
   } finally {
     await rm(root, { recursive: true, force: true });
   }

--- a/ui/src/components/chat/utils/attachmentNotes.spec.ts
+++ b/ui/src/components/chat/utils/attachmentNotes.spec.ts
@@ -42,6 +42,43 @@ describe('attachment path notes', () => {
     }]);
   });
 
+  it('hides PDF runtime metadata after refresh and restores the attachment', () => {
+    const filePath = '/workspace/政研室/.tmp/chat-uploads/run/files/file-0-report.pdf';
+    const parsed = parseUserAttachmentNote([
+      '分析一下这个文件内容，总结给我',
+      `[PDF attachment: ${filePath}, 54858 bytes, estimated 1 pages. Use read_file on this registered attachment path to inspect it.]`,
+      '[Registered attachment files in this session:]',
+      `- 年度报告.pdf: ${filePath}`,
+    ].join('\n'));
+
+    expect(parsed).toEqual({
+      content: '分析一下这个文件内容，总结给我',
+      attachments: [{
+        name: '年度报告.pdf',
+        path: filePath,
+        mimeType: 'application/pdf',
+      }],
+    });
+  });
+
+  it('hides standalone Office diagnostics after refresh and restores the attachment', () => {
+    const filePath = '/workspace/政研室/.tmp/chat-uploads/run/files/file-0-report.docx';
+    const parsed = parseUserAttachmentNote([
+      '分析一下这个文件内容，总结给我',
+      '[Attachment diagnostics]',
+      `- Attachment ${filePath} has Office/archive/binary extension .docx; it was registered as a file path but not shown inline.`,
+    ].join('\n'));
+
+    expect(parsed).toEqual({
+      content: '分析一下这个文件内容，总结给我',
+      attachments: [{
+        name: 'file-0-report.docx',
+        path: filePath,
+        mimeType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+      }],
+    });
+  });
+
   it('preserves a colon in the attachment filename', () => {
     const filePath = '/tmp/1-report__final.pdf';
     const parsed = parseUserAttachmentNote([

--- a/ui/src/components/chat/utils/attachmentNotes.ts
+++ b/ui/src/components/chat/utils/attachmentNotes.ts
@@ -13,6 +13,12 @@ import {
 const ATTACHMENT_NOTE_MARKER = '[Files attached by user and available for reading in the project:]';
 const ATTACHMENT_NOTE_END_MARKER = '[End files attached by user]';
 const ATTACHMENT_NOTE_JSON_PREFIX = '- attachment-json: ';
+const GENERATED_ATTACHMENT_BLOCK_MARKERS = [
+  '[Attachment diagnostics]',
+  '[Registered attachment files in this session:]',
+  '[PDF attachment:',
+  '<attachment ',
+];
 // Older transcripts have no end marker. Their next canonical text block may
 // be concatenated directly onto the final path during history projection.
 const LEGACY_ATTACHMENT_NOTE_TERMINATORS = [
@@ -132,6 +138,81 @@ function isImageAttachmentMime(mimeType: string | undefined): boolean {
   return Boolean(mimeType?.toLowerCase().startsWith('image/'));
 }
 
+function toChatAttachment(file: AttachmentPathNoteFile): ChatAttachment {
+  return {
+    name: file.name,
+    path: file.path,
+    mimeType: inferAttachmentMimeType(file.name, file.path),
+  };
+}
+
+function attachmentFromGeneratedPath(path: string, name?: string): AttachmentPathNoteFile | null {
+  const filePath = path.trim();
+  if (!isLikelyLegacyAttachmentPath(filePath)) return null;
+
+  const fallbackName = filePath.split(/[\\/]/).pop()?.trim();
+  const fileName = name?.trim() || fallbackName;
+  return fileName ? { name: fileName, path: filePath } : null;
+}
+
+function appendUniqueAttachment(
+  attachments: AttachmentPathNoteFile[],
+  seen: Set<string>,
+  candidate: AttachmentPathNoteFile | null,
+): void {
+  if (!candidate) return;
+  const key = candidate.path;
+  if (seen.has(key)) return;
+  seen.add(key);
+  attachments.push(candidate);
+}
+
+function generatedAttachmentBlockStart(value: string): number {
+  let start = -1;
+  for (const marker of GENERATED_ATTACHMENT_BLOCK_MARKERS) {
+    const index = value.indexOf(marker);
+    if (index >= 0 && (start < 0 || index < start)) start = index;
+  }
+  return start;
+}
+
+function parseGeneratedAttachmentBlocks(value: string): {
+  content: string;
+  attachments: AttachmentPathNoteFile[];
+} | null {
+  const start = generatedAttachmentBlockStart(value);
+  if (start < 0) return null;
+
+  const generated = value.slice(start);
+  const attachments: AttachmentPathNoteFile[] = [];
+  const seen = new Set<string>();
+  const registeredMarker = '[Registered attachment files in this session:]';
+  const registeredIndex = generated.indexOf(registeredMarker);
+  if (registeredIndex >= 0) {
+    const registeredLines = generated.slice(registeredIndex + registeredMarker.length).split(/\r?\n/);
+    for (const rawLine of registeredLines) {
+      appendUniqueAttachment(attachments, seen, parseAttachmentPathNoteLine(rawLine.trim()));
+    }
+  }
+
+  const inlineAttachmentPattern = /<attachment\s+path="([^"]+)"/giu;
+  for (const match of generated.matchAll(inlineAttachmentPattern)) {
+    appendUniqueAttachment(attachments, seen, attachmentFromGeneratedPath(match[1] ?? ''));
+  }
+
+  const pdfAttachmentPattern = /\[PDF attachment:\s*(.+?),\s*\d+\s+bytes,\s*estimated\s+\d+\s+pages?\.\s*Use read_file on this registered attachment path to inspect it\.\]/giu;
+  for (const match of generated.matchAll(pdfAttachmentPattern)) {
+    appendUniqueAttachment(attachments, seen, attachmentFromGeneratedPath(match[1] ?? ''));
+  }
+
+  const officeDiagnosticPattern = /Attachment\s+(.+?)\s+has Office\/archive\/binary extension\s+[^;]+;/giu;
+  for (const match of generated.matchAll(officeDiagnosticPattern)) {
+    appendUniqueAttachment(attachments, seen, attachmentFromGeneratedPath(match[1] ?? ''));
+  }
+
+  return { content: value.slice(0, start).trimEnd(), attachments };
+}
+
 export function parseUserAttachmentNote(content: unknown): {
   content: string;
   attachments: ChatAttachment[];
@@ -145,7 +226,14 @@ export function parseUserAttachmentNote(content: unknown): {
     ...parsedContentReferences.references.map(contentReferenceToAttachment),
   ];
   if (markerIndex < 0) {
-    return { content: text, attachments: selectionAttachments };
+    const generated = parseGeneratedAttachmentBlocks(text);
+    return {
+      content: generated?.content ?? text,
+      attachments: [
+        ...(generated?.attachments.map(toChatAttachment) ?? []),
+        ...selectionAttachments,
+      ],
+    };
   }
 
   const visibleContent = text.slice(0, markerIndex).trimEnd();
@@ -165,10 +253,9 @@ export function parseUserAttachmentNote(content: unknown): {
 
     const attachment = parseAttachmentPathNoteLine(line);
     if (attachment) {
-      const { name, path: filePath } = attachment;
-      const mimeType = inferAttachmentMimeType(name, filePath);
-      if (!isImageAttachmentMime(mimeType)) {
-        attachments.push({ name, path: filePath, mimeType });
+      const chatAttachment = toChatAttachment(attachment);
+      if (!isImageAttachmentMime(chatAttachment.mimeType)) {
+        attachments.push(chatAttachment);
       }
     }
     if (reachedLegacyTerminator) break;


### PR DESCRIPTION
## Summary
- Preserve original names for Web-uploaded attachments in persisted history.
- Suppress generated attachment diagnostics and PDF metadata after reload while restoring attachment cards.
- Keep Office conversion guidance without presenting normal registered binary attachments as upload failures.

## Reproduction
1. Upload a PDF, DOCX, or XLSX through the Web UI.
2. Send the message, then refresh or reopen the session.
3. Previously, history could expose generated metadata, omit the attachment card, or show a staged `file-0-*` name.

## Validation
- `corepack pnpm --dir ui exec vitest run src/components/chat/utils/attachmentNotes.spec.ts`
- `npm run build && node --test --test-force-exit --test-timeout 60000 dist/tests/context/attachment-resolver.spec.js dist/tests/gateway/attachment-guidance.spec.js`
- `corepack pnpm --dir ui build`