### PR TITLE
fix(release): retry failed builds once before publishing

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -189,6 +189,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: pilotdeck-desktop-macos-${{ matrix.arch }}
+          overwrite: true
           path: |
             apps/desktop/dist-electron/*-mac-${{ matrix.arch }}.dmg
             apps/desktop/dist-electron/*-mac-${{ matrix.arch }}.zip

--- a/.github/workflows/desktop-smoke.yml
+++ b/.github/workflows/desktop-smoke.yml
@@ -12,6 +12,7 @@ on:
       - pnpm-workspace.yaml
       - .github/workflows/desktop-*.yml
       - .github/workflows/release.yml
+      - .github/workflows/release-retry.yml
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/desktop-windows.yml
+++ b/.github/workflows/desktop-windows.yml
@@ -88,6 +88,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: pilotdeck-desktop-windows
+          overwrite: true
           path: |
             apps/desktop/dist-electron/*-setup.exe
             apps/desktop/dist-electron/latest-x64.yml

--- a/.github/workflows/release-retry.yml
+++ b/.github/workflows/release-retry.yml
@@ -1,0 +1,40 @@
+name: Retry Release Build
+
+on:
+  workflow_run:
+    workflows: [Daily Release]
+    types: [completed]
+    branches: [main]
+
+permissions:
+  contents: read
+  actions: write
+
+concurrency:
+  group: release-build-retry-${{ github.event.workflow_run.id }}
+  cancel-in-progress: false
+
+jobs:
+  retry:
+    if: >-
+      ${{ github.event.workflow_run.run_attempt == 1 &&
+          github.event.workflow_run.conclusion == 'failure' &&
+          contains(fromJSON('["schedule", "workflow_dispatch"]'), github.event.workflow_run.event) }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      # workflow_run's SHA is from the default branch. Never execute code or
+      # download artifacts from the failed run in this write-enabled workflow.
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - name: Retry failed build jobs once
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const { retryReleaseBuild } = require('./apps/desktop/scripts/retry-release-build.cjs');
+            const result = await retryReleaseBuild({ github, context });
+            core.info(result.message);
+            await core.summary.addRaw(result.message).write();

--- a/apps/desktop/scripts/detect-release.mjs
+++ b/apps/desktop/scripts/detect-release.mjs
@@ -20,7 +20,7 @@ const productionPaths = [
   "package.json", "pnpm-lock.yaml", "pnpm-workspace.yaml", "tsconfig.json",
   "Dockerfile", "docker-entrypoint.sh", ".dockerignore",
   ".github/workflows/desktop-build.yml", ".github/workflows/desktop-windows.yml",
-  ".github/workflows/release.yml",
+  ".github/workflows/release.yml", ".github/workflows/release-retry.yml",
 ];
 
 const shouldBuild = process.env.FORCE_RELEASE === "true"

--- a/apps/desktop/scripts/detect-release.test.mjs
+++ b/apps/desktop/scripts/detect-release.test.mjs
@@ -72,7 +72,7 @@ test("unchanged and documentation-only commits skip unless forced", (t) => {
 for (const file of [
   "ui/app.js", "apps/desktop/src/main.ts", "Dockerfile",
   ".github/workflows/desktop-build.yml", ".github/workflows/desktop-windows.yml",
-  ".github/workflows/release.yml",
+  ".github/workflows/release.yml", ".github/workflows/release-retry.yml",
 ]) {
   test(`production changes trigger a release: ${file}`, (t) => {
     const { git, commit, detect } = repository(t);

--- a/apps/desktop/scripts/retry-release-build.cjs
+++ b/apps/desktop/scripts/retry-release-build.cjs
@@ -1,0 +1,55 @@
+const isBuild = job => job.name === 'build' || job.name.startsWith('build / ');
+const isFailure = job => ['failure', 'timed_out'].includes(job.conclusion);
+
+function eligibleRun(run, repository) {
+  return Number.isSafeInteger(run?.id) && run.id > 0
+    && run.name === 'Daily Release'
+    && run.path === '.github/workflows/release.yml'
+    && run.head_repository?.full_name === repository
+    && run.head_branch === 'main'
+    && ['schedule', 'workflow_dispatch'].includes(run.event)
+    && run.status === 'completed' && run.conclusion === 'failure'
+    && run.run_attempt === 1;
+}
+
+function eligibleJobs(jobs) {
+  // A failed build must be the only reason publishing did not run. In
+  // particular, never retry a partially published Release or a cancelled build.
+  return jobs.length > 0 && jobs.every(job => job.status === 'completed')
+    && jobs.some(job => job.name === 'detect' && job.conclusion === 'success')
+    && jobs.some(job => job.name === 'release' && job.conclusion === 'skipped')
+    && jobs.some(job => isBuild(job) && isFailure(job))
+    && jobs.every(job => isBuild(job)
+      ? ['success', 'failure', 'timed_out', 'skipped'].includes(job.conclusion)
+      : ['success', 'skipped'].includes(job.conclusion));
+}
+
+async function retryReleaseBuild({ github, context }) {
+  const original = context.payload.workflow_run;
+  const repository = `${context.repo.owner}/${context.repo.repo}`;
+  const skip = message => ({ retried: false, message });
+  if (!eligibleRun(original, repository)) return skip('No retry: only the first failed Daily Release on main is eligible.');
+
+  const params = { ...context.repo, run_id: original.id };
+  const jobs = await github.paginate('GET /repos/{owner}/{repo}/actions/runs/{run_id}/attempts/{attempt_number}/jobs', {
+    ...params, attempt_number: 1, per_page: 100,
+  });
+  if (!eligibleJobs(jobs)) return skip('No retry: failure is outside the build stage, a job was cancelled, or publishing already ran.');
+
+  // The completed event can be stale after a manual retry. Check again directly
+  // before requesting a rerun; concurrency also serializes duplicate events.
+  const { data: latest } = await github.request('GET /repos/{owner}/{repo}/actions/runs/{run_id}', params);
+  if (!eligibleRun(latest, repository) || latest.head_sha !== original.head_sha) {
+    return skip('No retry: this run has already been retried or its state changed.');
+  }
+
+  // GitHub retains successful jobs, detect outputs, source SHA and artifacts.
+  // Dependent publishing starts only if all of the retried builds succeed.
+  await github.request('POST /repos/{owner}/{repo}/actions/runs/{run_id}/rerun-failed-jobs', params);
+  return {
+    retried: true,
+    message: `Requested the only automatic build retry for Daily Release run ${original.id}. Successful jobs and release metadata are retained.`,
+  };
+}
+
+module.exports = { retryReleaseBuild };

--- a/apps/desktop/scripts/retry-release-build.test.mjs
+++ b/apps/desktop/scripts/retry-release-build.test.mjs
@@ -1,0 +1,104 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import retry from './retry-release-build.cjs';
+
+const run = {
+  id: 34277867930, name: 'Daily Release', path: '.github/workflows/release.yml',
+  head_repository: { full_name: 'OpenBMB/PilotDeck' }, head_branch: 'main',
+  head_sha: '17aa46d0c55b83ae1d35658971ecc1c2a1e4ce14',
+  event: 'schedule', status: 'completed', conclusion: 'failure', run_attempt: 1,
+};
+const job = (name, conclusion) => ({ name, conclusion, status: 'completed' });
+const jobs = [
+  job('detect', 'success'), job('build / macOS arm64', 'success'),
+  job('build / macOS x64', 'success'), job('build / windows / build', 'failure'),
+  job('release', 'skipped'), job('skipped', 'skipped'),
+];
+
+function fixture({ event = run, current = event, results = jobs } = {}) {
+  const calls = [];
+  const github = {
+    paginate: async (route, params) => { calls.push({ route, params }); return results; },
+    request: async (route, params) => {
+      calls.push({ route, params });
+      return { data: route.startsWith('GET ') ? current : undefined };
+    },
+  };
+  const context = { repo: { owner: 'OpenBMB', repo: 'PilotDeck' }, payload: { workflow_run: event } };
+  return { github, context, calls, execute: () => retry.retryReleaseBuild({ github, context }) };
+}
+
+for (const event of ['schedule', 'workflow_dispatch']) {
+  test(`${event}: retries the failed build and dependents using the original run`, async () => {
+    const f = fixture({ event: { ...run, event } });
+    assert.equal((await f.execute()).retried, true);
+    assert.deepEqual(f.calls, [
+      {
+        route: 'GET /repos/{owner}/{repo}/actions/runs/{run_id}/attempts/{attempt_number}/jobs',
+        params: { owner: 'OpenBMB', repo: 'PilotDeck', run_id: run.id, attempt_number: 1, per_page: 100 },
+      },
+      { route: 'GET /repos/{owner}/{repo}/actions/runs/{run_id}', params: { owner: 'OpenBMB', repo: 'PilotDeck', run_id: run.id } },
+      { route: 'POST /repos/{owner}/{repo}/actions/runs/{run_id}/rerun-failed-jobs', params: { owner: 'OpenBMB', repo: 'PilotDeck', run_id: run.id } },
+    ]);
+  });
+}
+
+test('multiple failed platforms are retried with one request', async () => {
+  const f = fixture({ results: jobs.map(j => j.name === 'build / macOS x64' ? { ...j, conclusion: 'timed_out' } : j) });
+  assert.equal((await f.execute()).retried, true);
+  assert.equal(f.calls.filter(c => c.route.startsWith('POST ')).length, 1);
+});
+
+for (const [name, patch] of [
+  ['second attempt', { run_attempt: 2 }], ['later manual attempt', { run_attempt: 3 }],
+  ['missing attempt', { run_attempt: undefined }], ['successful run', { conclusion: 'success' }],
+  ['cancelled run', { conclusion: 'cancelled' }], ['unfinished run', { status: 'in_progress' }],
+  ['another branch', { head_branch: 'feature' }], ['PR event', { event: 'pull_request' }],
+  ['another repository', { head_repository: { full_name: 'someone/PilotDeck' } }],
+  ['another workflow', { name: 'Desktop Smoke' }], ['another workflow path', { path: '.github/workflows/other.yml' }],
+]) {
+  test(`ignores ${name} without requesting a rerun`, async () => {
+    const f = fixture({ event: { ...run, ...patch } });
+    assert.equal((await f.execute()).retried, false);
+    assert.deepEqual(f.calls, []);
+  });
+}
+
+for (const [name, results] of [
+  ['detection failure', jobs.map(j => j.name === 'detect' ? job(j.name, 'failure') : j)],
+  ['publication failure', jobs.map(j => j.name === 'release' ? job(j.name, 'failure') : j)],
+  ['publication already succeeded', jobs.map(j => j.name === 'release' ? job(j.name, 'success') : j)],
+  ['cancelled sibling build', jobs.map(j => j.name === 'build / macOS arm64' ? job(j.name, 'cancelled') : j)],
+  ['all builds succeeded', jobs.map(j => j.name === 'build / windows / build' ? job(j.name, 'success') : j)],
+  ['unknown failed job', [...jobs, job('new-stage', 'failure')]],
+  ['unfinished job', jobs.map(j => j.name === 'release' ? { ...j, status: 'queued' } : j)],
+  ['missing jobs', []], ['missing release job', jobs.filter(j => j.name !== 'release')],
+]) {
+  test(`does not retry ${name}`, async () => {
+    const f = fixture({ results });
+    assert.equal((await f.execute()).retried, false);
+    assert.equal(f.calls.some(c => c.route.startsWith('POST ')), false);
+  });
+}
+
+for (const patch of [{ run_attempt: 2 }, { status: 'queued' }, { conclusion: 'cancelled' }, { head_sha: 'different' }]) {
+  test(`rechecks the live run before retrying: ${JSON.stringify(patch)}`, async () => {
+    const f = fixture({ current: { ...run, ...patch } });
+    assert.equal((await f.execute()).retried, false);
+    assert.equal(f.calls.some(c => c.route.startsWith('POST ')), false);
+  });
+}
+
+test('a completed retry cannot trigger a third attempt', async () => {
+  const f = fixture();
+  assert.equal((await f.execute()).retried, true);
+  const next = fixture({ event: { ...run, run_attempt: 2 } });
+  assert.equal((await next.execute()).retried, false);
+  assert.deepEqual(next.calls, []);
+});
+
+test('API errors remain failures instead of reporting a successful retry', async () => {
+  const f = fixture();
+  f.github.request = async () => { throw new Error('GitHub API unavailable'); };
+  await assert.rejects(f.execute, /GitHub API unavailable/);
+});

--- a/docs/release.md
+++ b/docs/release.md
@@ -34,6 +34,20 @@ the latest unified release tag:
   plus an unsigned Windows installer, then publish one dated GitHub Release;
 - repeated manual release on the same date: use `-r2`, `-r3`, and so on.
 
+If the first Daily Release attempt fails only during builds,
+`.github/workflows/release-retry.yml` requests one automatic retry of the failed
+jobs on fresh runners. Successful platform builds and the original source SHA,
+release date, and revision are retained. Publishing proceeds after the retried
+builds succeed. Detection failures, publication failures, cancelled jobs, and
+second or later attempts are not automatically retried. The retry decision is
+recorded in the separate **Retry Release Build** workflow summary; both build
+attempts remain visible in the original run. This applies to scheduled and
+manually started Daily Release runs once the retry workflow is on `main`.
+
+Each platform upload can replace its own artifact when a failed build is retried,
+including when an earlier upload stored the artifact but failed before completing.
+Artifacts from successful platform jobs are retained.
+
 Release names and tags are `vYYYY.MM.DD`, for example `v2026.09.07`.
 Additional releases on that date use `v2026.09.07-r2`, `-r3`, and so on.
 The internal Electron version remains a numeric SemVer derived from the same


### PR DESCRIPTION
Daily Release currently stops after a transient platform build failure. Add one automatic retry of failed build jobs and their dependents, retaining successful builds and the original source SHA, release date, and revision.

The retry runs only after the first failed scheduled or manual Daily Release on main, with detection successful and publishing still skipped. Detection/publication failures, cancellations, and later attempts are excluded. The controller rechecks live run state before calling GitHub's failed-job rerun API. Platform uploads can replace their own artifacts if a previous failed attempt already uploaded them.

Validation: 42 release retry/detection tests passed; actionlint passed for all four changed workflows; a read-only replay using run 34277867930's actual API data selected the expected failed-job retry. The new workflow must land on main before its workflow_run trigger becomes active; no release was published or retried during local validation.
