### PR TITLE
fix(desktop): resolve NSIS includes and verify Windows release packaging

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -197,66 +197,8 @@ jobs:
           retention-days: 14
 
   windows:
-    runs-on: windows-latest
-    timeout-minutes: 60
-    env:
-      PILOTDECK_RELEASE_DATE: ${{ inputs.release_date }}
-      PILOTDECK_RELEASE_REVISION: ${{ inputs.revision }}
-      PILOTDECK_COMMIT_SHA: ${{ inputs.source_sha || github.sha }}
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          ref: ${{ inputs.source_sha || github.sha }}
-
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10.32.1
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22.23.1
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Verify managed process ownership and crash cleanup
-        run: node --test apps/desktop/scripts/process-scope.test.mjs
-
-      - name: Set desktop release metadata
-        run: node apps/desktop/scripts/set-ci-version.mjs
-
-      - name: Disable Windows signing
-        shell: pwsh
-        run: '"CSC_IDENTITY_AUTO_DISCOVERY=false" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append'
-
-      - name: Build Windows x64 installer
-        run: pnpm --filter pilotdeck-desktop run dist:win
-
-      - name: Verify Windows artifact
-        shell: pwsh
-        run: |
-          $installer = Get-ChildItem 'apps/desktop/dist-electron/*-setup.exe' | Select-Object -First 1
-          if (-not $installer) { throw 'Windows installer was not generated.' }
-          if ($installer.Length -le 0) { throw 'Windows installer is empty.' }
-          $env:ELECTRON_RUN_AS_NODE = '1'
-          & 'apps/desktop/dist-electron/win-unpacked/PilotDeck.exe' apps/desktop/scripts/verify-updater.cjs apps/desktop/dist-electron/win-unpacked/resources/app.asar | Out-Host
-          if ($LASTEXITCODE -ne 0) { throw 'Packaged updater validation failed.' }
-          Remove-Item Env:ELECTRON_RUN_AS_NODE
-
-      - name: Prepare Windows update feed
-        shell: pwsh
-        run: |
-          if (-not (Test-Path 'apps/desktop/dist-electron/latest.yml')) { throw 'Update feed was not generated.' }
-          Move-Item 'apps/desktop/dist-electron/latest.yml' 'apps/desktop/dist-electron/latest-x64.yml'
-          if (-not (Test-Path 'apps/desktop/dist-electron/win-unpacked/resources/elevate.exe')) { throw 'Update elevation helper is missing.' }
-
-      - name: Upload Windows installer
-        uses: actions/upload-artifact@v4
-        with:
-          name: pilotdeck-desktop-windows
-          path: |
-            apps/desktop/dist-electron/*-setup.exe
-            apps/desktop/dist-electron/latest-x64.yml
-          if-no-files-found: error
-          retention-days: 14
+    uses: ./.github/workflows/desktop-windows.yml
+    with:
+      source_sha: ${{ inputs.source_sha || github.sha }}
+      release_date: ${{ inputs.release_date }}
+      revision: ${{ inputs.revision || '0' }}

--- a/.github/workflows/desktop-smoke.yml
+++ b/.github/workflows/desktop-smoke.yml
@@ -49,13 +49,9 @@ jobs:
         # Requires electron-updater, intentionally absent from the Web-only job.
         run: pnpm --dir ui exec vitest run server/services/desktopUpdateNetwork.test.ts
 
-  windows-processes:
-    runs-on: windows-latest
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22.23.1
-      - name: Verify Windows process startup and Job cleanup
-        run: node --test apps/desktop/scripts/process-identity.test.mjs apps/desktop/scripts/process-scope.test.mjs
+  # Run the same installer build and artifact/feed validation as Daily Release.
+  # A process-only check cannot catch NSIS compilation or packaging regressions.
+  windows-installer:
+    uses: ./.github/workflows/desktop-windows.yml
+    with:
+      source_sha: ${{ github.sha }}

--- a/.github/workflows/desktop-windows.yml
+++ b/.github/workflows/desktop-windows.yml
@@ -1,0 +1,95 @@
+name: Windows Installer
+
+on:
+  workflow_call:
+    inputs:
+      source_sha:
+        description: Exact source commit to build
+        required: true
+        type: string
+      release_date:
+        description: Optional release date in YYYY-MM-DD
+        required: false
+        default: ""
+        type: string
+      revision:
+        description: Zero-based same-day build revision
+        required: false
+        default: "0"
+        type: string
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  PILOTDECK_UPDATE_REPOSITORY: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: windows-latest
+    timeout-minutes: 60
+    env:
+      PILOTDECK_RELEASE_DATE: ${{ inputs.release_date }}
+      PILOTDECK_RELEASE_REVISION: ${{ inputs.revision }}
+      PILOTDECK_COMMIT_SHA: ${{ inputs.source_sha || github.sha }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.source_sha || github.sha }}
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.32.1
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.23.1
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Verify managed process ownership and crash cleanup
+        run: node --test apps/desktop/scripts/process-identity.test.mjs apps/desktop/scripts/process-scope.test.mjs
+
+      - name: Compile and verify NSIS launch paths
+        run: node apps/desktop/scripts/verify-installer.cjs
+
+      - name: Set desktop release metadata
+        run: node apps/desktop/scripts/set-ci-version.mjs
+
+      - name: Disable Windows signing
+        shell: pwsh
+        run: '"CSC_IDENTITY_AUTO_DISCOVERY=false" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append'
+
+      - name: Build Windows x64 installer
+        run: pnpm --filter pilotdeck-desktop run dist:win
+
+      - name: Verify Windows artifact
+        shell: pwsh
+        run: |
+          $installer = Get-ChildItem 'apps/desktop/dist-electron/*-setup.exe' | Select-Object -First 1
+          if (-not $installer) { throw 'Windows installer was not generated.' }
+          if ($installer.Length -le 0) { throw 'Windows installer is empty.' }
+          $env:ELECTRON_RUN_AS_NODE = '1'
+          & 'apps/desktop/dist-electron/win-unpacked/PilotDeck.exe' apps/desktop/scripts/verify-updater.cjs apps/desktop/dist-electron/win-unpacked/resources/app.asar | Out-Host
+          if ($LASTEXITCODE -ne 0) { throw 'Packaged updater validation failed.' }
+          Remove-Item Env:ELECTRON_RUN_AS_NODE
+
+      - name: Prepare Windows update feed
+        shell: pwsh
+        run: |
+          if (-not (Test-Path 'apps/desktop/dist-electron/latest.yml')) { throw 'Update feed was not generated.' }
+          Move-Item 'apps/desktop/dist-electron/latest.yml' 'apps/desktop/dist-electron/latest-x64.yml'
+          if (-not (Test-Path 'apps/desktop/dist-electron/win-unpacked/resources/elevate.exe')) { throw 'Update elevation helper is missing.' }
+
+      - name: Upload Windows installer
+        uses: actions/upload-artifact@v4
+        with:
+          name: pilotdeck-desktop-windows
+          path: |
+            apps/desktop/dist-electron/*-setup.exe
+            apps/desktop/dist-electron/latest-x64.yml
+          if-no-files-found: error
+          retention-days: 14

--- a/apps/desktop/resources/installer.nsh
+++ b/apps/desktop/resources/installer.nsh
@@ -18,7 +18,7 @@ FunctionEnd
 !macro customHeader
   !macroundef StartApp
   ; NsisTarget expands this macro from its template directory, not resources/.
-  !include "${PROJECT_DIR}/resources/installer-start-app.nsh"
+  !include "${PROJECT_DIR}\resources\installer-start-app.nsh"
 !macroend
 
 !macro PilotDeckStartApp

--- a/apps/desktop/resources/installer.nsh
+++ b/apps/desktop/resources/installer.nsh
@@ -17,7 +17,8 @@ FunctionEnd
 ; after common.nsh is loaded and before the install section is expanded.
 !macro customHeader
   !macroundef StartApp
-  !include "installer-start-app.nsh"
+  ; NsisTarget expands this macro from its template directory, not resources/.
+  !include "${PROJECT_DIR}/resources/installer-start-app.nsh"
 !macroend
 
 !macro PilotDeckStartApp

--- a/apps/desktop/scripts/detect-release.mjs
+++ b/apps/desktop/scripts/detect-release.mjs
@@ -19,7 +19,8 @@ const productionPaths = [
   "src", "ui", "skills", "apps/desktop", "scripts",
   "package.json", "pnpm-lock.yaml", "pnpm-workspace.yaml", "tsconfig.json",
   "Dockerfile", "docker-entrypoint.sh", ".dockerignore",
-  ".github/workflows/desktop-build.yml", ".github/workflows/release.yml",
+  ".github/workflows/desktop-build.yml", ".github/workflows/desktop-windows.yml",
+  ".github/workflows/release.yml",
 ];
 
 const shouldBuild = process.env.FORCE_RELEASE === "true"

--- a/apps/desktop/scripts/detect-release.test.mjs
+++ b/apps/desktop/scripts/detect-release.test.mjs
@@ -69,7 +69,11 @@ test("unchanged and documentation-only commits skip unless forced", (t) => {
   assert.equal(forced.output.source_sha, sha);
 });
 
-for (const file of ["ui/app.js", "apps/desktop/src/main.ts", "Dockerfile", ".github/workflows/release.yml"]) {
+for (const file of [
+  "ui/app.js", "apps/desktop/src/main.ts", "Dockerfile",
+  ".github/workflows/desktop-build.yml", ".github/workflows/desktop-windows.yml",
+  ".github/workflows/release.yml",
+]) {
   test(`production changes trigger a release: ${file}`, (t) => {
     const { git, commit, detect } = repository(t);
     git("tag", "v2026.09.06");

--- a/apps/desktop/scripts/verify-installer.cjs
+++ b/apps/desktop/scripts/verify-installer.cjs
@@ -11,16 +11,27 @@ const libRoot = path.dirname(builderRequire.resolve('app-builder-lib/package.jso
 const { getMakeNsisPath, getNsisPluginsPath } = require(path.join(libRoot, 'out/toolsets/windows.js'));
 const { NsisScriptGenerator } = require(path.join(libRoot, 'out/targets/nsis/nsisScriptGenerator.js'));
 const templates = path.join(libRoot, 'templates/nsis');
-const resources = path.resolve(__dirname, '../resources');
+const projectDir = path.resolve(__dirname, '..');
+const { build } = require(path.join(projectDir, 'package.json'));
 (async () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'pilotdeck-nsis-test-'));
   try {
+    // Also exercise quoted includes when the checkout path contains spaces.
+    const fixtureDir = path.join(root, 'desktop project');
+    const fixtureResources = path.join(fixtureDir, 'resources');
+    fs.mkdirSync(fixtureResources, { recursive: true });
+    for (const name of ['installer.nsh', 'installer-start-app.nsh']) {
+      fs.copyFileSync(path.join(projectDir, 'resources', name), path.join(fixtureResources, name));
+    }
+    const buildResources = path.resolve(fixtureDir, build.directories.buildResources || 'build');
+    fs.mkdirSync(buildResources, { recursive: true });
     const binary = await getMakeNsisPath();
     const plugins = await getNsisPluginsPath();
     const generator = new NsisScriptGenerator();
-    generator.addIncludeDir(templates);
     generator.addIncludeDir(path.join(templates, 'include'));
-    generator.addIncludeDir(resources);
+    // NsisTarget adds buildResources, NOT the custom include's parent directory.
+    // Do not make a bare sibling include work here when production cannot find it.
+    generator.addIncludeDir(buildResources);
     generator.addPluginDir('x86-unicode', path.join(plugins, 'x86-unicode'));
     generator.include(path.join(templates, 'include/StdUtils.nsh'));
     generator.flags(['updated', 'force-run']);
@@ -32,7 +43,8 @@ const resources = path.resolve(__dirname, '../resources');
 !define PRODUCT_NAME "PilotDeck"
 !define PRODUCT_FILENAME "PilotDeck"
 !define VERSION "2026.907.0"
-!include "${path.join(resources, 'installer.nsh')}"
+!define PROJECT_DIR "${fixtureDir}"
+!include "${path.resolve(fixtureDir, build.nsis.include)}"
 !include "common.nsh"
 !include "MUI2.nsh"
 !insertmacro MUI_PAGE_INSTFILES
@@ -44,10 +56,9 @@ Section
 !macro doStartApp${launchSection}
 SectionEnd
 `;
-    // Absolute custom include avoids colliding with the builder's installer.nsi.
-    const file = path.join(root, 'test.nsi'); fs.writeFileSync(file, script);
-    const options = { cwd: resources, env: { ...process.env, ...binary.env }, encoding: 'utf8', maxBuffer: 10 * 1024 * 1024 };
-    const compiledLog = execFileSync(binary.path, ['-V4', file], options);
+    // Match NsisTarget.executeMakensis: stdin and the builder's template cwd.
+    const options = { cwd: templates, input: script, env: { ...process.env, ...binary.env }, encoding: 'utf8', maxBuffer: 10 * 1024 * 1024 };
+    const compiledLog = execFileSync(binary.path, ['-V4', '-INPUTCHARSET', 'UTF8', '-'], options);
 
     assert.equal((compiledLog.match(/Exec: .*explorer\.exe/g) || []).length, 2, 'interactive and silent launches both use explorer');
     assert.ok(!/Plugin command: ExecShellAsUser/.test(compiledLog), 'no default user-launch call survives expansion');

--- a/docs/release.md
+++ b/docs/release.md
@@ -217,6 +217,13 @@ proxy, without contacting GitHub or installing anything. It covers both config
 and environment proxy discovery/download paths, proxy authentication, and loopback bypass. The installer
 check downloads the builder's NSIS toolchain if uncached, compiles the launch
 paths using the installed templates, and checks that both use `explorer.exe`.
+It uses the builder's template working directory, stdin input, and include
+search paths, including a project path with spaces. Custom sibling includes
+must resolve from `${PROJECT_DIR}` rather than relying on the current directory.
+Desktop Smoke and Daily Release share the Windows Installer workflow: both
+build the actual NSIS installer, validate the packaged updater and elevation
+helper, and require the update feed. PR builds only upload Actions artifacts;
+they do not publish a Release.
 It does not run the generated EXE. Windows elevation/relaunch and signed macOS
 cross-version replacement still require real platform upgrade tests.
 


### PR DESCRIPTION
Windows Daily Release fails while compiling the NSIS uninstaller because `customHeader` includes `installer-start-app.nsh` by filename. electron-builder runs makensis from its own template directory and only adds the configured build resources directory, so the sibling file cannot be resolved.

Resolve the include from `PROJECT_DIR` using NSIS-native backslash separators. The native Windows compiler also caught mixed separators that the macOS compiler accepts. Correct the NSIS regression check to use the builder’s working directory, stdin compilation and include paths, and exercise a checkout path containing spaces. It still verifies that interactive and silent update launches both expand to `explorer.exe`.

Extract the existing Windows release job into a shared workflow used by Desktop Build and Desktop Smoke. PRs now build the actual installer and validate the packaged updater, elevation helper and update feed before uploading CI artifacts; they do not publish releases.

Validation:
- Reproduced the exact missing-include error with the corrected compiler harness before applying the fix.
- NSIS compilation and both launch-path assertions pass after the fix.
- All 39 desktop helper/process tests pass locally; workflow YAML parses and git diff checks pass.
- Native Windows validation on commit `985bf762` passed: process/Job cleanup, NSIS launch-path compilation, full `dist:win` installer generation, packaged updater verification, elevation helper and update feed checks, and artifact upload (299,441,381 bytes).
- [Windows build evidence](https://github.com/OpenBMB/PilotDeck/actions/runs/34120163487/job/101736150923).
- Desktop static checks, Web Regression and Docker checks passed on the same commit.

This validates packaging; interactive Windows elevation/relaunch and signed macOS cross-version upgrades still require platform acceptance testing.


Include the extracted `desktop-windows.yml` in release production-path detection so Windows-only packaging changes trigger scheduled releases. Regression coverage now includes all three production workflows. The new Windows-only case reproduced `should_build=false` before the fix; all 12 release detection tests pass after it on commit `7cfc12e9`. CI is rerunning for this follow-up commit.
