### PR TITLE
fix(context): stabilize session prompt dates and append daily updates

### DIFF
--- a/docs/trd/anthropic-prompt-cache.zh.md
+++ b/docs/trd/anthropic-prompt-cache.zh.md
@@ -31,6 +31,7 @@
 - 新会话先缓存 system；有消息时再按 recent3 标记消息。
 - 每次投影后重新计算计划；消息被裁剪、微压缩或完整压缩后递增 generation。
 - 会话首次正式组装请求时固定 system prompt 的 UTC 日期；正常追加消息、重试和跨天不单独刷新日期。实际投影历史被裁剪、改写或压缩完成后，在下一次正式组装时更新日期，随后再次固定。重复投影同一份已裁剪历史不算新的裁剪。
+- UTC 日期变化后，下一次请求在消息末尾追加一条 `date_update` 合成消息，告知真实当前日期；同日后续请求保留其原位置，不重复追加，以维持已有缓存前缀。预算预演包含候选日期消息但不提交；历史改写并刷新 system 日期后清除旧日期消息。这些消息只存在于请求投影中，与 runtime 同生命周期，不写入用户会话记录，也不参与 memory retrieval。
 - 预算估算使用 `previewOnly` 组装候选请求，不提交日期、历史摘要或 cache generation，也不消费待处理的压缩 reset。日期锚点与会话 runtime 同生命周期，重建 runtime 时重新初始化。
 - plan mode 先对真实对话完成投影和 memory retrieval，再追加 reminder；最终请求的缓存计划以追加后的消息序列为准。
 - continuation request 改变消息数量后清除旧缓存计划，由下一次完整请求重新建立 provider-boundary 断点。

--- a/docs/trd/anthropic-prompt-cache.zh.md
+++ b/docs/trd/anthropic-prompt-cache.zh.md
@@ -30,6 +30,8 @@
 
 - 新会话先缓存 system；有消息时再按 recent3 标记消息。
 - 每次投影后重新计算计划；消息被裁剪、微压缩或完整压缩后递增 generation。
+- 会话首次正式组装请求时固定 system prompt 的 UTC 日期；正常追加消息、重试和跨天不单独刷新日期。实际投影历史被裁剪、改写或压缩完成后，在下一次正式组装时更新日期，随后再次固定。重复投影同一份已裁剪历史不算新的裁剪。
+- 预算估算使用 `previewOnly` 组装候选请求，不提交日期、历史摘要或 cache generation，也不消费待处理的压缩 reset。日期锚点与会话 runtime 同生命周期，重建 runtime 时重新初始化。
 - plan mode 先对真实对话完成投影和 memory retrieval，再追加 reminder；最终请求的缓存计划以追加后的消息序列为准。
 - continuation request 改变消息数量后清除旧缓存计划，由下一次完整请求重新建立 provider-boundary 断点。
 - Router 将请求切换到不同 provider/model 时清除旧计划，当前请求无缓存降级。
@@ -38,7 +40,7 @@
 ## 测试映射与证据
 
 - `tests/context/cache-plan.spec.ts`：recent3 选择、fingerprint 和关闭条件。
-- `tests/context/cache-runtime.spec.ts`：DefaultContextRuntime 的协议门控、投影截断和 generation。
+- `tests/context/cache-runtime.spec.ts`：协议门控、投影截断、generation、跨天日期固定、会话隔离、历史改写后刷新及预算预演隔离。
 - `tests/model/request/anthropic-cache-plan.spec.ts`：system/recent3、5m TTL、tools 兼容和四断点上限。
 - `tests/agent/loop/model-override-defaults.spec.ts`：plan reminder 不占 projection 配额，memory 使用真实用户请求，最终断点与消息序列一致。
 - `tests/model/streaming/continuation-cache.spec.ts`：续传不复用旧缓存断点。

--- a/docs/trd/anthropic-prompt-cache.zh.md
+++ b/docs/trd/anthropic-prompt-cache.zh.md
@@ -30,8 +30,8 @@
 
 - 新会话先缓存 system；有消息时再按 recent3 标记消息。
 - 每次投影后重新计算计划；消息被裁剪、微压缩或完整压缩后递增 generation。
-- 会话首次正式组装请求时固定 system prompt 的 UTC 日期；正常追加消息、重试和跨天不单独刷新日期。实际投影历史被裁剪、改写或压缩完成后，在下一次正式组装时更新日期，随后再次固定。重复投影同一份已裁剪历史不算新的裁剪。
-- UTC 日期变化后，下一次请求在消息末尾追加一条 `date_update` 合成消息，告知真实当前日期；同日后续请求保留其原位置，不重复追加，以维持已有缓存前缀。预算预演包含候选日期消息但不提交；历史改写并刷新 system 日期后清除旧日期消息。这些消息只存在于请求投影中，与 runtime 同生命周期，不写入用户会话记录，也不参与 memory retrieval。
+- 会话首次正式组装请求时固定 system prompt 的 UTC 日期；正常追加消息、重试和跨天不单独刷新日期。仅在完整摘要压缩产生新 checkpoint 后，在下一次正式组装时更新日期，随后再次固定。微压缩、头部裁剪、中间删减及其他局部改写不刷新 system 日期；重复投影同一 checkpoint 也不刷新。
+- UTC 日期变化后，下一次请求在消息末尾追加一条 `date_update` 合成消息，告知真实当前日期；同日后续请求保留其原位置，不重复追加，以维持已有缓存前缀。预算预演包含候选日期消息但不提交；完整压缩刷新 system 日期后清除旧日期消息。裁剪和局部改写保留未变前缀中的日期消息；受影响的日期消息移除，并按需在新末尾补充当前日期，避免沿用失效下标或破坏工具配对。这些消息只存在于请求投影中，与 runtime 同生命周期，不写入用户会话记录，也不参与 memory retrieval。
 - 预算估算使用 `previewOnly` 组装候选请求，不提交日期、历史摘要或 cache generation，也不消费待处理的压缩 reset。日期锚点与会话 runtime 同生命周期，重建 runtime 时重新初始化。
 - plan mode 先对真实对话完成投影和 memory retrieval，再追加 reminder；最终请求的缓存计划以追加后的消息序列为准。
 - continuation request 改变消息数量后清除旧缓存计划，由下一次完整请求重新建立 provider-boundary 断点。
