### PR TITLE
fix(desktop): handle Windows process startup without CIM enumeration

### DIFF
--- a/.github/workflows/desktop-smoke.yml
+++ b/.github/workflows/desktop-smoke.yml
@@ -48,3 +48,14 @@ jobs:
       - name: Test desktop updater network
         # Requires electron-updater, intentionally absent from the Web-only job.
         run: pnpm --dir ui exec vitest run server/services/desktopUpdateNetwork.test.ts
+
+  windows-processes:
+    runs-on: windows-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.23.1
+      - name: Verify Windows process startup and Job cleanup
+        run: node --test apps/desktop/scripts/process-identity.test.mjs apps/desktop/scripts/process-scope.test.mjs

--- a/apps/desktop/scripts/process-identity.test.mjs
+++ b/apps/desktop/scripts/process-identity.test.mjs
@@ -1,0 +1,41 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import identities from '../../../ui/server/utils/processIdentity.cjs';
+import { waitForManagedEvent } from './process-test-helpers.mjs';
+
+test('Windows startup queries only requested PIDs without CIM enumeration', () => {
+  const result = identities.windowsProcesses([123,456,123], (_command,args,options) => {
+    assert.match(args.at(-1), /@\(123,456\)/);
+    assert.match(args.at(-1), /GetProcessById/);
+    assert.doesNotMatch(args.at(-1), /Get-CimInstance|GetProcesses\(\)/);
+    assert.equal(options.timeout, 15000);
+    return '[{"ProcessId":123,"Birth":"2026-09-07T12:34:56.1234567Z"}]';
+  });
+  assert.deepEqual(result,[{pid:123,birth:'2026-09-07T12:34:56.1234567Z'}]);
+});
+test('Windows query timeout is explicit and never fabricates ownership', () => {
+  assert.throws(()=>identities.windowsProcesses([123],()=>{throw Object.assign(new Error('spawn timed out'),{code:'ETIMEDOUT'});}), {code:'ETIMEDOUT',message:'Windows process identity query timed out after 15000 ms'});
+});
+test('invalid PID and missing creation time fail closed', () => {
+  assert.throws(()=>identities.windowsProcesses(['1;exit']),/Invalid process identity PID/);
+  assert.throws(()=>identities.windowsProcesses([123],()=>'{"ProcessId":123}'),/Missing process creation identity/);
+});
+test('Windows absence is distinct from an unidentifiable process', () => {
+  assert.deepEqual(identities.windowsProcesses([123],()=> '[]'),[]);
+  assert.deepEqual(identities.windowsProcesses([],()=>{throw new Error('must not start PowerShell');}),[]);
+});
+test('waiting for IPC rejects on bootstrap failure and removes listeners', async () => {
+  const child=new EventEmitter();child.exitCode=null;child.stderr=new EventEmitter();
+  const result=waitForManagedEvent(child,child,'message',1000);
+  child.emit('managed-exit',1,null,'Managed process startup failed: identity query timed out');
+  await assert.rejects(result,/identity query timed out/);
+  assert.equal(child.listenerCount('exit'),0);assert.equal(child.listenerCount('message'),0);
+});
+test('unexpected guardian exit fails an IPC wait without event-loop cancellation', async () => {
+  const child=new EventEmitter();child.exitCode=null;child.stderr=new EventEmitter();
+  const result=waitForManagedEvent(child,child,'message',1000);
+  child.stderr.emit('data',Buffer.from('PowerShell could not start'));
+  child.emit('exit',1,null);
+  await assert.rejects(result,/PowerShell could not start/);
+});

--- a/apps/desktop/scripts/process-scope.test.mjs
+++ b/apps/desktop/scripts/process-scope.test.mjs
@@ -1,27 +1,26 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { once } from 'node:events';
+import { waitForManagedEvent } from './process-test-helpers.mjs';
 import { spawnManaged, stopProcessTree, listProcesses } from '../../../ui/server/utils/processTree.js';
 const options = { stdio: ['ignore', 'pipe', 'pipe', 'ipc'] };
