### PR TITLE
fix(attachments): preserve upload history safely

### DIFF
--- a/src/adapters/channel/wecom/WeComChannel.ts
+++ b/src/adapters/channel/wecom/WeComChannel.ts
@@ -890,7 +890,7 @@ export class WeComChannel implements ChannelAdapter {
       path: filePath,
       mimeType,
       bytes: data.length,
-      metadata: { source: "wecom", mediaType: kind },
+      metadata: { channelKey: "wecom", source: "wecom", mediaType: kind },
     };
   }
 

--- a/src/cli/createLocalGateway.ts
+++ b/src/cli/createLocalGateway.ts
@@ -439,6 +439,7 @@ export function createLocalGateway(options: CreateLocalGatewayOptions = {}): Cre
           mimeType: attachment.mimeType,
           bytes: attachment.bytes,
           metadata: {
+            channelKey: "web",
             uploadId,
             attachmentId: attachment.attachmentId,
             relativePath: attachment.relativePath,

--- a/src/context/attachments/AttachmentResolver.ts
+++ b/src/context/attachments/AttachmentResolver.ts
@@ -145,7 +145,10 @@ export class AttachmentResolver {
         diagnostics: [
           {
             code: "attachment_unsupported",
-            severity: "warning",
+            // Office and archive formats are expected to be available only as
+            // registered paths. They need a document tool or conversion, but
+            // are not an upload failure that belongs in the user's message.
+            severity: BINARY_CONTAINER_EXTENSIONS.has(ext) ? "info" : "warning",
             message: unsupportedFileMessage(absolute, ext),
           },
         ],

--- a/src/context/attachments/AttachmentResolver.ts
+++ b/src/context/attachments/AttachmentResolver.ts
@@ -3,7 +3,7 @@ import { extname, resolve } from "node:path";
 import type { CanonicalContentBlock, CanonicalMessage } from "../../model/index.js";
 
 export type AttachmentRequest =
-  | { type: "file"; path: string }
+  | { type: "file"; path: string; name?: string }
   | { type: "image"; path: string; mimeType?: string }
   | { type: "pdf"; path: string };
 
@@ -98,7 +98,7 @@ export class AttachmentResolver {
   async resolve(request: AttachmentRequest): Promise<ResolvedAttachment> {
     switch (request.type) {
       case "file":
-        return this.resolveFile(request.path);
+        return this.resolveFile(request.path, request.name);
       case "image":
         return this.resolveImage(request.path, request.mimeType);
       case "pdf":
@@ -121,7 +121,7 @@ export class AttachmentResolver {
     return { role: "user", content: attachment.blocks };
   }
 
-  private async resolveFile(path: string): Promise<ResolvedAttachment> {
+  private async resolveFile(path: string, name?: string): Promise<ResolvedAttachment> {
     const absolute = resolve(path);
     let info;
     try {
@@ -138,7 +138,10 @@ export class AttachmentResolver {
         ],
       };
     }
-    const ext = extname(absolute).toLowerCase();
+    // Upload stores may use an opaque id as the on-disk path. Prefer the
+    // original filename for format detection while keeping the resolved path
+    // as the only filesystem target.
+    const ext = extname(name?.trim() ?? "").toLowerCase() || extname(absolute).toLowerCase();
     if (!TEXT_EXTENSIONS.has(ext)) {
       return {
         blocks: [],

--- a/src/gateway/client/InProcessGateway.ts
+++ b/src/gateway/client/InProcessGateway.ts
@@ -2479,7 +2479,9 @@ function buildAttachmentPathNote(
   }
 
   if (lines.length === 0) return undefined;
-  const guidance = hasDiagnostics || attachments.some(isAudioAttachment)
+  const guidance = hasDiagnostics
+    || attachments.some(isAudioAttachment)
+    || attachments.some((attachment) => !isReadFileInspectableAttachment(attachment))
     ? attachmentDiagnosticsGuidance(attachments, allowedReadFiles, projectRoot, installCommand)
     : "These are path references for reuse. If an image/PDF is already visible in this turn, do not call read_file just to view it.";
   return {
@@ -2524,7 +2526,9 @@ function isReadFileInspectableAttachment(attachment: ChannelAttachment): boolean
   if (mimeType === "application/json" || mimeType.endsWith("+json")) return true;
 
   const pathOrName = attachment.path || attachment.name || "";
-  const extension = extname(pathOrName).toLowerCase();
+  // Upload staging paths can be opaque IDs for legacy attachments. Prefer the
+  // original name so Office files still receive conversion guidance.
+  const extension = extname(attachment.name ?? "").toLowerCase() || extname(pathOrName).toLowerCase();
   if (extension === ".pdf" || extension === ".ipynb") return true;
   if (READ_FILE_BINARY_ATTACHMENT_EXTENSIONS.has(extension)) return false;
   return true;

--- a/src/gateway/client/InProcessGateway.ts
+++ b/src/gateway/client/InProcessGateway.ts
@@ -2428,11 +2428,12 @@ async function buildAgentInputWithAttachments(
   projectRoot?: string,
   funasrInstallCommand?: string,
 ): Promise<AgentInput> {
-  const resolvedAttachments = await attachmentsToContentBlocks(attachments);
+  const allowedReadFileSet = new Set(allowedReadFiles);
+  const resolvedAttachments = await attachmentsToContentBlocks(attachments, allowedReadFileSet);
   const attachmentBlocks = resolvedAttachments.blocks;
   const pathNote = buildAttachmentPathNote(
     attachments,
-    new Set(allowedReadFiles),
+    allowedReadFileSet,
     resolvedAttachments.directContentPaths,
     resolvedAttachments.hasDiagnostics,
     projectRoot,
@@ -2563,12 +2564,14 @@ async function collectRegisteredAttachmentReadFiles(
 
 async function attachmentsToContentBlocks(
   attachments: ChannelAttachment[] | undefined,
+  allowedReadFiles: Set<string>,
 ): Promise<{ blocks: CanonicalContentBlock[]; directContentPaths: Set<string>; hasDiagnostics: boolean }> {
   if (!attachments || attachments.length === 0) {
     return { blocks: [], directContentPaths: new Set<string>(), hasDiagnostics: false };
   }
   const blocks: CanonicalContentBlock[] = [];
   const resolverRequests: AttachmentRequest[] = [];
+  const resolverAttachments: ChannelAttachment[] = [];
   const resolverRequestPaths: Array<string | undefined> = [];
   const directContentPaths = new Set<string>();
   const diagnostics: string[] = [];
@@ -2600,26 +2603,47 @@ async function attachmentsToContentBlocks(
     }
     if (att.type === "image" || att.mimeType?.startsWith("image/")) {
       resolverRequests.push({ type: "image", path: att.path, mimeType: att.mimeType });
+      resolverAttachments.push(att);
       resolverRequestPaths.push(resolve(att.path));
     } else if (att.mimeType === "application/pdf" || att.path.toLowerCase().endsWith(".pdf")) {
       resolverRequests.push({ type: "pdf", path: att.path });
+      resolverAttachments.push(att);
       resolverRequestPaths.push(resolve(att.path));
     } else {
       resolverRequests.push({ type: "file", path: att.path });
+      resolverAttachments.push(att);
       resolverRequestPaths.push(resolve(att.path));
     }
   }
 
   if (resolverRequests.length > 0) {
-    const resolved = await new AttachmentResolver().resolveAll(resolverRequests);
-    blocks.push(...resolved.blocks);
-    for (const diagnostic of resolved.diagnostics) {
-      if (diagnostic.severity === "error" || diagnostic.severity === "warning") {
-        diagnostics.push(diagnostic.message);
+    const resolver = new AttachmentResolver();
+    for (let index = 0; index < resolverRequests.length; index += 1) {
+      const request = resolverRequests[index];
+      const attachment = resolverAttachments[index];
+      if (!request || !attachment) continue;
+
+      const resolved = await resolver.resolve(request);
+      blocks.push(...resolved.blocks);
+      const isRegistered = Boolean(
+        attachment.path && safeAllowedAttachmentPath(attachment.path, allowedReadFiles),
+      );
+      let hasVisibleDiagnostic = false;
+      for (const diagnostic of resolved.diagnostics) {
+        const shouldSurface = diagnostic.severity === "error"
+          || diagnostic.severity === "warning"
+          || (
+            diagnostic.severity === "info"
+            && diagnostic.code === "attachment_unsupported"
+            && !isRegistered
+          );
+        if (shouldSurface) {
+          diagnostics.push(diagnostic.message);
+          hasVisibleDiagnostic = true;
+        }
       }
-    }
-    if (resolved.blocks.length > 0 && diagnostics.length === 0) {
-      for (const requestPath of resolverRequestPaths) {
+      if (resolved.blocks.length > 0 && !hasVisibleDiagnostic) {
+        const requestPath = resolverRequestPaths[index];
         if (requestPath) directContentPaths.add(requestPath);
       }
     }

--- a/src/gateway/client/InProcessGateway.ts
+++ b/src/gateway/client/InProcessGateway.ts
@@ -2610,7 +2610,7 @@ async function attachmentsToContentBlocks(
       resolverAttachments.push(att);
       resolverRequestPaths.push(resolve(att.path));
     } else {
-      resolverRequests.push({ type: "file", path: att.path });
+      resolverRequests.push({ type: "file", path: att.path, name: att.name });
       resolverAttachments.push(att);
       resolverRequestPaths.push(resolve(att.path));
     }

--- a/tests/adapters/channel/wecom-attachments.spec.ts
+++ b/tests/adapters/channel/wecom-attachments.spec.ts
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import { rm } from "node:fs/promises";
+import test from "node:test";
+
+import { WeComChannel } from "../../../src/adapters/channel/wecom/WeComChannel.js";
+import type { ChannelAttachment } from "../../../src/gateway/index.js";
+
+test("WeCom inbound files are marked as registered channel attachments", async () => {
+  const channel = new WeComChannel({
+    uuid: () => "00000000-0000-4000-8000-000000000001",
+  });
+  const cacheInboundMedia = (channel as unknown as {
+    cacheInboundMedia: (
+      kind: "file",
+      media: Record<string, unknown>,
+    ) => Promise<ChannelAttachment | undefined>;
+  }).cacheInboundMedia.bind(channel);
+
+  const attachment = await cacheInboundMedia("file", {
+    filename: "report.docx",
+    content_type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    base64: Buffer.from("PKfake-office-document").toString("base64"),
+  });
+
+  assert.ok(attachment?.path);
+  try {
+    assert.equal(attachment.metadata?.channelKey, "wecom");
+  } finally {
+    await rm(attachment.path, { force: true });
+  }
+});

--- a/tests/context/attachment-resolver.spec.ts
+++ b/tests/context/attachment-resolver.spec.ts
@@ -6,7 +6,7 @@ import { tmpdir } from "node:os";
 
 import { AttachmentResolver } from "../../src/context/attachments/AttachmentResolver.js";
 
-test("Office attachments are reported unsupported before size checks", async () => {
+test("Office attachments are registered as non-inline information before size checks", async () => {
   const root = await mkdtemp(join(tmpdir(), "pilotdeck-attachment-resolver-"));
   try {
     const filePath = join(root, "sample.docx");
@@ -17,7 +17,7 @@ test("Office attachments are reported unsupported before size checks", async () 
     assert.equal(result.blocks.length, 0);
     assert.equal(result.diagnostics.length, 1);
     assert.equal(result.diagnostics[0]?.code, "attachment_unsupported");
-    assert.equal(result.diagnostics[0]?.severity, "warning");
+    assert.equal(result.diagnostics[0]?.severity, "info");
     assert.match(result.diagnostics[0]?.message ?? "", /read_file cannot inspect this format directly/);
   } finally {
     await rm(root, { recursive: true, force: true });

--- a/tests/context/attachment-resolver.spec.ts
+++ b/tests/context/attachment-resolver.spec.ts
@@ -6,13 +6,17 @@ import { tmpdir } from "node:os";
 
 import { AttachmentResolver } from "../../src/context/attachments/AttachmentResolver.js";
 
-test("Office attachments are registered as non-inline information before size checks", async () => {
+test("Office attachments use their original name when the stored path is opaque", async () => {
   const root = await mkdtemp(join(tmpdir(), "pilotdeck-attachment-resolver-"));
   try {
-    const filePath = join(root, "sample.docx");
+    const filePath = join(root, "opaque-upload-id");
     await writeFile(filePath, Buffer.from("PK".padEnd(128, "x")));
 
-    const result = await new AttachmentResolver({ maxFileBytes: 1 }).resolve({ type: "file", path: filePath });
+    const result = await new AttachmentResolver({ maxFileBytes: 1 }).resolve({
+      type: "file",
+      path: filePath,
+      name: "sample.docx",
+    });
 
     assert.equal(result.blocks.length, 0);
     assert.equal(result.diagnostics.length, 1);

--- a/tests/gateway/attachment-guidance.spec.ts
+++ b/tests/gateway/attachment-guidance.spec.ts
@@ -42,7 +42,7 @@ test("registered plain-text attachments with non-whitelisted names are described
   }
 });
 
-test("registered Office attachments are still described as not directly inspectable", async () => {
+test("registered Office attachments receive conversion guidance without raw diagnostics", async () => {
   const root = await mkdtemp(join(tmpdir(), "pilotdeck-attachment-guidance-"));
   try {
     const docxPath = join(root, "sample.docx");
@@ -70,6 +70,42 @@ test("registered Office attachments are still described as not directly inspecta
     const text = inputText(capturedInput);
     assert.match(text, /sample\.docx/);
     assert.match(text, /not directly inspectable with read_file/);
+    assert.doesNotMatch(text, /\[Attachment diagnostics\]/);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("registered PDF attachments retain their original name in the history path note", async () => {
+  const root = await mkdtemp(join(tmpdir(), "pilotdeck-attachment-guidance-"));
+  try {
+    const pdfPath = join(root, "file-0-opaque-upload-id.pdf");
+    await writeFile(pdfPath, Buffer.from("%PDF-1.7"));
+
+    let capturedInput: AgentInput | undefined;
+    const gateway = createGateway((input) => {
+      capturedInput = input;
+    });
+
+    for await (const _event of gateway.submitTurn({
+      sessionKey: "session-1",
+      channelKey: "web",
+      message: "分析附件",
+      attachments: [{
+        type: "file",
+        path: pdfPath,
+        name: "心理学科百年材料.pdf",
+        mimeType: "application/pdf",
+        metadata: { channelKey: "web" },
+      }],
+    })) {
+      // Drain the stream so the fake session runs to completion.
+    }
+
+    const text = inputText(capturedInput);
+    assert.match(text, /\[Registered attachment files in this session:\]/);
+    assert.match(text, /心理学科百年材料\.pdf/);
+    assert.match(text, new RegExp(pdfPath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
   } finally {
     await rm(root, { recursive: true, force: true });
   }

--- a/tests/gateway/attachment-guidance.spec.ts
+++ b/tests/gateway/attachment-guidance.spec.ts
@@ -45,7 +45,7 @@ test("registered plain-text attachments with non-whitelisted names are described
 test("registered Office attachments receive conversion guidance without raw diagnostics", async () => {
   const root = await mkdtemp(join(tmpdir(), "pilotdeck-attachment-guidance-"));
   try {
-    const docxPath = join(root, "sample.docx");
+    const docxPath = join(root, "opaque-upload-id");
     await writeFile(docxPath, Buffer.from("PK".padEnd(128, "x")));
 
     let capturedInput: AgentInput | undefined;

--- a/tests/gateway/attachment-guidance.spec.ts
+++ b/tests/gateway/attachment-guidance.spec.ts
@@ -76,6 +76,39 @@ test("registered Office attachments receive conversion guidance without raw diag
   }
 });
 
+test("unregistered Office attachments retain diagnostics instead of disappearing", async () => {
+  const root = await mkdtemp(join(tmpdir(), "pilotdeck-attachment-guidance-"));
+  try {
+    const docxPath = join(root, "sample.docx");
+    await writeFile(docxPath, Buffer.from("PK".padEnd(128, "x")));
+
+    let capturedInput: AgentInput | undefined;
+    const gateway = createGateway((input) => {
+      capturedInput = input;
+    });
+
+    for await (const _event of gateway.submitTurn({
+      sessionKey: "session-1",
+      channelKey: "wecom",
+      message: "inspect attachment",
+      attachments: [{
+        type: "file",
+        path: docxPath,
+        name: "sample.docx",
+        metadata: { source: "wecom", mediaType: "file" },
+      }],
+    })) {
+      // Drain the stream so the fake session runs to completion.
+    }
+
+    const text = inputText(capturedInput);
+    assert.match(text, /\[Attachment diagnostics\]/);
+    assert.match(text, /sample\.docx/);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("registered PDF attachments retain their original name in the history path note", async () => {
   const root = await mkdtemp(join(tmpdir(), "pilotdeck-attachment-guidance-"));
   try {

--- a/ui/src/components/chat/utils/attachmentNotes.spec.ts
+++ b/ui/src/components/chat/utils/attachmentNotes.spec.ts
@@ -42,6 +42,43 @@ describe('attachment path notes', () => {
     }]);
   });
 
+  it('hides PDF runtime metadata after refresh and restores the attachment', () => {
+    const filePath = '/workspace/政研室/.tmp/chat-uploads/run/files/file-0-report.pdf';
+    const parsed = parseUserAttachmentNote([
+      '分析一下这个文件内容，总结给我',
+      `[PDF attachment: ${filePath}, 54858 bytes, estimated 1 pages. Use read_file on this registered attachment path to inspect it.]`,
+      '[Registered attachment files in this session:]',
+      `- 年度报告.pdf: ${filePath}`,
+    ].join('\n'));
+
+    expect(parsed).toEqual({
+      content: '分析一下这个文件内容，总结给我',
+      attachments: [{
+        name: '年度报告.pdf',
+        path: filePath,
+        mimeType: 'application/pdf',
+      }],
+    });
+  });
+
+  it('hides standalone Office diagnostics after refresh and restores the attachment', () => {
+    const filePath = '/workspace/政研室/.tmp/chat-uploads/run/files/file-0-report.docx';
+    const parsed = parseUserAttachmentNote([
+      '分析一下这个文件内容，总结给我',
+      '[Attachment diagnostics]',
+      `- Attachment ${filePath} has Office/archive/binary extension .docx; it was registered as a file path but not shown inline.`,
+    ].join('\n'));
+
+    expect(parsed).toEqual({
+      content: '分析一下这个文件内容，总结给我',
+      attachments: [{
+        name: 'file-0-report.docx',
+        path: filePath,
+        mimeType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+      }],
+    });
+  });
+
   it('preserves a colon in the attachment filename', () => {
     const filePath = '/tmp/1-report__final.pdf';
     const parsed = parseUserAttachmentNote([

--- a/ui/src/components/chat/utils/attachmentNotes.spec.ts
+++ b/ui/src/components/chat/utils/attachmentNotes.spec.ts
@@ -85,7 +85,9 @@ describe('attachment path notes', () => {
 
   it.each([
     '请解释 <attachment path="/tmp/demo.txt"> 这段 XML',
+    '请解释 <attachment path="/tmp/demo.txt">example</attachment> 这段 XML',
     '正文中提到了 [PDF attachment:，但这不是附件元数据',
+    '请解释 [PDF attachment: /tmp/demo.pdf, 42 bytes, estimated 1 page. Use read_file on this registered attachment path to inspect it.] 这段文本',
     '请解释 [Attachment diagnostics] 这个标题',
     '请解释 [Registered attachment files in this session:] 这个标题',
   ])('preserves attachment-like user text: %s', (content) => {
@@ -95,7 +97,26 @@ describe('attachment path notes', () => {
     });
   });
 
-  it('restores generated attachments that follow a content reference block', () => {
+  it('restores a trailing generated inline attachment', () => {
+    const filePath = '/tmp/file-0-notes.txt';
+    const parsed = parseUserAttachmentNote([
+      '总结文件',
+      `<attachment path="${filePath}">\nhello\n</attachment>`,
+      '\n\n[Registered attachment files in this session:]\n',
+      `- notes.txt: ${filePath}`,
+    ].join(''));
+
+    expect(parsed).toEqual({
+      content: '总结文件',
+      attachments: [{
+        name: 'notes.txt',
+        path: filePath,
+        mimeType: 'text/plain',
+      }],
+    });
+  });
+
+  it('restores an upload and content reference from the projected production order', () => {
     const reference = createTextContentReference({
       id: 'reference-1',
       createdAt: '2026-08-16T09:00:00.000Z',
@@ -108,6 +129,7 @@ describe('attachment path notes', () => {
     const filePath = '/tmp/file-0-report';
     const parsed = parseUserAttachmentNote([
       '比较两个文件',
+      buildAttachmentPathNote([{ name: 'report.pdf', path: filePath }]),
       formatContentReferencePromptBlock([reference]),
       `[PDF attachment: ${filePath}, 42 bytes, estimated 1 page. Use read_file on this registered attachment path to inspect it.]`,
       '\n\n[Registered attachment files in this session:]\n',

--- a/ui/src/components/chat/utils/attachmentNotes.spec.ts
+++ b/ui/src/components/chat/utils/attachmentNotes.spec.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import type { ChatAttachment } from '../types/types';
 import {
+  createTextContentReference,
+  formatContentReferencePromptBlock,
+} from '../../../types/contentReference';
+import {
   buildAttachmentPathNote,
   mergeUserAttachments,
   parseUserAttachmentNote,
@@ -43,7 +47,7 @@ describe('attachment path notes', () => {
   });
 
   it('hides PDF runtime metadata after refresh and restores the attachment', () => {
-    const filePath = '/workspace/政研室/.tmp/chat-uploads/run/files/file-0-report.pdf';
+    const filePath = '/workspace/政研室/.tmp/chat-uploads/run/files/file-0-opaque-upload-id';
     const parsed = parseUserAttachmentNote([
       '分析一下这个文件内容，总结给我',
       `[PDF attachment: ${filePath}, 54858 bytes, estimated 1 pages. Use read_file on this registered attachment path to inspect it.]`,
@@ -76,6 +80,61 @@ describe('attachment path notes', () => {
         path: filePath,
         mimeType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
       }],
+    });
+  });
+
+  it.each([
+    '请解释 <attachment path="/tmp/demo.txt"> 这段 XML',
+    '正文中提到了 [PDF attachment:，但这不是附件元数据',
+    '请解释 [Attachment diagnostics] 这个标题',
+    '请解释 [Registered attachment files in this session:] 这个标题',
+  ])('preserves attachment-like user text: %s', (content) => {
+    expect(parseUserAttachmentNote(content)).toEqual({
+      content,
+      attachments: [],
+    });
+  });
+
+  it('restores generated attachments that follow a content reference block', () => {
+    const reference = createTextContentReference({
+      id: 'reference-1',
+      createdAt: '2026-08-16T09:00:00.000Z',
+      selectionMode: 'text',
+      source: { relativePath: 'notes.md', fileName: 'notes.md' },
+      renderer: { id: 'text', backend: 'builtin', locatorQuality: 'semantic' },
+      locator: { surface: 'document', quote: { exact: 'selection' } },
+      selectedText: 'selection',
+    });
+    const filePath = '/tmp/file-0-report';
+    const parsed = parseUserAttachmentNote([
+      '比较两个文件',
+      formatContentReferencePromptBlock([reference]),
+      `[PDF attachment: ${filePath}, 42 bytes, estimated 1 page. Use read_file on this registered attachment path to inspect it.]`,
+      '\n\n[Registered attachment files in this session:]\n',
+      `- report.pdf: ${filePath}`,
+    ].join(''));
+
+    expect(parsed.content).toBe('比较两个文件');
+    expect(parsed.attachments.map((attachment) => ({
+      kind: attachment.kind || 'file',
+      name: attachment.name,
+    }))).toEqual([
+      { kind: 'file', name: 'report.pdf' },
+      { kind: 'content-reference', name: 'notes.md' },
+    ]);
+  });
+
+  it('does not restore a registered image as a duplicate file card', () => {
+    const filePath = '/tmp/file-0-opaque-image-id';
+    const parsed = parseUserAttachmentNote([
+      '查看图片',
+      '[Registered attachment files in this session:]',
+      `- photo.png: ${filePath}`,
+    ].join('\n'));
+
+    expect(parsed).toEqual({
+      content: '查看图片',
+      attachments: [],
     });
   });
 

--- a/ui/src/components/chat/utils/attachmentNotes.ts
+++ b/ui/src/components/chat/utils/attachmentNotes.ts
@@ -13,6 +13,12 @@ import {
 const ATTACHMENT_NOTE_MARKER = '[Files attached by user and available for reading in the project:]';
 const ATTACHMENT_NOTE_END_MARKER = '[End files attached by user]';
 const ATTACHMENT_NOTE_JSON_PREFIX = '- attachment-json: ';
+const GENERATED_ATTACHMENT_BLOCK_MARKERS = [
+  '[Attachment diagnostics]',
+  '[Registered attachment files in this session:]',
+  '[PDF attachment:',
+  '<attachment ',
+];
 // Older transcripts have no end marker. Their next canonical text block may
 // be concatenated directly onto the final path during history projection.
 const LEGACY_ATTACHMENT_NOTE_TERMINATORS = [
@@ -132,6 +138,81 @@ function isImageAttachmentMime(mimeType: string | undefined): boolean {
   return Boolean(mimeType?.toLowerCase().startsWith('image/'));
 }
 
+function toChatAttachment(file: AttachmentPathNoteFile): ChatAttachment {
+  return {
+    name: file.name,
+    path: file.path,
+    mimeType: inferAttachmentMimeType(file.name, file.path),
+  };
+}
+
+function attachmentFromGeneratedPath(path: string, name?: string): AttachmentPathNoteFile | null {
+  const filePath = path.trim();
+  if (!isLikelyLegacyAttachmentPath(filePath)) return null;
+
+  const fallbackName = filePath.split(/[\\/]/).pop()?.trim();
+  const fileName = name?.trim() || fallbackName;
+  return fileName ? { name: fileName, path: filePath } : null;
+}
+
+function appendUniqueAttachment(
+  attachments: AttachmentPathNoteFile[],
+  seen: Set<string>,
+  candidate: AttachmentPathNoteFile | null,
+): void {
+  if (!candidate) return;
+  const key = candidate.path;
+  if (seen.has(key)) return;
+  seen.add(key);
+  attachments.push(candidate);
+}
+
+function generatedAttachmentBlockStart(value: string): number {
+  let start = -1;
+  for (const marker of GENERATED_ATTACHMENT_BLOCK_MARKERS) {
+    const index = value.indexOf(marker);
+    if (index >= 0 && (start < 0 || index < start)) start = index;
+  }
+  return start;
+}
+
+function parseGeneratedAttachmentBlocks(value: string): {
+  content: string;
+  attachments: AttachmentPathNoteFile[];
+} | null {
+  const start = generatedAttachmentBlockStart(value);
+  if (start < 0) return null;
+
+  const generated = value.slice(start);
+  const attachments: AttachmentPathNoteFile[] = [];
+  const seen = new Set<string>();
+  const registeredMarker = '[Registered attachment files in this session:]';
+  const registeredIndex = generated.indexOf(registeredMarker);
+  if (registeredIndex >= 0) {
+    const registeredLines = generated.slice(registeredIndex + registeredMarker.length).split(/\r?\n/);
+    for (const rawLine of registeredLines) {
+      appendUniqueAttachment(attachments, seen, parseAttachmentPathNoteLine(rawLine.trim()));
+    }
+  }
+
+  const inlineAttachmentPattern = /<attachment\s+path="([^"]+)"/giu;
+  for (const match of generated.matchAll(inlineAttachmentPattern)) {
+    appendUniqueAttachment(attachments, seen, attachmentFromGeneratedPath(match[1] ?? ''));
+  }
+
+  const pdfAttachmentPattern = /\[PDF attachment:\s*(.+?),\s*\d+\s+bytes,\s*estimated\s+\d+\s+pages?\.\s*Use read_file on this registered attachment path to inspect it\.\]/giu;
+  for (const match of generated.matchAll(pdfAttachmentPattern)) {
+    appendUniqueAttachment(attachments, seen, attachmentFromGeneratedPath(match[1] ?? ''));
+  }
+
+  const officeDiagnosticPattern = /Attachment\s+(.+?)\s+has Office\/archive\/binary extension\s+[^;]+;/giu;
+  for (const match of generated.matchAll(officeDiagnosticPattern)) {
+    appendUniqueAttachment(attachments, seen, attachmentFromGeneratedPath(match[1] ?? ''));
+  }
+
+  return { content: value.slice(0, start).trimEnd(), attachments };
+}
+
 export function parseUserAttachmentNote(content: unknown): {
   content: string;
   attachments: ChatAttachment[];
@@ -145,7 +226,14 @@ export function parseUserAttachmentNote(content: unknown): {
     ...parsedContentReferences.references.map(contentReferenceToAttachment),
   ];
   if (markerIndex < 0) {
-    return { content: text, attachments: selectionAttachments };
+    const generated = parseGeneratedAttachmentBlocks(text);
+    return {
+      content: generated?.content ?? text,
+      attachments: [
+        ...(generated?.attachments.map(toChatAttachment) ?? []),
+        ...selectionAttachments,
+      ],
+    };
   }
 
   const visibleContent = text.slice(0, markerIndex).trimEnd();
@@ -165,10 +253,9 @@ export function parseUserAttachmentNote(content: unknown): {
 
     const attachment = parseAttachmentPathNoteLine(line);
     if (attachment) {
-      const { name, path: filePath } = attachment;
-      const mimeType = inferAttachmentMimeType(name, filePath);
-      if (!isImageAttachmentMime(mimeType)) {
-        attachments.push({ name, path: filePath, mimeType });
+      const chatAttachment = toChatAttachment(attachment);
+      if (!isImageAttachmentMime(chatAttachment.mimeType)) {
+        attachments.push(chatAttachment);
       }
     }
     if (reachedLegacyTerminator) break;

--- a/ui/src/components/chat/utils/attachmentNotes.ts
+++ b/ui/src/components/chat/utils/attachmentNotes.ts
@@ -163,11 +163,16 @@ function appendUniqueAttachment(
   attachments.push(candidate);
 }
 
-function generatedDiagnosticsBlockStart(value: string): number | null {
+function generatedDiagnosticsBlockStart(value: string, end: number): number | null {
   const marker = '[Attachment diagnostics]';
-  for (let index = value.indexOf(marker); index >= 0; index = value.indexOf(marker, index + marker.length)) {
-    const suffix = value.slice(index + marker.length);
-    if (/^\s*-\s+(?:Attachment|Image|PDF attachment|File extension|Cannot determine image mime type)\b/u.test(suffix)) {
+  const diagnosticLine = /^\s*-\s+(?:Attachment|Image|PDF attachment|File extension|Cannot determine image mime type)\b/u;
+  for (let index = value.lastIndexOf(marker, end - 1);
+    index >= 0;
+    index = value.lastIndexOf(marker, index - 1)) {
+    const lines = value.slice(index + marker.length, end)
+      .split(/\r?\n/)
+      .filter((line) => line.trim().length > 0);
+    if (lines.length > 0 && lines.every((line) => diagnosticLine.test(line))) {
       return index;
     }
   }
@@ -180,9 +185,9 @@ function parseGeneratedAttachmentBlocks(value: string): {
 } | null {
   const attachments: AttachmentPathNoteFile[] = [];
   const seen = new Set<string>();
-  const starts: number[] = [];
+  const registeredPaths = new Set<string>();
   const registeredMarker = '[Registered attachment files in this session:]';
-  const registeredIndex = value.lastIndexOf(registeredMarker);
+  let registeredIndex = value.lastIndexOf(registeredMarker);
   if (registeredIndex >= 0) {
     const registeredLines = value.slice(registeredIndex + registeredMarker.length).split(/\r?\n/);
     let foundRegisteredAttachment = false;
@@ -191,37 +196,72 @@ function parseGeneratedAttachmentBlocks(value: string): {
       const candidate = parsed
         ? attachmentFromGeneratedPath(parsed.path, parsed.name)
         : null;
-      if (candidate) foundRegisteredAttachment = true;
+      if (candidate) {
+        foundRegisteredAttachment = true;
+        registeredPaths.add(candidate.path);
+      }
       appendUniqueAttachment(attachments, seen, candidate);
     }
-    if (foundRegisteredAttachment) starts.push(registeredIndex);
+    if (!foundRegisteredAttachment) registeredIndex = -1;
   }
 
+  const diagnosticsEnd = registeredIndex >= 0 ? registeredIndex : value.length;
+  const diagnosticsStart = generatedDiagnosticsBlockStart(value, diagnosticsEnd);
+  if (diagnosticsStart !== null) {
+    const officeDiagnosticPattern = /Attachment\s+(.+?)\s+has Office\/archive\/binary extension\s+[^;]+;/giu;
+    const diagnosticBlock = value.slice(diagnosticsStart, diagnosticsEnd);
+    for (const match of diagnosticBlock.matchAll(officeDiagnosticPattern)) {
+      appendUniqueAttachment(attachments, seen, attachmentFromGeneratedPath(match[1] ?? ''));
+    }
+  }
+
+  const embeddedBlocks: Array<{
+    start: number;
+    end: number;
+    attachment: AttachmentPathNoteFile;
+  }> = [];
   const inlineAttachmentPattern = /<attachment\s+path="([^"]+)">[\s\S]*?<\/attachment>/giu;
   for (const match of value.matchAll(inlineAttachmentPattern)) {
     const candidate = attachmentFromGeneratedPath(match[1] ?? '');
-    if (candidate && match.index !== undefined) starts.push(match.index);
-    appendUniqueAttachment(attachments, seen, candidate);
+    if (candidate && match.index !== undefined) {
+      embeddedBlocks.push({
+        start: match.index,
+        end: match.index + match[0].length,
+        attachment: candidate,
+      });
+    }
   }
 
   const pdfAttachmentPattern = /\[PDF attachment:\s*(.+?),\s*\d+\s+bytes,\s*estimated\s+\d+\s+pages?\.\s*Use read_file on this registered attachment path to inspect it\.\]/giu;
   for (const match of value.matchAll(pdfAttachmentPattern)) {
     const candidate = attachmentFromGeneratedPath(match[1] ?? '');
-    if (candidate && match.index !== undefined) starts.push(match.index);
-    appendUniqueAttachment(attachments, seen, candidate);
+    if (candidate && match.index !== undefined) {
+      embeddedBlocks.push({
+        start: match.index,
+        end: match.index + match[0].length,
+        attachment: candidate,
+      });
+    }
   }
 
-  const officeDiagnosticPattern = /Attachment\s+(.+?)\s+has Office\/archive\/binary extension\s+[^;]+;/giu;
-  for (const match of value.matchAll(officeDiagnosticPattern)) {
-    appendUniqueAttachment(attachments, seen, attachmentFromGeneratedPath(match[1] ?? ''));
+  let generatedStart = diagnosticsStart
+    ?? (registeredIndex >= 0 ? registeredIndex : value.length);
+  let foundGeneratedBlock = diagnosticsStart !== null || registeredIndex >= 0;
+  const acceptedEmbeddedBlocks: typeof embeddedBlocks = [];
+  for (const block of embeddedBlocks.sort((left, right) => right.start - left.start)) {
+    if (block.end > generatedStart) continue;
+    if (value.slice(block.end, generatedStart).trim().length > 0) continue;
+    if (registeredIndex >= 0 && !registeredPaths.has(block.attachment.path)) continue;
+    acceptedEmbeddedBlocks.push(block);
+    generatedStart = block.start;
+    foundGeneratedBlock = true;
+  }
+  for (const block of acceptedEmbeddedBlocks.reverse()) {
+    appendUniqueAttachment(attachments, seen, block.attachment);
   }
 
-  const diagnosticsStart = generatedDiagnosticsBlockStart(value);
-  if (diagnosticsStart !== null) starts.push(diagnosticsStart);
-  if (starts.length === 0) return null;
-
-  const start = Math.min(...starts);
-  return { content: value.slice(0, start).trimEnd(), attachments };
+  if (!foundGeneratedBlock) return null;
+  return { content: value.slice(0, generatedStart).trimEnd(), attachments };
 }
 
 export function parseUserAttachmentNote(content: unknown): {
@@ -229,12 +269,11 @@ export function parseUserAttachmentNote(content: unknown): {
   attachments: ChatAttachment[];
 } {
   const rawText = typeof content === 'string' ? content : '';
-  // The bounded client-authored note is authoritative and already hides all
-  // following canonical blocks. Parsing generated blocks as well can mistake
-  // legacy terminator fixtures for additional attachments.
-  const generated = rawText.includes(ATTACHMENT_NOTE_MARKER)
-    ? null
-    : parseGeneratedAttachmentBlocks(rawText);
+  const hasClientAttachmentNote = rawText.includes(ATTACHMENT_NOTE_MARKER);
+  // Strip trailing gateway-authored blocks before parsing content references.
+  // The client-authored note remains authoritative for attachment names when
+  // present, so generated attachments are merged only for legacy/channel input.
+  const generated = parseGeneratedAttachmentBlocks(rawText);
   const parsedContentReferences = parseContentReferencePromptBlock(generated?.content ?? rawText);
   const parsedSelections = parseDocumentSelectionPromptBlock(parsedContentReferences.content);
   const text = parsedSelections.content;
@@ -243,7 +282,9 @@ export function parseUserAttachmentNote(content: unknown): {
     ...parsedSelections.references.map(documentSelectionToAttachment),
     ...parsedContentReferences.references.map(contentReferenceToAttachment),
   ];
-  const generatedAttachments = (generated?.attachments.map(toChatAttachment) ?? [])
+  const generatedAttachments = (hasClientAttachmentNote
+    ? []
+    : generated?.attachments.map(toChatAttachment) ?? [])
     .filter((attachment) => !isImageAttachmentMime(attachment.mimeType));
   if (markerIndex < 0) {
     return {

--- a/ui/src/components/chat/utils/attachmentNotes.ts
+++ b/ui/src/components/chat/utils/attachmentNotes.ts
@@ -13,12 +13,6 @@ import {
 const ATTACHMENT_NOTE_MARKER = '[Files attached by user and available for reading in the project:]';
 const ATTACHMENT_NOTE_END_MARKER = '[End files attached by user]';
 const ATTACHMENT_NOTE_JSON_PREFIX = '- attachment-json: ';
-const GENERATED_ATTACHMENT_BLOCK_MARKERS = [
-  '[Attachment diagnostics]',
-  '[Registered attachment files in this session:]',
-  '[PDF attachment:',
-  '<attachment ',
-];
 // Older transcripts have no end marker. Their next canonical text block may
 // be concatenated directly onto the final path during history projection.
 const LEGACY_ATTACHMENT_NOTE_TERMINATORS = [
@@ -113,24 +107,26 @@ function sliceBeforeFirstMarker(value: string, markers: string[]): string {
 }
 
 function inferAttachmentMimeType(name: string, filePath: string): string | undefined {
-  const source = `${name} ${filePath}`.toLowerCase();
-  if (source.endsWith('.pdf')) return 'application/pdf';
-  if (source.endsWith('.doc')) return 'application/msword';
-  if (source.endsWith('.docx')) return 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
-  if (source.endsWith('.xls')) return 'application/vnd.ms-excel';
-  if (source.endsWith('.xlsx')) return 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
-  if (source.endsWith('.ppt')) return 'application/vnd.ms-powerpoint';
-  if (source.endsWith('.pptx')) return 'application/vnd.openxmlformats-officedocument.presentationml.presentation';
-  if (source.endsWith('.txt')) return 'text/plain';
-  if (source.endsWith('.md') || source.endsWith('.markdown')) return 'text/markdown';
-  if (source.endsWith('.json')) return 'application/json';
-  if (source.endsWith('.csv')) return 'text/csv';
-  if (source.endsWith('.xml')) return 'application/xml';
-  if (source.endsWith('.png')) return 'image/png';
-  if (source.endsWith('.jpg') || source.endsWith('.jpeg')) return 'image/jpeg';
-  if (source.endsWith('.gif')) return 'image/gif';
-  if (source.endsWith('.webp')) return 'image/webp';
-  if (source.endsWith('.svg') || source.endsWith('.svgz')) return 'image/svg+xml';
+  for (const source of [name, filePath]) {
+    const normalized = source.toLowerCase();
+    if (normalized.endsWith('.pdf')) return 'application/pdf';
+    if (normalized.endsWith('.doc')) return 'application/msword';
+    if (normalized.endsWith('.docx')) return 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
+    if (normalized.endsWith('.xls')) return 'application/vnd.ms-excel';
+    if (normalized.endsWith('.xlsx')) return 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
+    if (normalized.endsWith('.ppt')) return 'application/vnd.ms-powerpoint';
+    if (normalized.endsWith('.pptx')) return 'application/vnd.openxmlformats-officedocument.presentationml.presentation';
+    if (normalized.endsWith('.txt')) return 'text/plain';
+    if (normalized.endsWith('.md') || normalized.endsWith('.markdown')) return 'text/markdown';
+    if (normalized.endsWith('.json')) return 'application/json';
+    if (normalized.endsWith('.csv')) return 'text/csv';
+    if (normalized.endsWith('.xml')) return 'application/xml';
+    if (normalized.endsWith('.png')) return 'image/png';
+    if (normalized.endsWith('.jpg') || normalized.endsWith('.jpeg')) return 'image/jpeg';
+    if (normalized.endsWith('.gif')) return 'image/gif';
+    if (normalized.endsWith('.webp')) return 'image/webp';
+    if (normalized.endsWith('.svg') || normalized.endsWith('.svgz')) return 'image/svg+xml';
+  }
   return undefined;
 }
 
@@ -167,49 +163,64 @@ function appendUniqueAttachment(
   attachments.push(candidate);
 }
 
-function generatedAttachmentBlockStart(value: string): number {
-  let start = -1;
-  for (const marker of GENERATED_ATTACHMENT_BLOCK_MARKERS) {
-    const index = value.indexOf(marker);
-    if (index >= 0 && (start < 0 || index < start)) start = index;
+function generatedDiagnosticsBlockStart(value: string): number | null {
+  const marker = '[Attachment diagnostics]';
+  for (let index = value.indexOf(marker); index >= 0; index = value.indexOf(marker, index + marker.length)) {
+    const suffix = value.slice(index + marker.length);
+    if (/^\s*-\s+(?:Attachment|Image|PDF attachment|File extension|Cannot determine image mime type)\b/u.test(suffix)) {
+      return index;
+    }
   }
-  return start;
+  return null;
 }
 
 function parseGeneratedAttachmentBlocks(value: string): {
   content: string;
   attachments: AttachmentPathNoteFile[];
 } | null {
-  const start = generatedAttachmentBlockStart(value);
-  if (start < 0) return null;
-
-  const generated = value.slice(start);
   const attachments: AttachmentPathNoteFile[] = [];
   const seen = new Set<string>();
+  const starts: number[] = [];
   const registeredMarker = '[Registered attachment files in this session:]';
-  const registeredIndex = generated.indexOf(registeredMarker);
+  const registeredIndex = value.lastIndexOf(registeredMarker);
   if (registeredIndex >= 0) {
-    const registeredLines = generated.slice(registeredIndex + registeredMarker.length).split(/\r?\n/);
+    const registeredLines = value.slice(registeredIndex + registeredMarker.length).split(/\r?\n/);
+    let foundRegisteredAttachment = false;
     for (const rawLine of registeredLines) {
-      appendUniqueAttachment(attachments, seen, parseAttachmentPathNoteLine(rawLine.trim()));
+      const parsed = parseAttachmentPathNoteLine(rawLine.trim());
+      const candidate = parsed
+        ? attachmentFromGeneratedPath(parsed.path, parsed.name)
+        : null;
+      if (candidate) foundRegisteredAttachment = true;
+      appendUniqueAttachment(attachments, seen, candidate);
     }
+    if (foundRegisteredAttachment) starts.push(registeredIndex);
   }
 
-  const inlineAttachmentPattern = /<attachment\s+path="([^"]+)"/giu;
-  for (const match of generated.matchAll(inlineAttachmentPattern)) {
-    appendUniqueAttachment(attachments, seen, attachmentFromGeneratedPath(match[1] ?? ''));
+  const inlineAttachmentPattern = /<attachment\s+path="([^"]+)">[\s\S]*?<\/attachment>/giu;
+  for (const match of value.matchAll(inlineAttachmentPattern)) {
+    const candidate = attachmentFromGeneratedPath(match[1] ?? '');
+    if (candidate && match.index !== undefined) starts.push(match.index);
+    appendUniqueAttachment(attachments, seen, candidate);
   }
 
   const pdfAttachmentPattern = /\[PDF attachment:\s*(.+?),\s*\d+\s+bytes,\s*estimated\s+\d+\s+pages?\.\s*Use read_file on this registered attachment path to inspect it\.\]/giu;
-  for (const match of generated.matchAll(pdfAttachmentPattern)) {
-    appendUniqueAttachment(attachments, seen, attachmentFromGeneratedPath(match[1] ?? ''));
+  for (const match of value.matchAll(pdfAttachmentPattern)) {
+    const candidate = attachmentFromGeneratedPath(match[1] ?? '');
+    if (candidate && match.index !== undefined) starts.push(match.index);
+    appendUniqueAttachment(attachments, seen, candidate);
   }
 
   const officeDiagnosticPattern = /Attachment\s+(.+?)\s+has Office\/archive\/binary extension\s+[^;]+;/giu;
-  for (const match of generated.matchAll(officeDiagnosticPattern)) {
+  for (const match of value.matchAll(officeDiagnosticPattern)) {
     appendUniqueAttachment(attachments, seen, attachmentFromGeneratedPath(match[1] ?? ''));
   }
 
+  const diagnosticsStart = generatedDiagnosticsBlockStart(value);
+  if (diagnosticsStart !== null) starts.push(diagnosticsStart);
+  if (starts.length === 0) return null;
+
+  const start = Math.min(...starts);
   return { content: value.slice(0, start).trimEnd(), attachments };
 }
 
@@ -217,7 +228,14 @@ export function parseUserAttachmentNote(content: unknown): {
   content: string;
   attachments: ChatAttachment[];
 } {
-  const parsedContentReferences = parseContentReferencePromptBlock(content);
+  const rawText = typeof content === 'string' ? content : '';
+  // The bounded client-authored note is authoritative and already hides all
+  // following canonical blocks. Parsing generated blocks as well can mistake
+  // legacy terminator fixtures for additional attachments.
+  const generated = rawText.includes(ATTACHMENT_NOTE_MARKER)
+    ? null
+    : parseGeneratedAttachmentBlocks(rawText);
+  const parsedContentReferences = parseContentReferencePromptBlock(generated?.content ?? rawText);
   const parsedSelections = parseDocumentSelectionPromptBlock(parsedContentReferences.content);
   const text = parsedSelections.content;
   const markerIndex = text.indexOf(ATTACHMENT_NOTE_MARKER);
@@ -225,14 +243,12 @@ export function parseUserAttachmentNote(content: unknown): {
     ...parsedSelections.references.map(documentSelectionToAttachment),
     ...parsedContentReferences.references.map(contentReferenceToAttachment),
   ];
+  const generatedAttachments = (generated?.attachments.map(toChatAttachment) ?? [])
+    .filter((attachment) => !isImageAttachmentMime(attachment.mimeType));
   if (markerIndex < 0) {
-    const generated = parseGeneratedAttachmentBlocks(text);
     return {
-      content: generated?.content ?? text,
-      attachments: [
-        ...(generated?.attachments.map(toChatAttachment) ?? []),
-        ...selectionAttachments,
-      ],
+      content: text,
+      attachments: mergeUserAttachments(generatedAttachments, selectionAttachments),
     };
   }
 
@@ -261,7 +277,13 @@ export function parseUserAttachmentNote(content: unknown): {
     if (reachedLegacyTerminator) break;
   }
 
-  return { content: visibleContent, attachments: [...attachments, ...selectionAttachments] };
+  return {
+    content: visibleContent,
+    attachments: mergeUserAttachments(
+      attachments,
+      [...generatedAttachments, ...selectionAttachments],
+    ),
+  };
 }
 
 function attachmentIdentity(attachment: ChatAttachment): string {


### PR DESCRIPTION
## Summary

Supersedes #543 while preserving the original contributor's commit and authorship.

- preserve attachment names and cards after history refresh without truncating ordinary user text that merely resembles generated attachment metadata
- recover uploads when generated attachment notes follow content-reference blocks, and avoid duplicate file cards for images
- register WeCom inbound attachment paths so Office files receive conversion guidance
- keep diagnostics visible for unregistered/unsupported binary attachments instead of silently dropping them

## Tests

- `corepack pnpm --dir ui exec vitest run src/components/chat/utils/attachmentNotes.spec.ts`
- `node --import tsx --test --test-timeout=60000 tests/adapters/channel/wecom-attachments.spec.ts tests/context/attachment-resolver.spec.ts tests/gateway/attachment-guidance.spec.ts`
- `corepack pnpm --dir ui exec eslint src/components/chat/utils/attachmentNotes.ts src/components/chat/utils/attachmentNotes.spec.ts`
- `corepack pnpm exec tsc -p tsconfig.json --noEmit`
- `corepack pnpm --dir ui run build`
