### PR TITLE
Split macOS desktop releases by architecture

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -56,11 +56,25 @@ env:
 
 jobs:
   macos:
-    runs-on: macos-latest
+    name: macOS ${{ matrix.arch }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: arm64
+            runner: macos-latest
+            host_arch: arm64
+            binary_arch: arm64
+          - arch: x64
+            runner: macos-15-intel
+            host_arch: x86_64
+            binary_arch: x86_64
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 90
     env:
       PILOTDECK_DESKTOP_RELEASE_DATE: ${{ inputs.release_date }}
       PILOTDECK_DESKTOP_REVISION: ${{ inputs.revision }}
+      PILOTDECK_DESKTOP_NODE_ARCH: ${{ matrix.arch }}
       PILOTDECK_DESKTOP_REQUIRE_SIGNING: ${{ inputs.require_macos_signing && '1' || '0' }}
       APPLE_ID: ${{ secrets.APPLE_ID }}
       APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
@@ -80,8 +94,10 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Verify Apple Silicon build host
-        run: test "$(uname -m)" = arm64
+      - name: Verify macOS build host
+        env:
+          EXPECTED_HOST_ARCH: ${{ matrix.host_arch }}
+        run: test "$(uname -m)" = "$EXPECTED_HOST_ARCH"
 
       - name: Set desktop release metadata
         run: node apps/desktop/scripts/set-ci-version.mjs
@@ -121,18 +137,24 @@ jobs:
           echo "CSC_KEYCHAIN=$KEYCHAIN_PATH" >> "$GITHUB_ENV"
           echo "CSC_IDENTITY_AUTO_DISCOVERY=true" >> "$GITHUB_ENV"
 
-      - name: Build macOS universal installer
-        env:
-          PILOTDECK_DESKTOP_NODE_ARCH: universal
-        run: pnpm --filter pilotdeck-desktop run dist:mac
+      - name: Build macOS ${{ matrix.arch }} installer
+        run: pnpm --filter pilotdeck-desktop run dist:mac:${{ matrix.arch }}
 
       - name: Verify macOS artifact
         shell: bash
+        env:
+          MACOS_ARCH: ${{ matrix.arch }}
+          MACH_ARCH: ${{ matrix.binary_arch }}
         run: |
-          app_path="apps/desktop/dist-electron/mac-universal/PilotDeck.app"
-          dmg_path="$(find apps/desktop/dist-electron -maxdepth 1 -name '*.dmg' -print -quit)"
-          test -d "$app_path"
+          app_path="$(find apps/desktop/dist-electron -mindepth 2 -maxdepth 2 -type d -name 'PilotDeck.app' -print -quit)"
+          dmg_path="$(find apps/desktop/dist-electron -maxdepth 1 -name "*-mac-${MACOS_ARCH}.dmg" -print -quit)"
+          test -n "$app_path"
           test -n "$dmg_path"
+          test "$(lipo -archs "$app_path/Contents/MacOS/PilotDeck")" = "$MACH_ARCH"
+          test "$(lipo -archs "$app_path/Contents/Resources/node/bin/node")" = "$MACH_ARCH"
+          native_path="$(find "$app_path/Contents/Resources/runtime/node_modules/better-sqlite3" -name '*.node' -print -quit)"
+          test -n "$native_path"
+          test "$(lipo -archs "$native_path")" = "$MACH_ARCH"
           codesign --verify --deep --strict --verbose=2 "$app_path"
           hdiutil verify "$dmg_path"
 
@@ -140,7 +162,8 @@ jobs:
         if: ${{ inputs.require_macos_signing }}
         shell: bash
         run: |
-          app_path="apps/desktop/dist-electron/mac-universal/PilotDeck.app"
+          app_path="$(find apps/desktop/dist-electron -mindepth 2 -maxdepth 2 -type d -name 'PilotDeck.app' -print -quit)"
+          test -n "$app_path"
           codesign -dv --verbose=4 "$app_path" 2>&1 | grep -q 'Authority=Developer ID Application:'
           xcrun stapler validate "$app_path"
           spctl --assess --type execute --verbose=2 "$app_path"
@@ -148,8 +171,8 @@ jobs:
       - name: Upload macOS installer
         uses: actions/upload-artifact@v4
         with:
-          name: pilotdeck-desktop-macos
-          path: apps/desktop/dist-electron/*.dmg
+          name: pilotdeck-desktop-macos-${{ matrix.arch }}
+          path: apps/desktop/dist-electron/*-mac-${{ matrix.arch }}.dmg
           if-no-files-found: error
           retention-days: 14
 

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -134,7 +134,8 @@ jobs:
       - name: Verify complete cross-platform release
         shell: bash
         run: |
-          find release-assets -maxdepth 1 -name '*.dmg' -print -quit | grep -q .
+          find release-assets -maxdepth 1 -name '*-mac-arm64.dmg' -print -quit | grep -q .
+          find release-assets -maxdepth 1 -name '*-mac-x64.dmg' -print -quit | grep -q .
           find release-assets -maxdepth 1 -name '*-setup.exe' -print -quit | grep -q .
           test -s release-assets/desktop-release.json
           test -s release-assets/SHA256SUMS.txt

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -15,13 +15,16 @@ child processes, then opens the packaged Web UI inside an Electron window.
 ## Packaging
 
 ```bash
-pnpm --filter pilotdeck-desktop dist:mac
+# Run the command matching the Mac host architecture:
+pnpm --filter pilotdeck-desktop dist:mac:arm64
+pnpm --filter pilotdeck-desktop dist:mac:x64
 pnpm --filter pilotdeck-desktop dist:win
 ```
 
 Platform release builds should run on matching GitHub Actions runners:
 
-- macOS universal DMG artifacts on `macos-latest`
+- macOS arm64 DMG artifacts on `macos-latest`
+- macOS x64 DMG artifacts on `macos-15-intel`
 - Windows x64 NSIS installer artifacts on `windows-latest`
 
 macOS CI signs and notarizes release artifacts when the repository provides
@@ -38,9 +41,10 @@ these GitHub Secrets:
 CI release builds fail closed when signing credentials are absent. Local macOS
 development packages may still use ad-hoc signing.
 
-The packaging script stages a production-only runtime in `.runtime/app` before
-calling `electron-builder`; the final app should not include the workspace
-development dependency tree.
+Each packaging script stages one architecture-matched, production-only runtime
+in `.runtime/app` before calling `electron-builder`; the final app should not
+include the other macOS architecture or the workspace development dependency
+tree.
 
 See [`docs/desktop-release.md`](../../docs/desktop-release.md) for the daily
 release policy, required GitHub Secrets, manual recovery, and Web deployment

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -10,7 +10,9 @@
     "compile": "tsc -p tsconfig.json",
     "dev": "node scripts/build-runtime.mjs && tsc -p tsconfig.json && electron .",
     "pack": "node scripts/build-runtime.mjs && tsc -p tsconfig.json && electron-builder --dir",
-    "dist:mac": "PILOTDECK_DESKTOP_NODE_ARCH=universal node scripts/build-runtime.mjs && tsc -p tsconfig.json && electron-builder --mac --universal",
+    "dist:mac": "node scripts/build-runtime.mjs && tsc -p tsconfig.json && electron-builder --mac",
+    "dist:mac:arm64": "PILOTDECK_DESKTOP_NODE_ARCH=arm64 node scripts/build-runtime.mjs && tsc -p tsconfig.json && electron-builder --mac --arm64",
+    "dist:mac:x64": "PILOTDECK_DESKTOP_NODE_ARCH=x64 node scripts/build-runtime.mjs && tsc -p tsconfig.json && electron-builder --mac --x64",
     "dist:win": "node scripts/build-runtime.mjs && tsc -p tsconfig.json && electron-builder --win",
     "dist:win:portable": "node scripts/build-runtime.mjs && tsc -p tsconfig.json && electron-builder --win portable",
     "download-git-bash": "node scripts/download-git-bash.mjs",
@@ -77,13 +79,6 @@
         "filter": [
           "**/*"
         ]