-test('supervised runtime forwards IPC and stops its managed group', { timeout: 40000 }, async () => {
+test('supervised runtime forwards IPC and stops its managed group', { timeout: 120000 }, async () => {
   const child = spawnManaged(process.execPath, ['-e', `const {spawn}=require('node:child_process');const task=spawn(process.execPath,['-e','process.send(process.pid);setInterval(()=>{},1000)'],{stdio:['ignore','pipe','pipe','ipc']});task.on('message',pid=>process.send(pid));setInterval(()=>{},1000)`], options);
   child.stderr.on('data', data => process.stderr.write(data));
   try {
-    const [pid] = await once(child, 'message');
+    const [pid] = await waitForManagedEvent(child, child, 'message');
     assert.ok(Number.isInteger(pid));
     await stopProcessTree(child, { forceMs: 10000 });
     assert.equal((await listProcesses()).some(row => row.pid === pid && !row.zombie), false);
   } finally { await stopProcessTree(child, { forceMs: 10000 }).catch(() => {}); child.stdout.destroy(); child.stderr.destroy(); }
 });
-test('command exit is reported before inherited-group cleanup', { timeout: 40000 }, async () => {
+test('command exit is reported before inherited-group cleanup', { timeout: 120000 }, async () => {
   const child = spawnManaged(process.execPath, ['-e', `const {spawn}=require('node:child_process');const task=spawn(process.execPath,['-e','console.log(process.pid);setInterval(()=>{},1000)'],{stdio:['ignore','pipe','inherit']});task.stdout.on('data',data=>{process.stdout.write(data);setTimeout(()=>process.exit(2),100)});task.unref()`], options);
   child.stderr.on('data', data => process.stderr.write(data));
   try {
-    const exited = once(child, 'managed-exit');
-    const [data] = await once(child.stdout, 'data');
+    const [data] = await waitForManagedEvent(child, child.stdout, 'data');
     const pid = Number(data.toString().trim());
     assert.ok(Number.isInteger(pid) && pid > 0);
-    await exited;
+    await waitForManagedEvent(child, child, 'managed-exit');
     await stopProcessTree(child, { forceMs: 10000 });
     assert.equal((await listProcesses()).some(row => row.pid === pid && !row.zombie), false);
   } finally { await stopProcessTree(child, { forceMs: 10000 }).catch(() => {}); child.stdout.destroy(); child.stderr.destroy(); }
@@ -40,7 +39,7 @@ test('business background launches and cancellation keep native command semantic
   const child=spawnManaged(process.execPath,['--import','tsx','--input-type=module','-e',script],options);
   child.stderr.on('data',data=>process.stderr.write(data));
   try {
-    const [data]=await once(child.stdout,'data');
+    const [data]=await waitForManagedEvent(child, child.stdout, 'data');
     const result=JSON.parse(data.toString());
     assert.equal(result.background.timedOut,false);
     assert.equal(result.background.exitCode,0);
@@ -49,4 +48,12 @@ test('business background launches and cancellation keep native command semantic
     assert.equal(result.sibling.stdout.trim(),'sibling');
     assert.equal(result.sibling.exitCode,0);
   } finally { await stopProcessTree(child,{forceMs:10000});child.stdout.destroy();child.stderr.destroy(); }
+});
+
+// This must fail promptly on the real failure, including on Windows bootstrap.
+test('a failed command reports its failure instead of waiting indefinitely for IPC', { timeout: 120000 }, async () => {
+  const child = spawnManaged('pilotdeck-nonexistent-test-command', [], options);
+  try {
+    await assert.rejects(waitForManagedEvent(child, child, 'message'), /exited before message|startup failed/);
+  } finally { await stopProcessTree(child, { forceMs: 10000 }); child.stdout.destroy(); child.stderr.destroy(); }
 });

--- a/apps/desktop/scripts/process-test-helpers.mjs
+++ b/apps/desktop/scripts/process-test-helpers.mjs
@@ -1,0 +1,23 @@
+// A ref'ed deadline plus explicit child-exit handling makes failed bootstrap
+// report its cause instead of Node cancelling an unresolved IPC promise.
+export function waitForManagedEvent(child, emitter, event, timeoutMs = 90_000) {
+  const completion = child[Symbol.for('pilotdeck.processScope')]?.completion;
+  if (completion && emitter === child && event === 'managed-exit') return Promise.resolve([completion.code, completion.signal, completion.startupError]);
+  return new Promise((resolve, reject) => {
+    let diagnostic = '';
+    const cleanup = () => {
+      clearTimeout(timer); emitter.off(event, received); child.off('error', failed);
+      child.off('exit', exited); child.off('managed-exit', managedExit); child.stderr?.off('data', stderr);
+    };
+    const received = (...args) => { cleanup(); resolve(args); };
+    const failed = error => { cleanup(); reject(error); };
+    const exited = (code, signal, message) => failed(new Error(message || `Managed command exited before ${event} (code=${code}, signal=${signal}): ${diagnostic.trim()}`));
+    const managedExit = (code, signal, message) => { if (event !== 'managed-exit') exited(code, signal, message); };
+    const stderr = chunk => { diagnostic = (diagnostic + chunk.toString()).slice(-4000); };
+    const timer = setTimeout(() => failed(new Error(`Timed out waiting for ${event}: ${diagnostic.trim()}`)), timeoutMs);
+    emitter.once(event, received); child.once('error', failed); child.once('exit', exited);
+    child.on('managed-exit', managedExit); child.stderr?.on('data', stderr);
+    if (completion) exited(completion.code, completion.signal, completion.startupError);
+    else if (child.exitCode !== null || child.signalCode) exited(child.exitCode, child.signalCode);
+  });
+}

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -270,14 +270,14 @@ class RuntimeManager {
 
     child.stdout?.on("data", (chunk: Buffer) => this.logChunk(name, chunk));
     child.stderr?.on("data", (chunk: Buffer) => this.logChunk(name, chunk));
-    child.on("managed-exit", (code, signal) => {
+    child.on("managed-exit", (code, signal, startupError) => {
       // Retain the group record until stop() confirms all descendants exited.
       this.log(`[${name}] exited code=${code ?? "null"} signal=${signal ?? "null"}`);
       if (this.expectedExits.delete(child)) return;
       if (name === "gateway" && this.gatewayProcess === child) {
         this.gatewayProcess = null;
         if (!isQuitting) {
-          const detail = `Gateway exited code=${code ?? "null"} signal=${signal ?? "null"}`;
+          const detail = startupError || `Gateway exited code=${code ?? "null"} signal=${signal ?? "null"}`;
           this.setGatewayState({ state: "error", error: detail });
           publishRuntimeStatus({
             phase: "error",
@@ -975,9 +975,9 @@ function waitForPortOrProcessExit(
       child.off("managed-exit", onExit);
       callback();
     };
-    const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
+    const onExit = (code: number | null, signal: NodeJS.Signals | null, startupError?: string) => {
       finish(() => {
-        reject(new Error(`${name} exited before it was ready (code=${code ?? "null"} signal=${signal ?? "null"}). See runtime log: ${logPath}`));
+        reject(new Error(startupError || `${name} exited before it was ready (code=${code ?? "null"} signal=${signal ?? "null"}). See runtime log: ${logPath}`));
       });
     };
     child.once("managed-exit", onExit);

--- a/docs/release.md
+++ b/docs/release.md
@@ -243,5 +243,9 @@ sessions/groups are outside this guarantee; this is not a general process sandbo
 inherited-group cleanup after command exit, plus native Bash background launch
 and sibling cancellation behavior on POSIX. Both desktop platform build jobs
 run it before packaging.
-The Windows Job implementation still needs its first Windows CI/platform run;
-local macOS tests do not establish Windows runtime correctness.
+The Desktop Smoke workflow also runs the native Windows process tests on each
+relevant PR. Windows identity lookup uses targeted .NET process queries instead
+of CIM enumeration, allowing 15 seconds per query and a bounded 60-second
+bootstrap window. Shutdown retains identity checks and native Job termination;
+startup failure reports its cause before waiting for application IPC. These
+checks do not replace an actual Windows installation/upgrade test.

--- a/ui/server/utils/processGuardian.cjs
+++ b/ui/server/utils/processGuardian.cjs
@@ -3,42 +3,47 @@
 const fs = require('node:fs');
 const path = require('node:path');
 const cp = require('node:child_process');
-const { listProcesses } = require('./processIdentity.cjs');
+const { listProcesses, getProcessIdentity, WINDOWS_STARTUP_TIMEOUT_MS } = require('./processIdentity.cjs');
 const { writeRecord, isClosing } = require('./processScope.cjs');
 const file = process.argv[2];
 let record = JSON.parse(fs.readFileSync(file, 'utf8'));
 const directory = path.dirname(file);
 const closing = () => isClosing(directory, path.basename(file, '.json'));
 if (closing()) { writeRecord(file, { state: 'done', parent: record.parent }); process.exit(0); }
-const identity = listProcesses().find(row => row.pid === process.pid);
-if (!identity?.birth) throw new Error('Cannot establish guardian identity');
-record = { ...record, state: 'active', identity, members: [identity] };
-writeRecord(file, record);
+let identity;
 let worker;
 let exited = false;
 let code = 1;
 process.on('SIGTERM', () => {}); // Keep the POSIX group anchor until forced stop.
 process.on('SIGINT', () => {});
-function complete(value, signal) {
+function complete(value, signal, startupError) {
   if (exited) return;
   exited = true; code = value ?? 1;
-  fs.writeSync(record.completionFd, JSON.stringify({ code: value, signal }) + '\n');
+  fs.writeSync(record.completionFd, JSON.stringify({ code: value, signal, ...(startupError ? { startupError } : {}) }) + '\n');
   fs.closeSync(record.completionFd);
 }
 async function launch() {
+  const deadline = Date.now() + WINDOWS_STARTUP_TIMEOUT_MS;
+  identity = getProcessIdentity(process.pid);
+  if (!identity?.birth) throw new Error('Cannot establish guardian identity');
+  record = { ...record, state: 'active', identity, members: [identity] };
+  writeRecord(file, record);
   if (process.platform === 'win32') {
     const ready = `${file}.ready`, stopped = `${file}.stopped`, stop = `${file}.stop`;
     const holder = cp.spawn('powershell.exe', ['-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass',
-      '-File', path.join(__dirname, 'processJob.ps1'), String(process.pid), ready, stopped, stop, identity.birth], { stdio: 'ignore', windowsHide: true });
+      '-File', path.join(__dirname, 'processJob.ps1'), String(process.pid), ready, stopped, stop, identity.birth], { stdio: ['ignore', 'ignore', 'pipe'], windowsHide: true });
     let failed = false;
-    holder.on('error', () => { failed = true; });
+    let diagnostic = '';
+    holder.stderr.on('data', chunk => { diagnostic = (diagnostic + chunk.toString()).slice(-4000); });
+    holder.on('error', error => { failed = true; diagnostic = error.message; });
     holder.on('exit', () => { if (!fs.existsSync(ready)) failed = true; });
-    record.job = { ready, stopped, stop, holder: holder.pid, holderIdentity: listProcesses().find(row => row.pid === holder.pid) };
+    record.job = { ready, stopped, stop, holder: holder.pid };
+    writeRecord(file, record);
+    record.job.holderIdentity = getProcessIdentity(holder.pid);
     if (!record.job.holderIdentity) throw new Error('Windows Job supervisor identity unavailable');
     writeRecord(file, record);
-    const deadline = Date.now() + 15_000;
     while (!fs.existsSync(ready)) {
-      if (failed || Date.now() >= deadline) throw new Error('Windows process containment could not be established');
+      if (failed || Date.now() >= deadline) throw new Error(`Windows process containment could not be established: ${diagnostic.trim() || 'startup deadline exceeded'}`);
       await new Promise(resolve => setTimeout(resolve, 25));
     }
   }
@@ -57,7 +62,20 @@ async function launch() {
   worker.on('error', error => { process.stderr.write(`PilotDeck command failed: ${error.message}\n`); complete(1, null); });
   worker.on('exit', (value, signal) => complete(value, signal));
 }
-launch().catch(error => { record.uncertain = true; writeRecord(file, record); process.stderr.write(`${error.message}\n`); });
+launch().catch(error => {
+  const message = `Managed process startup failed: ${error.message}`;
+  process.stderr.write(`${message}\n`);
+  // No user command has run. Report bootstrap failure before tests/owners wait
+  // indefinitely for application IPC. An incomplete Job still requires cleanup.
+  if (!record.job) {
+    writeRecord(file, { state: 'done', parent: record.parent });
+    complete(1, null, message);
+    process.exit(1);
+  }
+  record.uncertain = true;
+  writeRecord(file, record);
+  complete(1, null, message);
+});
 const timer = setInterval(() => {
   try {
     if (!exited || closing()) return;

--- a/ui/server/utils/processIdentity.cjs
+++ b/ui/server/utils/processIdentity.cjs
@@ -1,13 +1,35 @@
 const { execFileSync } = require('node:child_process');
 const fs = require('node:fs');
-function listProcesses(platform = process.platform) {
-  if (platform === 'win32') {
-    const stdout = execFileSync('powershell.exe', ['-NoProfile', '-NonInteractive', '-Command',
-      "Get-CimInstance Win32_Process | Select-Object ProcessId,ParentProcessId,@{Name='Birth';Expression={$_.CreationDate.ToUniversalTime().ToString('o')}} | ConvertTo-Json -Compress"],
-    { timeout: 3000, maxBuffer: 8 * 1024 * 1024, windowsHide: true, encoding: 'utf8' });
-    const rows = JSON.parse(stdout || '[]');
-    return (Array.isArray(rows) ? rows : [rows]).map(row => ({ pid: row.ProcessId, parent: row.ParentProcessId, birth: row.Birth }));
+// Includes PowerShell cold startup. Query failures remain explicit; no PID-only fallback.
+const WINDOWS_QUERY_TIMEOUT_MS = 15_000;
+const WINDOWS_STARTUP_TIMEOUT_MS = 60_000;
+function windowsProcesses(pids, run = execFileSync) {
+  if (pids && !pids.every(pid => Number.isSafeInteger(pid) && pid > 0)) throw new Error('Invalid process identity PID');
+  if (pids?.length === 0) return [];
+  const source = pids
+    ? `@(${[...new Set(pids)].join(',')}) | ForEach-Object { try { [System.Diagnostics.Process]::GetProcessById($_) } catch [System.ArgumentException] {} }`
+    : '[System.Diagnostics.Process]::GetProcesses()';
+  const onError = pids ? 'if (!$item.HasExited) { throw }' : '';
+  const command = `$ErrorActionPreference='Stop'; $items=@(${source}); $result=@(foreach($item in $items) { try { [pscustomobject]@{ ProcessId=$item.Id; Birth=$item.StartTime.ToUniversalTime().ToString('o') } } catch { ${onError} } finally { $item.Dispose() } }); ConvertTo-Json -InputObject $result -Compress`;
+  try {
+    const stdout = run('powershell.exe', ['-NoProfile', '-NonInteractive', '-Command', command],
+      { timeout: WINDOWS_QUERY_TIMEOUT_MS, maxBuffer: 8 * 1024 * 1024, windowsHide: true, encoding: 'utf8' });
+    const parsed = JSON.parse(stdout || '[]');
+    return (Array.isArray(parsed) ? parsed : [parsed]).map(row => {
+      if (!Number.isSafeInteger(row.ProcessId) || !row.Birth) throw new Error('Missing process creation identity');
+      return { pid: row.ProcessId, birth: row.Birth };
+    });
+  } catch (error) {
+    const detail = error.code === 'ETIMEDOUT' ? `timed out after ${WINDOWS_QUERY_TIMEOUT_MS} ms` : error.message;
+    throw Object.assign(new Error(`Windows process identity query ${detail}`), { code: error.code, cause: error });
   }
+}
+function getProcessIdentities(pids, platform = process.platform) {
+  return platform === 'win32' ? windowsProcesses(pids) : listProcesses(platform).filter(row => pids.includes(row.pid));
+}
+function getProcessIdentity(pid, platform = process.platform) { return getProcessIdentities([pid], platform)[0]; }
+function listProcesses(platform = process.platform) {
+  if (platform === 'win32') return windowsProcesses();
   const stdout = execFileSync('ps', ['-axo', 'pid=,ppid=,pgid=,stat=,lstart='],
     { timeout: 2000, maxBuffer: 8 * 1024 * 1024, encoding: 'utf8', env: { ...process.env, LC_ALL: 'C' } });
   return stdout.trim().split('\n').filter(Boolean).flatMap(line => {
@@ -23,4 +45,4 @@ function listProcesses(platform = process.platform) {
   });
 }
 const sameProcess = (left, right) => Boolean(left && right && left.birth && left.pid === right.pid && left.birth === right.birth && left.group === right.group);
-module.exports = { listProcesses, sameProcess };
+module.exports = { listProcesses, getProcessIdentity, getProcessIdentities, sameProcess, windowsProcesses, WINDOWS_QUERY_TIMEOUT_MS, WINDOWS_STARTUP_TIMEOUT_MS };

--- a/ui/server/utils/processScope.cjs
+++ b/ui/server/utils/processScope.cjs
@@ -5,6 +5,7 @@ const path = require('node:path');
 const os = require('node:os');
 const { randomUUID } = require('node:crypto');
 const cp = require('node:child_process');
+const { WINDOWS_STARTUP_TIMEOUT_MS } = require('./processIdentity.cjs');
 const KEY = Symbol.for('pilotdeck.processScope');
 function writeRecord(file, value) {
   const temp = `${file}.${process.pid}.tmp`;
@@ -30,7 +31,8 @@ function attach(child, scope) {
   const report = (result) => {
     if (completed) return;
     completed = true;
-    child.emit('managed-exit', result.code, result.signal);
+    scope.completion = result;
+    child.emit('managed-exit', result.code, result.signal, result.startupError);
   };
   child.stdio[scope.completionFd].setEncoding('utf8').on('data', chunk => {
     buffered += chunk;
@@ -62,6 +64,7 @@ function spawnManaged(command, args, options, node = process.execPath) {
   // No preload or environment propagation into business commands.
   const stdio = Array.isArray(options.stdio) ? [...options.stdio] : ['ignore', 'pipe', 'pipe'];
   scope.completionFd = stdio.length;
+  if (process.platform === 'win32') scope.startupDeadline = Date.now() + WINDOWS_STARTUP_TIMEOUT_MS;
   stdio.push('pipe');
   // shell belongs to the real command, not the Node guardian executable.
   const record = JSON.parse(fs.readFileSync(scope.file, 'utf8'));

--- a/ui/server/utils/processTree.js
+++ b/ui/server/utils/processTree.js
@@ -21,7 +21,9 @@ function readRecords(directory, root) {
 
 async function stopRegisteredTree(child, {
   platform = process.platform, graceMs = 1500, forceMs = 3000,
-  inspect = () => listProcesses(platform), signal = (pid, name) => process.kill(pid, name),
+  inspect = () => platform === 'win32'
+    ? identities.getProcessIdentities([...new Set(records().flatMap(entry => [entry.identity?.pid, entry.job?.holder].filter(Boolean)))], platform)
+    : listProcesses(platform), signal = (pid, name) => process.kill(pid, name),
   scope = child[scopes.KEY], records = () => readRecords(scope.directory, scope.entry),
   closeScope = () => { try { mkdirSync(path.join(scope.directory, scope.entry ? `${scope.entry}.closing` : 'closing')); } catch (error) { if (error.code !== 'EEXIST') throw error; } },
   cleanup = () => {
@@ -114,7 +116,7 @@ async function stopRegisteredTree(child, {
     closeScope();
     // Let launchers racing shutdown register or cancel before signalling. A
     // crashed launcher leaves 'pending', which causes a bounded, explicit error.
-    const registrationDeadline = Date.now() + forceMs;
+    const registrationDeadline = scope.startupDeadline || Date.now() + forceMs;
     while ((await snapshot(), records().some(entry => entry.state === 'pending' || (entry.job && !existsSync(entry.job.ready) && !existsSync(entry.job.stopped)))) && Date.now() < registrationDeadline) await pause(50);
     await send('SIGTERM');
     if (!(await waitForExit(graceMs))) {
@@ -165,6 +167,6 @@ export function runManagedCommand(command, args, {
     child.stdout.on('data', data => progress(data.toString()));
     child.stderr.on('data', data => progress(data.toString()));
     child.once('error', error => void finish(error));
-    child.once('managed-exit', code => void finish(code === 0 ? null : Object.assign(new Error(`${command} failed (${code}).`), { reason: 'buildFailed' })));
+    child.once('managed-exit', (code, _signal, startupError) => void finish(code === 0 ? null : Object.assign(new Error(startupError || `${command} failed (${code}).`), { reason: startupError ? 'processStartFailed' : 'buildFailed' })));
   });
 }


### PR DESCRIPTION
## Summary

Windows Daily Release failed before packaging because the guardian's full CIM process query exceeded its three-second timeout. The guardian exited, leaving the smoke test awaiting IPC until Node cancelled the suite.

- Query only the guardian/Job-holder PIDs through .NET process APIs, including during shutdown. Allow 15 seconds per query and a bounded 60-second bootstrap window; retain creation-time verification and native Job termination.
- Report guardian bootstrap errors through the managed-command completion channel and surface the cause during desktop startup. An incomplete Job retains its cleanup record; failure does not permit installation.
- Make process tests reject on command/guardian failure with a bounded wait instead of leaving IPC promises unresolved.
- Run the native Windows process tests in Desktop Smoke on relevant PRs, before production release builds.

## Validation

- 10 identity/process smoke tests passed locally on macOS.
- 57 process shutdown, Web update and desktop updater regression tests passed locally.
- Desktop TypeScript compilation passed.
- Native Windows CI passed: 9 tests passed, no failures or cancellations; the POSIX-only Bash test was skipped. Real startup/IPC, command exit plus Job cleanup, and failed-command reporting all passed. [Windows job](https://github.com/OpenBMB/PilotDeck/actions/runs/34116934468/job/101725848754).
- All PR checks passed: Windows processes, desktop static checks, Web regression, and Docker build.
- A real signed installer upgrade remains release validation; it is not replaced by these process tests.

