### PR TITLE
feat(transcription): route Web recordings to Trans-Speech

### DIFF
--- a/products/_example/config/pilotdeck.yaml
+++ b/products/_example/config/pilotdeck.yaml
@@ -22,6 +22,28 @@ memory:
 #     provider: glm                                 # glm | tavily | custom
 #     apiKey: "..."
 #     # endpoint: https://api.z.ai/api/paas/v4/web_search
+#   transSpeech:
+#     enabled: true
+#     baseUrl: "http://trans-speech:8090"
+#     language: "zh"
+#     asrProfile: "sensevoice"
+#     diarize: true
+#     timeoutMs: 330000
+#     maxConcurrentTasks: 1
+#     generate:
+#       polish: true
+#       minutes: true
+#       actions: false
+
+# Web 附件上传与 Trans-Speech 共用同一文件大小限制。
+# webui:
+#   attachments:
+#     maxFileSizeMB: 101
+
+# Trans-Speech 部署环境不使用内置 FunASR。
+# extension:
+#   builtinPluginsEnabled:
+#     funasr: false
 
 # 品牌配置（待贡献点就绪后生效）
 # brand:

--- a/skills/audio-transcription/SKILL.md
+++ b/skills/audio-transcription/SKILL.md
@@ -1,32 +1,25 @@
 ---
 name: audio-transcription
-description: Transcribe a project-local audio recording, generate subtitles, analyze a recording, or produce meeting notes from audio using local FunASR.
+description: Transcribe a Web-uploaded WAV, MP3, M4A, or FLAC recording through the configured Trans-Speech service.
 ---
 
 # Audio Transcription
 
 Use this Skill only when the user explicitly asks to transcribe audio, create subtitles, analyze a recording, or make meeting notes from a recording. Do not invoke ASR merely because an audio attachment is present.
 
-PilotDeck provides this Skill itself; there is no Skill file to install. First check whether `mcp__funasr__transcribe_audio` is available. If its local runtime or models are missing, run the exact `npm --prefix "..." run install:asr` command shown by the attachment or MCP diagnostic. It points at the PilotDeck source checkout or installed app directory:
-
-```bash
-npm --prefix "<PilotDeck directory>" run install:asr
-```
-
-The installer downloads the platform-specific official FunASR llama.cpp runtime and the local models. It does not require Docker, Python, or a cloud API. After it completes, retry `mcp__funasr__transcribe_audio` in the same session.
-
-For platform, cache, download-source, and network troubleshooting details, read `../../docs/funasr-installation.md` relative to this Skill directory.
+PilotDeck provides this Skill and the `trans_speech` tool. The tool reads the registered Web-uploaded file locally and sends it to the configured Trans-Speech service as multipart data; do not convert the path to a container path.
 
 ## Workflow
 
 1. Identify the registered audio attachment path in the session message.
-2. Pass that project-local host path directly as `audio_path`; do not convert it to a container path. The tool rejects paths outside the current project, including symlinks that escape it.
-3. Call `mcp__funasr__transcribe_audio` with `language: "auto"`. This is the only language value supported by the local SenseVoice CLI.
+2. Confirm it is WAV, MP3, M4A, or FLAC. Tell the user that other audio formats are unsupported; do not use another ASR provider.
+3. Call `trans_speech` with `{"action":"start","audio_path":"<exact registered path>"}`. The tool accepts only Web-uploaded files within the active project, including the current and legacy upload directories.
 4. Preserve timestamped segments for subtitles, verbatim transcripts, or auditable meeting records.
 5. Only after transcription, summarize, translate, or extract action items as requested.
 
 ## Constraints
 
 - Do not use `read_file` to decode audio.
-- Do not send the audio to a cloud service or substitute a different ASR provider without the user's direction.
-- The tool is intentionally limited to a real local file inside the active project.
+- Do not substitute a different ASR provider.
+- Do not invoke transcription merely because an audio attachment is present.
+- The tool is intentionally limited to a real Web-uploaded file inside the active project.

--- a/src/cli/createLocalGateway.ts
+++ b/src/cli/createLocalGateway.ts
@@ -61,7 +61,12 @@ import {
 } from "../mcp/index.js";
 import { createModelRuntime, type ModelRuntime } from "../model/index.js";
 import { createDefaultPermissionContext, type PermissionRule } from "../permission/index.js";
-import { loadPilotConfig, resolvePilotHome, type PilotProxyConfig } from "../pilot/index.js";
+import {
+  chatAttachmentMaxFileSizeBytes,
+  loadPilotConfig,
+  resolvePilotHome,
+  type PilotProxyConfig,
+} from "../pilot/index.js";
 import { createPilotConfigStoreSync, type PilotConfigStore } from "../pilot/config/PilotConfigStore.js";
 import type { PilotAgentModelSelection, PilotConfigSnapshot } from "../pilot/config/types.js";
 import { DEFAULT_JUDGE_TIMEOUT_MS, DEFAULT_ALLOWED_TOOLS, DEFAULT_TRIGGER_TIERS, type RouterConfig } from "../router/config/schema.js";
@@ -90,7 +95,7 @@ import type { RouterEventBus, RouterEvent } from "../router/protocol/events.js";
 import type { EdgeClawMemoryProvider } from "../context/index.js";
 import { loadBuiltinPlugins } from "../extension/plugins/builtin/loadBuiltinPlugins.js";
 import { SkillManager, migrateLegacyBundledSkillCopies } from "../extension/skills/index.js";