@@ -41,7 +41,7 @@
 ## 测试映射与证据
 
 - `tests/context/cache-plan.spec.ts`：recent3 选择、fingerprint 和关闭条件。
-- `tests/context/cache-runtime.spec.ts`：协议门控、投影截断、generation、跨天日期固定、会话隔离、历史改写后刷新及预算预演隔离。
+- `tests/context/cache-runtime.spec.ts`：协议门控、投影截断、generation、跨天日期固定、会话隔离、完整压缩后刷新、裁剪保持日期与未变前缀、微压缩 reset 隔离及预算预演隔离。
 - `tests/model/request/anthropic-cache-plan.spec.ts`：system/recent3、5m TTL、tools 兼容和四断点上限。
 - `tests/agent/loop/model-override-defaults.spec.ts`：plan reminder 不占 projection 配额，memory 使用真实用户请求，最终断点与消息序列一致。
 - `tests/model/streaming/continuation-cache.spec.ts`：续传不复用旧缓存断点。

--- a/src/agent/loop/AgentLoop.ts
+++ b/src/agent/loop/AgentLoop.ts
@@ -2046,7 +2046,7 @@ export class AgentLoop {
   private async createModelRequest(
     messages: CanonicalMessage[],
     input: AgentLoopInput,
-    options: { emitInstructionEvents?: boolean } = {},
+    options: { emitInstructionEvents?: boolean; previewOnly?: boolean } = {},
   ): Promise<CanonicalModelRequest> {
     const contextRuntime = this.dependencies.context ?? new NullContextRuntime();
     const planTodo = this.dependencies.planTodoManager?.forSession(input.sessionId);
@@ -2073,6 +2073,7 @@ export class AgentLoop {
     const requestProvider = input.modelOverride?.provider ?? this.config.provider;
     const requestModel = input.modelOverride?.model ?? this.config.model;
     const prepared = await contextRuntime.prepareForModel({
+      previewOnly: options.previewOnly,
       sessionId: input.sessionId,
       turnId: input.turnId,
       cwd: this.config.cwd,
@@ -2163,6 +2164,7 @@ export class AgentLoop {
     return async (candidateMessages) => {
       let candidateRequest = await this.createModelRequest(candidateMessages, input, {
         emitInstructionEvents: false,
+        previewOnly: true,
       });
       if (options.decision && options.baseRequest) {
         const patchedBase = { ...options.baseRequest, messages: candidateRequest.messages };

--- a/src/context/DefaultContextRuntime.ts
+++ b/src/context/DefaultContextRuntime.ts
@@ -167,27 +167,39 @@ export class DefaultContextRuntime implements ContextRuntime {
       });
     }
 
-    // Ordinary appends advance recent3 but must not advance the prompt date.
-    // Hash projected content to detect committed pruning/compaction, including
-    // changes made by callers, without retaining another copy of large media.
+    // Track the unchanged prefix so pruning only relocates date notices after
+    // the first changed message, without retaining another copy of large media.
     const messageFingerprints = projection.messages.map((message) => createHash("sha256")
       .update(stableSerialize({ role: message.role, content: message.content }))
       .digest("hex"));
     const previousTime = this.promptTimeState.get(input.sessionId);
-    const historyRewritten = previousTime !== undefined && (
-      messageFingerprints.length < previousTime.messages.length
-      || previousTime.messages.some((hash, index) => hash !== messageFingerprints[index])
-    );
-    const refreshTime = !input.previewOnly && (
-      historyRewritten || this.cacheResetSessions.has(input.sessionId)
-    );
+    let unchangedPrefixLength = 0;
+    while (previousTime && unchangedPrefixLength < messageFingerprints.length
+      && messageFingerprints[unchangedPrefixLength] === previousTime.messages[unchangedPrefixLength]) {
+      unchangedPrefixLength += 1;
+    }
+    // Only a new full-compaction checkpoint refreshes the system date. Cache
+    // resets also cover micro-pruning and must not invalidate the system prefix.
+    // Inspect the checkpoint to cover manual compaction performed by callers.
+    const boundary = projection.messages[0];
+    const summary = projection.messages[1];
+    const newCheckpoint = previousTime !== undefined
+      && boundary?.role === "user"
+      && boundary.content.some((block) => block.type === "text" && block.text.startsWith("<compact-boundary"))
+      && summary?.role === "assistant"
+      && summary.content.some((block) => block.type === "text" && block.text.startsWith("[CONTEXT COMPACTION - REFERENCE ONLY]"))
+      && unchangedPrefixLength < 2;
+    const refreshTime = !input.previewOnly && newCheckpoint;
     const currentTime = this.now();
     const currentDate = currentTime.toISOString().slice(0, 10);
     const promptTimestamp = !previousTime || refreshTime ? currentTime.getTime() : previousTime.timestamp;
     // Keep each rollover at its original position so later requests extend the
     // same cache prefix. These request-only messages share the prompt anchor's
-    // lifetime; a rewritten history gets a fresh system date instead.
-    const dateUpdates = historyRewritten || refreshTime ? [] : [...(previousTime?.dateUpdates ?? [])];
+    // lifetime. Keep notices inside the unchanged prefix; replace affected
+    // notices with the current date at the new tail. This avoids stale indexes
+    // after pruning and never changes a prefix that pruning itself preserved.
+    const dateUpdates = refreshTime ? [] : (previousTime?.dateUpdates ?? [])
+      .filter((update) => update.index <= unchangedPrefixLength);
     const lastDate = dateUpdates.at(-1)?.date ?? new Date(promptTimestamp).toISOString().slice(0, 10);
     if (currentDate !== lastDate) {
       dateUpdates.push({

--- a/src/context/DefaultContextRuntime.ts
+++ b/src/context/DefaultContextRuntime.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import type { CanonicalMessage } from "../model/index.js";
 import { ToolResultBudget } from "./budget/ToolResultBudget.js";
 import type { TokenBudgetManager, TokenBudgetSnapshot } from "./budget/TokenBudgetManager.js";
@@ -8,7 +9,7 @@ import {
   buildPostCompactMessages,
   truncateHeadPreservingCheckpoint,
 } from "./compaction/CompactionEngine.js";
-import { buildCachePlan } from "./cache/CachePlan.js";
+import { buildCachePlan, stableSerialize } from "./cache/CachePlan.js";
 import type { MicroCompactionEngine } from "./compaction/MicroCompactionEngine.js";
 import type { SnipEngine } from "./compaction/SnipEngine.js";
 import { ensureTrailingUserMessage } from "./compaction/toolPairIntegrity.js";
@@ -110,6 +111,7 @@ export class DefaultContextRuntime implements ContextRuntime {
   readonly autoCompactionPolicy?: AutoCompactionPolicy;
   private readonly cachePlanState = new Map<string, { fingerprint: string; generation: number }>();
   private readonly cacheResetSessions = new Set<string>();
+  private readonly promptTimeState = new Map<string, { timestamp: number; messages: string[] }>();
   private readonly microCompaction?: MicroCompactionEngine;
   private readonly snipEngine?: SnipEngine;
   private readonly overflowRecovery?: ContextOverflowRecovery;
@@ -161,6 +163,21 @@ export class DefaultContextRuntime implements ContextRuntime {
       });
     }
 
+    // Ordinary appends advance recent3 but must not advance the prompt date.
+    // Hash projected content to detect committed pruning/compaction, including
+    // changes made by callers, without retaining another copy of large media.
+    const messageFingerprints = projection.messages.map((message) => createHash("sha256")
+      .update(stableSerialize({ role: message.role, content: message.content }))
+      .digest("hex"));
+    const previousTime = this.promptTimeState.get(input.sessionId);
+    const historyRewritten = previousTime !== undefined && (
+      messageFingerprints.length < previousTime.messages.length
+      || previousTime.messages.some((hash, index) => hash !== messageFingerprints[index])
+    );
+    const refreshTime = !input.previewOnly && (
+      historyRewritten || this.cacheResetSessions.has(input.sessionId)
+    );
+    const promptTimestamp = !previousTime || refreshTime ? this.now().getTime() : previousTime.timestamp;
     const prompt = this.promptAssembler.assemble({
       cwd: input.cwd,
       provider: input.provider,
@@ -171,7 +188,7 @@ export class DefaultContextRuntime implements ContextRuntime {
       tools: input.tools,
       customSystemPrompt: input.customSystemPrompt,
       appendSystemPrompt: input.appendSystemPrompt,
-      now: this.now,
+      now: () => new Date(promptTimestamp),
     });
 
     const parts = [...prompt.parts];
@@ -250,12 +267,17 @@ export class DefaultContextRuntime implements ContextRuntime {
     const cachePlanFingerprint = buildCachePlan(cachePlanInput, 0)?.fingerprint;
     const cachePlan = buildCachePlan(
       cachePlanInput,
-      this.nextCachePlanGeneration(
+      input.previewOnly ? (this.cachePlanState.get(input.sessionId)?.generation ?? 0) : this.nextCachePlanGeneration(
         input.sessionId,
         cachePlanFingerprint,
         this.cacheResetSessions.delete(input.sessionId),
       ),
     );
+
+    // Budget probes must not consume resets or commit hypothetical histories.
+    if (!input.previewOnly) {
+      this.promptTimeState.set(input.sessionId, { timestamp: promptTimestamp, messages: messageFingerprints });
+    }
 
     return {
       messages: projection.messages,

--- a/src/context/DefaultContextRuntime.ts
+++ b/src/context/DefaultContextRuntime.ts
@@ -111,7 +111,11 @@ export class DefaultContextRuntime implements ContextRuntime {
   readonly autoCompactionPolicy?: AutoCompactionPolicy;
   private readonly cachePlanState = new Map<string, { fingerprint: string; generation: number }>();
   private readonly cacheResetSessions = new Set<string>();
-  private readonly promptTimeState = new Map<string, { timestamp: number; messages: string[] }>();
+  private readonly promptTimeState = new Map<string, {
+    timestamp: number;
+    messages: string[];
+    dateUpdates: Array<{ index: number; date: string; message: CanonicalMessage }>;
+  }>();
   private readonly microCompaction?: MicroCompactionEngine;
   private readonly snipEngine?: SnipEngine;
   private readonly overflowRecovery?: ContextOverflowRecovery;
@@ -177,7 +181,36 @@ export class DefaultContextRuntime implements ContextRuntime {
     const refreshTime = !input.previewOnly && (
       historyRewritten || this.cacheResetSessions.has(input.sessionId)
     );
-    const promptTimestamp = !previousTime || refreshTime ? this.now().getTime() : previousTime.timestamp;
+    const currentTime = this.now();
+    const currentDate = currentTime.toISOString().slice(0, 10);
+    const promptTimestamp = !previousTime || refreshTime ? currentTime.getTime() : previousTime.timestamp;
+    // Keep each rollover at its original position so later requests extend the
+    // same cache prefix. These request-only messages share the prompt anchor's
+    // lifetime; a rewritten history gets a fresh system date instead.
+    const dateUpdates = historyRewritten || refreshTime ? [] : [...(previousTime?.dateUpdates ?? [])];
+    const lastDate = dateUpdates.at(-1)?.date ?? new Date(promptTimestamp).toISOString().slice(0, 10);
+    if (currentDate !== lastDate) {
+      dateUpdates.push({
+        index: projection.messages.length,
+        date: currentDate,
+        message: {
+          role: "user",
+          content: [{ type: "text", text:
+            `<date-update>\ncurrent_date: ${currentDate} (UTC)\n` +
+            "The date has changed. Use this date for today and relative dates, " +
+            "superseding earlier environment dates.\n</date-update>",
+          }],
+          metadata: { synthetic: true, purpose: "date_update" },
+        },
+      });
+    }
+    const requestMessages: CanonicalMessage[] = [];
+    let messageIndex = 0;
+    for (const update of dateUpdates) {
+      requestMessages.push(...projection.messages.slice(messageIndex, update.index), update.message);
+      messageIndex = update.index;
+    }
+    requestMessages.push(...projection.messages.slice(messageIndex));
     const prompt = this.promptAssembler.assemble({
       cwd: input.cwd,
       provider: input.provider,
@@ -261,7 +294,7 @@ export class DefaultContextRuntime implements ContextRuntime {
       model: input.model,
       systemPrompt: joined,
       tools: input.tools,
-      messages: projection.messages,
+      messages: requestMessages,
       enabled: input.protocol === "anthropic" && input.supportsPromptCache === true,
     };
     const cachePlanFingerprint = buildCachePlan(cachePlanInput, 0)?.fingerprint;
@@ -276,11 +309,11 @@ export class DefaultContextRuntime implements ContextRuntime {
 
     // Budget probes must not consume resets or commit hypothetical histories.
     if (!input.previewOnly) {
-      this.promptTimeState.set(input.sessionId, { timestamp: promptTimestamp, messages: messageFingerprints });
+      this.promptTimeState.set(input.sessionId, { timestamp: promptTimestamp, messages: messageFingerprints, dateUpdates });
     }
 
     return {
-      messages: projection.messages,
+      messages: requestMessages,
       systemPrompt: joined,
       systemPromptParts: parts,
       tools: input.tools,

--- a/src/context/protocol/types.ts
+++ b/src/context/protocol/types.ts
@@ -43,6 +43,8 @@ export type ModelContext = {
 };
 
 export type ContextPrepareInput = {
+  /** Budget-only assembly; do not commit prompt time or cache state. */
+  previewOnly?: boolean;
   sessionId: string;
   turnId: string;
   cwd: string;

--- a/src/router/tokenSaver/extractLastUserMessage.ts
+++ b/src/router/tokenSaver/extractLastUserMessage.ts
@@ -6,6 +6,11 @@ export function extractLastUserMessage(messages: CanonicalMessage[]): string | u
     if (message.role !== "user") {
       continue;
     }
+    // Request-only date notices update the answering model, not the task
+    // whose complexity determines the route.
+    if (message.metadata?.synthetic === true && message.metadata?.purpose === "date_update") {
+      continue;
+    }
     const text = message.content
       .filter((block): block is import("../../model/index.js").CanonicalTextBlock => block.type === "text")
       .map((block) => block.text)

--- a/tests/context/cache-runtime.spec.ts
+++ b/tests/context/cache-runtime.spec.ts
@@ -2,6 +2,9 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import { DefaultContextRuntime } from "../../src/context/DefaultContextRuntime.js";
+import { MicroCompactionEngine } from "../../src/context/compaction/MicroCompactionEngine.js";
+import { AutoCompactionPolicy } from "../../src/context/compaction/AutoCompactionPolicy.js";
+import { TokenBudgetManager } from "../../src/context/budget/TokenBudgetManager.js";
 import type { CanonicalMessage, CanonicalToolSchema } from "../../src/model/index.js";
 import type { ContextPrepareInput } from "../../src/context/protocol/types.js";
 
@@ -90,6 +93,14 @@ function message(text: string): CanonicalMessage {
   return { role: "user", content: [{ type: "text", text }] };
 }
 
+function checkpoint(text: string): CanonicalMessage[] {
+  return [
+    message('<compact-boundary trigger="manual" />'),
+    { role: "assistant", content: [{ type: "text", text: `[CONTEXT COMPACTION - REFERENCE ONLY]\n${text}` }] },
+    message("continue"),
+  ];
+}
+
 function promptDate(context: { systemPrompt?: string }): string | undefined {
   return context.systemPrompt?.match(/now: (\d{4}-\d{2}-\d{2})/)?.[1];
 }
@@ -113,10 +124,9 @@ test("session prompt date survives midnight, retries, and normal appends", async
   assert.equal(promptDate(other), "2026-09-11");
 });
 
-test("date refreshes after history rewrites, then freezes again", async () => {
+test("pruning and local rewrites preserve the system date", async () => {
   for (const rewritten of [
     [message("tail")], // Head truncation / overflow recovery.
-    [message("summary"), message("tail")], // Full compaction.
     [message("head"), message("short tool result"), message("tail")], // Micro compaction.
     [message("head"), message("tail")], // Middle snip with stable head.
   ]) {
@@ -125,14 +135,14 @@ test("date refreshes after history rewrites, then freezes again", async () => {
     await runtime.prepareForModel(input({ messages: [message("head"), message("long tool result"), message("tail")] }));
     now = new Date("2026-09-11T12:00:00Z");
     const compacted = await runtime.prepareForModel(input({ messages: rewritten }));
-    assert.equal(promptDate(compacted), "2026-09-11");
+    assert.equal(promptDate(compacted), "2026-09-10");
     now = new Date("2026-09-12T12:00:00Z");
     const next = await runtime.prepareForModel(input({ messages: [...rewritten, message("next")] }));
-    assert.equal(promptDate(next), "2026-09-11");
+    assert.equal(promptDate(next), "2026-09-10");
   }
 });
 
-test("sliding window refreshes only when the projected history actually changes", async () => {
+test("sliding window preserves the system date when projected history changes", async () => {
   let now = new Date("2026-09-10T12:00:00Z");
   const runtime = new DefaultContextRuntime({ now: () => now });
   const messages = [message("old"), message("head"), message("tail")];
@@ -141,7 +151,7 @@ test("sliding window refreshes only when the projected history actually changes"
   const retry = await runtime.prepareForModel(input({ messages, maxMessages: 2 }));
   assert.equal(promptDate(retry), "2026-09-10");
   const advanced = await runtime.prepareForModel(input({ messages: [...messages, message("next")], maxMessages: 2 }));
-  assert.equal(promptDate(advanced), "2026-09-11");
+  assert.equal(promptDate(advanced), "2026-09-10");
 });
 
 test("discarded budget candidates do not change the live date or cache generation", async () => {
@@ -149,13 +159,13 @@ test("discarded budget candidates do not change the live date or cache generatio
   const runtime = new DefaultContextRuntime({ now: () => now });
   const first = await runtime.prepareForModel(input());
   now = new Date("2026-09-11T12:00:00Z");
-  const candidate = await runtime.prepareForModel(input({ previewOnly: true, messages: [message("hypothetical summary")] }));
+  const candidate = await runtime.prepareForModel(input({ previewOnly: true, messages: checkpoint("hypothetical summary") }));
   assert.equal(promptDate(candidate), "2026-09-10");
   const unchanged = await runtime.prepareForModel(input());
   assert.equal(unchanged.systemPrompt, first.systemPrompt);
   assert.equal(unchanged.cachePlan?.generation, (first.cachePlan?.generation ?? 0) + 1);
   assert.equal(dateUpdates(unchanged).length, 1);
-  const committed = await runtime.prepareForModel(input({ messages: [message("hypothetical summary")] }));
+  const committed = await runtime.prepareForModel(input({ messages: checkpoint("hypothetical summary") }));
   assert.equal(promptDate(committed), "2026-09-11");
 });
 
@@ -215,17 +225,97 @@ test("rollover previews neither consume the notice nor commit its position", asy
   assert.deepEqual(repeated.cachePlan, actual.cachePlan);
 });
 
-test("rewrites retire rollover messages when the system date refreshes", async () => {
+test("full compaction retires rollover messages and refreshes the system date", async () => {
   let now = new Date("2026-09-10T12:00:00Z");
   const runtime = new DefaultContextRuntime({ now: () => now });
   await runtime.prepareForModel(input());
   now = new Date("2026-09-11T12:00:00Z");
   assert.equal(dateUpdates(await runtime.prepareForModel(input())).length, 1);
-  const rewritten = await runtime.prepareForModel(input({ messages: [message("summary")] }));
+  const rewritten = await runtime.prepareForModel(input({ messages: checkpoint("summary") }));
   assert.equal(promptDate(rewritten), "2026-09-11");
   assert.equal(dateUpdates(rewritten).length, 0);
-  const next = await runtime.prepareForModel(input({ messages: [message("summary"), message("continue")] }));
+  const next = await runtime.prepareForModel(input({ messages: [...checkpoint("summary"), message("continue")] }));
   assert.equal(dateUpdates(next).length, 0);
+  now = new Date("2026-09-12T12:00:00Z");
+  const pruned = await runtime.prepareForModel(input({ messages: checkpoint("summary") }));
+  assert.equal(promptDate(pruned), "2026-09-11");
+  assert.equal(dateUpdates(pruned).length, 1);
+  const compactedAgain = await runtime.prepareForModel(input({ messages: checkpoint("new summary") }));
+  assert.equal(promptDate(compactedAgain), "2026-09-12");
+  assert.equal(dateUpdates(compactedAgain).length, 0);
+});
+
+test("micro-compaction cache resets do not refresh the prompt date", async () => {
+  let now = new Date("2026-09-10T12:00:00Z");
+  const runtime = new DefaultContextRuntime({
+    now: () => now,
+    microCompaction: new MicroCompactionEngine(),
+    tokenBudget: new TokenBudgetManager(),
+    autoCompactionPolicy: new AutoCompactionPolicy(),
+  });
+  const messages: CanonicalMessage[] = [message("inspect these files")];
+  for (let index = 0; index < 5; index += 1) {
+    messages.push(
+      { role: "assistant", content: [{ type: "tool_call", id: `read-${index}`, name: "read_file", input: {} }] },
+      { role: "user", content: [{ type: "tool_result", toolCallId: `read-${index}`, content: [{ type: "text", text: "source code line\n".repeat(1000) }] }] },
+    );
+  }
+  const first = await runtime.prepareForModel(input({ messages }));
+  now = new Date("2026-09-11T12:00:00Z");
+  let evaluations = 0;
+  const compacted = await runtime.tryAutoCompact({
+    sessionId: input().sessionId,
+    messages,
+    budgetEvaluator: async () => ({
+      tokens: ++evaluations === 1 ? 8500 : 7000,
+      maxContextTokens: 10000,
+      warningRatio: 0.8,
+      blockingRatio: 0.9,
+      state: evaluations === 1 ? "warning" : "ok",
+      ratio: evaluations === 1 ? 0.85 : 0.7,
+    }),
+  });
+  assert.equal(compacted.type, "compacted");
+  if (compacted.type !== "compacted") return;
+  assert.equal(compacted.tier, "micro");
+  const prepared = await runtime.prepareForModel(input({ messages: compacted.messages }));
+  assert.equal(prepared.systemPrompt, first.systemPrompt);
+  assert.equal(dateUpdates(prepared).length, 1);
+  assert.match(JSON.stringify(dateUpdates(prepared)), /2026-09-11/);
+  assert.ok(prepared.cachePlan!.generation > first.cachePlan!.generation);
+});
+
+test("pruning preserves prefix notices and relocates affected notices safely", async () => {
+  let now = new Date("2026-09-10T12:00:00Z");
+  const runtime = new DefaultContextRuntime({ now: () => now });
+  const first = await runtime.prepareForModel(input());
+  now = new Date("2026-09-11T12:00:00Z");
+  const rollover = await runtime.prepareForModel(input());
+  const messages: CanonicalMessage[] = [
+    ...input().messages,
+    { role: "assistant", content: [{ type: "tool_call", id: "read", name: "read_file", input: {} }] },
+    { role: "user", content: [{ type: "tool_result", toolCallId: "read", content: [{ type: "text", text: "long result" }] }] },
+    message("continue"),
+  ];
+  now = new Date("2026-09-12T12:00:00Z");
+  await runtime.prepareForModel(input({ messages }));
+  const rewritten = [...messages];
+  rewritten[2] = { role: "user", content: [{ type: "tool_result", toolCallId: "read", content: [{ type: "text", text: "short result" }] }] };
+  const prepared = await runtime.prepareForModel(input({ messages: rewritten }));
+  assert.equal(prepared.systemPrompt, first.systemPrompt);
+  assert.deepEqual(prepared.messages.slice(0, rollover.messages.length), rollover.messages);
+  assert.deepEqual(prepared.messages.slice(2, 4), rewritten.slice(1, 3));
+  assert.equal(dateUpdates(prepared).length, 2);
+  assert.equal(prepared.messages.at(-1)?.metadata?.purpose, "date_update");
+  const preview = await runtime.prepareForModel(input({ previewOnly: true, messages: [message("continue")] }));
+  assert.equal(preview.systemPrompt, first.systemPrompt);
+  assert.deepEqual((await runtime.prepareForModel(input({ messages: rewritten }))).messages, prepared.messages);
+  const truncated = await runtime.prepareForModel(input({ messages: [message("continue")] }));
+  assert.equal(truncated.systemPrompt, first.systemPrompt);
+  assert.equal(truncated.messages.length, 2);
+  assert.equal(dateUpdates(truncated).length, 1);
+  assert.match(JSON.stringify(dateUpdates(truncated)), /2026-09-12/);
+  assert.deepEqual((await runtime.prepareForModel(input({ messages: [message("continue")] }))).messages, truncated.messages);
 });
 
 test("date notices preserve tool pairing and do not replace memory retrieval queries", async () => {

--- a/tests/context/cache-runtime.spec.ts
+++ b/tests/context/cache-runtime.spec.ts
@@ -101,7 +101,9 @@ test("session prompt date survives midnight, retries, and normal appends", async
   now = new Date("2026-09-11T00:01:00Z");
   const retry = await runtime.prepareForModel(input());
   assert.equal(retry.systemPrompt, first.systemPrompt);
-  assert.deepEqual(retry.cachePlan, first.cachePlan);
+  assert.equal(dateUpdates(retry).length, 1);
+  assert.deepEqual(retry.messages.slice(0, first.messages.length), first.messages);
+  assert.deepEqual((await runtime.prepareForModel(input())).cachePlan, retry.cachePlan);
   const next = await runtime.prepareForModel(input({
     turnId: "next-turn",
     messages: [...input().messages, message("next request")],
@@ -151,8 +153,9 @@ test("discarded budget candidates do not change the live date or cache generatio
   assert.equal(promptDate(candidate), "2026-09-10");
   const unchanged = await runtime.prepareForModel(input());
   assert.equal(unchanged.systemPrompt, first.systemPrompt);
-  assert.deepEqual(unchanged.cachePlan, first.cachePlan);
-  const committed = await runtime.prepareForModel(input({ messages: candidate.messages }));
+  assert.equal(unchanged.cachePlan?.generation, (first.cachePlan?.generation ?? 0) + 1);
+  assert.equal(dateUpdates(unchanged).length, 1);
+  const committed = await runtime.prepareForModel(input({ messages: [message("hypothetical summary")] }));
   assert.equal(promptDate(committed), "2026-09-11");
 });
 
@@ -164,4 +167,91 @@ test("date anchoring also applies to providers without an explicit cache plan", 
   const next = await runtime.prepareForModel(input({ protocol: "openai" }));
   assert.equal(next.systemPrompt, first.systemPrompt);
   assert.equal(next.cachePlan, undefined);
+});
+
+function dateUpdates(context: { messages: CanonicalMessage[] }): CanonicalMessage[] {
+  return context.messages.filter((entry) => entry.metadata?.purpose === "date_update");
+}
+
+test("rollovers append once per UTC day and preserve the previous request prefix", async () => {
+  let now = new Date("2026-09-10T23:59:59Z");
+  const runtime = new DefaultContextRuntime({ now: () => now });
+  const messages = input().messages;
+  const first = await runtime.prepareForModel(input({ messages }));
+  assert.equal(dateUpdates(first).length, 0);
+  now = new Date("2026-09-11T00:00:00Z");
+  messages.push(message("today?"));
+  const rollover = await runtime.prepareForModel(input({ messages }));
+  assert.match(JSON.stringify(dateUpdates(rollover)), /current_date: 2026-09-11/);
+  assert.equal(dateUpdates(rollover).length, 1);
+  messages.push({ role: "assistant", content: [{ type: "text", text: "September 11" }] });
+  messages.push(message("continue"));
+  const next = await runtime.prepareForModel(input({ messages }));
+  assert.equal(dateUpdates(next).length, 1);
+  assert.deepEqual(next.messages.slice(0, rollover.messages.length), rollover.messages);
+  now = new Date("2026-09-12T00:00:00Z");
+  const tomorrow = await runtime.prepareForModel(input({ messages }));
+  assert.equal(dateUpdates(tomorrow).length, 2);
+  assert.deepEqual(tomorrow.messages.slice(0, next.messages.length), next.messages);
+  assert.equal(tomorrow.systemPrompt, first.systemPrompt);
+  assert.deepEqual(tomorrow.cacheBreakpoints, [tomorrow.messages.length - 3, tomorrow.messages.length - 2, tomorrow.messages.length - 1]);
+  const other = await runtime.prepareForModel(input({ sessionId: "another" }));
+  assert.equal(dateUpdates(other).length, 0);
+  assert.equal(promptDate(other), "2026-09-12");
+});
+
+test("rollover previews neither consume the notice nor commit its position", async () => {
+  let now = new Date("2026-09-10T12:00:00Z");
+  const runtime = new DefaultContextRuntime({ now: () => now });
+  await runtime.prepareForModel(input());
+  now = new Date("2026-09-11T12:00:00Z");
+  const preview = await runtime.prepareForModel(input({ previewOnly: true, messages: [...input().messages, message("discarded")] }));
+  assert.equal(dateUpdates(preview).length, 1);
+  const actual = await runtime.prepareForModel(input());
+  assert.equal(actual.messages.length, 2);
+  assert.equal(dateUpdates(actual).length, 1);
+  const repeated = await runtime.prepareForModel(input());
+  assert.deepEqual(repeated.messages, actual.messages);
+  assert.deepEqual(repeated.cachePlan, actual.cachePlan);
+});
+
+test("rewrites retire rollover messages when the system date refreshes", async () => {
+  let now = new Date("2026-09-10T12:00:00Z");
+  const runtime = new DefaultContextRuntime({ now: () => now });
+  await runtime.prepareForModel(input());
+  now = new Date("2026-09-11T12:00:00Z");
+  assert.equal(dateUpdates(await runtime.prepareForModel(input())).length, 1);
+  const rewritten = await runtime.prepareForModel(input({ messages: [message("summary")] }));
+  assert.equal(promptDate(rewritten), "2026-09-11");
+  assert.equal(dateUpdates(rewritten).length, 0);
+  const next = await runtime.prepareForModel(input({ messages: [message("summary"), message("continue")] }));
+  assert.equal(dateUpdates(next).length, 0);
+});
+
+test("date notices preserve tool pairing and do not replace memory retrieval queries", async () => {
+  let now = new Date("2026-09-10T12:00:00Z");
+  const queries: string[] = [];
+  const runtime = new DefaultContextRuntime({
+    now: () => now,
+    memoryResolver: {
+      async retrieve(request) {
+        queries.push(request.query);
+        assert.equal(dateUpdates({ messages: request.recentMessages }).length, 0);
+        return { diagnostics: [] };
+      },
+      async captureTurn() {},
+    },
+  });
+  await runtime.prepareForModel(input());
+  now = new Date("2026-09-11T12:00:00Z");
+  const messages: CanonicalMessage[] = [
+    ...input().messages,
+    { role: "assistant", content: [{ type: "tool_call", id: "read-1", name: "read_file", input: {} }] },
+    { role: "user", content: [{ type: "tool_result", toolCallId: "read-1", content: [{ type: "text", text: "file" }] }] },
+  ];
+  const rollover = await runtime.prepareForModel(input({ messages }));
+  assert.deepEqual(rollover.messages.slice(0, 3), messages);
+  assert.equal(rollover.messages[3].metadata?.purpose, "date_update");
+  assert.deepEqual(queries, ["request", "request"]);
+  assert.equal(messages.length, 3);
 });

--- a/tests/context/cache-runtime.spec.ts
+++ b/tests/context/cache-runtime.spec.ts
@@ -85,3 +85,83 @@ test("non-Anthropic and unsupported models do not receive a cache plan", async (
   assert.equal(unsupported.cachePlan, undefined);
   assert.equal(unsupported.cacheBreakpoints, undefined);
 });
+
+function message(text: string): CanonicalMessage {
+  return { role: "user", content: [{ type: "text", text }] };
+}
+
+function promptDate(context: { systemPrompt?: string }): string | undefined {
+  return context.systemPrompt?.match(/now: (\d{4}-\d{2}-\d{2})/)?.[1];
+}
+
+test("session prompt date survives midnight, retries, and normal appends", async () => {
+  let now = new Date("2026-09-10T23:59:59Z");
+  const runtime = new DefaultContextRuntime({ now: () => now });
+  const first = await runtime.prepareForModel(input());
+  now = new Date("2026-09-11T00:01:00Z");
+  const retry = await runtime.prepareForModel(input());
+  assert.equal(retry.systemPrompt, first.systemPrompt);
+  assert.deepEqual(retry.cachePlan, first.cachePlan);
+  const next = await runtime.prepareForModel(input({
+    turnId: "next-turn",
+    messages: [...input().messages, message("next request")],
+  }));
+  assert.equal(next.systemPrompt, first.systemPrompt);
+  const other = await runtime.prepareForModel(input({ sessionId: "other-session" }));
+  assert.equal(promptDate(other), "2026-09-11");
+});
+
+test("date refreshes after history rewrites, then freezes again", async () => {
+  for (const rewritten of [
+    [message("tail")], // Head truncation / overflow recovery.
+    [message("summary"), message("tail")], // Full compaction.
+    [message("head"), message("short tool result"), message("tail")], // Micro compaction.
+    [message("head"), message("tail")], // Middle snip with stable head.
+  ]) {
+    let now = new Date("2026-09-10T12:00:00Z");
+    const runtime = new DefaultContextRuntime({ now: () => now });
+    await runtime.prepareForModel(input({ messages: [message("head"), message("long tool result"), message("tail")] }));
+    now = new Date("2026-09-11T12:00:00Z");
+    const compacted = await runtime.prepareForModel(input({ messages: rewritten }));
+    assert.equal(promptDate(compacted), "2026-09-11");
+    now = new Date("2026-09-12T12:00:00Z");
+    const next = await runtime.prepareForModel(input({ messages: [...rewritten, message("next")] }));
+    assert.equal(promptDate(next), "2026-09-11");
+  }
+});
+
+test("sliding window refreshes only when the projected history actually changes", async () => {
+  let now = new Date("2026-09-10T12:00:00Z");
+  const runtime = new DefaultContextRuntime({ now: () => now });
+  const messages = [message("old"), message("head"), message("tail")];
+  await runtime.prepareForModel(input({ messages, maxMessages: 2 }));
+  now = new Date("2026-09-11T12:00:00Z");
+  const retry = await runtime.prepareForModel(input({ messages, maxMessages: 2 }));
+  assert.equal(promptDate(retry), "2026-09-10");
+  const advanced = await runtime.prepareForModel(input({ messages: [...messages, message("next")], maxMessages: 2 }));
+  assert.equal(promptDate(advanced), "2026-09-11");
+});
+
+test("discarded budget candidates do not change the live date or cache generation", async () => {
+  let now = new Date("2026-09-10T12:00:00Z");
+  const runtime = new DefaultContextRuntime({ now: () => now });
+  const first = await runtime.prepareForModel(input());
+  now = new Date("2026-09-11T12:00:00Z");
+  const candidate = await runtime.prepareForModel(input({ previewOnly: true, messages: [message("hypothetical summary")] }));
+  assert.equal(promptDate(candidate), "2026-09-10");
+  const unchanged = await runtime.prepareForModel(input());
+  assert.equal(unchanged.systemPrompt, first.systemPrompt);
+  assert.deepEqual(unchanged.cachePlan, first.cachePlan);
+  const committed = await runtime.prepareForModel(input({ messages: candidate.messages }));
+  assert.equal(promptDate(committed), "2026-09-11");
+});
+
+test("date anchoring also applies to providers without an explicit cache plan", async () => {
+  let now = new Date("2026-09-10T12:00:00Z");
+  const runtime = new DefaultContextRuntime({ now: () => now });
+  const first = await runtime.prepareForModel(input({ protocol: "openai" }));
+  now = new Date("2026-09-11T12:00:00Z");
+  const next = await runtime.prepareForModel(input({ protocol: "openai" }));
+  assert.equal(next.systemPrompt, first.systemPrompt);
+  assert.equal(next.cachePlan, undefined);
+});

--- a/tests/router/tokenSaver.spec.ts
+++ b/tests/router/tokenSaver.spec.ts
@@ -4,6 +4,52 @@ import test from "node:test";
 import type { CanonicalModelRequest, ModelRuntime } from "../../src/model/index.js";
 import { ModelProviderError } from "../../src/model/index.js";
 import { classifyAndRoute } from "../../src/router/index.js";
+import { DefaultContextRuntime } from "../../src/context/DefaultContextRuntime.js";
+
+test("classifies the real task after context appends a midnight date update", async () => {
+  let now = new Date("2026-09-10T23:59:00Z");
+  const context = new DefaultContextRuntime({ now: () => now });
+  const input = {
+    sessionId: "midnight-routing",
+    turnId: "first",
+    cwd: "/workspace",
+    provider: "main",
+    model: "main-model",
+    permissionMode: "default",
+    runMode: "agent",
+    additionalWorkingDirectories: [],
+    tools: [],
+    messages: [{ role: "user" as const, content: [{ type: "text" as const, text: "hello" }] }],
+  };
+  await context.prepareForModel(input);
+  now = new Date("2026-09-11T00:01:00Z");
+  const task = "Design a distributed transaction coordinator with crash recovery.";
+  const prepared = await context.prepareForModel({
+    ...input,
+    turnId: "second",
+    messages: [
+      ...input.messages,
+      { role: "assistant", content: [{ type: "text", text: "Ready." }] },
+      { role: "user", content: [{ type: "text", text: task }] },
+    ],
+  });
+  assert.equal(prepared.messages.at(-1)?.metadata?.purpose, "date_update");
+  let request: CanonicalModelRequest | undefined;
+  const judgeRuntime = {
+    complete: async (nextRequest: CanonicalModelRequest) => {
+      request = nextRequest;
+      return {
+        role: "assistant",
+        content: [{ type: "text", text: "<tier>medium</tier>" }],
+        finishReason: "stop",
+      };
+    },
+  } as unknown as ModelRuntime;
+  await classifyAndRoute({ config: config(), messages: prepared.messages, judgeRuntime });
+  const judgePrompt = JSON.stringify(request?.messages);
+  assert.ok(judgePrompt.includes(task), "judge must receive the actual user task");
+  assert.ok(!judgePrompt.includes("<date-update>"), "date notices must not become classification input");
+});
 
 test("records the normalized judge error when token-saver falls back", async () => {
   let attempts = 0;


### PR DESCRIPTION
A session that crosses UTC midnight currently changes its system prompt date, invalidating the otherwise stable prompt prefix. This change anchors the system date to the first committed request and appends a synthetic current-date message on the first request after a UTC date change. Later requests retain that notice at its original position without adding another notice on the same day.

- Refresh the system date after projected history is rewritten, truncated, or compacted, and retire prior date notices. Repeated projection of the same truncated history keeps the anchor stable.
- Treat budget evaluation as `previewOnly`: include candidate date notices in estimates without committing prompt-time state, cache generation, or consuming pending compaction resets.
- Compute cache breakpoints from the final projected messages. Keep date notices out of memory retrieval and the persisted user transcript; their lifetime matches the context runtime, including for providers without explicit cache plans.

Validation: 117 related context, agent-loop, Anthropic request, and continuation tests passed with `node --import tsx --test tests/context/*.spec.ts tests/agent/loop/*.spec.ts tests/model/request/anthropic-cache-plan.spec.ts tests/model/streaming/continuation-cache.spec.ts`. TypeScript checking (`tsc --noEmit -p tsconfig.json`) and `git diff --check` passed. Tests ran on Node 24.20.0; the declared Node 22 runtime has not been revalidated locally.