-      },
-      {
-        "from": ".runtime/app-x64",
-        "to": "runtime-x64",
-        "filter": [
-          "**/*"
-        ]
       }
     ],
     "mac": {
@@ -93,7 +88,6 @@
       "gatekeeperAssess": false,
       "entitlements": "resources/entitlements.mac.plist",
       "entitlementsInherit": "resources/entitlements.mac.plist",
-      "x64ArchFiles": "Contents/Resources/{runtime,runtime-x64}/**/*",
       "signIgnore": [
         "Contents/Resources/runtime/node_modules/playwright-core/\\.local-browsers/"
       ],

--- a/apps/desktop/scripts/after-pack.cjs
+++ b/apps/desktop/scripts/after-pack.cjs
@@ -153,22 +153,15 @@ module.exports = async function afterPack(context) {
   const desktopRoot = resolve(__dirname, "..");
   const resourcesDir = getResourcesDir(context);
   const source = resolve(desktopRoot, ".runtime", "app", "node_modules");
-  const x64Source = resolve(desktopRoot, ".runtime", "app-x64", "node_modules");
   const runtimeRoot = join(resourcesDir, "runtime");
-  const x64RuntimeRoot = join(resourcesDir, "runtime-x64");
   const nodeRoot = join(resourcesDir, "node");
   const target = copyRuntimeNodeModules(source, runtimeRoot, "runtime");
-  const x64Target = existsSync(join(x64RuntimeRoot, "package.json"))
-    ? copyRuntimeNodeModules(x64Source, x64RuntimeRoot, "x64 runtime")
-    : null;
   const runtimeSymlinks = materializeSymlinks(runtimeRoot);
-  const x64RuntimeSymlinks = existsSync(x64RuntimeRoot) ? materializeSymlinks(x64RuntimeRoot) : 0;
   const nodeSymlinks = materializeSymlinks(nodeRoot);
   console.log(
-    `[desktop] afterPack materialized ${runtimeSymlinks} runtime symlinks, ${x64RuntimeSymlinks} x64 runtime symlinks, and ${nodeSymlinks} node symlinks`,
+    `[desktop] afterPack materialized ${runtimeSymlinks} runtime symlinks and ${nodeSymlinks} node symlinks`,
   );
 
   verifyPackagedRuntime(target, context, "runtime");
-  if (x64Target) verifyPackagedRuntime(x64Target, context, "x64 runtime");
   ensureMacSigningFallback(context);
 };

--- a/apps/desktop/scripts/build-runtime.mjs
+++ b/apps/desktop/scripts/build-runtime.mjs
@@ -25,7 +25,6 @@ const desktopRoot = resolve(__dirname, "..");
 const repoRoot = resolve(desktopRoot, "..", "..");
 const runtimePackageRoot = resolve(desktopRoot, "runtime");
 const defaultRuntimeRoot = resolve(desktopRoot, ".runtime", "app");
-const x64RuntimeRoot = resolve(desktopRoot, ".runtime", "app-x64");
 const desktopPackage = readJson(resolve(desktopRoot, "package.json"));
 const bundledNodeBinary = resolve(
   desktopRoot,
@@ -34,7 +33,11 @@ const bundledNodeBinary = resolve(
   process.platform === "win32" ? "node.exe" : "bin/node",
 );
 let runtimeRoot = defaultRuntimeRoot;
-let currentRuntimeArch = process.arch;
+const targetRuntimeArch = (process.env.PILOTDECK_DESKTOP_NODE_ARCH || process.arch).trim().toLowerCase();
+if (!new Set(["arm64", "x64"]).has(targetRuntimeArch)) {
+  throw new Error(`Unsupported desktop runtime architecture: ${targetRuntimeArch}`);
+}
+let currentRuntimeArch = targetRuntimeArch;
 const DESKTOP_BUILD = desktopPackage.version;
 const DESKTOP_PLAYWRIGHT_BROWSER = "chrome-for-testing";
 const uiServerDependencies = [
@@ -228,10 +231,7 @@ function prepareRuntimeTree(installEnv = process.env) {
   const uiPackage = readJson(resolve(repoRoot, "ui", "package.json"));
   const runtimePackage = readJson(resolve(runtimePackageRoot, "package.json"));
   verifyRuntimePackageManifest(rootPackage, uiPackage, runtimePackage);
-  const installRoot = resolve(
-    desktopRoot,
-    runtimeRoot === x64RuntimeRoot ? ".runtime-install-x64" : ".runtime-install",
-  );
+  const installRoot = resolve(desktopRoot, ".runtime-install");
   rmSync(installRoot, { recursive: true, force: true });
   mkdirSync(installRoot, { recursive: true });
   cpSync(resolve(runtimePackageRoot, "package.json"), resolve(installRoot, "package.json"));
@@ -491,15 +491,6 @@ function rewriteUiServerSourceImports(serverRoot) {
 
 run(process.execPath, [resolve(desktopRoot, "scripts", "download-node.mjs")], desktopRoot);
 assertBundledNodeRuntime();
-if (
-  process.platform === "darwin" &&
-  process.env.PILOTDECK_DESKTOP_NODE_ARCH === "universal" &&
-  process.arch !== "arm64"
-) {
-  throw new Error(
-    "macOS universal desktop builds must run on an Apple Silicon host so arm64 and x64 native modules can both be staged and verified.",
-  );
-}
 if (process.platform === "win32") {
   run(process.execPath, [resolve(desktopRoot, "scripts", "download-git-bash.mjs")], desktopRoot);
 }
@@ -529,16 +520,16 @@ for (const file of sourceRequired) {
 
 function stageRuntime(root, env = process.env, options = {}) {
   runtimeRoot = root;
-  currentRuntimeArch = options.runtimeArch || process.arch;
+  currentRuntimeArch = options.runtimeArch || targetRuntimeArch;
   try {
     prepareRuntimeTree(env);
     pruneRuntimeTree();
   } finally {
-    currentRuntimeArch = process.arch;
+    currentRuntimeArch = targetRuntimeArch;
   }
 }
 
-function verifyRuntime(root, label = "runtime", runtimeArch = process.arch) {
+function verifyRuntime(root, label = "runtime", runtimeArch = targetRuntimeArch) {
   const previousRuntimeRoot = runtimeRoot;
   runtimeRoot = root;
 
@@ -638,33 +629,5 @@ function verifyRuntimeNativeModule(moduleName, label, runtimeArch) {
   }
 }
 
-function shouldStageX64Runtime() {
-  return process.platform === "darwin" && process.env.PILOTDECK_DESKTOP_NODE_ARCH === "universal";
-}
-
-function prepareRuntimePlaceholders() {
-  if (shouldStageX64Runtime()) return;
-  rmSync(x64RuntimeRoot, { recursive: true, force: true });
-  mkdirSync(x64RuntimeRoot, { recursive: true });
-  writeFileSync(resolve(x64RuntimeRoot, ".placeholder"), "not used for this build\n");
-}
-
-stageRuntime(defaultRuntimeRoot);
-verifyRuntime(defaultRuntimeRoot);
-
-if (shouldStageX64Runtime()) {
-  stageRuntime(
-    x64RuntimeRoot,
-    {
-      ...process.env,
-      npm_config_arch: "x64",
-      npm_config_target_arch: "x64",
-      npm_config_platform: "darwin",
-      npm_config_target_platform: "darwin",
-    },
-    { runtimeArch: "x64" },
-  );
-  verifyRuntime(x64RuntimeRoot, "x64 runtime", "x64");
-} else {
-  prepareRuntimePlaceholders();
-}
+stageRuntime(defaultRuntimeRoot, process.env, { runtimeArch: targetRuntimeArch });
+verifyRuntime(defaultRuntimeRoot, "runtime", targetRuntimeArch);

--- a/apps/desktop/scripts/create-release-manifest.test.mjs
+++ b/apps/desktop/scripts/create-release-manifest.test.mjs
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const scriptsRoot = dirname(fileURLToPath(import.meta.url));
+
+test("release manifest records separate macOS architecture installers", () => {
+  const assetsDir = mkdtempSync(join(tmpdir(), "pilotdeck-release-assets-"));
+  try {
+    for (const name of [
+      "PilotDeck-2026.903.0-mac-arm64.dmg",
+      "PilotDeck-2026.903.0-mac-x64.dmg",
+      "PilotDeck-2026.903.0-win-x64-setup.exe",
+    ]) {
+      writeFileSync(resolve(assetsDir, name), name);
+    }
+
+    const result = spawnSync(
+      process.execPath,
+      [resolve(scriptsRoot, "create-release-manifest.mjs"), assetsDir],
+      {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          PILOTDECK_DESKTOP_VERSION: "2026.903.0",
+          PILOTDECK_DESKTOP_RELEASE_TAG: "desktop-v2026.09.03",
+          PILOTDECK_DESKTOP_RELEASE_DATE: "2026-09-03",
+          PILOTDECK_DESKTOP_BUILD_TIME: "2026-09-03T02:00:00+08:00",
+          PILOTDECK_COMMIT_SHA: "0123456789abcdef",
+          PILOTDECK_UPDATE_REPOSITORY: "OpenBMB/PilotDeck",
+        },
+      },
+    );
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+
+    const manifest = JSON.parse(readFileSync(resolve(assetsDir, "desktop-release.json"), "utf8"));
+    assert.deepEqual(
+      manifest.assets
+        .map(({ name, platform, arch }) => ({ name, platform, arch }))
+        .sort((left, right) => left.name.localeCompare(right.name)),
+      [
+        { name: "PilotDeck-2026.903.0-mac-arm64.dmg", platform: "darwin", arch: "arm64" },
+        { name: "PilotDeck-2026.903.0-mac-x64.dmg", platform: "darwin", arch: "x64" },
+        { name: "PilotDeck-2026.903.0-win-x64-setup.exe", platform: "win32", arch: "x64" },
+      ],
+    );
+  } finally {
+    rmSync(assetsDir, { recursive: true, force: true });
+  }
+});

--- a/apps/desktop/scripts/download-node.mjs
+++ b/apps/desktop/scripts/download-node.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { chmodSync, cpSync, existsSync, mkdirSync, rmSync, renameSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, rmSync, renameSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
@@ -23,8 +23,8 @@ const archMap = {
 };
 
 const nodePlatform = platformMap[process.platform];
-const nodeArch = requestedArch === "universal" ? "universal" : archMap[requestedArch];
-if (!nodePlatform || !nodeArch || (requestedArch === "universal" && process.platform !== "darwin")) {
+const nodeArch = archMap[requestedArch];
+if (!nodePlatform || !nodeArch) {
   throw new Error(`Unsupported platform for bundled Node: ${process.platform}/${requestedArch}`);
 }
 
@@ -74,12 +74,12 @@ function bundledNodeMatchesRequest() {
   if (!existsSync(nodeBinary)) return false;
   const versionCheck = spawnSync(nodeBinary, ["--version"], { encoding: "utf8" });
   if (versionCheck.stdout.trim() !== `v${version}`) return false;
-  if (nodeArch !== "universal") return true;
+  if (process.platform !== "darwin") return true;
 
   const archCheck = spawnSync("lipo", ["-archs", nodeBinary], { encoding: "utf8" });
   if (archCheck.status !== 0) return false;
-  const archs = new Set(archCheck.stdout.trim().split(/\s+/u));
-  return archs.has("x86_64") && archs.has("arm64");
+  const expectedArch = nodeArch === "x64" ? "x86_64" : nodeArch;
+  return archCheck.stdout.trim() === expectedArch;
 }
 
 function downloadSourceForArchive(archiveName) {
@@ -123,28 +123,6 @@ async function installSingleArchNode(arch) {
   await extractNodeArchive(arch, targetDir);
 }
 
-async function installUniversalDarwinNode() {
-  if (process.platform !== "darwin") {
-    throw new Error("Universal bundled Node is only supported on macOS");
-  }
-
-  const arm64Dir = resolve(tmpDir, "node-arm64");
-  const x64Dir = resolve(tmpDir, "node-x64");
-  await extractNodeArchive("arm64", arm64Dir);
-  await extractNodeArchive("x64", x64Dir);
-
-  cpSync(arm64Dir, targetDir, { recursive: true });
-  const targetBinary = join(targetDir, "bin", "node");
-  console.log("[desktop] creating universal bundled Node binary");
-  runChecked("lipo", [
-    "-create",
-    join(arm64Dir, "bin", "node"),
-    join(x64Dir, "bin", "node"),
-    "-output",
-    targetBinary,
-  ]);
-}
-
 if (bundledNodeMatchesRequest()) {
   pruneNodeDistribution();
   console.log(`[desktop] bundled Node already present: v${version} (${nodeArch})`);
@@ -156,11 +134,7 @@ mkdirSync(tmpDir, { recursive: true });
 
 rmSync(targetDir, { recursive: true, force: true });
 
-if (nodeArch === "universal") {
-  await installUniversalDarwinNode();
-} else {
-  await installSingleArchNode(nodeArch);
-}
+await installSingleArchNode(nodeArch);
 
 rmSync(tmpDir, { recursive: true, force: true });
 if (process.platform !== "win32") chmodSync(nodeBinary, 0o755);

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -642,10 +642,6 @@ function resolveRuntimeRoot(): string {
     return path.resolve(process.env.PILOTDECK_DESKTOP_RUNTIME_ROOT);
   }
   if (app.isPackaged) {
-    if (process.platform === "darwin" && process.arch === "x64") {
-      const x64Runtime = path.join(process.resourcesPath, "runtime-x64");
-      if (fs.existsSync(x64Runtime)) return x64Runtime;
-    }
     return path.join(process.resourcesPath, "runtime");
   }
   return path.resolve(__dirname, "..", "..", "..");

--- a/docs/desktop-release.md
+++ b/docs/desktop-release.md
@@ -30,17 +30,18 @@ known baseline failures; all other UI/server tests remain in the merge gate.
 the latest desktop release tag:
 
 - no production change: skip the release;
-- production change: build a signed and notarized macOS installer plus an
-  unsigned Windows installer, then publish one dated GitHub Release;
+- production change: build signed and notarized macOS arm64 and x64 installers
+  plus an unsigned Windows installer, then publish one dated GitHub Release;
 - repeated manual release on the same date: use `-r2`, `-r3`, and so on.
 
 Release tags are `desktop-vYYYY.MM.DD`. The internal Electron version is a
 numeric SemVer derived from the same Shanghai date. GitHub Actions may also be
 started manually with an optional release revision.
 
-Every release contains the DMG, Windows installer, `desktop-release.json`, and
-`SHA256SUMS`. The desktop updater ignores unrelated Web/server releases and only
-considers tags beginning with `desktop-v`.
+Every release contains architecture-specific macOS DMGs, the Windows installer,
+`desktop-release.json`, and `SHA256SUMS`. The desktop updater ignores unrelated
+Web/server releases, considers only tags beginning with `desktop-v`, and selects
+the installer matching the current machine architecture.
 
 Release publishing and packaged updater metadata use the repository running the
 workflow. Production builds from upstream `main` therefore publish to and check
@@ -61,9 +62,10 @@ macOS:
 - `APPLE_TEAM_ID`
 - `MACOS_KEYCHAIN_PASSWORD` (optional)
 
-The macOS universal job runs on GitHub's Apple Silicon `macos-latest` image and
-fails early if the host architecture is not arm64. This is required so both
-arm64 and Rosetta/x64 native dependencies are installed and tested.
+The macOS jobs run in parallel on GitHub's Apple Silicon `macos-latest` and
+Intel `macos-15-intel` images. Each job fails early when the runner architecture
+does not match its installer, and verifies the Electron executable, bundled
+Node.js, and native runtime modules before uploading the DMG.
 
 The macOS certificate must be a Developer ID Application certificate. The
 Windows installer does not require a signing certificate. GitHub's automatic
@@ -74,7 +76,9 @@ Windows installer does not require a signing certificate. GitHub's automatic
 ```bash
 pnpm install --frozen-lockfile
 pnpm --filter pilotdeck-desktop test
-pnpm --filter pilotdeck-desktop dist:mac
+# Run the command matching the Mac host architecture:
+pnpm --filter pilotdeck-desktop dist:mac:arm64
+pnpm --filter pilotdeck-desktop dist:mac:x64
 # Run the following on Windows:
 pnpm --filter pilotdeck-desktop dist:win
 ```
@@ -94,7 +98,8 @@ UI manifests, or if its committed lockfile is stale.
 
 ## Recovery
 
-If one platform fails, fix the credential or build issue and rerun the failed
-workflow. A release is created only after both platform artifacts are downloaded
-and verified. For a deliberate second release on the same Shanghai
-date, run the daily workflow manually and set revision `2` or higher.
+If one architecture or platform fails, fix the credential or build issue and
+rerun the failed workflow. A release is created only after both macOS DMGs and
+the Windows installer are downloaded and verified. For a deliberate additional
+release on the same Shanghai date, leave revision empty to select the next
+available `-rN` tag automatically.

--- a/ui/server/services/desktopUpdateService.js
+++ b/ui/server/services/desktopUpdateService.js
@@ -550,10 +550,15 @@ function scoreExtension(name, platform) {
 
 function scoreArch(name, arch) {
   if (/(universal|all)/.test(name)) return 20;
-  if (arch === 'arm64') return /(arm64|aarch64)/.test(name) ? 25 : 0;
-  if (arch === 'x64') return /(x64|x86_64|amd64)/.test(name) ? 25 : 0;
-  if (arch === 'ia32') return /(ia32|x86|i386)/.test(name) ? 25 : 0;
-  return 0;
+  const assetArch = /(arm64|aarch64)/.test(name)
+    ? 'arm64'
+    : /(x64|x86_64|amd64)/.test(name)
+      ? 'x64'
+      : /(ia32|i386|(?:^|[-_.])x86(?:[-_.]|$))/.test(name)
+        ? 'ia32'
+        : null;
+  if (!assetArch) return 0;
+  return assetArch === arch ? 25 : -200;
 }
 
 function readPackageVersion(projectRoot) {

--- a/ui/server/services/desktopUpdateService.test.js
+++ b/ui/server/services/desktopUpdateService.test.js
@@ -6,6 +6,7 @@ import {
   normalizeRepository,
   normalizeDesktopReleaseVersion,
   parseVersionParts,
+  selectDesktopAsset,
 } from './desktopUpdateService.js';
 
 describe('desktop release versions', () => {
@@ -33,5 +34,28 @@ describe('desktop release versions', () => {
 
   it('exposes the normalized version from GitHub releases', () => {
     expect(mapGitHubRelease({ tag_name: 'desktop-v2026.09.02-r2' }).version).toBe('2026.902.1');
+  });
+
+  it('selects the native macOS installer for the current architecture', () => {
+    const release = {
+      assets: [
+        { name: 'PilotDeck-2026.903.0-mac-x64.dmg' },
+        { name: 'PilotDeck-2026.903.0-mac-arm64.dmg' },
+        { name: 'PilotDeck-2026.903.0-mac-universal.dmg' },
+      ],
+    };
+
+    expect(selectDesktopAsset(release, { platform: 'darwin', arch: 'arm64' })?.name)
+      .toBe('PilotDeck-2026.903.0-mac-arm64.dmg');
+    expect(selectDesktopAsset(release, { platform: 'darwin', arch: 'x64' })?.name)
+      .toBe('PilotDeck-2026.903.0-mac-x64.dmg');
+  });
+
+  it('never offers a macOS installer built only for another architecture', () => {
+    const release = {
+      assets: [{ name: 'PilotDeck-2026.903.0-mac-x64.dmg' }],
+    };
+
+    expect(selectDesktopAsset(release, { platform: 'darwin', arch: 'arm64' })).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

- build separate arm64 and x64 macOS DMGs in parallel on native GitHub runners
- package only the matching bundled Node.js and production runtime for each architecture
- require both macOS artifacts before publishing the daily desktop release
- make the desktop updater select the installer matching the current Mac architecture
- document the new local and CI build commands

## Validation

- `pnpm --filter pilotdeck-desktop test` — 18 passed
- `pnpm --filter pilotdeck-desktop run compile` — passed
- `pnpm --dir ui exec vitest run server/services/desktopUpdateService.test.js` — 7 passed
- workflow YAML parse and release matrix assertions — passed
- full local arm64 DMG build — passed; Electron, Node.js, and better-sqlite3 verified as arm64
- full local x64 DMG build under Rosetta — passed; Electron, Node.js, and better-sqlite3 verified as x86_64
- `codesign --verify --deep --strict` and `hdiutil verify` — passed for both DMGs

The native GitHub runner matrix provides the final Intel and Apple Silicon CI build environments.