-import { getPilotDeckInstallCommand, patchProjectScopedMcpSpec } from "../mcp/runtime/projectMcpSpec.js";
+import { patchProjectScopedMcpSpec } from "../mcp/runtime/projectMcpSpec.js";
 import { ExtensionWatchManager, type ExtensionWatchEvent } from "./ExtensionWatchManager.js";
 import { createTelemetryCollector, type TelemetryClient } from "../telemetry/index.js";
 import { UploadStore } from "../gateway/dialog/UploadStore.js";
@@ -345,7 +350,6 @@ export function createLocalGateway(options: CreateLocalGatewayOptions = {}): Cre
     };
   };
   const gateway = new InProcessGateway(router, {
-    funasrInstallCommand: getPilotDeckInstallCommand(),
     now,
     serverInfo: { mode: "in_process", projectKey: projectRoot },
     telemetry,
@@ -881,7 +885,10 @@ class ProjectRuntimeRegistry {
             }
           : {}),
       ...(transSpeechConfig?.enabled ? {
-        transSpeech: { config: transSpeechConfig },
+        transSpeech: {
+          config: transSpeechConfig,
+          maxFileSizeBytes: chatAttachmentMaxFileSizeBytes(snapshot.config.webui),
+        },
       } : {}),
     });
     for (const tool of this._extraTools) {

--- a/src/gateway/client/InProcessGateway.ts
+++ b/src/gateway/client/InProcessGateway.ts
@@ -83,7 +83,7 @@ import type {
 import { permissionEntryToRule, permissionSettingsToRuleSet, readPermissionSettings } from "../../permission/index.js";
 import type { PermissionRule } from "../../permission/index.js";
 import { SkillManagerError, type SkillManager } from "../../extension/skills/index.js";
-import { getPilotDeckInstallCommand } from "../../mcp/runtime/projectMcpSpec.js";
+import { SUPPORTED_AUDIO_EXTENSIONS } from "../../transcription/types.js";
 import { AttachmentResolver, type AttachmentRequest } from "../../context/attachments/AttachmentResolver.js";
 import type {
   SkillAddressInput,
@@ -115,8 +115,6 @@ const MAX_GATEWAY_TOOL_DATA_STRING_CHARS = 4_000;
 const DEFAULT_REPLACEMENT_TRANSACTION_TIMEOUT_MS = 60_000;
 
 export type InProcessGatewayOptions = {
-  /** Absolute command used by the model to install bundled FunASR assets. */
-  funasrInstallCommand?: string;
   now?: () => Date;
   uuid?: () => string;
   serverInfo?: Partial<GatewayServerInfo>;
@@ -540,7 +538,6 @@ export class InProcessGateway implements Gateway {
           attachments,
           allowedReadFiles,
           input.projectKey,
-          this.options.funasrInstallCommand ?? getPilotDeckInstallCommand(),
         );
         const syntheticMessages: CanonicalMessage[] = (input.syntheticMessages ?? []).map((s) => ({
           role: "user" as const,
@@ -742,7 +739,6 @@ export class InProcessGateway implements Gateway {
       attachments,
       allowedReadFiles,
       input.projectKey,
-      this.options.funasrInstallCommand ?? getPilotDeckInstallCommand(),
     );
     const message: CanonicalMessage = {
       role: "user",
@@ -2411,7 +2407,6 @@ async function buildAgentInputWithAttachments(
   attachments: ChannelAttachment[] | undefined,
   allowedReadFiles: string[],
   projectRoot?: string,
-  funasrInstallCommand?: string,
 ): Promise<AgentInput> {
   const resolvedAttachments = await attachmentsToContentBlocks(attachments);
   const attachmentBlocks = resolvedAttachments.blocks;
@@ -2421,7 +2416,6 @@ async function buildAgentInputWithAttachments(
     resolvedAttachments.directContentPaths,
     resolvedAttachments.hasDiagnostics,
     projectRoot,
-    funasrInstallCommand,
   );
   if (attachmentBlocks.length === 0 && !pathNote) {
     return { type: "text", text: message };
@@ -2445,7 +2439,6 @@ function buildAttachmentPathNote(
   directContentPaths: Set<string>,
   hasDiagnostics: boolean,
   projectRoot?: string,
-  installCommand = "npm run install:asr",
 ): CanonicalContentBlock | undefined {
   if (!attachments || attachments.length === 0) return undefined;
   const seen = new Set<string>();
@@ -2467,7 +2460,7 @@ function buildAttachmentPathNote(
   const guidance = hasDiagnostics
     || attachments.some(isAudioAttachment)
     || attachments.some((attachment) => !isReadFileInspectableAttachment(attachment))
-    ? attachmentDiagnosticsGuidance(attachments, allowedReadFiles, projectRoot, installCommand)
+    ? attachmentDiagnosticsGuidance(attachments, allowedReadFiles, projectRoot)
     : "These are path references for reuse. If an image/PDF is already visible in this turn, do not call read_file just to view it.";
   return {
     type: "text",
@@ -2479,17 +2472,29 @@ function attachmentDiagnosticsGuidance(
   attachments: ChannelAttachment[],
   allowedReadFiles: Set<string>,
   projectRoot?: string,
-  installCommand = "npm run install:asr",
 ): string {
   const audioAttachments = attachments.filter((attachment) => isAudioAttachment(attachment));
   if (audioAttachments.length > 0) {
-    const audioPaths = audioAttachments
-      .map((attachment) => attachment.path && mapAudioPathForFunAsr(attachment.path, projectRoot))
+    const webAudioAttachments = audioAttachments.filter(isWebAudioAttachment);
+    const compatibleAttachments = webAudioAttachments.filter(isTransSpeechAudioAttachment);
+    const unsupportedAttachments = webAudioAttachments.filter((attachment) => !isTransSpeechAudioAttachment(attachment));
+    const nonWebAttachments = audioAttachments.filter((attachment) => !isWebAudioAttachment(attachment));
+    const unsupportedHint = unsupportedAttachments.length > 0
+      ? ` Trans-Speech supports only WAV, MP3, M4A, and FLAC; do not transcribe ${unsupportedAttachments.map(attachmentDisplayName).join(", ")}.`
+      : "";
+    const nonWebHint = nonWebAttachments.length > 0
+      ? ` Trans-Speech accepts only Web-uploaded audio; do not transcribe ${nonWebAttachments.map(attachmentDisplayName).join(", ")}.`
+      : "";
+    if (compatibleAttachments.length === 0) {
+      return `Audio attachments are not readable with read_file.${unsupportedHint}${nonWebHint}`;
+    }
+    const audioPaths = compatibleAttachments
+      .map((attachment) => attachment.path && mapAudioPathForTransSpeech(attachment.path, projectRoot))
       .filter((path): path is string => Boolean(path));
     const mappedHint = audioPaths.length > 0
-      ? ` Pass the registered project-local path${audioPaths.length === 1 ? ` ${audioPaths[0]}` : "s " + audioPaths.join(", ")} to transcribe_audio.`
-      : " Pass a project-local host path to transcribe_audio; paths outside this project are rejected.";
-    return `Audio attachments are not readable with read_file. When the user asks for transcription, subtitles, or audio analysis, use the funasr MCP server's mcp__funasr__transcribe_audio tool.${mappedHint} If that tool reports that its runtime is missing, run ${installCommand} and retry the tool in this session.`;
+      ? ` Call trans_speech with {"action":"start","audio_path":"<the exact registered path>"}; use ${audioPaths.join(", ")}.`
+      : " Call trans_speech with {\"action\":\"start\",\"audio_path\":\"<the exact registered project-local path>\"}; paths outside this project are rejected.";
+    return `Audio attachments are not readable with read_file. When the user asks for transcription, subtitles, or audio analysis, use trans_speech.${mappedHint}${unsupportedHint}${nonWebHint}`;
   }
 
   const hasInspectableAttachment = attachments.some((attachment) => {
@@ -2578,8 +2583,8 @@ async function attachmentsToContentBlocks(
 
     if (!att.path) continue;
     if (isAudioAttachment(att)) {
-      // Keep audio as a registered path reference. The ASR Skill invokes the
-      // FunASR MCP tool on demand, so audio should not be sent through the
+      // Keep audio as a registered path reference. The transcription Skill
+      // invokes trans_speech on demand, so audio is never sent through the
       // text/image/PDF attachment resolver.
       continue;
     }
@@ -2626,7 +2631,19 @@ function isAudioAttachment(attachment: ChannelAttachment): boolean {
   return /\.(?:aac|flac|m4a|mp3|oga|ogg|opus|wav|webm)$/iu.test(pathOrName);
 }
 
-function mapAudioPathForFunAsr(audioPath: string, projectRoot?: string): string | undefined {
+function isTransSpeechAudioAttachment(attachment: ChannelAttachment): boolean {
+  return SUPPORTED_AUDIO_EXTENSIONS.has(extname(attachment.path || attachment.name || "").toLowerCase());
+}
+
+function isWebAudioAttachment(attachment: ChannelAttachment): boolean {
+  return attachment.metadata?.channelKey === "web";
+}
+
+function attachmentDisplayName(attachment: ChannelAttachment): string {
+  return attachment.name || attachment.path?.split(/[\\/]/).pop() || "audio attachment";
+}
+
+function mapAudioPathForTransSpeech(audioPath: string, projectRoot?: string): string | undefined {
   if (!projectRoot) return undefined;
   const absoluteRoot = resolve(projectRoot);
   const absolutePath = resolve(audioPath);

--- a/src/pilot/config/index.ts
+++ b/src/pilot/config/index.ts
@@ -1,5 +1,11 @@
 export { loadPilotConfig } from "./loadPilotConfig.js";
 export {
+  BYTES_PER_MEBIBYTE,
+  chatAttachmentMaxFileSizeBytes,
+  DEFAULT_CHAT_ATTACHMENT_MAX_FILE_SIZE_MB,
+  parseWebUiConfig,
+} from "./parseWebUiConfig.js";
+export {
   createPilotConfigStore,
   type PilotConfigListener,
   type PilotConfigStore,
@@ -30,5 +36,6 @@ export {
   type PilotProxyConfig,
   type PilotToolsConfig,
   type PilotTransSpeechConfig,
+  type PilotWebUiConfig,
   type PilotWebSearchConfig,
 } from "./types.js";

--- a/src/pilot/config/loadPilotConfig.ts
+++ b/src/pilot/config/loadPilotConfig.ts
@@ -11,6 +11,7 @@ import { mergeConfigSources } from "./merge.js";
 import { parseMemoryConfig } from "./parseMemoryConfig.js";
 import { parseAdaptersConfig, parseGatewayConfig } from "./parseGatewayConfig.js";
 import { parseToolsConfig } from "./parseToolsConfig.js";
+import { parseWebUiConfig } from "./parseWebUiConfig.js";
 import { parseRouterConfig } from "../../router/config/parseRouterConfig.js";
 import { redactConfig } from "./redact.js";
 import {
@@ -124,6 +125,7 @@ export function loadPilotConfig(options: PilotConfigLoadOptions = {}): PilotConf
   const alwaysOn = parseAlwaysOnConfig(rawConfig.alwaysOn, diagnostics);
   const cron = parseCronConfig(rawConfig.cron, diagnostics);
   const tools = parseToolsConfig(rawConfig.tools, diagnostics);
+  const webui = parseWebUiConfig(rawConfig.webui, diagnostics);
   const telemetry = parseTelemetryConfig(rawConfig.telemetry);
   const proxy = parseProxyConfig(rawConfig, diagnostics);
   throwConfigErrorIfFatal(diagnostics);
@@ -139,6 +141,7 @@ export function loadPilotConfig(options: PilotConfigLoadOptions = {}): PilotConf
     alwaysOn,
     cron,
     tools,
+    webui,
     telemetry,
     proxy,
   });
@@ -160,6 +163,7 @@ export function loadPilotConfig(options: PilotConfigLoadOptions = {}): PilotConf
       ...(alwaysOn ? { alwaysOn } : {}),
       ...(cron ? { cron } : {}),
       ...(tools ? { tools } : {}),
+      webui,
       telemetry,
       ...(proxy ? { proxy } : {}),
     },

--- a/src/pilot/config/parseWebUiConfig.ts
+++ b/src/pilot/config/parseWebUiConfig.ts
@@ -1,0 +1,66 @@
+import { isRecord } from "../../model/config/schema.js";
+import type { PilotConfigDiagnostic, PilotWebUiConfig } from "./types.js";
+
+export const DEFAULT_CHAT_ATTACHMENT_MAX_FILE_SIZE_MB = 20;
+export const BYTES_PER_MEBIBYTE = 1024 * 1024;
+
+/**
+ * Keep the core runtime's transcription limit aligned with the Web upload
+ * setting without taking ownership of unrelated Web UI configuration.
+ */
+export function parseWebUiConfig(
+  raw: unknown,
+  diagnostics: PilotConfigDiagnostic[],
+): PilotWebUiConfig {
+  const defaults: PilotWebUiConfig = {
+    attachments: { maxFileSizeMB: DEFAULT_CHAT_ATTACHMENT_MAX_FILE_SIZE_MB },
+  };
+  if (raw === undefined) return defaults;
+  if (!isRecord(raw)) {
+    diagnostics.push({
+      code: "WEBUI_CONFIG_INVALID",
+      severity: "fatal",
+      message: "webui must be an object.",
+      path: "webui",
+      recoverable: false,
+    });
+    return defaults;
+  }
+
+  const attachments = raw.attachments;
+  if (attachments === undefined) return defaults;
+  if (!isRecord(attachments)) {
+    diagnostics.push({
+      code: "WEBUI_ATTACHMENTS_INVALID",
+      severity: "fatal",
+      message: "webui.attachments must be an object.",
+      path: "webui.attachments",
+      recoverable: false,
+    });
+    return defaults;
+  }
+
+  const maxFileSizeMB = attachments.maxFileSizeMB;
+  if (!isPositiveSafeInteger(maxFileSizeMB)) {
+    diagnostics.push({
+      code: "WEBUI_ATTACHMENTS_MAX_FILE_SIZE_INVALID",
+      severity: "fatal",
+      message: "webui.attachments.maxFileSizeMB must be a positive safe integer that can be converted to bytes.",
+      path: "webui.attachments.maxFileSizeMB",
+      recoverable: false,
+    });
+    return defaults;
+  }
+  return { attachments: { maxFileSizeMB } };
+}
+
+export function chatAttachmentMaxFileSizeBytes(config: PilotWebUiConfig | undefined): number {
+  return (config?.attachments.maxFileSizeMB ?? DEFAULT_CHAT_ATTACHMENT_MAX_FILE_SIZE_MB) * BYTES_PER_MEBIBYTE;
+}
+
+function isPositiveSafeInteger(value: unknown): value is number {
+  return typeof value === "number"
+    && Number.isSafeInteger(value)
+    && value > 0
+    && value <= Math.floor(Number.MAX_SAFE_INTEGER / BYTES_PER_MEBIBYTE);
+}

--- a/src/pilot/config/types.ts
+++ b/src/pilot/config/types.ts
@@ -55,6 +55,13 @@ export type PilotExtensionConfig = {
   includeHookEvents: boolean;
 };
 
+/** The Web upload limit shared by the Web server and recording transcription. */
+export type PilotWebUiConfig = {
+  attachments: {
+    maxFileSizeMB: number;
+  };
+};
+
 export type PilotAgentModelSelection = {
   id: string;
   provider: string;
@@ -268,6 +275,7 @@ export type PilotConfig = {
   tools?: PilotToolsConfig;
   telemetry?: PilotTelemetryConfig;
   proxy?: PilotProxyConfig;
+  webui?: PilotWebUiConfig;
 };
 
 export type PilotConfigSnapshot = {

--- a/src/tool/builtin/transSpeech.ts
+++ b/src/tool/builtin/transSpeech.ts
@@ -33,7 +33,7 @@ export type TransSpeechToolOutput = {
   duplicateTaskId?: string;
 };
 
-export type CreateTransSpeechToolOptions = Pick<TranscriptionServiceOptions, "config" | "fetchImpl" | "now">;
+export type CreateTransSpeechToolOptions = Pick<TranscriptionServiceOptions, "config" | "maxFileSizeBytes" | "fetchImpl" | "now">;
 
 export function createTransSpeechTool(
   options: CreateTransSpeechToolOptions,
@@ -56,7 +56,7 @@ export function createTransSpeechTool(
       additionalProperties: false,
       properties: {
         action: { type: "string", enum: ["start", "retry", "cancel"] },
-        audio_path: { type: "string", description: "Exact path of an audio attachment uploaded in this chat. Required for start." },
+        audio_path: { type: "string", description: "Exact path of a Web audio attachment uploaded in this chat. Required for start." },
         task_id: { type: "string", description: "Recording task id. Required for retry and cancel." },
         force_duplicate: { type: "boolean", description: "Set true only after the user explicitly chooses to create another task for a duplicate audio file." },
         include_actions: { type: "boolean", description: "Generate action items only when the user explicitly requests them." },

--- a/src/transcription/TranscriptionService.ts
+++ b/src/transcription/TranscriptionService.ts
@@ -1,13 +1,13 @@
 import { createHash } from "node:crypto";
 import { realpath, readFile, stat } from "node:fs/promises";
-import { extname, isAbsolute, join, relative, resolve } from "node:path";
+import { extname, isAbsolute, join, relative, resolve, sep } from "node:path";
 
 import { PilotDeckToolRuntimeError } from "../tool/protocol/errors.js";
 import type { PilotTransSpeechEnabledConfig } from "../pilot/config/types.js";
+import { chatAttachmentMaxFileSizeBytes } from "../pilot/config/parseWebUiConfig.js";
 import { TransSpeechClient, TransSpeechClientError } from "./TransSpeechClient.js";
 import { TranscriptionTaskStore } from "./TranscriptionTaskStore.js";
 import {
-  MAX_TRANSCRIPTION_FILE_BYTES,
   SUPPORTED_AUDIO_EXTENSIONS,
   TRANSCRIPTION_MINUTES_FILE,
   TRANSCRIPTION_POLISHED_TRANSCRIPT_FILE,
@@ -21,6 +21,8 @@ import {
 
 export type TranscriptionServiceOptions = {
   config: PilotTransSpeechEnabledConfig;
+  /** Parsed from webui.attachments.maxFileSizeMB by the local gateway runtime. */
+  maxFileSizeBytes?: number;
   fetchImpl?: typeof fetch;
   now?: () => Date;
 };
@@ -64,6 +66,7 @@ const cancellationRequests = new Set<string>();
 export class TranscriptionService {
   private readonly client: TransSpeechClient;
   private readonly now: () => Date;
+  private readonly maxFileSizeBytes: number;
 
   constructor(private readonly options: TranscriptionServiceOptions) {
     this.client = new TransSpeechClient({
@@ -72,10 +75,11 @@ export class TranscriptionService {
       fetchImpl: options.fetchImpl,
     });
     this.now = options.now ?? (() => new Date());
+    this.maxFileSizeBytes = options.maxFileSizeBytes ?? chatAttachmentMaxFileSizeBytes(undefined);
   }
 
   async start(workspaceRoot: string, input: StartTranscriptionInput): Promise<TranscriptionServiceResult> {
-    const source = await validateUploadedAudio(workspaceRoot, input.audioPath);
+    const source = await validateUploadedAudio(workspaceRoot, input.audioPath, this.maxFileSizeBytes);
     const sourceHash = await hashFile(source.path);
     const store = new TranscriptionTaskStore(workspaceRoot);
     const actions = input.includeActions ?? this.options.config.generate.actions;
@@ -359,15 +363,23 @@ export class TranscriptionService {
   }
 }
 
-async function validateUploadedAudio(workspaceRoot: string, value: string): Promise<{ path: string; bytes: number; createdAt: string }> {
+async function validateUploadedAudio(
+  workspaceRoot: string,
+  value: string,
+  maxFileSizeBytes: number,
+): Promise<{ path: string; bytes: number; createdAt: string }> {
   if (!value || value.includes("\0")) throw new PilotDeckToolRuntimeError("invalid_tool_input", "audio_path must be a non-empty file path.");
-  const uploadRoot = resolve(workspaceRoot, ".tmp", "chat-attachments");
+  const currentUploadRoot = resolve(workspaceRoot, ".tmp", "chat-uploads");
+  const legacyUploadRoot = resolve(workspaceRoot, ".tmp", "chat-attachments");
   const sourcePath = resolve(isAbsolute(value) ? value : join(workspaceRoot, value));
-  const realUploadRoot = await realpath(uploadRoot).catch(() => uploadRoot);
+  const [realCurrentUploadRoot, realLegacyUploadRoot] = await Promise.all([
+    realpath(currentUploadRoot).catch(() => currentUploadRoot),
+    realpath(legacyUploadRoot).catch(() => legacyUploadRoot),
+  ]);
   const realSource = await realpath(sourcePath).catch(() => undefined);
   if (!realSource) throw new PilotDeckToolRuntimeError("file_not_found", "Uploaded audio file was not found.");
-  if (!isWithin(realSource, realUploadRoot)) {
-    throw new PilotDeckToolRuntimeError("path_not_allowed", "audio_path must reference an audio file uploaded in this workspace.");
+  if (!isCurrentWebUploadFile(realSource, realCurrentUploadRoot) && !isWithin(realSource, realLegacyUploadRoot)) {
+    throw new PilotDeckToolRuntimeError("path_not_allowed", "audio_path must reference a Web audio file uploaded in this workspace.");
   }
   const extension = extname(realSource).toLowerCase();
   if (!SUPPORTED_AUDIO_EXTENSIONS.has(extension)) {
@@ -378,11 +390,24 @@ async function validateUploadedAudio(workspaceRoot: string, value: string): Prom
   if (info.size === 0) {
     throw new PilotDeckToolRuntimeError("invalid_tool_input", "Audio files must not be empty.");
   }
-  if (info.size > MAX_TRANSCRIPTION_FILE_BYTES) {
-    throw new PilotDeckToolRuntimeError("invalid_tool_input", "Audio files must not exceed 20MB.");
+  if (info.size > maxFileSizeBytes) {
+    throw new PilotDeckToolRuntimeError(
+      "invalid_tool_input",
+      `Audio files must not exceed ${formatMiB(maxFileSizeBytes)}MB.`,
+    );
   }
   const sourceCreatedAt = info.birthtimeMs > 0 ? info.birthtime : info.mtime;
   return { path: realSource, bytes: info.size, createdAt: sourceCreatedAt.toISOString() };
+}
+
+function formatMiB(bytes: number): string {
+  return String(bytes / (1024 * 1024));
+}
+
+function isCurrentWebUploadFile(candidate: string, root: string): boolean {
+  if (!isWithin(candidate, root)) return false;
+  const segments = relative(root, candidate).split(sep);
+  return segments.length === 3 && segments[1] === "files" && segments.every(Boolean);
 }
 
 async function hashFile(path: string): Promise<string> {

--- a/src/transcription/types.ts
+++ b/src/transcription/types.ts
@@ -7,7 +7,6 @@ export const TRANSCRIPTION_POLISHED_TRANSCRIPT_FILE = "逐字整理稿.md";
 export const TRANSCRIPTION_MINUTES_FILE = "会议纪要.md";
 
 export const SUPPORTED_AUDIO_EXTENSIONS = new Set([".wav", ".mp3", ".m4a", ".flac"]);
-export const MAX_TRANSCRIPTION_FILE_BYTES = 20 * 1024 * 1024;
 
 export type TranscriptionTaskStatus =
   | "created"

--- a/tests/extension/plugins/funasr-builtin.spec.ts
+++ b/tests/extension/plugins/funasr-builtin.spec.ts
@@ -82,13 +82,13 @@ test("FunASR can be disabled through builtinPluginsEnabled", async () => {
   }
 });
 
-test("audio-transcription Skill documents local runtime installation and same-session retry", async () => {
+test("audio-transcription Skill documents the Trans-Speech workflow", async () => {
   const skill = await readFile(join(process.cwd(), "skills", "audio-transcription", "SKILL.md"), "utf8");
-  assert.match(skill, /install:asr/);
-  assert.match(skill, /same session/i);
-  assert.match(skill, /mcp__funasr__transcribe_audio/);
-  assert.match(skill, /project-local host path/);
-  assert.doesNotMatch(skill, /\/audio\//);
-  assert.match(skill, /funasr-installation\.md/);
+  assert.match(skill, /trans_speech/);
+  assert.match(skill, /WAV, MP3, M4A, or FLAC/);
+  assert.match(skill, /Web-uploaded/i);
+  assert.doesNotMatch(skill, /install:asr/);
+  assert.doesNotMatch(skill, /mcp__funasr__transcribe_audio/);
+  assert.doesNotMatch(skill, /funasr-installation\.md/);
   assert.match(skill, /Do not invoke ASR merely because an audio attachment is present/);
 });

--- a/tests/gateway/attachment-guidance.spec.ts
+++ b/tests/gateway/attachment-guidance.spec.ts
@@ -144,11 +144,87 @@ test("registered PDF attachments retain their original name in the history path 
   }
 });
 
-test("registered audio attachments advertise FunASR paths instead of read_file conversion", async () => {
+test("registered Web recordings advertise trans_speech paths instead of read_file conversion", async () => {
   const root = await mkdtemp(join(tmpdir(), "pilotdeck-attachment-guidance-"));
   try {
     const audioPath = join(root, "meeting.wav");
     await writeFile(audioPath, Buffer.from("RIFF"));
+
+    let capturedInput: AgentInput | undefined;
+    const gateway = createGateway((input) => {
+      capturedInput = input;
+    });
+
+    for await (const _event of gateway.submitTurn({
+      sessionKey: "session-1",
+      channelKey: "web",
+      projectKey: root,
+      message: "please transcribe this recording",
+      attachments: [{
+        type: "file",
+        path: audioPath,
+        name: "meeting.wav",
+        mimeType: "audio/wav",
+        metadata: { channelKey: "web" },
+      }],
+    })) {
+      // Drain the stream so the fake session runs to completion.
+    }
+
+    const text = inputText(capturedInput);
+    assert.match(text, /meeting\.wav/);
+    assert.match(text, /trans_speech/);
+    assert.match(text, /"action":"start"/);
+    assert.match(text, new RegExp(audioPath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+    assert.doesNotMatch(text, /funasr/i);
+    assert.doesNotMatch(text, /install:asr/);
+    assert.doesNotMatch(text, /not directly inspectable with read_file/);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("unsupported audio formats are not directed to trans_speech", async () => {
+  const root = await mkdtemp(join(tmpdir(), "pilotdeck-attachment-guidance-"));
+  try {
+    const audioPath = join(root, "meeting.webm");
+    await writeFile(audioPath, Buffer.from("webm"));
+
+    let capturedInput: AgentInput | undefined;
+    const gateway = createGateway((input) => {
+      capturedInput = input;
+    });
+
+    for await (const _event of gateway.submitTurn({
+      sessionKey: "session-1",
+      channelKey: "web",
+      projectKey: root,
+      message: "please transcribe this recording",
+      attachments: [{
+        type: "file",
+        path: audioPath,
+        name: "meeting.webm",
+        mimeType: "audio/webm",
+        metadata: { channelKey: "web" },
+      }],
+    })) {
+      // Drain the stream so the fake session runs to completion.
+    }
+
+    const text = inputText(capturedInput);
+    assert.match(text, /WAV, MP3, M4A, and FLAC/);
+    assert.doesNotMatch(text, /use trans_speech/i);
+    assert.doesNotMatch(text, /funasr/i);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("non-Web recordings are not directed to trans_speech", async () => {
+  const root = await mkdtemp(join(tmpdir(), "pilotdeck-attachment-guidance-"));
+  try {
+    const audioPath = join(root, "meeting.m4a");
+    await writeFile(audioPath, Buffer.from("m4a"));
 
     let capturedInput: AgentInput | undefined;
     const gateway = createGateway((input) => {
@@ -163,8 +239,8 @@ test("registered audio attachments advertise FunASR paths instead of read_file c
       attachments: [{
         type: "file",
         path: audioPath,
-        name: "meeting.wav",
-        mimeType: "audio/wav",
+        name: "meeting.m4a",
+        mimeType: "audio/mp4",
         metadata: { channelKey: "feishu" },
       }],
     })) {
@@ -172,12 +248,9 @@ test("registered audio attachments advertise FunASR paths instead of read_file c
     }
 
     const text = inputText(capturedInput);
-    assert.match(text, /meeting\.wav/);
-    assert.match(text, /transcribe_audio/);
-    assert.match(text, new RegExp(audioPath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
-    assert.match(text, /retry the tool in this session/);
-    assert.match(text, /npm --prefix/);
-    assert.doesNotMatch(text, /not directly inspectable with read_file/);
+    assert.match(text, /only Web-uploaded audio/);
+    assert.doesNotMatch(text, /use trans_speech/i);
+    assert.doesNotMatch(text, /funasr/i);
   } finally {
     await rm(root, { recursive: true, force: true });
   }

--- a/tests/pilot/config/parseWebUiConfig.spec.ts
+++ b/tests/pilot/config/parseWebUiConfig.spec.ts
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  chatAttachmentMaxFileSizeBytes,
+  DEFAULT_CHAT_ATTACHMENT_MAX_FILE_SIZE_MB,
+  parseWebUiConfig,
+} from "../../../src/pilot/config/parseWebUiConfig.js";
+import type { PilotConfigDiagnostic } from "../../../src/pilot/config/types.js";
+
+test("Web attachment size defaults to 20 MiB for the core runtime", () => {
+  const diagnostics: PilotConfigDiagnostic[] = [];
+  const config = parseWebUiConfig(undefined, diagnostics);
+
+  assert.equal(config.attachments.maxFileSizeMB, DEFAULT_CHAT_ATTACHMENT_MAX_FILE_SIZE_MB);
+  assert.equal(chatAttachmentMaxFileSizeBytes(config), 20 * 1024 * 1024);
+  assert.deepEqual(diagnostics, []);
+});
+
+test("Web attachment size is converted for Trans-Speech without a second tool setting", () => {
+  const diagnostics: PilotConfigDiagnostic[] = [];
+  const config = parseWebUiConfig({ attachments: { maxFileSizeMB: 101 } }, diagnostics);
+
+  assert.equal(config.attachments.maxFileSizeMB, 101);
+  assert.equal(chatAttachmentMaxFileSizeBytes(config), 101 * 1024 * 1024);
+  assert.deepEqual(diagnostics, []);
+});
+
+test("invalid Web attachment limits are fatal in the core runtime", () => {
+  const diagnostics: PilotConfigDiagnostic[] = [];
+  parseWebUiConfig({ attachments: { maxFileSizeMB: 0 } }, diagnostics);
+
+  assert.equal(diagnostics[0]?.code, "WEBUI_ATTACHMENTS_MAX_FILE_SIZE_INVALID");
+  assert.equal(diagnostics[0]?.severity, "fatal");
+});

--- a/tests/tool/builtin/transSpeech.spec.ts
+++ b/tests/tool/builtin/transSpeech.spec.ts
@@ -26,6 +26,30 @@ test("trans_speech is registered only when its local service is configured", () 
   assert.equal(createBuiltinRegistry({ transSpeech: { config } }).has("trans_speech"), true);
 });
 
+test("the configured attachment size reaches the registered trans_speech tool", async () => {
+  const workspace = await mkdtemp(join(tmpdir(), "pilotdeck-trans-speech-tool-"));
+  try {
+    const attachmentDirectory = join(workspace, ".tmp", "chat-attachments", "upload-1");
+    const audioPath = join(attachmentDirectory, "meeting.wav");
+    await mkdir(attachmentDirectory, { recursive: true });
+    await writeFile(audioPath, "recording");
+    const tool = createBuiltinRegistry({ transSpeech: { config, maxFileSizeBytes: 4 } }).get("trans_speech");
+    assert.ok(tool);
+
+    await assert.rejects(
+      tool.execute({ action: "start", audio_path: audioPath }, {
+        cwd: workspace,
+        env: {},
+        sessionId: "session",
+        turnId: "turn",
+      } as any),
+      { code: "invalid_tool_input" },
+    );
+  } finally {
+    await rm(workspace, { recursive: true, force: true });
+  }
+});
+
 test("trans_speech creates result-file entries and reports progress for an uploaded recording", async () => {
   const workspace = await mkdtemp(join(tmpdir(), "pilotdeck-trans-speech-tool-"));
   try {

--- a/tests/transcription/transcription-service.spec.ts
+++ b/tests/transcription/transcription-service.spec.ts
@@ -13,7 +13,6 @@ import {
   TRANSCRIPTION_TASK_DIRECTORY,
   TRANSCRIPTION_TASK_INFO_FILE,
   TRANSCRIPTION_TRANSCRIPT_FILE,
-  MAX_TRANSCRIPTION_FILE_BYTES,
   type TranscriptionTaskInfo,
 } from "../../src/transcription/types.js";
 
@@ -581,20 +580,25 @@ test("tasks from the same workspace wait for configured capacity", async () => {
   }
 });
 
-test("rejects paths outside chat attachments, unsupported formats, and files above the upload limit", async () => {
+test("rejects paths outside Web uploads, unsupported formats, and files above the configured limit", async () => {
   const fixture = await createFixture();
   try {
-    const service = new TranscriptionService({ config, fetchImpl: completeFetch() });
+    const maxFileSizeBytes = 64;
+    const service = new TranscriptionService({ config, maxFileSizeBytes, fetchImpl: completeFetch() });
     const outsideAudio = join(fixture.workspace, "outside.wav");
+    const unmanagedCurrentUpload = join(fixture.workspace, ".tmp", "chat-uploads", "unmanaged.wav");
     const unsupported = join(fixture.uploadDirectory, "meeting.txt");
     const empty = join(fixture.uploadDirectory, "empty.mp3");
     const tooLarge = join(fixture.uploadDirectory, "too-large.mp3");
     await writeFile(outsideAudio, "outside");
+    await mkdir(join(fixture.workspace, ".tmp", "chat-uploads"), { recursive: true });
+    await writeFile(unmanagedCurrentUpload, "unmanaged");
     await writeFile(unsupported, "not audio");
     await writeFile(empty, "");
-    await writeFile(tooLarge, Buffer.alloc(MAX_TRANSCRIPTION_FILE_BYTES + 1));
+    await writeFile(tooLarge, Buffer.alloc(maxFileSizeBytes + 1));
 
     await assert.rejects(service.start(fixture.workspace, { audioPath: outsideAudio }), { code: "path_not_allowed" });
+    await assert.rejects(service.start(fixture.workspace, { audioPath: unmanagedCurrentUpload }), { code: "path_not_allowed" });
     await assert.rejects(service.start(fixture.workspace, { audioPath: unsupported }), { code: "invalid_tool_input" });
     await assert.rejects(service.start(fixture.workspace, { audioPath: empty }), { code: "invalid_tool_input" });
     await assert.rejects(service.start(fixture.workspace, { audioPath: tooLarge }), { code: "invalid_tool_input" });
@@ -604,11 +608,13 @@ test("rejects paths outside chat attachments, unsupported formats, and files abo
   }
 });
 
-test("accepts all supported audio extensions and the exact 20MB boundary", async () => {
+test("accepts all supported audio extensions and the configured size boundary", async () => {
   const fixture = await createFixture();
   try {
+    const maxFileSizeBytes = 64;
     const service = new TranscriptionService({
       config: { ...config, generate: { polish: false, minutes: false, actions: false } },
+      maxFileSizeBytes,
       fetchImpl: completeFetch(),
     });
     for (const extension of [".WAV", ".MP3", ".M4A", ".FLAC"]) {
@@ -619,9 +625,31 @@ test("accepts all supported audio extensions and the exact 20MB boundary", async
     }
 
     const atLimit = join(fixture.uploadDirectory, "at-limit.mp3");
-    await writeFile(atLimit, Buffer.alloc(MAX_TRANSCRIPTION_FILE_BYTES, 1));
+    await writeFile(atLimit, Buffer.alloc(maxFileSizeBytes, 1));
     const result = await service.start(fixture.workspace, { audioPath: atLimit, forceDuplicate: true });
-    assert.equal(result.task.source.bytes, MAX_TRANSCRIPTION_FILE_BYTES);
+    assert.equal(result.task.source.bytes, maxFileSizeBytes);
+  } finally {
+    await fixture.cleanup();
+  }
+});
+
+test("accepts both current and legacy Web upload directories", async () => {
+  const fixture = await createFixture();
+  try {
+    const currentUploadDirectory = join(fixture.workspace, ".tmp", "chat-uploads", "upload-2", "files");
+    const currentAudio = join(currentUploadDirectory, "recording.flac");
+    await mkdir(currentUploadDirectory, { recursive: true });
+    await writeFile(currentAudio, "current Web upload");
+
+    const service = new TranscriptionService({
+      config: { ...config, generate: { polish: false, minutes: false, actions: false } },
+      fetchImpl: completeFetch(),
+    });
+    const legacy = await service.start(fixture.workspace, { audioPath: fixture.audioPath });
+    const current = await service.start(fixture.workspace, { audioPath: currentAudio });
+
+    assert.equal(legacy.task.status, "pending_review");
+    assert.equal(current.task.status, "pending_review");
   } finally {
     await fixture.cleanup();
   }


### PR DESCRIPTION
## Summary

- Route Web-uploaded WAV, MP3, M4A, and FLAC recordings to the configured Trans-Speech service.
- Keep transcription file-size limits aligned with the Web attachment-size setting.
- Support both current and legacy Web upload paths.

## Scope

- Target branch: `campus-agent`
- Includes one commit: `dd8adf82`